### PR TITLE
Java, PHP, Python binding enhancements for better API request control

### DIFF
--- a/src/main/resources/Java/api.mustache
+++ b/src/main/resources/Java/api.mustache
@@ -8,6 +8,7 @@ import {{invokerPackage}}.ApiInvoker;
 
 import com.sun.jersey.multipart.FormDataMultiPart;
 
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
 
 import java.io.File;
@@ -17,6 +18,7 @@ import java.util.*;
 public class {{classname}} {
   String basePath = "{{basePath}}";
   ApiInvoker apiInvoker = ApiInvoker.getInstance();
+  Cookie cookie = null;
 
   public ApiInvoker getInvoker() {
     return apiInvoker;
@@ -28,6 +30,10 @@ public class {{classname}} {
   
   public String getBasePath() {
     return basePath;
+  }
+
+  public void setCookie(Cookie cookie) {
+    this.cookie = cookie;
   }
 
   {{#operation}}
@@ -90,7 +96,7 @@ public class {{classname}} {
     }
 
     try {
-      String response = apiInvoker.invokeAPI(basePath, path, "{{httpMethod}}", queryParams, postBody, headerParams, formParams, contentType);
+      String response = apiInvoker.invokeAPI(basePath, path, "{{httpMethod}}", queryParams, postBody, headerParams, formParams, contentType, cookie);
       if(response != null){
         return {{#returnType}}({{{returnType}}}) ApiInvoker.deserialize(response, "{{returnContainer}}", {{returnBaseType}}.class){{/returnType}};
       }

--- a/src/main/resources/Java/apiInvoker.mustache
+++ b/src/main/resources/Java/apiInvoker.mustache
@@ -13,6 +13,7 @@ import com.sun.jersey.api.client.filter.LoggingFilter;
 import com.sun.jersey.api.client.WebResource.Builder;
 import com.sun.jersey.multipart.FormDataMultiPart;
 
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.core.MediaType;
 
@@ -84,7 +85,7 @@ public class ApiInvoker {
     }
   }
 
-  public String invokeAPI(String host, String path, String method, Map<String, String> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType) throws ApiException {
+  public String invokeAPI(String host, String path, String method, Map<String, String> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, Cookie cookie) throws ApiException {
     Client client = getClient(host);
 
     StringBuilder b = new StringBuilder();
@@ -104,6 +105,10 @@ public class ApiInvoker {
     Builder builder = client.resource(host + path + querystring).accept("application/json");
     for(String key : headerParams.keySet()) {
       builder.header(key, headerParams.get(key));
+    }
+
+    if (cookie != null) {
+      builder = builder.cookie(cookie);
     }
 
     for(String key : defaultHeaderMap.keySet()) {

--- a/src/main/resources/php/Swagger.mustache
+++ b/src/main/resources/php/Swagger.mustache
@@ -32,9 +32,10 @@ class APIClient {
 	 * @param string $apiKey your API key
 	 * @param string $apiServer the address of the API server
 	 */
-	function __construct($apiKey, $apiServer) {
+	function __construct($apiKey, $apiServer, $apiKeyName='api_key') {
 		$this->apiKey = $apiKey;
 		$this->apiServer = $apiServer;
+		$this->apiKeyName = $apiKeyName;
 	}
 
 
@@ -56,13 +57,13 @@ class APIClient {
 		if ($headerParams != null) {
 			foreach ($headerParams as $key => $val) {
 				$headers[] = "$key: $val";
-				if ($key == 'api_key') {
+				if ($key == $this->apiKeyName) {
 				    $added_api_key = True;
 				}
 			}
 		}
 		if (! $added_api_key) {
-		    $headers[] = "api_key: " . $this->apiKey;
+		    $headers[] = $this->apiKeyName . ": " . $this->apiKey;
 		}
 
 		if (is_object($postData) or is_array($postData)) {

--- a/src/main/resources/python/swagger.mustache
+++ b/src/main/resources/python/swagger.mustache
@@ -19,13 +19,14 @@ from models import *
 class ApiClient:
     """Generic API client for Swagger client library builds"""
 
-    def __init__(self, apiKey=None, apiServer=None):
+    def __init__(self, apiKey=None, apiServer=None, apiKeyName='api_key', cookie=None):
         if apiKey == None:
             raise Exception('You must pass an apiKey when instantiating the '
                             'APIClient')
         self.apiKey = apiKey
+        self.apiKeyName = apiKeyName
         self.apiServer = apiServer
-        self.cookie = None
+        self.cookie = cookie
 
     def callAPI(self, resourcePath, method, queryParams, postData,
                 headerParams=None):
@@ -37,7 +38,7 @@ class ApiClient:
                 headers[param] = value
 
         #headers['Content-type'] = 'application/json'
-        headers['api_key'] = self.apiKey
+        headers[self.apiKeyName] = self.apiKey
 
         if self.cookie:
             headers['Cookie'] = self.cookie


### PR DESCRIPTION
Adapting the Java, PHP, and Python bindings to account for API Keys that are of a different name than 'api_key' as well as adding cookie support in Java and Python bindings