### PR TITLE
Lack of models description bugfix

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -424,6 +424,7 @@ class Codegen(config: CodegenConfig) {
         "classname" -> config.toModelName(className),
         "classVarName" -> config.toVarName(className), // suggested name of object created from this class
         "modelPackage" -> config.modelPackage,
+        "description" -> model.description,
         "newline" -> "\n")
 
     val l = new ListBuffer[AnyRef]
@@ -551,7 +552,6 @@ class Codegen(config: CodegenConfig) {
 
     models.foreach(m => {
       val json = writeJson(m._2)
-
       modelList += HashMap(
         "modelName" -> m._1,
         "model" -> modelToMap(m._1, m._2),


### PR DESCRIPTION
I've noticed that when you try to get model's description to custom-made template it's imposible because there is no such. So my fix makes it possible now to get description for model to customize model's views.
