### PR TITLE
Refactorization SwaggerSerializers -> SwaggerModelSerializer because of namespace collision

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -21,7 +21,7 @@ import com.wordnik.swagger.codegen.util._
 import com.wordnik.swagger.codegen.language.CodegenConfig
 import com.wordnik.swagger.codegen.spec.SwaggerSpecValidator
 import com.wordnik.swagger.model._
-import com.wordnik.swagger.model.SwaggerSerializers
+import com.wordnik.swagger.model.SwaggerModelSerializer
 import com.wordnik.swagger.codegen.spec.ValidationMessage
 
 import java.io.{ File, FileWriter }
@@ -63,12 +63,15 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
       }
     }
 
+    implicit val basePath = getBasePath(host, doc.basePath)
+    println("base path is " + basePath)
+
     val apis: List[ApiListing] = getApis(host, doc, authorization)
 
-    SwaggerSerializers.validationMessages.filter(_.level == ValidationMessage.ERROR).size match {
+    SwaggerModelSerializer.validationMessages.filter(_.level == ValidationMessage.ERROR).size match {
       case i: Int if i > 0 => {
         println("********* Failed to read swagger json!")
-        SwaggerSerializers.validationMessages.foreach(msg => {
+        SwaggerModelSerializer.validationMessages.foreach(msg => {
           println(msg)
         })
         Option(System.getProperty("skipErrors")) match {

--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -42,7 +42,7 @@ object Codegen {
 }
 
 class Codegen(config: CodegenConfig) {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   def generateSource(bundle: Map[String, AnyRef], templateFile: String): String = {
     val allImports = new HashSet[String]
@@ -81,12 +81,12 @@ class Codegen(config: CodegenConfig) {
               lb
             })
             opList += apiToMap(apiPath, operation)
-          
+
             CoreUtils.extractModelNames(operation).foreach(i => allImports += i)
           }
         })
       }
-     
+
       case None =>
     }
 
@@ -223,14 +223,14 @@ class Codegen(config: CodegenConfig) {
     var paramList = new ListBuffer[HashMap[String, AnyRef]]
     var errorList = new ListBuffer[HashMap[String, AnyRef]]
     var bodyParamRequired: Option[String] = Some("true")
-    
+
     if (operation.responseMessages != null) {
-  		operation.responseMessages.foreach(param => { 
+  		operation.responseMessages.foreach(param => {
         val params = new HashMap[String, AnyRef]
         params += "code" -> param.code.toString()
         params += "reason" -> param.message
         params += "hasMore" -> "true"
-        errorList += params	 
+        errorList += params
       })
     }
 
@@ -483,7 +483,7 @@ class Codegen(config: CodegenConfig) {
           "defaultValue" -> config.toDeclaration(propertyDocSchema)._2,
           "description" -> propertyDocSchema.description,
           "notes" -> propertyDocSchema.description,
-          "allowableValues" -> rawAllowableValuesToString(propertyDocSchema.allowableValues),        
+          "allowableValues" -> rawAllowableValuesToString(propertyDocSchema.allowableValues),
           (if(propertyDocSchema.required) "required" else "isNotRequired") -> "true",
           "getter" -> config.toGetter(prop._1, config.toDeclaration(propertyDocSchema)._1),
           "setter" -> config.toSetter(prop._1, config.toDeclaration(propertyDocSchema)._1),
@@ -525,7 +525,7 @@ class Codegen(config: CodegenConfig) {
   }
 
   def write1_1(m: AnyRef): String = {
-    implicit val formats = SwaggerSerializers.formats("1.1")
+    implicit val formats = SwaggerModelSerializer.formats("1.1")
     write(m)
   }
 

--- a/src/main/scala/com/wordnik/swagger/codegen/SpecConverter.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/SpecConverter.scala
@@ -11,7 +11,7 @@ import org.json4s.jackson.Serialization.{ read, write }
 
 object SpecConverter {
   def main(args: Array[String]) = {
-    implicit val formats = SwaggerSerializers.formats("1.2")
+    implicit val formats = SwaggerModelSerializer.formats("1.2")
 
     if(args == null || args.length < 2) {
       println("Usage: SpecConverter {host} {outputDir}\nIf no API key is required, use an empty string")

--- a/src/main/scala/com/wordnik/swagger/codegen/util/ApiExtractor.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/ApiExtractor.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable.{ ListBuffer, HashMap, HashSet }
 
 object ApiExtractor extends RemoteUrl {
   def fetchApiListings(version: String, basePath: String, apis: List[ApiListingReference], authorization: Option[AuthorizationValue] = None): List[ApiListing] = {
-    implicit val formats = SwaggerSerializers.formats(version)
+    implicit val formats = SwaggerModelSerializer.formats(version)
     (for (api <- apis) yield {
       try{
         val json = (basePath.startsWith("http")) match {
@@ -57,7 +57,7 @@ object ApiExtractor extends RemoteUrl {
   }
 
   def extractApiOperations(version: String, basePath: String, references: List[ApiListingReference], authorization: Option[AuthorizationValue] = None) = {
-    implicit val formats = SwaggerSerializers.formats(version)
+    implicit val formats = SwaggerModelSerializer.formats(version)
     for (api <- references) yield {
       val json = basePath.startsWith("http") match {
         case true => {

--- a/src/main/scala/com/wordnik/swagger/codegen/util/ResourceExtractor.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/ResourceExtractor.scala
@@ -37,7 +37,7 @@ object ResourceExtractor extends RemoteUrl {
         case e: JString => e.s
         case _ => ""
       }
-      SwaggerSerializers.formats(version)
+      SwaggerModelSerializer.formats(version)
     }
 		parse(json).extract[ResourceListing]
 	}

--- a/src/main/scala/com/wordnik/swagger/model/SwaggerModelSerializer.scala
+++ b/src/main/scala/com/wordnik/swagger/model/SwaggerModelSerializer.scala
@@ -10,7 +10,7 @@ import org.json4s.jackson.Serialization.{read, write}
 
 import scala.collection.mutable.{ListBuffer, LinkedHashMap}
 
-object SwaggerSerializers {
+object SwaggerModelSerializer {
   import ValidationMessage._
 
   val jsonSchemaTypeMap = Map(
@@ -44,7 +44,7 @@ object SwaggerSerializers {
       case _           => {
         val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-]*)\\].*".r
         `type` match {
-          case ComplexTypeMatcher(container, value) => 
+          case ComplexTypeMatcher(container, value) =>
             toJsonSchemaContainer(container) ~ {
               ("items" -> {if(isSimpleType(value))
                   toJsonSchema("type", value)
@@ -74,11 +74,11 @@ object SwaggerSerializers {
     version match {
       case "1.1" => LegacySerializers.formats
       case "1.2" => {
-        DefaultFormats + 
-          new ModelSerializer + 
+        DefaultFormats +
+          new ModelSerializer +
           new ModelPropertySerializer +
-          new ModelRefSerializer + 
-          new AllowableValuesSerializer + 
+          new ModelRefSerializer +
+          new AllowableValuesSerializer +
           new ParameterSerializer +
           new OperationSerializer +
           new ResponseMessageSerializer +
@@ -246,7 +246,7 @@ object SwaggerSerializers {
         case Some(m) => m.values.toList
         case _ => List.empty
       }
-      val t =  SwaggerSerializers.jsonSchemaTypeMap.getOrElse(
+      val t =  SwaggerModelSerializer.jsonSchemaTypeMap.getOrElse(
             ((json \ "type").extractOrElse(""), (json \ "format").extractOrElse(""))
           , (json \ "type").extractOrElse(""))
 
@@ -309,7 +309,7 @@ object SwaggerSerializers {
 
       val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-]*)\\].*".r
       val output = x.responseClass match {
-        case ComplexTypeMatcher(container, value) => 
+        case ComplexTypeMatcher(container, value) =>
           toJsonSchemaContainer(container) ~ {
             ("items" -> {if(isSimpleType(value))
                 toJsonSchema("type", value)
@@ -357,14 +357,14 @@ object SwaggerSerializers {
             case e: JObject => e.extract[String]
             case e: JString => e.s
             case e: JInt => e.num.toString
-            case e: JDouble => e.num.toString          
+            case e: JDouble => e.num.toString
             case _ => ""
           }
           val max = (json \ "max") match {
             case e: JObject => e.extract[String]
             case e: JString => e.s
             case e: JInt => e.num.toString
-            case e: JDouble => e.num.toString          
+            case e: JDouble => e.num.toString
             case _ => ""
           }
           if(min != "" && max != "")
@@ -374,7 +374,7 @@ object SwaggerSerializers {
         }
       }
 
-      val t =  SwaggerSerializers.jsonSchemaTypeMap.getOrElse(
+      val t =  SwaggerModelSerializer.jsonSchemaTypeMap.getOrElse(
             ((json \ "type").extractOrElse(""), (json \ "format").extractOrElse(""))
           , (json \ "type").extractOrElse(""))
 
@@ -442,9 +442,9 @@ object SwaggerSerializers {
       ("paramType" -> x.paramType)
 
       x.allowableValues match {
-        case AllowableListValues(values, "LIST") => 
+        case AllowableListValues(values, "LIST") =>
           output ~ ("enum" -> Extraction.decompose(values))
-        case AllowableRangeValues(min, max)  => 
+        case AllowableRangeValues(min, max)  =>
           output ~ ("minimum" -> min) ~ ("maximum" -> max)
         case _ => output
       }
@@ -508,7 +508,7 @@ object SwaggerSerializers {
         case e: JString => e.s
         case _ => {
           // convert the jsonschema types into swagger types.  Note, this logic will move elsewhere soon
-          val t = SwaggerSerializers.jsonSchemaTypeMap.getOrElse(
+          val t = SwaggerModelSerializer.jsonSchemaTypeMap.getOrElse(
             ((json \ "type").extractOrElse(""), (json \ "format").extractOrElse(""))
           , (json \ "type").extractOrElse(""))
           val isUnique = (json \ "uniqueItems") match {
@@ -573,9 +573,9 @@ object SwaggerSerializers {
       ("items" -> Extraction.decompose(x.items))
 
       x.allowableValues match {
-        case AllowableListValues(values, "LIST") => 
+        case AllowableListValues(values, "LIST") =>
           output ~ ("enum" -> Extraction.decompose(values))
-        case AllowableRangeValues(min, max)  => 
+        case AllowableRangeValues(min, max)  =>
           output ~ ("minimum" -> min) ~ ("maximum" -> max)
         case _ => output
       }
@@ -636,9 +636,9 @@ object SwaggerSerializers {
         case _ => AnyAllowableValues
       }
     }, {
-      case AllowableListValues(values, "LIST") => 
+      case AllowableListValues(values, "LIST") =>
         ("valueType" -> "LIST") ~ ("values" -> Extraction.decompose(values))
-      case AllowableRangeValues(min, max)  => 
+      case AllowableRangeValues(min, max)  =>
         ("valueType" -> "RANGE") ~ ("min" -> min) ~ ("max" -> max)
     }
   ))

--- a/src/test/scala/swaggerSpec1_1/CoreUtilsTest.scala
+++ b/src/test/scala/swaggerSpec1_1/CoreUtilsTest.scala
@@ -58,7 +58,7 @@ class CoreUtilsTest extends FlatSpec with ShouldMatchers {
 }
 
 object CoreUtilsTest {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
 	def sampleApis1 = {
 		parse("""

--- a/src/test/scala/swaggerSpec1_1/ModelSerializerValidations.scala
+++ b/src/test/scala/swaggerSpec1_1/ModelSerializerValidations.scala
@@ -16,10 +16,10 @@ import scala.collection.mutable.LinkedHashMap
 
 @RunWith(classOf[JUnitRunner])
 class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "fail resource listing without base path" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "apiVersion":"1.2.3",
@@ -27,11 +27,11 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
     }
     """
     parse(jsonString).extract[ResourceListing]
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "fail resource listing without apiVersion" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "basePath": "http://foo.com",
@@ -39,11 +39,11 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
     }
     """
     parse(jsonString).extract[ResourceListing]
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "fail with missing paths in a ResourceListing" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "apiVersion":"1.2.3",
@@ -65,17 +65,17 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
       }
       case _ => fail("didn't parse the underlying apis")
     }
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 }
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
 
   it should "deserialize an ApiListingReference" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "description":"the description"
@@ -87,7 +87,7 @@ class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
       }
       case _ => fail("wrong type returned, should be ApiListingReference")
     }
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "serialize an ApiListingReference" in {
@@ -98,10 +98,10 @@ class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "fail to deserialize an ApiDescription with path, method, return type" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "description":"the description",
@@ -131,7 +131,7 @@ class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
     """
     parse(jsonString).extract[ApiDescription] match {
       case p: ApiDescription => {
-        SwaggerSerializers.validationMessages.size should be (3)
+        SwaggerModelSerializer.validationMessages.size should be (3)
       }
       case _ => fail("wrong type returned, should be ApiDescription")
     }
@@ -140,10 +140,10 @@ class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class OperationValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "fail to deserialize an Operation with missing param type" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "httpMethod":"GET",
@@ -170,7 +170,7 @@ class OperationValidationTest extends FlatSpec with ShouldMatchers {
     val json = parse(jsonString)
     json.extract[Operation] match {
       case op: Operation => {
-        SwaggerSerializers.validationMessages.size should be (1)
+        SwaggerModelSerializer.validationMessages.size should be (1)
       }
       case _ => fail("wrong type returned, should be Operation")
     }
@@ -196,7 +196,7 @@ class OperationValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ResponseMessageValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ResponseMessage" in {
     val jsonString = """
@@ -223,7 +223,7 @@ class ResponseMessageValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ParameterValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize another param" in {
     val jsonString = """
@@ -294,7 +294,7 @@ class ParameterValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model" in {
     val jsonString = """
@@ -371,7 +371,7 @@ class ModelValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelRefValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model ref" in {
     val jsonString = """
@@ -398,7 +398,7 @@ class ModelRefValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertyValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model property with allowable values and ref" in {
     val jsonString = """
@@ -502,7 +502,7 @@ class ModelPropertyValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class AllowableValuesValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize allowable value list" in {
     val allowableValuesListString = """
@@ -515,7 +515,7 @@ class AllowableValuesValidationTest extends FlatSpec with ShouldMatchers {
     json.extract[AllowableValues] match {
       case avl: AllowableListValues => {
         avl.valueType should be ("LIST")
-        avl.values should be (List("1","2","3"))        
+        avl.values should be (List("1","2","3"))
       }
     }
   }
@@ -537,7 +537,7 @@ class AllowableValuesValidationTest extends FlatSpec with ShouldMatchers {
     json.extract[AllowableValues] match {
       case avr: AllowableRangeValues => {
         avr.min should be ("abc")
-        avr.max should be ("3")        
+        avr.max should be ("3")
       }
       case _ => fail("wrong type returned, should be AllowabeValuesList")
     }

--- a/src/test/scala/swaggerSpec1_1/ModelSerializersTest.scala
+++ b/src/test/scala/swaggerSpec1_1/ModelSerializersTest.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable.LinkedHashMap
 
 @RunWith(classOf[JUnitRunner])
 class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ResourceListing with no apis" in {
     val jsonString = """
@@ -80,7 +80,7 @@ class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ApiListingReference" in {
     val jsonString = """
@@ -107,7 +107,7 @@ class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ApiDescription with no ops" in {
     val jsonString = """
@@ -194,7 +194,7 @@ class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
 
   it should "serialize an ApiDescription" in {
     val l = ApiDescription(
-      "/foo/bar", 
+      "/foo/bar",
       Some("the description"),
       List(Operation(
         "get",
@@ -216,7 +216,7 @@ class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class OperationSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an Operation" in {
     val jsonString = """
@@ -287,7 +287,7 @@ class OperationSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ErrorResponseSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ResponseResponse" in {
     val jsonString = """
@@ -314,7 +314,7 @@ class ErrorResponseSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ParameterSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize another param" in {
     val jsonString = """
@@ -385,7 +385,7 @@ class ParameterSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelSerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model" in {
     val jsonString = """
@@ -462,7 +462,7 @@ class ModelSerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelRefSerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model ref" in {
     val jsonString = """
@@ -489,7 +489,7 @@ class ModelRefSerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertySerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model property with allowable values and ref" in {
     val jsonString = """
@@ -593,7 +593,7 @@ class ModelPropertySerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class AllowableValuesSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize allowable value list" in {
     val allowableValuesListString = """
@@ -606,7 +606,7 @@ class AllowableValuesSerializersTest extends FlatSpec with ShouldMatchers {
     json.extract[AllowableValues] match {
       case avl: AllowableListValues => {
         avl.valueType should be ("LIST")
-        avl.values should be (List("1","2","3"))        
+        avl.values should be (List("1","2","3"))
       }
     }
   }
@@ -628,7 +628,7 @@ class AllowableValuesSerializersTest extends FlatSpec with ShouldMatchers {
     json.extract[AllowableValues] match {
       case avr: AllowableRangeValues => {
         avr.min should be ("abc")
-        avr.max should be ("3")        
+        avr.max should be ("3")
       }
       case _ => fail("wrong type returned, should be AllowabeValuesList")
     }

--- a/src/test/scala/swaggerSpec1_1/SwaggerModelTest.scala
+++ b/src/test/scala/swaggerSpec1_1/SwaggerModelTest.scala
@@ -29,7 +29,7 @@ import scala.io._
 
 @RunWith(classOf[JUnitRunner])
 class SwaggerModelTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
 	behavior of "Swagger Model"
 

--- a/src/test/scala/swaggerSpec1_2/CoreUtilsTest.scala
+++ b/src/test/scala/swaggerSpec1_2/CoreUtilsTest.scala
@@ -58,7 +58,7 @@ class CoreUtilsTest extends FlatSpec with ShouldMatchers {
 }
 
 object CoreUtilsTest {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   def sampleApis1 = {
     parse("""

--- a/src/test/scala/swaggerSpec1_2/ModelSerializerValidations.scala
+++ b/src/test/scala/swaggerSpec1_2/ModelSerializerValidations.scala
@@ -16,10 +16,10 @@ import scala.collection.mutable.LinkedHashMap
 
 @RunWith(classOf[JUnitRunner])
 class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "not have base path" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "apiVersion":"1.2.3",
@@ -27,11 +27,11 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
     }
     """
     parse(jsonString).extract[ResourceListing]
-    SwaggerSerializers.validationMessages.size should be (0)
+    SwaggerModelSerializer.validationMessages.size should be (0)
   }
 
   it should "fail resource listing without apiVersion" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "basePath": "http://foo.com",
@@ -39,11 +39,11 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
     }
     """
     parse(jsonString).extract[ResourceListing]
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "fail with missing paths in a ResourceListing" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "apiVersion":"1.2.3",
@@ -64,16 +64,16 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
       }
       case _ => fail("didn't parse the underlying apis")
     }
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 }
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ApiListingReference" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "description":"the description"
@@ -85,7 +85,7 @@ class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
       }
       case _ => fail("wrong type returned, should be ApiListingReference")
     }
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "serialize an ApiListingReference" in {
@@ -96,10 +96,10 @@ class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "fail to deserialize an ApiDescription with path, method, return type" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "description":"the description",
@@ -126,7 +126,7 @@ class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
     """
     parse(jsonString).extract[ApiDescription] match {
       case p: ApiDescription => {
-        SwaggerSerializers.validationMessages.size should be (3)
+        SwaggerModelSerializer.validationMessages.size should be (3)
       }
       case _ => fail("wrong type returned, should be ApiDescription")
     }
@@ -135,10 +135,10 @@ class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class OperationValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "fail to deserialize an Operation with missing param type" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "httpMethod":"GET",
@@ -162,7 +162,7 @@ class OperationValidationTest extends FlatSpec with ShouldMatchers {
     val json = parse(jsonString)
     json.extract[Operation] match {
       case op: Operation => {
-        SwaggerSerializers.validationMessages.size should be (1)
+        SwaggerModelSerializer.validationMessages.size should be (1)
       }
       case _ => fail("wrong type returned, should be Operation")
     }
@@ -188,7 +188,7 @@ class OperationValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ResponseMessageValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ResponseMessage" in {
     val jsonString = """
@@ -215,7 +215,7 @@ class ResponseMessageValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ParameterValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize another param" in {
     val jsonString = """
@@ -283,7 +283,7 @@ class ParameterValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model" in {
     val jsonString = """
@@ -360,7 +360,7 @@ class ModelValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelRefValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model ref" in {
     val jsonString = """
@@ -387,7 +387,7 @@ class ModelRefValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertyValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model property with allowable values and ref" in {
     val jsonString = """
@@ -485,7 +485,7 @@ class ModelPropertyValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class AllowableValuesValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize allowable value list" in {
     val allowableValuesListString = """
@@ -498,7 +498,7 @@ class AllowableValuesValidationTest extends FlatSpec with ShouldMatchers {
     json.extract[AllowableValues] match {
       case avl: AllowableListValues => {
         avl.valueType should be ("LIST")
-        avl.values should be (List("1","2","3"))        
+        avl.values should be (List("1","2","3"))
       }
     }
   }
@@ -520,7 +520,7 @@ class AllowableValuesValidationTest extends FlatSpec with ShouldMatchers {
     json.extract[AllowableValues] match {
       case avr: AllowableRangeValues => {
         avr.min should be ("abc")
-        avr.max should be ("3")        
+        avr.max should be ("3")
       }
       case _ => fail("wrong type returned, should be AllowabeValuesList")
     }

--- a/src/test/scala/swaggerSpec1_2/ModelSerializersTest.scala
+++ b/src/test/scala/swaggerSpec1_2/ModelSerializersTest.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable.LinkedHashMap
 
 @RunWith(classOf[JUnitRunner])
 class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ResourceListing with no apis" in {
     val jsonString = """
@@ -70,7 +70,7 @@ class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ApiListingReference" in {
     val jsonString = """
@@ -97,7 +97,7 @@ class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ApiListing" in {
     val jsonString = """
@@ -130,7 +130,7 @@ class ApiListingSerializersTest extends FlatSpec with ShouldMatchers {
 
   it should "serialize an ApiListing" in {
     val l = ApiListing(
-      apiVersion = "1.2.3", 
+      apiVersion = "1.2.3",
       swaggerVersion = "1.2",
       basePath = "/foo/bar",
       resourcePath = "/a/b"
@@ -141,7 +141,7 @@ class ApiListingSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
   it should "deserialize an ApiDescription with no ops" in {
     val jsonString = """
     {
@@ -226,7 +226,7 @@ class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
 
   it should "serialize an ApiDescription" in {
     val l = ApiDescription(
-      "/foo/bar", 
+      "/foo/bar",
       Some("the description"),
       List(Operation(
         "get",
@@ -248,7 +248,7 @@ class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class OperationSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an Operation" in {
     val jsonString = """
@@ -413,7 +413,7 @@ class OperationSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ErrorResponseSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an Response" in {
     val jsonString = """
@@ -440,7 +440,7 @@ class ErrorResponseSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ParameterSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize another param" in {
     val jsonString = """
@@ -508,7 +508,7 @@ class ParameterSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelSerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model" in {
     val jsonString = """
@@ -651,7 +651,7 @@ class ModelSerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelRefSerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model ref" in {
     val jsonString = """
@@ -678,7 +678,7 @@ class ModelRefSerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertySerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model property with allowable values and ref" in {
     val jsonString = """
@@ -829,7 +829,7 @@ class ModelPropertySerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class AllowableValuesSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize allowable value list" in {
     val allowableValuesListString = """
@@ -842,7 +842,7 @@ class AllowableValuesSerializersTest extends FlatSpec with ShouldMatchers {
     json.extract[AllowableValues] match {
       case avl: AllowableListValues => {
         avl.valueType should be ("LIST")
-        avl.values should be (List("1","2","3"))        
+        avl.values should be (List("1","2","3"))
       }
     }
   }
@@ -864,7 +864,7 @@ class AllowableValuesSerializersTest extends FlatSpec with ShouldMatchers {
     json.extract[AllowableValues] match {
       case avr: AllowableRangeValues => {
         avr.min should be ("abc")
-        avr.max should be ("3")        
+        avr.max should be ("3")
       }
       case _ => fail("wrong type returned, should be AllowabeValuesList")
     }


### PR DESCRIPTION
When using codegen at the same time with swagger core appears a problem of class name collision with https://github.com/wordnik/swagger-core/blob/master/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerSerializers.scala?source=cc
