### PR TITLE
Update Objective-C's run-time type-check in SWGApiClient to allow NSArrays

### DIFF
--- a/src/main/resources/objc/SWGApiClient.m
+++ b/src/main/resources/objc/SWGApiClient.m
@@ -280,7 +280,7 @@ static bool loggingEnabled = false;
     }
 
     if(body != nil) {
-        if([body isKindOfClass:[NSDictionary class]]){
+        if([body isKindOfClass:[NSDictionary class]] || [body isKindOfClass:[NSArray class]]){
             [request setValue:requestContentType forHTTPHeaderField:@"Content-Type"];
         }
         else if ([body isKindOfClass:[SWGFile class]]) {}


### PR DESCRIPTION
SWGApiClient.m's run-type type checking could allow NSArrays to be passed (for Swagger-generated methods that rely on Swagger/JSON "array" parameters in the HTTP body).  Editing the one "if" statement fixed it for my use case and it  works without further issues.
