### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ If you need to make static pages or don't want the sandbox of the swagger-ui, yo
 Will produce the output here:
 
 ```
-https://github.com/wordnik/swagger-codegen/tree/master/samples/docs/swagger-static-docs
+https://github.com/wordnik/swagger-codegen/tree/master/samples/swagger-static-docs/docs
 ```
 
 which is based on these templates:


### PR DESCRIPTION
Encountered broken link in README. Fixed to what I think is the correct link, but as this is the first time I've ever looked at swagger, I could be wrong.
