### PR TITLE
Introduce configurable package separator

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -228,7 +228,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
    */
   def prepareModelMap(models: Map[String, Model]): List[Map[String, AnyRef]] = {
     val allImports = new HashSet[String]
-    val outputDirectory = (destinationDir + File.separator + modelPackage.getOrElse("").replace(".", File.separator))
+    val outputDirectory = (destinationDir + File.separator + toFilePath(modelPackage))
     (for ((name, schema) <- models) yield {
       if (!defaultIncludes.contains(name)) {
         val modelMap: Map[String, AnyRef] = codegen.modelToMap(name, schema)
@@ -371,7 +371,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
       m += "invokerPackage" -> invokerPackage
       m += "operations" -> operations
       m += "models" -> None
-      m += "outputDirectory" -> (destinationDir + File.separator + apiPackage.getOrElse("").replace(".", File.separator))
+      m += "outputDirectory" -> (destinationDir + File.separator + toFilePath(apiPackage))
       m += "newline" -> "\n"
       m += "modelPackage" -> modelPackage
 

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -228,7 +228,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
    */
   def prepareModelMap(models: Map[String, Model]): List[Map[String, AnyRef]] = {
     val allImports = new HashSet[String]
-    val outputDirectory = (destinationDir + File.separator + toFilePath(modelPackage))
+    val outputDirectory = (destinationDir + File.separator + pathFromPackage(modelPackage))
     (for ((name, schema) <- models) yield {
       if (!defaultIncludes.contains(name)) {
         val modelMap: Map[String, AnyRef] = codegen.modelToMap(name, schema)
@@ -371,7 +371,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
       m += "invokerPackage" -> invokerPackage
       m += "operations" -> operations
       m += "models" -> None
-      m += "outputDirectory" -> (destinationDir + File.separator + toFilePath(apiPackage))
+      m += "outputDirectory" -> (destinationDir + File.separator + pathFromPackage(apiPackage))
       m += "newline" -> "\n"
       m += "modelPackage" -> modelPackage
 

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicPHPGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicPHPGenerator.scala
@@ -46,6 +46,8 @@ class BasicPHPGenerator extends BasicGenerator {
   // file suffix
   override def fileSuffix = ".php"
 
+  override def packageSeparator = "\\"
+
   // reserved words which need special quoting
   // These will all be object properties, in which context we don't need
   // to worry about escaping them for PHP.
@@ -154,7 +156,7 @@ class BasicPHPGenerator extends BasicGenerator {
 
   // supporting classes
   override def supportingFiles = List(
-    ("Swagger.mustache", destinationDir + File.separator + apiPackage.get,
+    ("Swagger.mustache", destinationDir + File.separator + pathFromPackage(apiPackage),
      "Swagger.php")
   )
 }

--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -380,7 +380,7 @@ class Codegen(config: CodegenConfig) {
               baseType
             else
               config.modelPackage match {
-                case Some(p) => p + "." + baseType
+                case Some(p) => p + config.packageSeparator + baseType
                 case _ => baseType
               }
           },

--- a/src/main/scala/com/wordnik/swagger/codegen/PathUtil.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/PathUtil.scala
@@ -16,6 +16,8 @@
 
 package com.wordnik.swagger.codegen
 
+import java.io.File
+
 trait PathUtil {
   def getResourcePath(host: String, fileMap: Option[String] = None) = {
     fileMap match {
@@ -60,4 +62,7 @@ trait PathUtil {
   def resourceNameFromFullPath(apiPath: String) = {
     apiPath.split("/")(1).split("\\.")(0).replaceAll("/", "")
   }
+
+  def toFilePath(packagePath:Option[String]):String = packagePath.getOrElse("").replace("//", File.separator)
+
 }

--- a/src/main/scala/com/wordnik/swagger/codegen/PathUtil.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/PathUtil.scala
@@ -63,7 +63,9 @@ trait PathUtil {
     apiPath.split("/")(1).split("\\.")(0).replaceAll("/", "")
   }
 
-  def pathFromPackage(packagePath:Option[String]):String = packagePath.getOrElse("").replace(packageSeparator, File.separator)
+  def pathFromPackage(packagePath:Option[String]):String = {
+    packagePath.getOrElse("").replace(packageSeparator, File.separator)
+  }
 
   def packageSeparator:String = "."
 

--- a/src/main/scala/com/wordnik/swagger/codegen/PathUtil.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/PathUtil.scala
@@ -63,6 +63,8 @@ trait PathUtil {
     apiPath.split("/")(1).split("\\.")(0).replaceAll("/", "")
   }
 
-  def toFilePath(packagePath:Option[String]):String = packagePath.getOrElse("").replace("//", File.separator)
+  def pathFromPackage(packagePath:Option[String]):String = packagePath.getOrElse("").replace(packageSeparator, File.separator)
+
+  def packageSeparator:String = "."
 
 }

--- a/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
@@ -29,6 +29,7 @@ abstract class CodegenConfig {
   def destinationDir: String
   def toModelName(name: String): String
   def toApiName(name: String): String
+  def packageSeparator:String
 
   def toModelFilename(name: String) = name
   def toApiFilename(name: String) = toApiName(name)

--- a/src/test/scala/PathUtilTest.scala
+++ b/src/test/scala/PathUtilTest.scala
@@ -24,14 +24,15 @@ import org.scalatest.Matchers
 
 @RunWith(classOf[JUnitRunner])
 class PathUtilTest extends FlatSpec with Matchers {
-  val config = new BasicScalaGenerator
+  val pathUtil = new PathUtil {
+  }
 
   behavior of "PathUtil"
   /*
    * We will take an api in the spec and create an API name from it
    */
   it should "convert an api name" in {
-  	config.toApiName("fun") should be ("FunApi")
+  	pathUtil.toApiName("fun") should be ("FunApi")
   }
 
   /*
@@ -39,7 +40,7 @@ class PathUtilTest extends FlatSpec with Matchers {
    * i.e. /foo will follow rules to become FooApi
   */
   it should "convert a path" in {
-  	config.apiNameFromPath("/foo/bar/cats/dogs") should be ("FooApi")
+  	pathUtil.apiNameFromPath("/foo/bar/cats/dogs") should be ("FooApi")
   }
 
   /**
@@ -48,8 +49,7 @@ class PathUtilTest extends FlatSpec with Matchers {
    **/
   it should "get determine the basePath implicitly" in {
     sys.props -= "fileMap"
-    new PathUtilImpl().getBasePath("http://foo.com/api-docs", "") should be ("http://foo.com/api-docs")
+    pathUtil.getBasePath("http://foo.com/api-docs", "") should be ("http://foo.com/api-docs")
   }
-}
 
-class PathUtilImpl extends PathUtil
+}

--- a/src/test/scala/PathUtilTest.scala
+++ b/src/test/scala/PathUtilTest.scala
@@ -52,4 +52,9 @@ class PathUtilTest extends FlatSpec with Matchers {
     pathUtil.getBasePath("http://foo.com/api-docs", "") should be ("http://foo.com/api-docs")
   }
 
+  it should "be able to convert package path to file path" in {
+    pathUtil.toFilePath(Some("com.example.package")) should be ("com/example/package")
+    pathUtil.toFilePath(None) should be ("")
+  }
+
 }

--- a/src/test/scala/PathUtilTest.scala
+++ b/src/test/scala/PathUtilTest.scala
@@ -52,9 +52,12 @@ class PathUtilTest extends FlatSpec with Matchers {
     pathUtil.getBasePath("http://foo.com/api-docs", "") should be ("http://foo.com/api-docs")
   }
 
+  /**
+   * We need convert package path to file path to place generated files to right place.
+   */
   it should "be able to convert package path to file path" in {
-    pathUtil.toFilePath(Some("com.example.package")) should be ("com/example/package")
-    pathUtil.toFilePath(None) should be ("")
+    pathUtil.pathFromPackage(Some("com.example.package")) should be ("com/example/package")
+    pathUtil.pathFromPackage(None) should be ("")
   }
 
 }


### PR DESCRIPTION
In several languages (PHP for example) package separator is not dot. So we have to somehow configure that separator for such languages. 

Benefits:
 1) we can use packages (namespaces for PHP) in templates 
 2) files can be placed into the right place  