### PR TITLE
update php swagger to use serialize to show error response 

### DIFF
--- a/src/main/resources/php/Swagger.mustache
+++ b/src/main/resources/php/Swagger.mustache
@@ -105,6 +105,9 @@ class APIClient {
 				" took more than 5s to return" );
 		} else if ($response_info['http_code'] == 200) {
 			$data = json_decode($response);
+      if (json_last_error() > 0) {
+        $data = $response;
+      }
 		} else if ($response_info['http_code'] == 401) {
 			throw new Exception("Unauthorized API request to " . $url .
 					": ".serialize($response) );

--- a/src/main/resources/php/Swagger.mustache
+++ b/src/main/resources/php/Swagger.mustache
@@ -107,7 +107,7 @@ class APIClient {
 			$data = json_decode($response);
 		} else if ($response_info['http_code'] == 401) {
 			throw new Exception("Unauthorized API request to " . $url .
-					": ".json_decode($response)->message );
+					": ".serialize($response) );
 		} else if ($response_info['http_code'] == 404) {
 			$data = null;
 		} else {


### PR DESCRIPTION
update php swagger to use serialize to show error response as the json response may not contain the 'message' attribute, which will result in exception