### PR TITLE
Windows path problem fixed (again)

### DIFF
--- a/src/main/java/com/wordnik/swagger/codegen/languages/JavaClientCodegen.java
+++ b/src/main/java/com/wordnik/swagger/codegen/languages/JavaClientCodegen.java
@@ -56,11 +56,11 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
 
   @Override
   public String apiFileFolder() {
-    return outputFolder + File.separator + sourceFolder + File.separator + apiPackage().replaceAll("\\.", File.separator);
+    return outputFolder + "/" + sourceFolder + "/" + apiPackage().replaceAll("\\.", "/");
   }
 
   public String modelFileFolder() {
-    return outputFolder + File.separator + sourceFolder + File.separator + modelPackage().replaceAll("\\.", File.separator);
+    return outputFolder + "/" + sourceFolder + "/" + modelPackage().replaceAll("\\.", "/");
   }
 
   @Override


### PR DESCRIPTION
Has already been resolved by #269 

```
java.lang.StringIndexOutOfBoundsException: String index out of range: 1
at java.lang.String.charAt(String.java:658)
at java.util.regex.Matcher.appendReplacement(Matcher.java:762)
at java.util.regex.Matcher.replaceAll(Matcher.java:906)
at java.lang.String.replaceAll(String.java:2162)
at com.wordnik.swagger.codegen.languages.JavaClientCodegen.modelFileFolder(JavaClientCodegen.java:63)
at com.wordnik.swagger.codegen.DefaultGenerator.generate(DefaultGenerator.java:50)
at com.wordnik.swagger.codegen.Codegen.main(Codegen.java:51)
```
