### PR TITLE
fixing replaceAll bug on windows with escaping paths, changed replaceAll...

### DIFF
--- a/samples/client/petstore/csharp/CSharpPetstoreCodegen.scala
+++ b/samples/client/petstore/csharp/CSharpPetstoreCodegen.scala
@@ -37,8 +37,8 @@ object CSharpPetstoreCodegen extends BasicCSharpGenerator {
   // supporting classes
   override def supportingFiles =
     List(
-      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiInvoker.cs"),
-      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiException.cs"),
+      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiInvoker.cs"),
+      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiException.cs"),
       ("Newtonsoft.Json.dll", "samples/client/petstore/csharp/bin", "Newtonsoft.Json.dll"),
       ("compile.mustache", "samples/client/petstore/csharp", "compile.bat"))
 }

--- a/samples/client/petstore/java/JavaPetstoreCodegen.scala
+++ b/samples/client/petstore/java/JavaPetstoreCodegen.scala
@@ -37,8 +37,8 @@ object JavaPetstoreCodegen extends BasicJavaGenerator {
   // supporting classes
   override def supportingFiles =
     List(
-      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiInvoker.java"),
-      ("JsonUtil.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "JsonUtil.java"),
-      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiException.java"),
+      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiInvoker.java"),
+      ("JsonUtil.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "JsonUtil.java"),
+      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiException.java"),
       ("pom.mustache", "samples/client/petstore/java", "pom.xml"))
 }

--- a/samples/client/petstore/scala/ScalaPetstoreCodegen.scala
+++ b/samples/client/petstore/scala/ScalaPetstoreCodegen.scala
@@ -33,7 +33,7 @@ object ScalaPetstoreCodegen extends BasicScalaGenerator {
 
   // supporting classes
   override def supportingFiles = List(
-    ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiInvoker.scala"),
+    ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiInvoker.scala"),
     ("pom.mustache", "samples/client/petstore/scala", "pom.xml")
   )
 }

--- a/samples/client/wordnik-api/java/JavaWordnikApiCodegen.scala
+++ b/samples/client/wordnik-api/java/JavaWordnikApiCodegen.scala
@@ -39,8 +39,8 @@ object JavaWordnikApiCodegen extends BasicJavaGenerator {
   // supporting classes
   override def supportingFiles =
     List(
-      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiInvoker.java"),
-      ("JsonUtil.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "JsonUtil.java"),
-      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiException.java"),
+      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiInvoker.java"),
+      ("JsonUtil.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "JsonUtil.java"),
+      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiException.java"),
       ("pom.mustache", destinationRoot, "pom.xml"))
 }

--- a/samples/client/wordnik-api/scala/ScalaWordnikApiCodegen.scala
+++ b/samples/client/wordnik-api/scala/ScalaWordnikApiCodegen.scala
@@ -35,6 +35,6 @@ object ScalaWordnikApiCodegen extends BasicScalaGenerator {
 
   // supporting classes
   override def supportingFiles = List(
-    ("apiInvoker.mustache", destinationDir + "/" + invokerPackage.get.replaceAll("\\.", java.io.File.separator), "ApiInvoker.scala"),
+    ("apiInvoker.mustache", destinationDir + "/" + invokerPackage.get.replace(".", java.io.File.separator), "ApiInvoker.scala"),
     ("pom.mustache", destinationRoot, "pom.xml"))
 }

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicCSharpGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicCSharpGenerator.scala
@@ -182,8 +182,8 @@ class BasicCSharpGenerator extends BasicGenerator {
   // supporting classes
   override def supportingFiles =
     List(
-      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiInvoker.java"),
-      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiException.java"),
+      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiInvoker.java"),
+      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiException.java"),
       ("Newtonsoft.Json.dll", "generated-code/csharp/bin", "Newtonsoft.Json.dll"),
       ("compile.mustache", "generated-code/csharp", "compile.bat"))
 }

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -151,7 +151,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
         m += "models" -> List((name, schema))
         m += "package" -> modelPackage
         m += "invokerPackage" -> invokerPackage
-        m += "outputDirectory" -> (destinationDir + File.separator + modelPackage.getOrElse("").replaceAll("\\.", File.separator))
+        m += "outputDirectory" -> (destinationDir + File.separator + modelPackage.getOrElse("").replace(".", File.separator))
         m += "newline" -> "\n"
 
         Some(m.toMap)
@@ -177,7 +177,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
       m += "invokerPackage" -> invokerPackage
       m += "apis" -> Map(className -> operationList.toList)
       m += "models" -> None
-      m += "outputDirectory" -> (destinationDir + File.separator + apiPackage.getOrElse("").replaceAll("\\.", File.separator))
+      m += "outputDirectory" -> (destinationDir + File.separator + apiPackage.getOrElse("").replace(".", File.separator))
       m += "newline" -> "\n"
 
       Some(m.toMap)

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala
@@ -172,8 +172,8 @@ class BasicJavaGenerator extends BasicGenerator {
   // supporting classes
   override def supportingFiles =
     List(
-      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiInvoker.java"),
-      ("JsonUtil.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "JsonUtil.java"),
-      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replaceAll("\\.", java.io.File.separator) + java.io.File.separator, "ApiException.java"),
+      ("apiInvoker.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiInvoker.java"),
+      ("JsonUtil.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "JsonUtil.java"),
+      ("apiException.mustache", destinationDir + java.io.File.separator + invokerPackage.get.replace(".", java.io.File.separator) + java.io.File.separator, "ApiException.java"),
       ("pom.mustache", "generated-code/java", "pom.xml"))
 }


### PR DESCRIPTION
...() to replace()
