### PR TITLE
Add an 'httpMethodLowerCase' property

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -362,6 +362,7 @@ class Codegen(config: CodegenConfig) {
         "requiredParams" -> requiredParams.toList,
         "errorList" -> errorList,
         "httpMethod" -> operation.method.toUpperCase,
+        "httpMethodLowerCase" -> operation.method.toLowerCase,
         operation.method.toLowerCase -> "true")
     if (requiredParams.size > 0) properties += "requiredParamCount" -> requiredParams.size.toString
     operation.responseClass.indexOf("[") match {


### PR DESCRIPTION
Some libraries use lower case httpMethod names for method calls. For
example, Ruby's Faraday library uses 'get', 'put', 'post', 'delete'.

Rather than this unweildy Ruby code produced by a mustache template:
  self.send("GET".downcase, path, request_opts)

This patch would allow for a more tidy output such as:
  get(path, request_opts)
