### PR TITLE
added “getter” and “setter” to operation parameter properties

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -255,6 +255,8 @@ class Codegen(config: CodegenConfig) {
         }
 
         params += "dataType" -> u
+        params += "getter" -> config.toGetter(param.name, u)
+        params += "setter" -> config.toSetter(param.name, u)
 
         param.allowableValues match {
           case a: AllowableValues => params += "allowableValues" -> allowableValuesToString(a)


### PR DESCRIPTION
This change adds “getter” and “setter” properties to the parameter object, so that you could generate "parameter objects" with these accessor methods.
