### PR TITLE
Improve groupId, artifactId, name in generated pom.xml

### DIFF
--- a/src/main/resources/Java/pom.mustache
+++ b/src/main/resources/Java/pom.mustache
@@ -1,10 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.wordnik</groupId>
-  <artifactId>{{artifactId}}</artifactId>
+  <groupId>{{package}}</groupId>
+  <artifactId>api-client</artifactId>
   <packaging>jar</packaging>
-  <name>{{artifactId}}</name>
+  <name>api-client</name>
   <version>1.0.0</version>
   <scm>
     <connection>scm:git:git@github.com:wordnik/swagger-mustache.git</connection>


### PR DESCRIPTION
1. Replace hardcoded groupId (`com.wordnik`) with `package` variable.
2. artifactId and name were using non-existent variable `artifactId`.
   This results in an empty artifactId, which makes Maven puke.
   Replaced them with a sensible hardcoded value, "api-client".
