### PR TITLE
clone the parameter map when creating list of required parameters

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -308,11 +308,7 @@ class Codegen(config: CodegenConfig) {
 
     val requiredParams = new ListBuffer[HashMap[String, AnyRef]]
     paramList.filter(p => p.contains("required") && p("required") == "true").foreach(param => {
-      requiredParams += HashMap(
-        "paramName" -> param("paramName"),
-        "defaultValue" -> param("defaultValue"),
-        "baseName" -> param("baseName"),
-        "hasMore" -> "true")
+      requiredParams += (param.clone += "hasMore" -> "true")
     })
     requiredParams.size match {
       case 0 =>


### PR DESCRIPTION
This change allows mustache templates to use all properties describing required parameters when generating code for operations. This way parameter properties such as "description", "swaggerDataType" and others remain available when the required parameters list is used to drive the code generation.
