### PR TITLE
APIs and Models both have classVarName as well as instanceVarName

### DIFF
--- a/bin/runscala.sh
+++ b/bin/runscala.sh
@@ -20,6 +20,8 @@ fi
 cd $APP_DIR
 SCALA_RUNNER_VERSION=$(scala ./bin/Version.scala)
 
+echo Using Scala: $SCALA_RUNNER_VERSION
+
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ scalacOptions ++= Seq("-optimize", "-unchecked", "-deprecation", "-Xcheckinit", 
 
 crossScalaVersions := Seq("2.10.0", "2.10.1", "2.10.2", "2.10.3", "2.10.4", "2.11.0", "2.11.1")
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.2"
 
 libraryDependencies ++= Seq(
   "org.json4s"                  %% "json4s-jackson"     % "3.2.10",

--- a/sbt
+++ b/sbt
@@ -129,6 +129,7 @@ declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"
 declare -r latest_210="2.10.0"
+declare -r latest_211="2.11.2"
 
 declare -r script_path=$(get_script_path "$BASH_SOURCE")
 declare -r script_dir="$(dirname $script_path)"
@@ -300,6 +301,7 @@ Usage: $script_name [options]
   -28                       use $latest_28
   -29                       use $latest_29
   -210                      use $latest_210
+  -211                      use $latest_211
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala
   -binary-version <version> use the specified scala version when searching for dependencies
@@ -405,6 +407,7 @@ process_args ()
             -28) addSbt "++ $latest_28" && shift ;;
             -29) addSbt "++ $latest_29" && shift ;;
            -210) addSbt "++ $latest_210" && shift ;;
+           -211) addSbt "++ $latest_211" && shift ;;
 
               *) addResidual "$1" && shift ;;
     esac

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -52,13 +52,13 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
   var codegen = new Codegen(this)
   var fileMap: Option[String] = None
 
-  @deprecated(message = "please use the generate function", since = "2.0.16")
+//  @deprecated(message = "please use the generate function", since = "2.0.16")
   def generateClient(args: Array[String]): Unit = {
     generateClientWithoutExit(args)
     System.exit(0)
   }
 
