### PR TITLE
Only check in lists and dictionaries

### DIFF
--- a/src/main/resources/python/swagger.mustache
+++ b/src/main/resources/python/swagger.mustache
@@ -159,7 +159,7 @@ class ApiClient:
         instance = objClass()
 
         for attr, attrType in instance.swaggerTypes.iteritems():
-            if attr in obj and type(obj) in [list, dict]:
+            if obj is not None and attr in obj and type(obj) in [list, dict]:
                 value = obj[attr]
                 if attrType in ['str', 'int', 'long', 'float', 'bool']:
                     attrType = eval(attrType)


### PR DESCRIPTION
The "in" operator also works on strings which can cause problems with this line if the attribute and the object are named the same thing.

Signed-off-by: George Sibble gsibble@gmail.com
