### PR TITLE
Sort operations in generated code

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -93,7 +93,7 @@ class Codegen(config: CodegenConfig) {
     // This function forces AnyRef to a String for purposes of sorting
     val forceString = (x: AnyRef) => x match { case y: String => y case z: AnyRef => ""}
 
-    val f = new ListBuffer[AnyRef]
+    val f = new ListBuffer[Map[String, AnyRef]]
     classNameToOperationList.map(m =>
       f += Map(
         "classname" -> m._1,


### PR DESCRIPTION
This update sorts the operations in each class before generating client code.

Previously the operations were not sorted, so regenerating client code could result in git changesets when there were no real changes, only a reordering of the methods within their classes.  This code sorts by path, verb (httpMethod), and finally method name (nickname).  The last of these is only a failsafe, as there should never be two methods with the same path and verb assigned to them.

An alternative method would be to sort the list according to the method name (nickname) only, which would produce output classes with properly ordered methods.  However, in my experience the method names are more likely to change than the path and verb, and so this ordering creates a more stable sort.