### PR TITLE
Models namespace rename

### DIFF
--- a/src/main/resources/flash/build.xml
+++ b/src/main/resources/flash/build.xml
@@ -63,7 +63,7 @@
             <arg line="-source-path ${sourcepath}"/>
             <arg line="-footer 'Copyright Wordnik'"/>
             <arg line="-package com.wordnik.swagger.api 'Contains the apis which are used by clients to make calls to the services deployed'"/>
-            <arg line="-package com.wordnik.swagger.model 'Contains common classes which encapsulate data elements required'"/>
+            <arg line="-package com.wordnik.swagger.codegen.model 'Contains common classes which encapsulate data elements required'"/>
             <arg line="-package com.wordnik.swagger.common 'Contains classes which are used by the api classes to invoke the deployed api like SwaggerApi - a base class, ApiUserCredentials, etc.'"/>
             <arg line="-package com.wordnik.swagger.event 'Results of calls made to Wordnik are returned via dispatched events. This package contains such event classes. Right now thats just ApiClientEvent and Response.'"/>
             <arg line="-package com.wordnik.swagger.exception 'Contains classes that encapsulate the errors generated'"/>

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicAndroidJavaClient.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicAndroidJavaClient.scala
@@ -18,7 +18,7 @@ package com.wordnik.swagger.codegen
 
 import com.wordnik.swagger.codegen.BasicJavaGenerator
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 object BasicAndroidJavaClient extends BasicAndroidJavaGenerator {
   def main(args: Array[String]) = generateClient(args)

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicCSharpGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicCSharpGenerator.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 object BasicCSharpGenerator extends BasicCSharpGenerator {
   def main(args: Array[String]) = generateClient(args)

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicFlashCodegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicFlashCodegen.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 abstract class BasicFlashCodegen extends BasicGenerator {
   override def defaultIncludes = Set(

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -20,8 +20,8 @@ import com.wordnik.swagger.codegen._
 import com.wordnik.swagger.codegen.util._
 import com.wordnik.swagger.codegen.language.CodegenConfig
 import com.wordnik.swagger.codegen.spec.SwaggerSpecValidator
-import com.wordnik.swagger.model._
-import com.wordnik.swagger.model.SwaggerSerializers
+import com.wordnik.swagger.codegen.model._
+import com.wordnik.swagger.codegen.model.SwaggerModelSerializer
 import com.wordnik.swagger.codegen.spec.ValidationMessage
 
 import java.io.{ File, FileWriter }
@@ -63,12 +63,15 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
       }
     }
 
+    implicit val basePath = getBasePath(host, doc.basePath)
+    println("base path is " + basePath)
+
     val apis: List[ApiListing] = getApis(host, doc, authorization)
 
-    SwaggerSerializers.validationMessages.filter(_.level == ValidationMessage.ERROR).size match {
+    SwaggerModelSerializer.validationMessages.filter(_.level == ValidationMessage.ERROR).size match {
       case i: Int if i > 0 => {
         println("********* Failed to read swagger json!")
-        SwaggerSerializers.validationMessages.foreach(msg => {
+        SwaggerModelSerializer.validationMessages.foreach(msg => {
           println(msg)
         })
         Option(System.getProperty("skipErrors")) match {
@@ -118,10 +121,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
   }
 
 
-  def getApis(host: String, doc: ResourceListing, authorization: Option[ApiKeyValue]): List[ApiListing] = {
-    implicit val basePath = getBasePath(host, doc.basePath)
-    println("base path is " + basePath)
-
+  def getApis(host: String, doc: ResourceListing, authorization: Option[ApiKeyValue])(implicit basePath: String): List[ApiListing] = {
     val apiReferences = doc.apis
     if (apiReferences == null)
       throw new Exception("No APIs specified by resource")

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 object BasicJavaGenerator extends BasicJavaGenerator {
   def main(args: Array[String]) = generateClient(args)

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 object BasicObjcGenerator extends BasicObjcGenerator {
   def main(args: Array[String]) = generateClient(args)

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicPHPGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicPHPGenerator.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import java.io.File
 

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicPythonGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicPythonGenerator.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import java.io.File
 

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicRubyGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicRubyGenerator.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import java.io.File
 

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicScalaGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicScalaGenerator.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 object BasicScalaGenerator extends BasicScalaGenerator {
   def main(args: Array[String]) = generateClient(args)

--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.util.CoreUtils
 import com.wordnik.swagger.codegen.language.CodegenConfig
 import com.wordnik.swagger.codegen.spec.SwaggerSpec._
@@ -42,7 +42,7 @@ object Codegen {
 }
 
 class Codegen(config: CodegenConfig) {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   def generateSource(bundle: Map[String, AnyRef], templateFile: String): String = {
     val allImports = new HashSet[String]
@@ -525,7 +525,7 @@ class Codegen(config: CodegenConfig) {
   }
 
   def write1_1(m: AnyRef): String = {
-    implicit val formats = SwaggerSerializers.formats("1.1")
+    implicit val formats = SwaggerModelSerializer.formats("1.1")
     write(m)
   }
 

--- a/src/main/scala/com/wordnik/swagger/codegen/ScalaAsyncClientGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/ScalaAsyncClientGenerator.scala
@@ -2,7 +2,7 @@ package com.wordnik.swagger.codegen
 
 import scala.collection.mutable
 import java.io.{File, FileWriter}
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import scala.collection.mutable.{HashMap, ListBuffer}
 import language.CodegenConfig
 import scala.io.Source

--- a/src/main/scala/com/wordnik/swagger/codegen/SpecConverter.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/SpecConverter.scala
@@ -1,7 +1,7 @@
 package com.wordnik.swagger.codegen
 
 import com.wordnik.swagger.codegen.util.{ ResourceExtractor, ApiExtractor }
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import java.io.File
 
@@ -11,7 +11,7 @@ import org.json4s.jackson.Serialization.{ read, write }
 
 object SpecConverter {
   def main(args: Array[String]) = {
-    implicit val formats = SwaggerSerializers.formats("1.2")
+    implicit val formats = SwaggerModelSerializer.formats("1.2")
 
     if(args == null || args.length < 2) {
       println("Usage: SpecConverter {host} {outputDir}\nIf no API key is required, use an empty string")

--- a/src/main/scala/com/wordnik/swagger/codegen/SwaggerDocGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/SwaggerDocGenerator.scala
@@ -16,7 +16,7 @@
 
 import com.wordnik.swagger.codegen.BasicGenerator
 import com.wordnik.swagger.codegen.spec.SwaggerSpec
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import scala.collection.mutable.{ HashMap, ListBuffer }
 

--- a/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen.language
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import scala.collection.mutable.{ HashMap, HashSet }
 

--- a/src/main/scala/com/wordnik/swagger/codegen/model/AuthorizationModels.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/model/AuthorizationModels.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package com.wordnik.swagger.model
+package com.wordnik.swagger.codegen.model
 
 trait AuthorizationType {
   def `type`: String

--- a/src/main/scala/com/wordnik/swagger/codegen/model/LegacySerializers.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/model/LegacySerializers.scala
@@ -1,6 +1,6 @@
-package com.wordnik.swagger.model.legacy
+package com.wordnik.swagger.codegen.model.legacy
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.spec.ValidationMessage
 
 import org.json4s._

--- a/src/main/scala/com/wordnik/swagger/codegen/model/SwaggerModelSerializer.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/model/SwaggerModelSerializer.scala
@@ -1,4 +1,4 @@
-package com.wordnik.swagger.model
+package com.wordnik.swagger.codegen.model
 
 import com.wordnik.swagger.codegen.spec.ValidationMessage
 import legacy.LegacySerializers
@@ -10,7 +10,7 @@ import org.json4s.jackson.Serialization.{read, write}
 
 import scala.collection.mutable.{ListBuffer, LinkedHashMap}
 
-object SwaggerSerializers {
+object SwaggerModelSerializer {
   import ValidationMessage._
 
   val jsonSchemaTypeMap = Map(
@@ -246,7 +246,7 @@ object SwaggerSerializers {
         case Some(m) => m.values.toList
         case _ => List.empty
       }
-      val t =  SwaggerSerializers.jsonSchemaTypeMap.getOrElse(
+      val t =  SwaggerModelSerializer.jsonSchemaTypeMap.getOrElse(
             ((json \ "type").extractOrElse(""), (json \ "format").extractOrElse(""))
           , (json \ "type").extractOrElse(""))
 
@@ -374,7 +374,7 @@ object SwaggerSerializers {
         }
       }
 
-      val t =  SwaggerSerializers.jsonSchemaTypeMap.getOrElse(
+      val t =  SwaggerModelSerializer.jsonSchemaTypeMap.getOrElse(
             ((json \ "type").extractOrElse(""), (json \ "format").extractOrElse(""))
           , (json \ "type").extractOrElse(""))
 
@@ -508,7 +508,7 @@ object SwaggerSerializers {
         case e: JString => e.s
         case _ => {
           // convert the jsonschema types into swagger types.  Note, this logic will move elsewhere soon
-          val t = SwaggerSerializers.jsonSchemaTypeMap.getOrElse(
+          val t = SwaggerModelSerializer.jsonSchemaTypeMap.getOrElse(
             ((json \ "type").extractOrElse(""), (json \ "format").extractOrElse(""))
           , (json \ "type").extractOrElse(""))
           val isUnique = (json \ "uniqueItems") match {

--- a/src/main/scala/com/wordnik/swagger/codegen/model/SwaggerModels.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/model/SwaggerModels.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-package com.wordnik.swagger.model
+package com.wordnik.swagger.codegen.model
 
 import scala.collection.mutable.LinkedHashMap
 

--- a/src/main/scala/com/wordnik/swagger/codegen/spec/SwaggerSpecValidator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/spec/SwaggerSpecValidator.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen.spec
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.PathUtil
 import com.wordnik.swagger.codegen.spec.SwaggerSpec._
 import com.wordnik.swagger.codegen.util.CoreUtils

--- a/src/main/scala/com/wordnik/swagger/codegen/spec/Validator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/spec/Validator.scala
@@ -18,7 +18,7 @@ package com.wordnik.swagger.codegen.spec
 
 import com.wordnik.swagger.codegen.util.{CoreUtils, ApiExtractor, ResourceExtractor}
 import com.wordnik.swagger.codegen.PathUtil
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import scala.collection.JavaConversions._
 

--- a/src/main/scala/com/wordnik/swagger/codegen/util/ApiExtractor.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/ApiExtractor.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen.util
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization.read
@@ -29,7 +29,7 @@ import scala.collection.mutable.{ ListBuffer, HashMap, HashSet }
 
 object ApiExtractor extends RemoteUrl {
   def fetchApiListings(version: String, basePath: String, apis: List[ApiListingReference], authorization: Option[AuthorizationValue] = None): List[ApiListing] = {
-    implicit val formats = SwaggerSerializers.formats(version)
+    implicit val formats = SwaggerModelSerializer.formats(version)
     (for (api <- apis) yield {
       try{
         val json = (basePath.startsWith("http")) match {
@@ -57,7 +57,7 @@ object ApiExtractor extends RemoteUrl {
   }
 
   def extractApiOperations(version: String, basePath: String, references: List[ApiListingReference], authorization: Option[AuthorizationValue] = None) = {
-    implicit val formats = SwaggerSerializers.formats(version)
+    implicit val formats = SwaggerModelSerializer.formats(version)
     for (api <- references) yield {
       val json = basePath.startsWith("http") match {
         case true => {

--- a/src/main/scala/com/wordnik/swagger/codegen/util/CoreUtils.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/CoreUtils.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen.util
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import scala.collection.mutable.{ HashSet, ListBuffer, HashMap }
 import scala.collection.JavaConversions._

--- a/src/main/scala/com/wordnik/swagger/codegen/util/RemoteUrl.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/RemoteUrl.scala
@@ -1,6 +1,6 @@
 package com.wordnik.swagger.codegen.util
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import java.net._
 import java.io.InputStream

--- a/src/main/scala/com/wordnik/swagger/codegen/util/ResourceExtractor.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/ResourceExtractor.scala
@@ -16,7 +16,7 @@
 
 package com.wordnik.swagger.codegen.util
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -37,7 +37,7 @@ object ResourceExtractor extends RemoteUrl {
         case e: JString => e.s
         case _ => ""
       }
-      SwaggerSerializers.formats(version)
+      SwaggerModelSerializer.formats(version)
     }
 		parse(json).extract[ResourceListing]
 	}

--- a/src/test/scala/BasicCSharpGeneratorTest.scala
+++ b/src/test/scala/BasicCSharpGeneratorTest.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.{BasicCSharpGenerator, PathUtil}
 import com.wordnik.swagger.codegen.util._
 import com.wordnik.swagger.codegen.language._

--- a/src/test/scala/BasicGeneratorTest.scala
+++ b/src/test/scala/BasicGeneratorTest.scala
@@ -16,7 +16,7 @@
 
 import com.wordnik.swagger.codegen.BasicGenerator
 import com.wordnik.swagger.codegen.util._
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/src/test/scala/BasicJavaGeneratorTest.scala
+++ b/src/test/scala/BasicJavaGeneratorTest.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.{BasicJavaGenerator, PathUtil}
 import com.wordnik.swagger.codegen.util._
 import com.wordnik.swagger.codegen.language._

--- a/src/test/scala/BasicScalaGeneratorTest.scala
+++ b/src/test/scala/BasicScalaGeneratorTest.scala
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.{BasicScalaGenerator, Codegen, PathUtil}
 import com.wordnik.swagger.codegen.util._
 import com.wordnik.swagger.codegen.language._

--- a/src/test/scala/swaggerSpec1_1/CoreUtilsTest.scala
+++ b/src/test/scala/swaggerSpec1_1/CoreUtilsTest.scala
@@ -2,7 +2,7 @@ package swaggerSpec1_1
 
 import com.wordnik.swagger.codegen.util.CoreUtils
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.util._
 
 import org.junit.runner.RunWith
@@ -58,7 +58,7 @@ class CoreUtilsTest extends FlatSpec with ShouldMatchers {
 }
 
 object CoreUtilsTest {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
 	def sampleApis1 = {
 		parse("""

--- a/src/test/scala/swaggerSpec1_1/ModelSerializerValidations.scala
+++ b/src/test/scala/swaggerSpec1_1/ModelSerializerValidations.scala
@@ -1,6 +1,6 @@
 package swaggerSpec1_1
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import org.json4s._
 import org.json4s.JsonDSL._
@@ -16,10 +16,10 @@ import scala.collection.mutable.LinkedHashMap
 
 @RunWith(classOf[JUnitRunner])
 class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "fail resource listing without base path" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "apiVersion":"1.2.3",
@@ -27,11 +27,11 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
     }
     """
     parse(jsonString).extract[ResourceListing]
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "fail resource listing without apiVersion" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "basePath": "http://foo.com",
@@ -39,11 +39,11 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
     }
     """
     parse(jsonString).extract[ResourceListing]
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "fail with missing paths in a ResourceListing" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "apiVersion":"1.2.3",
@@ -65,17 +65,17 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
       }
       case _ => fail("didn't parse the underlying apis")
     }
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 }
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
 
   it should "deserialize an ApiListingReference" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "description":"the description"
@@ -87,7 +87,7 @@ class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
       }
       case _ => fail("wrong type returned, should be ApiListingReference")
     }
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "serialize an ApiListingReference" in {
@@ -98,10 +98,10 @@ class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "fail to deserialize an ApiDescription with path, method, return type" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "description":"the description",
@@ -131,7 +131,7 @@ class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
     """
     parse(jsonString).extract[ApiDescription] match {
       case p: ApiDescription => {
-        SwaggerSerializers.validationMessages.size should be (3)
+        SwaggerModelSerializer.validationMessages.size should be (3)
       }
       case _ => fail("wrong type returned, should be ApiDescription")
     }
@@ -140,10 +140,10 @@ class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class OperationValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "fail to deserialize an Operation with missing param type" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "httpMethod":"GET",
@@ -170,7 +170,7 @@ class OperationValidationTest extends FlatSpec with ShouldMatchers {
     val json = parse(jsonString)
     json.extract[Operation] match {
       case op: Operation => {
-        SwaggerSerializers.validationMessages.size should be (1)
+        SwaggerModelSerializer.validationMessages.size should be (1)
       }
       case _ => fail("wrong type returned, should be Operation")
     }
@@ -196,7 +196,7 @@ class OperationValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ResponseMessageValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ResponseMessage" in {
     val jsonString = """
@@ -223,7 +223,7 @@ class ResponseMessageValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ParameterValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize another param" in {
     val jsonString = """
@@ -294,7 +294,7 @@ class ParameterValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model" in {
     val jsonString = """
@@ -371,7 +371,7 @@ class ModelValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelRefValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model ref" in {
     val jsonString = """
@@ -398,7 +398,7 @@ class ModelRefValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertyValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model property with allowable values and ref" in {
     val jsonString = """
@@ -502,7 +502,7 @@ class ModelPropertyValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class AllowableValuesValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize allowable value list" in {
     val allowableValuesListString = """

--- a/src/test/scala/swaggerSpec1_1/ModelSerializersTest.scala
+++ b/src/test/scala/swaggerSpec1_1/ModelSerializersTest.scala
@@ -1,6 +1,6 @@
 package swaggerSpec1_1
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import org.json4s._
 import org.json4s.JsonDSL._
@@ -16,7 +16,7 @@ import scala.collection.mutable.LinkedHashMap
 
 @RunWith(classOf[JUnitRunner])
 class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ResourceListing with no apis" in {
     val jsonString = """
@@ -80,7 +80,7 @@ class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ApiListingReference" in {
     val jsonString = """
@@ -107,7 +107,7 @@ class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ApiDescription with no ops" in {
     val jsonString = """
@@ -216,7 +216,7 @@ class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class OperationSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an Operation" in {
     val jsonString = """
@@ -287,7 +287,7 @@ class OperationSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ErrorResponseSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize an ResponseResponse" in {
     val jsonString = """
@@ -314,7 +314,7 @@ class ErrorResponseSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ParameterSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize another param" in {
     val jsonString = """
@@ -385,7 +385,7 @@ class ParameterSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelSerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model" in {
     val jsonString = """
@@ -462,7 +462,7 @@ class ModelSerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelRefSerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model ref" in {
     val jsonString = """
@@ -489,7 +489,7 @@ class ModelRefSerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertySerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize a model property with allowable values and ref" in {
     val jsonString = """
@@ -593,7 +593,7 @@ class ModelPropertySerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class AllowableValuesSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   it should "deserialize allowable value list" in {
     val allowableValuesListString = """

--- a/src/test/scala/swaggerSpec1_1/SwaggerModelTest.scala
+++ b/src/test/scala/swaggerSpec1_1/SwaggerModelTest.scala
@@ -15,7 +15,7 @@
  */
 package swaggerSpec1_1
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization.read
@@ -29,7 +29,7 @@ import scala.io._
 
 @RunWith(classOf[JUnitRunner])
 class SwaggerModelTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
 	behavior of "Swagger Model"
 

--- a/src/test/scala/swaggerSpec1_1/UtilsTest.scala
+++ b/src/test/scala/swaggerSpec1_1/UtilsTest.scala
@@ -15,7 +15,7 @@
  */
 package swaggerSpec1_1
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.util.{ResourceExtractor, ApiExtractor, CoreUtils}
 
 import org.junit.runner.RunWith

--- a/src/test/scala/swaggerSpec1_2/CoreUtilsTest.scala
+++ b/src/test/scala/swaggerSpec1_2/CoreUtilsTest.scala
@@ -2,7 +2,7 @@ package swaggerSpec1_2
 
 import com.wordnik.swagger.codegen.util.CoreUtils
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.util._
 
 import org.junit.runner.RunWith
@@ -58,7 +58,7 @@ class CoreUtilsTest extends FlatSpec with ShouldMatchers {
 }
 
 object CoreUtilsTest {
-  implicit val formats = SwaggerSerializers.formats("1.1")
+  implicit val formats = SwaggerModelSerializer.formats("1.1")
 
   def sampleApis1 = {
     parse("""

--- a/src/test/scala/swaggerSpec1_2/ModelSerializerValidations.scala
+++ b/src/test/scala/swaggerSpec1_2/ModelSerializerValidations.scala
@@ -1,6 +1,6 @@
 package swaggerSpec1_2
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import org.json4s._
 import org.json4s.JsonDSL._
@@ -16,10 +16,10 @@ import scala.collection.mutable.LinkedHashMap
 
 @RunWith(classOf[JUnitRunner])
 class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "not have base path" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "apiVersion":"1.2.3",
@@ -27,11 +27,11 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
     }
     """
     parse(jsonString).extract[ResourceListing]
-    SwaggerSerializers.validationMessages.size should be (0)
+    SwaggerModelSerializer.validationMessages.size should be (0)
   }
 
   it should "fail resource listing without apiVersion" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "basePath": "http://foo.com",
@@ -39,11 +39,11 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
     }
     """
     parse(jsonString).extract[ResourceListing]
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "fail with missing paths in a ResourceListing" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "apiVersion":"1.2.3",
@@ -64,16 +64,16 @@ class ResourceListingValidationTest extends FlatSpec with ShouldMatchers {
       }
       case _ => fail("didn't parse the underlying apis")
     }
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 }
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ApiListingReference" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "description":"the description"
@@ -85,7 +85,7 @@ class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
       }
       case _ => fail("wrong type returned, should be ApiListingReference")
     }
-    SwaggerSerializers.validationMessages.size should be (1)
+    SwaggerModelSerializer.validationMessages.size should be (1)
   }
 
   it should "serialize an ApiListingReference" in {
@@ -96,10 +96,10 @@ class ApiListingReferenceValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "fail to deserialize an ApiDescription with path, method, return type" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "description":"the description",
@@ -126,7 +126,7 @@ class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
     """
     parse(jsonString).extract[ApiDescription] match {
       case p: ApiDescription => {
-        SwaggerSerializers.validationMessages.size should be (3)
+        SwaggerModelSerializer.validationMessages.size should be (3)
       }
       case _ => fail("wrong type returned, should be ApiDescription")
     }
@@ -135,10 +135,10 @@ class ApiDescriptionValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class OperationValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "fail to deserialize an Operation with missing param type" in {
-    SwaggerSerializers.validationMessages.clear
+    SwaggerModelSerializer.validationMessages.clear
     val jsonString = """
     {
       "httpMethod":"GET",
@@ -162,7 +162,7 @@ class OperationValidationTest extends FlatSpec with ShouldMatchers {
     val json = parse(jsonString)
     json.extract[Operation] match {
       case op: Operation => {
-        SwaggerSerializers.validationMessages.size should be (1)
+        SwaggerModelSerializer.validationMessages.size should be (1)
       }
       case _ => fail("wrong type returned, should be Operation")
     }
@@ -188,7 +188,7 @@ class OperationValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ResponseMessageValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ResponseMessage" in {
     val jsonString = """
@@ -215,7 +215,7 @@ class ResponseMessageValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ParameterValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize another param" in {
     val jsonString = """
@@ -283,7 +283,7 @@ class ParameterValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model" in {
     val jsonString = """
@@ -360,7 +360,7 @@ class ModelValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelRefValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model ref" in {
     val jsonString = """
@@ -387,7 +387,7 @@ class ModelRefValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertyValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model property with allowable values and ref" in {
     val jsonString = """
@@ -485,7 +485,7 @@ class ModelPropertyValidationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class AllowableValuesValidationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize allowable value list" in {
     val allowableValuesListString = """

--- a/src/test/scala/swaggerSpec1_2/ModelSerializersTest.scala
+++ b/src/test/scala/swaggerSpec1_2/ModelSerializersTest.scala
@@ -1,6 +1,6 @@
 package swaggerSpec1_2
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 
 import org.json4s._
 import org.json4s.JsonDSL._
@@ -16,7 +16,7 @@ import scala.collection.mutable.LinkedHashMap
 
 @RunWith(classOf[JUnitRunner])
 class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ResourceListing with no apis" in {
     val jsonString = """
@@ -70,7 +70,7 @@ class ResourceListingSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ApiListingReference" in {
     val jsonString = """
@@ -97,7 +97,7 @@ class ApiListingReferenceSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiListingSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an ApiListing" in {
     val jsonString = """
@@ -141,7 +141,7 @@ class ApiListingSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
   it should "deserialize an ApiDescription with no ops" in {
     val jsonString = """
     {
@@ -248,7 +248,7 @@ class ApiDescriptionSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class OperationSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an Operation" in {
     val jsonString = """
@@ -413,7 +413,7 @@ class OperationSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ErrorResponseSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize an Response" in {
     val jsonString = """
@@ -440,7 +440,7 @@ class ErrorResponseSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ParameterSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize another param" in {
     val jsonString = """
@@ -508,7 +508,7 @@ class ParameterSerializersTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelSerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model" in {
     val jsonString = """
@@ -651,7 +651,7 @@ class ModelSerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelRefSerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model ref" in {
     val jsonString = """
@@ -678,7 +678,7 @@ class ModelRefSerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertySerializationTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize a model property with allowable values and ref" in {
     val jsonString = """
@@ -829,7 +829,7 @@ class ModelPropertySerializationTest extends FlatSpec with ShouldMatchers {
 
 @RunWith(classOf[JUnitRunner])
 class AllowableValuesSerializersTest extends FlatSpec with ShouldMatchers {
-  implicit val formats = SwaggerSerializers.formats("1.2")
+  implicit val formats = SwaggerModelSerializer.formats("1.2")
 
   it should "deserialize allowable value list" in {
     val allowableValuesListString = """

--- a/src/test/scala/swaggerSpec1_2/UtilsTest.scala
+++ b/src/test/scala/swaggerSpec1_2/UtilsTest.scala
@@ -15,7 +15,7 @@
  */
 package swaggerSpec1_2
 
-import com.wordnik.swagger.model._
+import com.wordnik.swagger.codegen.model._
 import com.wordnik.swagger.codegen.util.{ResourceExtractor, ApiExtractor, CoreUtils}
 
 import org.junit.runner.RunWith


### PR DESCRIPTION
I have a problem when I try to use Codegen and Core projects together. Because models are inconsistent my project compiles but during runtime I get an Error: NoSuchMethodError. So I figure that out that because models are slightly different. My proposition is to move codegen models package inside codegen namespace.
