### PR TITLE
Fix for sidebar never scrolling in static docs, preventing the user from seeing all operations.

### DIFF
--- a/samples/docs/swagger-static-docs/src/main/webapp/assets/js/main.js
+++ b/samples/docs/swagger-static-docs/src/main/webapp/assets/js/main.js
@@ -71,5 +71,5 @@ $(function(){
     resize();
     $(window).bind('hashchange', function() {
         choose(window.location.href.toString());
-    }).trigger('hashchange');
+    });
 });


### PR DESCRIPTION
Viewport wasn't sizing  correctly.  This change binds the size of the sidebar and content to the window.
