### PR TITLE
Explicitly defined type of a few properties

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
@@ -103,13 +103,13 @@ class BasicObjcGenerator extends BasicGenerator {
   apiTemplateFiles += "api-body.mustache" -> ".m"
 
   // package for models
-  override def invokerPackage = None
+  override def invokerPackage: Option[String] = None
 
   // package for models
-  override def modelPackage = None
+  override def modelPackage: Option[String] = None
 
   // package for api classes
-  override def apiPackage = None
+  override def apiPackage: Option[String] = None
 
   // response classes
   override def processResponseClass(responseClass: String): Option[String] = {


### PR DESCRIPTION
As per [this issue](https://github.com/wordnik/swagger-codegen/issues/130) this change makes the signature of those three properties consistent with their superclass so that traits assuming that signature can be mixed in.
