### PR TITLE
Prevent Objective-C generator from producing invalid var names.

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
@@ -82,10 +82,11 @@ class BasicObjcGenerator extends BasicGenerator {
 
   // objective c doesn't like variables starting with "new"
   override def toVarName(name: String): String = {
-    if(name.startsWith("new") || reservedWords.contains(name)) {
-      escapeReservedWord(name)
+    val paramName = name.replaceAll("[^a-zA-Z0-9_]","")
+    if(paramName.startsWith("new") || reservedWords.contains(paramName)) {
+      escapeReservedWord(paramName)
     }
-    else name
+    else paramName
   }
 
   // naming for the apis


### PR DESCRIPTION
I was running into trouble with header parameters, since things like `X-Parameter-Name` are not valid Objective-C identifiers.

This fix was lifted from [the Java generator](https://github.com/wordnik/swagger-codegen/blob/c8c59fe93a14644dbdd2bc15910ea6a16edddc98/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala#L106).
