### PR TITLE
JAXRS Codegen should omit @PATH variable when it is not necessary

### DIFF
--- a/src/main/java/com/wordnik/swagger/codegen/CodegenOperation.java
+++ b/src/main/java/com/wordnik/swagger/codegen/CodegenOperation.java
@@ -5,7 +5,7 @@ import com.wordnik.swagger.models.*;
 import java.util.*;
 
 public class CodegenOperation {
-  public Boolean hasParams, returnTypeIsPrimitive, returnSimpleType;
+  public Boolean hasParams, returnTypeIsPrimitive, returnSimpleType, subresourceOperation;
   public String path, operationId, returnType, httpMethod, returnBaseType,
     returnContainer, summary, notes, baseName, defaultResponse;
 

--- a/src/main/java/com/wordnik/swagger/codegen/languages/JaxRSServerCodegen.java
+++ b/src/main/java/com/wordnik/swagger/codegen/languages/JaxRSServerCodegen.java
@@ -80,6 +80,7 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
     else {
       if(co.path.startsWith("/" + basePath))
         co.path = co.path.substring(("/" + basePath).length());
+        co.subresourceOperation = !co.path.isEmpty();
     }
     List<CodegenOperation> opList = operations.get(basePath);
     if(opList == null) {

--- a/src/main/resources/JavaJaxRS/api.mustache
+++ b/src/main/resources/JavaJaxRS/api.mustache
@@ -20,7 +20,7 @@ import javax.ws.rs.*;
 public class {{classname}} {
   {{#operation}}
   @{{httpMethod}}
-  @Path("{{path}}")
+  {{#subresourceOperation}}@Path("{{path}}"){{/subresourceOperation}}
   @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}})
   @ApiResponses(value = { {{#responses}}
     @ApiResponse(code = {{{code}}}, message = "{{{message}}}"){{#hasMore}},


### PR DESCRIPTION
Fix JaxRS codegen to only generate @PATH annotation on a given resource function when that function is a "sub resource" (e.g. @PATH("/{id}") or @PATH("/{id}/operation").

*Swagger YAML:*

```
paths:
  /charges:
    post:
      description: Create a charge
      operationId: createCharge
      parameters:
        -
          name: body
          in: body
          description: Charge to create
          required: true
          schema:
            $ref: '#/definitions/Charge'
      responses:
        200:
          description: Success - Duplicate transaction detected and previous charge returned
          schema:
            $ref: '#/definitions/Charge'
```

*Would generate the following:*
```
@Path("/charges")
@Api(value = "/charges", description = "the charges API")
@Produces({"application/json"})
public class ChargesApi {

  @POST
  @Path("")
  @ApiOperation(value = "", notes = "Create a charge", response = Charge.class)
  @ApiResponses(value = {
    @ApiResponse(code = 201, message = "Created"),
    @ApiResponse(code = 400, message = "Data validation error"),
    @ApiResponse(code = 0, message = "Unexpected error")
  })
```

@Path("") doesn't compile and is superfluous because the the @Path variable for the class covers the POST operation. 

I'm not wed to the naming of the CodegenOperation field I added (i.e. subresourceOperation). Let me know if you want something else. 