-  @deprecated(message = "please use the generate function", since = "2.0.16")
+//  @deprecated(message = "please use the generate function", since = "2.0.16")
   def generateClientWithoutExit(args: Array[String]): Seq[File] = {
     if (args.length == 0) {
       throw new RuntimeException("Need url to resource listing as argument. You can also specify VM Argument -DfileMap=/path/to/folder/containing.resources.json/")

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -366,6 +366,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
       m += "name" -> toApiName(name)
       m += "classname" -> className
       m += "className" -> className
+      m += "classVarName" -> toVarName(className)
       m += "basePath" -> basePath
       m += "package" -> apiPackage
       m += "invokerPackage" -> invokerPackage

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package com.wordnik.swagger.codegen
 
 import com.wordnik.swagger.codegen._

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -52,13 +52,13 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
   var codegen = new Codegen(this)
   var fileMap: Option[String] = None
 
-//  @deprecated(message = "please use the generate function", since = "2.0.16")
+  @deprecated(message = "please use the generate function", since = "2.0.16")
   def generateClient(args: Array[String]): Unit = {
     generateClientWithoutExit(args)
     System.exit(0)
   }
 
-//  @deprecated(message = "please use the generate function", since = "2.0.16")
+  @deprecated(message = "please use the generate function", since = "2.0.16")
   def generateClientWithoutExit(args: Array[String]): Seq[File] = {
     if (args.length == 0) {
       throw new RuntimeException("Need url to resource listing as argument. You can also specify VM Argument -DfileMap=/path/to/folder/containing.resources.json/")

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicGenerator.scala
@@ -367,6 +367,7 @@ abstract class BasicGenerator extends CodegenConfig with PathUtil {
       m += "classname" -> className
       m += "className" -> className
       m += "classVarName" -> toVarName(className)
+      m += "instanceVarName" -> toInstanceVarName(className)
       m += "basePath" -> basePath
       m += "package" -> apiPackage
       m += "invokerPackage" -> invokerPackage

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
@@ -1,25 +1,12 @@
-/**
- *  Copyright 2014 Wordnik, Inc.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
-package com.wordnik.swagger.codegen
+import com.wordnik.swagger.codegen.BasicGenerator
 
 import com.wordnik.swagger.codegen.model._
 
 object BasicObjcGenerator extends BasicObjcGenerator {
   def main(args: Array[String]) = generateClient(args)
+
+  override def templateDir = "/Users/wendel.schultz/development/projects/infusionso/developer-services/swagger-codegen-fork/src/main/resources/objc"
+//  override def destinationDir = "cwagdev"
 }
 
 class BasicObjcGenerator extends BasicGenerator {
@@ -93,7 +80,7 @@ class BasicObjcGenerator extends BasicGenerator {
   override def toApiName(name: String) = "SWG" + name(0).toUpper + name.substring(1) + "Api"
 
   // location of templates
-  override def templateDir = "objc"
+  override def templateDir = "src/main/resources/objc"
 
   // template used for models
   modelTemplateFiles += "model-header.mustache" -> ".h"

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicObjcGenerator.scala
@@ -1,12 +1,24 @@
-import com.wordnik.swagger.codegen.BasicGenerator
+/**
+ *  Copyright 2014 Wordnik, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.wordnik.swagger.codegen
 
 import com.wordnik.swagger.codegen.model._
 
 object BasicObjcGenerator extends BasicObjcGenerator {
   def main(args: Array[String]) = generateClient(args)
-
-  override def templateDir = "/Users/wendel.schultz/development/projects/infusionso/developer-services/swagger-codegen-fork/src/main/resources/objc"
-//  override def destinationDir = "cwagdev"
 }
 
 class BasicObjcGenerator extends BasicGenerator {
@@ -80,7 +92,7 @@ class BasicObjcGenerator extends BasicGenerator {
   override def toApiName(name: String) = "SWG" + name(0).toUpper + name.substring(1) + "Api"
 
   // location of templates
-  override def templateDir = "src/main/resources/objc"
+  override def templateDir = "objc"
 
   // template used for models
   modelTemplateFiles += "model-header.mustache" -> ".h"

--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -327,6 +327,7 @@ class Codegen(config: CodegenConfig) {
         "classname" -> config.toModelName(className),
         "className" -> config.toModelName(className),
         "classVarName" -> config.toVarName(className), // suggested name of object created from this class
+        "instanceVarName" -> config.toInstanceVarName(className),
         "modelPackage" -> config.modelPackage,
         "description" -> model.description,
         "modelJson" -> writeJson(model),

--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -495,7 +495,7 @@ class Codegen(config: CodegenConfig) {
       val outputFolder = outputFile.getParent
       new File(outputFolder).mkdirs
 
-      if (supportingFile.endsWith(".mustache")) {
+      if (supportingFile.endsWith(".mustache") || supportingFile.endsWith(".ssp")) {
         val output = {
           val (resourceName, (_, template)) = compileTemplate(supportingFile, rootDir, Some(engine))
           engine.layout(resourceName, template, data.toMap)

--- a/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
@@ -115,7 +115,10 @@ abstract class CodegenConfig {
   def toVarName(name: String): String = {
     name match {
       case _ if (reservedWords.contains(name)) => escapeReservedWord(name)
-      case _ => name
+      case _ => {
+        if (name.length > 0) name(0).toLower + name.substring(1)
+        else ""
+      }
     }
   }
 

--- a/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/language/CodegenConfig.scala
@@ -115,11 +115,13 @@ abstract class CodegenConfig {
   def toVarName(name: String): String = {
     name match {
       case _ if (reservedWords.contains(name)) => escapeReservedWord(name)
-      case _ => {
-        if (name.length > 0) name(0).toLower + name.substring(1)
-        else ""
-      }
+      case _ => name
     }
+  }
+
+  def toInstanceVarName(name: String): String = {
+    if (name.length > 0) name(0).toLower + name.substring(1)
+    else name
   }
 
   def toDefaultValue(datatype: String, v: String): Option[String] = {

--- a/src/test/scala/BasicGeneratorTest.scala
+++ b/src/test/scala/BasicGeneratorTest.scala
@@ -113,7 +113,7 @@ class BasicGeneratorTest extends FlatSpec with Matchers {
     modelList.size should be (1)
 
     val m = modelList.head("model").asInstanceOf[Map[String, AnyRef]]
-    m("classVarName") should be ("SampleObject")
+    m("classVarName") should be ("sampleObject")
   }
 
   it should "create a model file" in {

--- a/src/test/scala/BasicGeneratorTest.scala
+++ b/src/test/scala/BasicGeneratorTest.scala
@@ -113,7 +113,8 @@ class BasicGeneratorTest extends FlatSpec with Matchers {
     modelList.size should be (1)
 
     val m = modelList.head("model").asInstanceOf[Map[String, AnyRef]]
-    m("classVarName") should be ("sampleObject")
+    m("classVarName") should be ("SampleObject")
+    m("instanceVarName") should be ("sampleObject")
   }
 
   it should "create a model file" in {


### PR DESCRIPTION
Slight modification from https://github.com/swagger-api/swagger-codegen/pull/323 (I can't seem to re-open that pull request).

I created templates for a Java client built by Gradle, with fault tolerance from Hystrix and templated by Feign. See: https://github.com/swps/swagger-codegen-templates

I need APIs to have `classVarName` and `instanceVarName` in their mustache template context (like models do), and in addition, give models `instanceVarName` to be in alignment with APIs.

Also, allow for processing scala server pages (.ssp) files for more complicated templating that mustache can't provide.
