### PR TITLE
made Models optional

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/spec/SwaggerSpecValidator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/spec/SwaggerSpecValidator.scala
@@ -49,10 +49,13 @@ class SwaggerSpecValidator(private val doc: ResourceListing,
     apis.foreach(api => {
       fixSubDoc(api)
 
-      if (api.models != null) {
-        fixReturnModels(api.models.toMap, apis)
-        fixInputDataTypes(api.models.toMap, apis)
-        fixModels(api.models.toMap)
+      api.models match { 
+       case Some(models) => {
+          fixReturnModels(models.toMap, apis)
+          fixInputDataTypes(models.toMap, apis)
+	  fixModels(models.toMap)
+	}
+	case None => LOGGER.warning("no models found for listing  " + api.basePath)
       }
     })
 

--- a/src/main/scala/com/wordnik/swagger/codegen/util/CoreUtils.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/CoreUtils.scala
@@ -29,7 +29,9 @@ object CoreUtils {
     val modelObjects = new HashMap[String, Model]
     apis.foreach(api => {
       for ((nm, model) <- extractApiModels(api)) modelObjects += nm -> model
-      api.models.foreach(model => modelObjects += model._1 -> model._2)
+      if(api.models.isDefined) {
+	api.models.get.foreach(model => modelObjects += model._1 -> model._2)
+      }
     })
     modelObjects.toMap
   }
@@ -65,8 +67,9 @@ object CoreUtils {
           .foreach(p => modelNames += p.dataType)
       })
     )
-    for ((name, m) <- sd.models) 
-      modelObjects += name -> m
+    if(sd.models.isDefined)
+      for ((name, m) <- sd.models.get)
+        modelObjects += name -> m
 
     // extract all base model names, strip away Containers like List[] and primitives
     val baseNames = (for (modelName <- (modelNames.toList filterNot primitives.contains))

--- a/src/main/scala/com/wordnik/swagger/model/SwaggerModelSerializer.scala
+++ b/src/main/scala/com/wordnik/swagger/model/SwaggerModelSerializer.scala
@@ -53,7 +53,7 @@ object SwaggerSerializers {
           ""
         }),
         (json \ "apis").extract[List[ApiDescription]],
-        (json \ "models").extract[Map[String, Model]]
+        (json \ "models").extractOpt[Map[String, Model]]
       )
     }, {
       case x: ApiListing =>

--- a/src/main/scala/com/wordnik/swagger/model/SwaggerModels.scala
+++ b/src/main/scala/com/wordnik/swagger/model/SwaggerModels.scala
@@ -54,7 +54,7 @@ case class ApiListing (
   basePath: String,
   var resourcePath: String,
   apis: List[ApiDescription] = List(),
-  models: Map[String, Model] = Map())
+  models: Option[Map[String, Model]] = None)
 
 case class ApiDescription (
   path: String,

--- a/src/test/scala/SwaggerModelTest.scala
+++ b/src/test/scala/SwaggerModelTest.scala
@@ -57,7 +57,8 @@ class SwaggerModelTest extends FlatSpec with ShouldMatchers {
 		apiListing.basePath should be ("http://petstore.swagger.wordnik.com/api")
 		apiListing.resourcePath should be ("/pet")
 		apiListing.apis.size should be (4)
-		apiListing.models.size should be (3)
+		apiListing.models.isDefined should be (true)
+		apiListing.models.get.size should be (3)
 
 		val apiMap = apiListing.apis.map(api => (api.path, api)).toMap
 		val petBaseApi = apiMap("/pet.{format}/{petId}")
@@ -115,7 +116,9 @@ class SwaggerModelTest extends FlatSpec with ShouldMatchers {
     val json = Source.fromFile("src/test/resources/petstore/pet.json").mkString
     val apiListing = parse(json).extract[ApiListing]
 
-    val models = apiListing.models
+    val modelsOpt = apiListing.models
+    modelsOpt.isDefined should be (true)
+    val models = modelsOpt.get
     models.size should be (3)
     val pet = models("Pet")
 
@@ -134,7 +137,9 @@ class SwaggerModelTest extends FlatSpec with ShouldMatchers {
  		val json = Source.fromFile("src/test/resources/petstore/pet.json").mkString
 		val apiListing = parse(json).extract[ApiListing]
 
-		val models = apiListing.models
+		val modelsOpt = apiListing.models
+		modelsOpt.isDefined should be (true)
+ 		val models = modelsOpt.get
 		models.size should be (3)
 
 		val pet = models("Pet")


### PR DESCRIPTION
The code generation currently fails if an API listing has no models. This patch makes models an Option and fixes that use case.
