### PR TITLE
Add integer datatype

### DIFF
--- a/src/main/resources/php/Swagger.mustache
+++ b/src/main/resources/php/Swagger.mustache
@@ -107,7 +107,7 @@ class APIClient {
 			$data = json_decode($response);
 		} else if ($response_info['http_code'] == 401) {
 			throw new Exception("Unauthorized API request to " . $url .
-					": ".json_decode($response)->message );
+					": ".json_decode($response)->error );
 		} else if ($response_info['http_code'] == 404) {
 			$data = null;
 		} else {


### PR DESCRIPTION
It seems that both 'int' and 'integer' are used in resources files but when trying to use the client, the integer type is not recognised. This patch allows the client to correctly 'deserialize' integer values.
