### PR TITLE
message -> error

### DIFF
--- a/src/main/resources/php/Swagger.mustache
+++ b/src/main/resources/php/Swagger.mustache
@@ -107,7 +107,7 @@ class APIClient {
 			$data = json_decode($response);
 		} else if ($response_info['http_code'] == 401) {
 			throw new Exception("Unauthorized API request to " . $url .
-					": ".json_decode($response)->message );
+					": ".json_decode($response)->error );
 		} else if ($response_info['http_code'] == 404) {
 			$data = null;
 		} else {


### PR DESCRIPTION
The response doesn't have a 'message' attribute in the case of a 401 but an
'error' attribute.
