### PR TITLE
Fix Ruby Request class: no access to inject_format on Class object

### DIFF
--- a/src/main/resources/ruby/swagger/request.mustache
+++ b/src/main/resources/ruby/swagger/request.mustache
@@ -81,7 +81,7 @@ module Swagger
       # Stick a .{format} placeholder into the path if there isn't
       # one already or an actual format like json or xml
       # e.g. /words/blah => /words.{format}/blah
-      if Swagger::Configuration.inject_format
+      if Swagger.configuration.inject_format
         unless ['.json', '.xml', '{format}'].any? {|s| p.downcase.include? s }
           p = p.sub(/^(\/?\w+)/, "\\1.#{format}")
         end


### PR DESCRIPTION
As far as I can tell, this is meant to access the 'configuration' object of Swagger, not the Configuration class.
