### PR TITLE
coerce API names for classesand files to valid Java names

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicJavaGenerator.scala
@@ -107,6 +107,16 @@ class BasicJavaGenerator extends BasicGenerator {
     super.toVarName(paramName)
   }
 
+  override def toApiFilename(name: String): String = {
+    val paramName = name.replaceAll("[^a-zA-Z0-9_]","")
+    super.toApiFilename(paramName)
+  }
+
+  override def toApiName(name: String): String = {
+    val paramName = name.replaceAll("[^a-zA-Z0-9_]","")
+    super.toApiName(paramName)
+  }
+
   // response classes
   override def processResponseClass(responseClass: String): Option[String] = {
     responseClass match {


### PR DESCRIPTION
While working with my server folks, I found they had some API names that included the dash character.
It seemed easier for me to make the names Java safe, compared with convincing them to change the server.

---
- Swagger allows names of apis to include characters like '-' Java does not like that
- use same replace strings as used in toVarName
