### PR TITLE
Adding the casting of integer -> int for python generated code

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicPythonGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicPythonGenerator.scala
@@ -97,6 +97,7 @@ class BasicPythonGenerator extends BasicGenerator {
     }
   }
   override def typeMapping = Map(
+    "integer" -> "int",
     "float" -> "float",
     "long" -> "long",
     "double" -> "float",


### PR DESCRIPTION
Fixing an issue in auto-generated python models where attribute datatypes were set to `integer` instead of `int` and causing casting issues due to `integer` not being a valid python primitive.
