### PR TITLE
update deserialize to handle both array(primitive) and Array(model)

### DIFF
--- a/src/main/resources/php/Swagger.mustache
+++ b/src/main/resources/php/Swagger.mustache
@@ -194,7 +194,7 @@ class APIClient {
   {
     if (null === $data) {
       $deserialized = null;
-    } else if (substr($class, 0, 6) == 'array[') {
+    } else if (strcasecmp(substr($class, 0, 6),'array[') == 0) {
       $subClass = substr($class, 6, -1);
       $values = array();
       foreach ($data as $value) {


### PR DESCRIPTION
currently, Array(model) won't be handled properly due to capitalized "Array". this PR aims to update the code for PHP SDKs to handle both array(primitive) and Array(model)
