### PR TITLE
Fix 3 ruby client issues

### DIFF
--- a/src/main/resources/ruby/swagger/configuration.mustache
+++ b/src/main/resources/ruby/swagger/configuration.mustache
@@ -3,8 +3,7 @@ module Swagger
   class Configuration
     require 'swagger/version'    
     
-    attr_accessor :format, :api_key, :username, :password, :auth_token, :scheme, :host, :base_path,
-        :user_agent, :logger, :inject_format
+    attr_accessor :format, :api_key, :username, :password, :auth_token, :scheme, :host, :base_path, :user_agent, :logger, :inject_format, :force_ending_format, :camelize_params
     
     # Defaults go in here..
     def initialize
@@ -14,6 +13,8 @@ module Swagger
       @base_path = '/v4'
       @user_agent = "ruby-#{Swagger::VERSION}"
       @inject_format = true
+      @force_ending_format = false
+      @camelize_params = true
     end
 
   end

--- a/src/main/resources/ruby/swagger/request.mustache
+++ b/src/main/resources/ruby/swagger/request.mustache
@@ -87,6 +87,15 @@ module Swagger
         end
       end
 
+      # Stick a .{format} placeholder on the end of the path if there isn't
+      # one already or an actual format like json or xml
+      # e.g. /words/blah => /words/blah.{format}
+      if Swagger.configuration.force_ending_format
+        unless ['.json', '.xml', '{format}'].any? {|s| p.downcase.include? s }
+          p = "#{p}.#{format}"	 
+        end
+      end
+
       p = p.sub("{format}", self.format.to_s)
       
       URI.encode [Swagger.configuration.base_path, p].join("/").gsub(/\/+/, '/')
@@ -121,7 +130,9 @@ module Swagger
       self.params.each_pair do |key, value|
         next if self.path.include? "{#{key}}"                                   # skip path params
         next if value.blank? && value.class != FalseClass                       # skip empties
-        key = key.to_s.camelize(:lower).to_sym unless key.to_sym == :api_key    # api_key is not a camelCased param
+       	if Swagger.configuration.camelize_params
+          key = key.to_s.camelize(:lower).to_sym unless key.to_sym == :api_key    # api_key is not a camelCased param
+        end
         query_values[key] = value.to_s
       end
     

--- a/src/main/scala/ImprovedRubyGenerator.scala
+++ b/src/main/scala/ImprovedRubyGenerator.scala
@@ -1,0 +1,18 @@
+import com.wordnik.swagger.codegen.BasicRubyGenerator
+
+object ImprovedRubyGenerator extends BasicRubyGenerator {
+  def main(args: Array[String]) = generateClient(args)
+
+  //fix bad syntax in class name name was {some_name}_api
+  override def toApiName(name: String) = {
+    var fixedName = name.replaceAll("(\\{|\\})","")
+    fixedName(0).toUpper + fixedName.substring(1) + "_api"
+  }
+
+  //fix bad syntax on class name
+  override def toModelFilename(name: String) = name.toLowerCase.replaceAll("(\\{|\\})","")
+
+  //fix bad syntax on filename
+  override def toApiFilename(name: String) = name.toLowerCase.replaceAll("(\\{|\\})","") + "_api"
+
+}


### PR DESCRIPTION
fix syntax errors on file and class names. Allow for non camelized param...s. Allow for format appended to end of full path opposed to on first path element.

So I ran into 3 issues, one major problem and two more minor issues. I ran into these issues while trying to use the generated client to consume the churn api located here: http://churn.picoappz.com/docs/index.html#!/churn
- bad file names and invalid ruby syntax
- my api has some params with underscore name and the client code camel cased the param keys
- The .json for the url was being injected in the middle of some uris opposed to at the end.
### bad file names and invalid ruby syntax

some of my api endpoints have params in the URL such as /{project_name} I followed that pattern on the pet-store example. http://swagger.wordnik.com/#!/user but when running `./bin/runscala.sh -DskipErrors com.wordnik.swagger.codegen.BasicRubyGenerator http://churn.picoappz.com/api-docs` I was getting files like so

```
wrote api generated-code/ruby/lib/{project_name}_api.rb
wrote api generated-code/ruby/lib/projects_api.rb
wrote api generated-code/ruby/lib/{project_path}_api.rb
```

This is a awkward file name to say the least, but more at issue was the class name, which isn't valid Ruby

```
class {project_name}_api
>> ruby -c lib/\{project_name\}_api.rb
lib/{project_name}_api.rb:3: syntax error, unexpected '}', expecting tASSOC
class {project_name}_api
                ^
lib/{project_name}_api.rb:35: syntax error, unexpected keyword_end, expecting $end
```

I wasn't sure if this meant I actually had created a bad json docs or if this was just an error. I also made a custom class opposed to editing the original as I don't know scala very well and I think there is a more generic or general way to solve this across everywhere the code uses the `name` variable opposed to just copying my regex `replaceAll("(\\{|\\})","")` all over the place. With some help I could fix the base class and write a test. I would need a bit of any idea of the best place to inject that code (perhaps where we call into the Ruby generator to set `name`?).
### Optional Camel Casing of query keys

   My api takes `project_name` as a param. It was coming through as projectName. I added an optional config `camelize_params`. Which made it easy to disable key camelizing.
### format URI injection

  This one was a bit odd, I am still now sure exactly why it would try to put json after the first url piece a ending slash. I was seeing `http://churn.picoappz.com/al3x/sovereign` become `http://churn.picoappz.com/al3x.json/sovereign` opposed to `http://churn.picoappz.com/al3x/sovereign.json`. Since the way this was written might make sense for some apis opposed to changing the code for all cases. I allowed a different format injection option. `force_ending_format` would inject the format, but at the end of the uri. Like my first issue I question if this was a code generation bug of if my docs are incorrect in some way leading to this behavior.

I think this PR would need a bit of work before getting merged in, but I wanted to make sure that the team actually things these are bugs with the code generation not with the api documents before digging in deeper. After getting some feedback about the issues, I will be happy to improve the changes and try to add some tests to get it merged in.

With my changes I am able to run: `/bin/runscala.sh -DskipErrors src/main/scala/ImprovedRubyGenerator.scala http://churn.picoappz.com/api-docs` to generate the code, and the below gist shows usage.

https://gist.github.com/danmayer/8638368

Possibly related to bad docs, I am having a issue with the commits endpoint in both swagger-ui and the generated client. So I assume my docs are messed up related to that endpoints usage. I think this is a different issue, so I will bring it up in IRC. I just wanted to mention it here in case anyone looks over my docs and notices a problem.

http://churn.picoappz.com/guard/guard/commits/47b818dbdea16d4a8212ca668387af186f371845.json
