### PR TITLE
[2.0 spec] Make SchemaObject properties for strings available to the code generator

### DIFF
--- a/src/main/java/com/wordnik/swagger/codegen/CodegenProperty.java
+++ b/src/main/java/com/wordnik/swagger/codegen/CodegenProperty.java
@@ -1,13 +1,16 @@
 package com.wordnik.swagger.codegen;
 
-import com.wordnik.swagger.models.*;
-import com.wordnik.swagger.models.properties.*;
-
 import java.util.*;
 
 public class CodegenProperty {
   public String baseName, complexType, getter, setter, description, datatype,
     name, min, max, defaultValue, baseType;
+  /** maxLength validation for strings, see http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.1 */
+  public Integer maxLength;
+  /** minLength validation for strings, see http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.2 */
+  public Integer minLength;
+  /** pattern validation for strings, see http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.3 */
+  public String pattern;
   public Double minimum, maximum, exclusiveMinimum, exclusiveMaximum;
   public Boolean hasMore = null, required = null, secondaryParam = null;
   public Boolean isPrimitiveType, isContainer, isNotContainer;

--- a/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -369,6 +369,9 @@ public class DefaultCodegen {
 
     if(p instanceof StringProperty) {
       StringProperty sp = (StringProperty) p;
+      property.maxLength = sp.getMaxLength();
+      property.minLength = sp.getMinLength();
+      property.pattern = sp.getPattern();
       if(sp.getEnum() != null) {
         List<String> _enum = sp.getEnum();
         property._enum = _enum;


### PR DESCRIPTION
implements maxLength/minLength/pattern as specified in the 2.0-spec
