### PR TITLE
Introduced the isRef attribute to ModelProperty...

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/model/SwaggerModelSerializer.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/model/SwaggerModelSerializer.scala
@@ -553,6 +553,10 @@ object SwaggerSerializers {
             case Some(e: ModelRef) if(e.`type` != null || e.ref != None) => Some(e)
             case _ => None
           }
+        },
+        isRef = (json \ "$ref") match {
+          case e: JString => true
+          case _ => false
         }
       )
     }, {

--- a/src/main/scala/com/wordnik/swagger/codegen/model/SwaggerModels.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/model/SwaggerModels.scala
@@ -61,7 +61,8 @@ case class ModelProperty(
   required: Boolean = false,
   description: Option[String] = None,
   allowableValues: AllowableValues = AnyAllowableValues,
-  var items: Option[ModelRef] = None)
+  var items: Option[ModelRef] = None,
+  isRef: Boolean = false)
 
 case class ModelRef(
   `type`: String,


### PR DESCRIPTION
 in order to be able to determine whether the property was defined using $ref

That allows a custom generator (for MongoDB for example) to use this information in order to determine whether an attribute should be a reference to another document (if defined with "$ref"), or just an embedded, sub-document (if defined with "type").