### PR TITLE
Display an error when an API fails to parse.

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/util/ApiExtractor.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/ApiExtractor.scala
@@ -43,11 +43,15 @@ object ApiExtractor extends RemoteUrl {
             Some(parse(json).extract[ApiListing])
           }
           catch {
-            case e:java.io.FileNotFoundException => {
+            case e: java.io.FileNotFoundException => {
               println("WARNING!  Unable to read API " + basePath + api.path)
               None
             }
-            case _ : Throwable=> None
+            case e: Throwable => {
+              println("WARNING!  Unable to read API " + basePath + api.path)
+              e.printStackTrace()
+              None
+            }
           }
         }).flatten.toList
   }


### PR DESCRIPTION
Originally, the code would silently discard API's that would fail to parse. It still discards them, but now it at least tells you about it.
