### PR TITLE
Fixes a bug where the wrong name was being used for header parameters in the Android code generator.

### DIFF
--- a/src/main/resources/android-java/api.mustache
+++ b/src/main/resources/android-java/api.mustache
@@ -19,11 +19,11 @@ public class {{classname}} {
   public ApiInvoker getInvoker() {
     return apiInvoker;
   }
-  
+
   public void setBasePath(String basePath) {
     this.basePath = basePath;
   }
-  
+
   public String getBasePath() {
     return basePath;
   }
@@ -45,10 +45,10 @@ public class {{classname}} {
     Map<String, String> headerParams = new HashMap<String, String>();
 
     {{#queryParams}}if(!"null".equals(String.valueOf({{paramName}})))
-      queryParams.put("{{paramName}}", String.valueOf({{paramName}}));
+      queryParams.put("{{baseName}}", String.valueOf({{paramName}}));
     {{/queryParams}}
 
-    {{#headerParams}}headerParams.put("{{paramName}}", {{paramName}});
+    {{#headerParams}}headerParams.put("{{baseName}}", {{paramName}});
     {{/headerParams}}
 
     String contentType = "application/json";


### PR DESCRIPTION
This is the same fix that was made to the Java generator a while back.
