### PR TITLE
Fix Java Generator to always generate valid Java variable names

### DIFF
--- a/src/main/resources/Java/api.mustache
+++ b/src/main/resources/Java/api.mustache
@@ -41,10 +41,10 @@ public class {{classname}} {
     {{/requiredParamCount}}
 
     {{#queryParams}}if(!"null".equals(String.valueOf({{paramName}})))
-      queryParams.put("{{paramName}}", String.valueOf({{paramName}}));
+      queryParams.put("{{baseName}}", String.valueOf({{paramName}}));
     {{/queryParams}}
 
-    {{#headerParams}}headerParams.put("{{paramName}}", {{paramName}});
+    {{#headerParams}}headerParams.put("{{baseName}}", {{paramName}});
     {{/headerParams}}
 
     String contentType = "application/json";

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala
@@ -93,6 +93,11 @@ class BasicJavaGenerator extends BasicGenerator {
   // file suffix
   override def fileSuffix = ".java"
 
+  override def toVarName(name: String): String = {
+    val paramName = name.replaceAll("[^a-zA-Z0-9_]","")
+    super.toVarName(paramName)
+  }
+
   // response classes
   override def processResponseClass(responseClass: String): Option[String] = {
     responseClass match {


### PR DESCRIPTION
Current BasicJavaGenerator can generate Java that won't compile as the variable names are invalid. This patch guarantees valid Java variable names.
