### PR TITLE
Change "success" response status code in Java ApiInvoker to all 2xx responses vs. just 200.

### DIFF
--- a/src/main/resources/Java/apiInvoker.mustache
+++ b/src/main/resources/Java/apiInvoker.mustache
@@ -12,6 +12,7 @@ import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.api.client.filter.LoggingFilter;
 import com.sun.jersey.api.client.WebResource.Builder;
 
+import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.core.MediaType;
 
 import java.util.Map;
@@ -123,7 +124,7 @@ public class ApiInvoker {
     else {
       throw new ApiException(500, "unknown method type " + method);
     }
-    if(response.getClientResponseStatus() == ClientResponse.Status.OK) {
+    if(response.getClientResponseStatus().getFamily() == Family.SUCCESSFUL) {
       return (String) response.getEntity(String.class);
     }
     else {


### PR DESCRIPTION
Ensure that all bona fide 2xx responses are treated in the same way that "200 OK" is.

Previously, was explicitly checking for response code 200 (ClientResponse.Status.OK).

Now, checks the family of the response to make sure it is successful (Family.SUCCESSFUL). This enables us to POST to resources that return 201 created - without having to handle a checked ApiException.

This is a trivial change BUT it will break any implementations that attempt to catch / parse the ApiException currently thrown when a 201 is returned.
