### PR TITLE
Fix deserialization of "authorizations" fields

### DIFF
--- a/src/main/scala/com/wordnik/swagger/model/LegacySerializers.scala
+++ b/src/main/scala/com/wordnik/swagger/model/LegacySerializers.scala
@@ -183,6 +183,10 @@ object LegacySerializers {
   class OperationSerializer extends CustomSerializer[Operation](formats => ({
     case json =>
       implicit val fmts: Formats = formats
+      val authorizations = (json \ "authorizations").extractOpt[Map[String, AuthorizationType]] match {
+        case Some(m) => m.values.toList
+        case _ => List.empty
+      }
       Operation(
         (json \ "httpMethod").extractOrElse(
           (json \ "method").extractOrElse({
@@ -204,7 +208,7 @@ object LegacySerializers {
         (json \ "produces").extract[List[String]],
         (json \ "consumes").extract[List[String]],
         (json \ "protocols").extract[List[String]],
-        (json \ "authorizations").extract[List[String]],
+        authorizations,
         (json \ "parameters").extract[List[Parameter]],
         (json \ "errorResponses").extract[List[ResponseMessage]],
         (json \ "deprecated").extractOpt[String]

--- a/src/main/scala/com/wordnik/swagger/model/SwaggerModelSerializer.scala
+++ b/src/main/scala/com/wordnik/swagger/model/SwaggerModelSerializer.scala
@@ -100,6 +100,10 @@ object SwaggerSerializers {
 
   class ApiListingSerializer extends CustomSerializer[ApiListing](implicit formats => ({
     case json =>
+      val authorizations = (json \ "authorizations").extractOpt[Map[String, AuthorizationType]] match {
+        case Some(m) => m.values.toList
+        case _ => List.empty
+      }
       ApiListing(
         (json \ "apiVersion").extractOrElse({
           !!(json, RESOURCE, "apiVersion", "missing required field", ERROR)
@@ -120,7 +124,7 @@ object SwaggerSerializers {
         (json \ "produces").extract[List[String]],
         (json \ "consumes").extract[List[String]],
         (json \ "protocols").extract[List[String]],
-        (json \ "authorizations").extract[List[String]],
+        authorizations,
         (json \ "apis").extract[List[ApiDescription]],
         (json \ "models").extractOpt[Map[String, Model]],
         (json \ "description").extractOpt[String],
@@ -238,6 +242,10 @@ object SwaggerSerializers {
   class OperationSerializer extends CustomSerializer[Operation](implicit formats => ({
     case json =>
 
+      val authorizations = (json \ "authorizations").extractOpt[Map[String, AuthorizationType]] match {
+        case Some(m) => m.values.toList
+        case _ => List.empty
+      }
       val t =  SwaggerSerializers.jsonSchemaTypeMap.getOrElse(
             ((json \ "type").extractOrElse(""), (json \ "format").extractOrElse(""))
           , (json \ "type").extractOrElse(""))
@@ -291,7 +299,7 @@ object SwaggerSerializers {
         (json \ "produces").extract[List[String]],
         (json \ "consumes").extract[List[String]],
         (json \ "protocols").extract[List[String]],
-        (json \ "authorizations").extract[List[String]],
+        authorizations,
         (json \ "parameters").extract[List[Parameter]],
         (json \ "responseMessages").extract[List[ResponseMessage]],
         (json \ "deprecated").extractOpt[String]

--- a/src/main/scala/com/wordnik/swagger/model/SwaggerModels.scala
+++ b/src/main/scala/com/wordnik/swagger/model/SwaggerModels.scala
@@ -76,7 +76,7 @@ case class ApiListing (
   var produces: List[String] = List.empty,
   var consumes: List[String] = List.empty,
   var protocols: List[String] = List.empty,
-  var authorizations: List[String] = List.empty,
+  var authorizations: List[AuthorizationType] = List.empty,
   apis: List[ApiDescription] = List(),
   models: Option[Map[String, Model]] = None,
   description: Option[String] = None,
@@ -97,7 +97,7 @@ case class Operation (
   var produces: List[String] = List.empty,
   var consumes: List[String] = List.empty,
   var protocols: List[String] = List.empty,
-  var authorizations: List[String] = List.empty,
+  var authorizations: List[AuthorizationType] = List.empty,
   parameters: List[Parameter] = List.empty,
   responseMessages: List[ResponseMessage] = List.empty,
   `deprecated`: Option[String] = None)

--- a/src/test/scala/swaggerSpec1_2/ModelSerializersTest.scala
+++ b/src/test/scala/swaggerSpec1_2/ModelSerializersTest.scala
@@ -31,14 +31,10 @@ class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
         p.apiVersion should be ("1.2.3")
         p.swaggerVersion should be ("1.2")
         p.apis.size should be (0)
+        p.authorizations.size should be (0)
       }
       case _ => fail("wrong type returned, should be ResourceListing")
     }
-  }
-
-  it should "serialize an ApiListingReference with no apis" in {
-    val l = ApiListingReference("/foo/bar", Some("the description"))
-    write(l) should be ("""{"path":"/foo/bar","description":"the description"}""")
   }
 
   it should "deserialize an ResourceListing" in {
@@ -54,7 +50,8 @@ class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
           "path":"/c",
           "description":"path c apis"
         }
-      ]
+      ],
+      "authorizations": {}
     }
     """
     val json = parse(jsonString)
@@ -63,15 +60,12 @@ class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
         p.apiVersion should be ("1.2.3")
         p.swaggerVersion should be ("1.2")
         p.apis.size should be (2)
+        p.authorizations.size should be (0)
       }
       case _ => fail("wrong type returned, should be ResourceListing")
     }
   }
 
-  it should "serialize an ApiListingReference" in {
-    val l = ApiListingReference("/foo/bar", Some("the description"))
-    write(l) should be ("""{"path":"/foo/bar","description":"the description"}""")
-  }
 }
 
 @RunWith(classOf[JUnitRunner])
@@ -102,9 +96,52 @@ class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
 }
 
 @RunWith(classOf[JUnitRunner])
-class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
+class ApiListingSerializersTest extends FlatSpec with ShouldMatchers {
   implicit val formats = SwaggerSerializers.formats("1.2")
 
+  it should "deserialize an ApiListing" in {
+    val jsonString = """
+    {
+      "apiVersion":"1.2.3",
+      "swaggerVersion":"1.2",
+      "basePath": "/foo/bar",
+      "resourcePath": "/a/b",
+      "produces": [ "application/json" ],
+      "authorizations": {},
+      "apis": []
+    }
+    """
+    val json = parse(jsonString)
+    json.extract[ApiListing] match {
+      case p: ApiListing=> {
+        p.apiVersion should be ("1.2.3")
+        p.swaggerVersion should be ("1.2")
+        p.basePath should be ("/foo/bar")
+        p.resourcePath should be ("/a/b")
+        p.produces should be (List("application/json"))
+        p.authorizations.size should be (0)
+        p.models should be (None)
+        p.description should be (None)
+        p.position should be (0)
+      }
+      case _ => fail("wrong type returned, should be ApiListing")
+    }
+  }
+
+  it should "serialize an ApiListing" in {
+    val l = ApiListing(
+      apiVersion = "1.2.3", 
+      swaggerVersion = "1.2",
+      basePath = "/foo/bar",
+      resourcePath = "/a/b"
+    )
+    write(l) should be ("""{"apiVersion":"1.2.3","resourcePath":"/a/b","swaggerVersion":"1.2","basePath":"/foo/bar"}""")
+  }
+}
+
+@RunWith(classOf[JUnitRunner])
+class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
+  implicit val formats = SwaggerSerializers.formats("1.2")
   it should "deserialize an ApiDescription with no ops" in {
     val jsonString = """
     {
@@ -151,7 +188,8 @@ class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
               "enum":["a","b","c"],
               "paramType":"query"
             }
-          ]
+          ],
+          "authorizations":{}
         }
       ]
     }
@@ -179,6 +217,7 @@ class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
             m.dataType should be ("string")
             m.paramType should be ("query")
           })
+          op.authorizations.size should be (0)
         })
       }
       case _ => fail("wrong type returned, should be ApiDescription")
@@ -230,7 +269,8 @@ class OperationSerializersTest extends FlatSpec with ShouldMatchers {
           "enum":["a","b","c"],
           "paramType":"query"
         }
-      ]
+      ],
+      "authorizations":{}
     }
     """
     val json = parse(jsonString)
@@ -252,6 +292,7 @@ class OperationSerializersTest extends FlatSpec with ShouldMatchers {
           m.dataType should be ("string")
           m.paramType should be ("query")
         })
+        op.authorizations.size should be (0)
       }
       case _ => fail("wrong type returned, should be Operation")
     }


### PR DESCRIPTION
codegen was choking on the JSON produced by swagger 1.3.2, because the format of the authorizations fields has changed.

Deserializer should expect a `Map[String, AuthorizationType]`, not a `List[String]`.

Note that this is basically the same fix as wordnik/swagger-core@52b7e0b4aee3ea6aa19422ffeeb95dcce53f2c35
