### PR TITLE
Add the API version to the Mustache model when generating supporting files

### DIFF
--- a/src/main/resources/Java/pom.mustache
+++ b/src/main/resources/Java/pom.mustache
@@ -5,7 +5,7 @@
   <artifactId>api-client</artifactId>
   <packaging>jar</packaging>
   <name>api-client</name>
-  <version>1.0.0</version>
+  <version>{{apiVersion}}</version>
   <scm>
     <connection>scm:git:git@github.com:wordnik/swagger-mustache.git</connection>
     <developerConnection>scm:git:git@github.com:wordnik/swagger-codegen.git</developerConnection>

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -133,7 +133,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
       println("wrote api " + filename)
     })
 
-    codegen.writeSupportingClasses(operationMap, allModels.toMap)
+    codegen.writeSupportingClasses(operationMap, allModels.toMap, doc.apiVersion)
   }
 
   def extractApiOperations(apiListings: List[ApiListing], allModels: HashMap[String, Model] )(implicit basePath:String) = {

--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -529,7 +529,7 @@ class Codegen(config: CodegenConfig) {
     write(m)
   }
 
-  def writeSupportingClasses(apis: Map[(String, String), List[(String, Operation)]], models: Map[String, Model]) = {
+  def writeSupportingClasses(apis: Map[(String, String), List[(String, Operation)]], models: Map[String, Model], apiVersion: String) = {
     val rootDir = new java.io.File(".")
     val engine = new TemplateEngine(Some(rootDir))
 
@@ -568,7 +568,8 @@ class Codegen(config: CodegenConfig) {
         "modelPackage" -> config.modelPackage,
         "apiPackage" -> config.apiPackage,
         "apis" -> apiList,
-        "models" -> modelList) ++ config.additionalParams
+        "models" -> modelList,
+        "apiVersion" -> apiVersion) ++ config.additionalParams
 
     config.supportingFiles.map(file => {
       val supportingFile = file._1

--- a/src/main/scala/com/wordnik/swagger/codegen/ScalaAsyncClientGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/ScalaAsyncClientGenerator.scala
@@ -114,7 +114,7 @@ object ScalaAsyncClientGenerator extends App {
 }
 
 class AsyncClientCodegen(clientName: String, config: CodegenConfig, rootDir: Option[File] = None) extends Codegen(config) {
-  override def writeSupportingClasses(apis: Map[(String, String), List[(String, Operation)]], models: Map[String, Model]) = {
+  override def writeSupportingClasses(apis: Map[(String, String), List[(String, Operation)]], models: Map[String, Model], apiVersion: String) = {
     val engine = new TemplateEngine(rootDir orElse Some(new File(".")))
 
     val apiList = new ListBuffer[Map[String, AnyRef]]
@@ -377,7 +377,7 @@ class ScalaAsyncClientGenerator(cfg: SwaggerGenConfig) extends BasicGenerator {
       println("wrote api " + filename)
     })
 
-    codegen.writeSupportingClasses(operationMap, allModels.toMap)
+    codegen.writeSupportingClasses(operationMap, allModels.toMap, doc.apiVersion)
   }
 
 


### PR DESCRIPTION
This makes it easy to generate a client with version numbering in sync with the server's advertised API version.
