### PR TITLE
adding a space in call to completionHandler to kill latest Xcode parse errors

### DIFF
--- a/src/main/resources/objc/api-body.mustache
+++ b/src/main/resources/objc/api-body.mustache
@@ -54,8 +54,8 @@ static NSString * basePath = @"{{basePath}}";
 
 {{#operation}}
 -(NSNumber*) {{nickname}}WithCompletionBlock{{^allParams}}: {{/allParams}}{{#allParams}}{{#secondaryParam}} {{paramName}}{{/secondaryParam}}:({{{dataType}}}) {{paramName}}{{newline}}        {{/allParams}}
-        {{#returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)({{returnType}} output, NSError* error))completionBlock{{/returnBaseType}}
-        {{^returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock{{/returnBaseType}} {
+        {{#returnBaseType}}{{#hasParams}}completionHandler : {{/hasParams}}(void (^)({{returnType}} output, NSError* error))completionBlock{{/returnBaseType}}
+        {{^returnBaseType}}{{#hasParams}}completionHandler : {{/hasParams}}(void (^)(NSError* error))completionBlock{{/returnBaseType}} {
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@{{path}}", basePath];
 

--- a/src/main/resources/objc/api-header.mustache
+++ b/src/main/resources/objc/api-header.mustache
@@ -25,8 +25,8 @@
 
  */
 -(NSNumber*) {{nickname}}WithCompletionBlock {{^allParams}}:{{/allParams}}{{#allParams}}{{#secondaryParam}} {{paramName}}{{/secondaryParam}}:({{{dataType}}}) {{paramName}} {{#hasMore}}{{newline}}        {{/hasMore}}{{/allParams}}
-        {{#returnBaseType}}{{#hasParams}}{{newline}}        completionHandler: {{/hasParams}}(void (^)({{returnType}} output, NSError* error))completionBlock;{{/returnBaseType}}
-        {{^returnBaseType}}{{#hasParams}}{{newline}}        completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock;{{/returnBaseType}}
+        {{#returnBaseType}}{{#hasParams}}{{newline}}        completionHandler : {{/hasParams}}(void (^)({{returnType}} output, NSError* error))completionBlock;{{/returnBaseType}}
+        {{^returnBaseType}}{{#hasParams}}{{newline}}        completionHandler : {{/hasParams}}(void (^)(NSError* error))completionBlock;{{/returnBaseType}}
 
 {{newline}}
 {{/operation}}


### PR DESCRIPTION
Simple fix for latest version of Xcode parsing errors 
