### PR TITLE
Fix Object Type Detection

### DIFF
--- a/src/main/resources/python/swagger.mustache
+++ b/src/main/resources/python/swagger.mustache
@@ -98,7 +98,7 @@ class ApiClient:
     def sanitizeForSerialization(self, obj):
         """Dump an object into JSON for POSTing."""
 
-        if not obj:
+        if type(obj) == type(None):
             return None
         elif type(obj) in [str, int, long, float, bool]:
             return obj

--- a/src/main/resources/python3/swagger.mustache
+++ b/src/main/resources/python3/swagger.mustache
@@ -102,7 +102,7 @@ class ApiClient:
     def sanitizeForSerialization(self, obj):
         """Dump an object into JSON for POSTing."""
 
-        if not obj:
+        if type(obj) == type(None):
             return None
         elif type(obj) in [str, int, float, bool]:
             return obj


### PR DESCRIPTION
Prior to this patch, zero integers and False booleans were being converted to None since both evaluate the origin if statement (it not obj) to True.  This can screw up APIs expecting False values or an integer, not a null.

Signed-off-by: George Sibble gsibble@gmail.com
