### PR TITLE
Extract actual work from generateClient so that we can call it without killing the JVM.

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -44,12 +44,17 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
   var codegen = new Codegen(this)
 
   def generateClient(args: Array[String]) = {
+    generateClientWithoutExit(args)
+    System.exit(0)
+  }
+
+  def generateClientWithoutExit(args: Array[String]) {
     if (args.length == 0) {
       throw new RuntimeException("Need url to resource listing as argument. You can also specify VM Argument -DfileMap=/path/to/folder/containing.resources.json/")
     }
     val host = args(0)
     val authorization = {
-      Option (System.getProperty("header")) match {
+      Option(System.getProperty("header")) match {
         case Some(e) => {
           // this is ugly and will be replaced with proper arg parsing like in ScalaAsyncClientGenerator soon
           val authInfo = e.split(":")
@@ -129,7 +134,6 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
     })
 
     codegen.writeSupportingClasses(operationMap, allModels.toMap)
-    System.exit(0)
   }
 
   def extractApiOperations(apiListings: List[ApiListing], allModels: HashMap[String, Model] )(implicit basePath:String) = {


### PR DESCRIPTION
We wanted to run generateClient as part of a sbt task, but the existing method was killing sbt due to System.exit(0). We extracted the actual logic into a separate method that we can call from sbt.

Not sure what the original reason for calling System.exit(0) was, but assuming it was put there for a reason and not removing it for backwards compatibility.
