### PR TITLE
Allow filtering endpoints for which to generate clients.

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -55,13 +55,14 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
     val host = args(0)
     val apiKey = if(args.length > 1) Some(args(1)) else None
     val authorization = authenticate(apiKey)
-    val doc = {
+    val unfilteredDoc = {
       try {
         ResourceExtractor.fetchListing(getResourcePath(host), authorization)
       } catch {
         case e: Exception => throw new Exception("unable to read from " + host, e)
       }
     }
+    val doc: ResourceListing = unfilteredDoc.copy(apis = unfilteredDoc.apis.filter(apiFilter))
 
     val apis: List[ApiListing] = getApis(host, doc, authorization)
 

--- a/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
@@ -48,18 +48,13 @@ abstract class CodegenConfig {
   def invokerPackage: Option[String] = None
   def apiPackage: Option[String] = None
   def modelPackage: Option[String] = None
+  val apiFilter: (ApiListingReference) => Boolean = (api) => true // Include all APIs by default.
 
   def reservedWords: Set[String] = Set()
 
   // swagger primitive types
   def importMapping: Map[String, String] = Map()
   def escapeReservedWord(word: String) = word
-
-  // only process these apis (by name)
-  val apisToProcess = new HashSet[String]
-
-  // only process these models
-  val modelsToProcess = new HashSet[String]
 
   // method name from operation.nickname
   def toMethodName(name: String): String = name


### PR DESCRIPTION
Adds a callback that generators can implement to filter the APIs for which to generate clients/models.

Also removes some dead code that looks like it was the beginnings of a plan to do the same thing.