### PR TITLE
fix for broken links when using file system to browse

### DIFF
--- a/src/main/resources/swagger-static/index.mustache
+++ b/src/main/resources/swagger-static/index.mustache
@@ -32,12 +32,12 @@
     		{{#apis}}
         <div class="section-box">
           <div class="section-header">
-            <a href="/#!/{{className}}">{{className}}</a>
+            <a href="#!/{{className}}">{{className}}</a>
           </div>
           <ul>
 			      {{#operations}}
 			      {{#operation}}
-            <li><a href="/#!/{{className}}#{{nickname}}">{{nickname}}</a></li>
+            <li><a href="#!/{{className}}#{{nickname}}">{{nickname}}</a></li>
             {{/operation}}
             {{/operations}}
           </ul>

--- a/src/main/resources/swagger-static/model.mustache
+++ b/src/main/resources/swagger-static/model.mustache
@@ -5,7 +5,7 @@
   {{#vars}}
 <ul class="parameter">
   <li class="param-required-{{required}}">{{name}} : {{datatype}}
-	  <div class="param-description">{{description}}</div>
+	  <br/>{description}}
   </li>
 </ul>
   {{/vars}}


### PR DESCRIPTION
Just removing that beginning slash, and making the models put a break after each one.
