### PR TITLE
Make response headers available to the code generator

### DIFF
--- a/src/main/java/com/wordnik/swagger/codegen/CodegenOperation.java
+++ b/src/main/java/com/wordnik/swagger/codegen/CodegenOperation.java
@@ -19,7 +19,7 @@ public class CodegenOperation {
   public List<CodegenParameter> formParams = new ArrayList<CodegenParameter>();
   public List<String> tags;
   public List<CodegenResponse> responses = new ArrayList<CodegenResponse>();
-
+  public final List<CodegenProperty> responseHeaders = new ArrayList<CodegenProperty>();
   public Set<String> imports = new HashSet<String>();
   public List<Map<String, String>> examples;
   public ExternalDocs externalDocs;

--- a/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -606,7 +606,8 @@ public class DefaultCodegen {
       }
     }
 
-    if(methodResponse != null && methodResponse.getSchema() != null) {
+    if(methodResponse != null) {
+     if (methodResponse.getSchema() != null) {
       CodegenProperty cm = fromProperty("response", methodResponse.getSchema());
 
       Property responseProperty = methodResponse.getSchema();
@@ -632,6 +633,8 @@ public class DefaultCodegen {
         op.returnSimpleType = true;
       if (languageSpecificPrimitives().contains(op.returnBaseType) || op.returnBaseType == null)
         op.returnTypeIsPrimitive = true;
+     }
+     addHeaders(methodResponse, op.responseHeaders);
     }
 
     if(op.returnBaseType == null) {
@@ -806,6 +809,14 @@ public class DefaultCodegen {
       output.add(kv);
     }
     return output;
+  }
+
+  private void addHeaders(Response response, List<CodegenProperty> target) {
+    if (response.getHeaders() != null) {
+      for (Map.Entry<String, Property> headers : response.getHeaders().entrySet()) {
+        target.add(fromProperty(headers.getKey(), headers.getValue()));
+      }
+    }
   }
 
   private List<CodegenParameter> addHasMore(List<CodegenParameter> objs) {


### PR DESCRIPTION
Follow-up to https://github.com/swagger-api/swagger-core/pull/781

"With this additional field (and a similar extension to swagger-codegen), it is possible to use response headers (as defined by https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#responseObject) from a specification for code generation"
