### PR TITLE
Bug - changed scallop version.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "io.backchat.inflector"       %% "scala-inflector"    % "1.3.5",
   "commons-io"                   % "commons-io"         % "2.3",
   "ch.qos.logback"               % "logback-classic"    % "1.0.13" % "provided",
-  "org.rogach"                  %% "scallop"            % "0.9.4",
+  "org.rogach"                  %% "scallop"            % "0.8.1",
   "junit"                        % "junit"              % "4.11" % "test",
   "org.scalatest"               %% "scalatest"          % "1.9.1" % "test"
 )


### PR DESCRIPTION
org.fusesource.scalate use reflection in version 2.10.0 and scallop in version 0.9.4 use reflection in version 2.10.1. When I try to run codegen in IDE or use it as dependency (local maven) then compiler throw error 

```
Exception in thread "main" org.fusesource.scalate.TemplateException: scala.reflect.internal.TreeInfo.firstArgument(Lscala/reflect/internal/Trees$Tree;)Lscala/reflect/internal/Trees$Tree;
    at org.fusesource.scalate.TemplateEngine.compileAndLoad(TemplateEngine.scala:732)
    at org.fusesource.scalate.TemplateEngine.compile(TemplateEngine.scala:346)
    at com.wordnik.swagger.codegen.Codegen.compileTemplate(Codegen.scala:185)
    at com.wordnik.swagger.codegen.Codegen$$anonfun$3.apply(Codegen.scala:140)

```

I can not find newer stable version of org.fusesource.scalate so change scallop version to older is way to redeem the problem.
