### PR TITLE
PHP - Improved/fixed serialization and deserialize.

### DIFF
--- a/src/main/resources/php/Swagger.mustache
+++ b/src/main/resources/php/Swagger.mustache
@@ -203,7 +203,7 @@ class APIClient {
       }
       $deserialized = $values;
     } elseif ($class == 'DateTime') {
-      $deserialized = new DateTime($data);
+      $deserialized = new \DateTime($data);
     } elseif (in_array($class, array('string', 'int', 'float', 'bool'))) {
       settype($data, $class);
       $deserialized = $data;


### PR DESCRIPTION
Current version had problem with sanitizing DataTime (only main model was sanitized). Sanitizer overriding field, which should be kept untouched. "deserialize" method had dead code: block begin with "if (preg_match("/array<(.*)>/", $type, $matches)) {".
