### PR TITLE
C# template compiler error for non-string parameters

### DIFF
--- a/src/main/resources/csharp/api.mustache
+++ b/src/main/resources/csharp/api.mustache
@@ -48,8 +48,11 @@
         }
         {{/requiredParamCount}}
 
-        {{#queryParams}}if ({{paramName}} != null)
-          queryParams.Add("{{paramName}}", {{paramName}});
+		string paramStr = null;
+        {{#queryParams}}if ({{paramName}} != null){
+          paramStr = ({{paramName}} != null && {{paramName}} is DateTime) ? ((DateTime)(object){{paramName}}).ToString("u") : Convert.ToString({{paramName}});
+          queryParams.Add("{{paramName}}", paramStr);
+		}
         {{/queryParams}}
 
         {{#headerParams}}headerParams.Add("{{paramName}}", {{paramName}});


### PR DESCRIPTION
When swagger definition defines non-string parameters, C# codegen template results cannot be compiled
