### PR TITLE
Output the resourcePath when no models are found rather than the basePath

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/spec/SwaggerSpecValidator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/spec/SwaggerSpecValidator.scala
@@ -55,7 +55,7 @@ class SwaggerSpecValidator(private val doc: ResourceListing,
           fixInputDataTypes(models.toMap, apis)
 	  fixModels(models.toMap)
 	}
-	case None => LOGGER.warning("no models found for listing  " + api.basePath)
+	case None => LOGGER.warning("No models found for listing: " + api.resourcePath)
       }
     })
 


### PR DESCRIPTION
I kept getting a warning that no models were found for an endpoint (that doesn't have models) and it just output the base path. I didn't think this was very helpful so I changed it to output the resourcePath.
