### PR TITLE
PHP - Removed escapeReservedWord method.

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicPHPGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicPHPGenerator.scala
@@ -152,9 +152,6 @@ class BasicPHPGenerator extends BasicGenerator {
     (declaredType, defaultValue)
   }
 
-  // escape keywords
-  override def escapeReservedWord(word: String) = "`" + word + "`"
-
   // supporting classes
   override def supportingFiles = List(
     ("Swagger.mustache", destinationDir + File.separator + apiPackage.get,


### PR DESCRIPTION
Word between single-quotes in PHP is interpreted as system command. In php not exist escape method, which can use everywhere.
Single-quote content as command: http://php.net/manual/en/language.operators.execution.php
