### PR TITLE
Update deprecated method calls

### DIFF
--- a/samples/client/petstore/scala/src/test/scala/PetApiTest.scala
+++ b/samples/client/petstore/scala/src/test/scala/PetApiTest.scala
@@ -3,15 +3,14 @@ import com.wordnik.petstore.model._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
 import scala.collection.mutable.{ ListBuffer, HashMap }
 import scala.collection.JavaConverters._
 import scala.beans.BeanProperty
 
 @RunWith(classOf[JUnitRunner])
-class PetApiTest extends FlatSpec with ShouldMatchers {
+class PetApiTest extends FlatSpec with Matchers {
   behavior of "PetApi"
   val api = new PetApi
 

--- a/samples/client/petstore/scala/src/test/scala/StoreApiTest.scala
+++ b/samples/client/petstore/scala/src/test/scala/StoreApiTest.scala
@@ -4,15 +4,14 @@ import com.wordnik.petstore.model._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
 import scala.collection.mutable.{ ListBuffer, HashMap }
 import scala.collection.JavaConversions._
 import scala.beans.BeanProperty
 
 @RunWith(classOf[JUnitRunner])
-class StoreApiTest extends FlatSpec with ShouldMatchers {
+class StoreApiTest extends FlatSpec with Matchers {
   behavior of "StoreApi"
   val api = new StoreApi
 

--- a/samples/client/petstore/scala/src/test/scala/UserApiTest.scala
+++ b/samples/client/petstore/scala/src/test/scala/UserApiTest.scala
@@ -3,15 +3,14 @@ import com.wordnik.petstore.model._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
 import scala.collection.mutable.{ ListBuffer, HashMap }
 import scala.collection.JavaConversions._
 import scala.beans.BeanProperty
 
 @RunWith(classOf[JUnitRunner])
-class UserApiTest extends FlatSpec with ShouldMatchers {
+class UserApiTest extends FlatSpec with Matchers {
   behavior of "UserApi"
   val api = new UserApi
   api.apiInvoker.defaultHeaders += "api_key" -> "special-key"

--- a/samples/client/wordnik-api/scala/src/test/scala/AccountApiTest.scala
+++ b/samples/client/wordnik-api/scala/src/test/scala/AccountApiTest.scala
@@ -3,15 +3,14 @@ import com.wordnik.client.model._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
 import scala.collection.mutable.{ ListBuffer, HashMap }
 import scala.collection.JavaConversions._
 import scala.beans.BeanProperty
 
 @RunWith(classOf[JUnitRunner])
-class AccountApiTest extends FlatSpec with ShouldMatchers with BaseApiTest {
+class AccountApiTest extends FlatSpec with Matchers with BaseApiTest {
   behavior of "AccountApi"
   val api = new AccountApi
 

--- a/samples/client/wordnik-api/scala/src/test/scala/WordApiTest.scala
+++ b/samples/client/wordnik-api/scala/src/test/scala/WordApiTest.scala
@@ -6,8 +6,7 @@ import com.wordnik.swagger.core.util.JsonUtil
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
 import scala.collection.mutable.{ ListBuffer, HashMap }
 import scala.collection.JavaConversions._
@@ -16,7 +15,7 @@ import scala.beans.BeanProperty
 import scala.io.Source
 
 @RunWith(classOf[JUnitRunner])
-class WordApiTest extends FlatSpec with ShouldMatchers with BaseApiTest {
+class WordApiTest extends FlatSpec with Matchers with BaseApiTest {
   behavior of "WordApi"
   val api = new WordApi
 

--- a/samples/client/wordnik-api/scala/src/test/scala/WordListApiTest.scala
+++ b/samples/client/wordnik-api/scala/src/test/scala/WordListApiTest.scala
@@ -3,15 +3,14 @@ import com.wordnik.client.model._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
 import scala.collection.mutable.{ ListBuffer, HashMap }
 import scala.collection.JavaConversions._
 import scala.beans.BeanProperty
 
 @RunWith(classOf[JUnitRunner])
-class WordListApiTest extends FlatSpec with ShouldMatchers with BaseApiTest {
+class WordListApiTest extends FlatSpec with Matchers with BaseApiTest {
   behavior of "WordListApi"
   val api = new WordListApi
 

--- a/samples/client/wordnik-api/scala/src/test/scala/WordsApiTest.scala
+++ b/samples/client/wordnik-api/scala/src/test/scala/WordsApiTest.scala
@@ -3,15 +3,14 @@ import com.wordnik.client.model._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
 import scala.collection.mutable.{ ListBuffer, HashMap }
 import scala.collection.JavaConversions._
 import scala.beans.BeanProperty
 
 @RunWith(classOf[JUnitRunner])
-class WordsApiTest extends FlatSpec with ShouldMatchers with BaseApiTest {
+class WordsApiTest extends FlatSpec with Matchers with BaseApiTest {
   behavior of "WordsApi"
   val api = new WordsApi
 

--- a/src/main/scala/com/wordnik/swagger/codegen/util/RemoteUrl.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/util/RemoteUrl.scala
@@ -19,7 +19,7 @@ trait RemoteUrl {
 						connection
 					}
 					else if(auth.passAs == "query") {
-						new URL(url + "?%s=%s".format(URLEncoder.encode(auth.keyName), URLEncoder.encode(auth.value))).openConnection()
+						new URL(url + "?%s=%s".format(URLEncoder.encode(auth.keyName, "UTF-8"), URLEncoder.encode(auth.value, "UTF-8"))).openConnection()
 					}
 					else {
 						new URL(url).openConnection()


### PR DESCRIPTION
1. Update specs to inherit via `with Matchers`
2. Update `URLEncoder.encode` to pass "UTF-8" as charset
