### PR TITLE
JaxRS @ApiResponse annotations for 200 response codes are not generated 

### DIFF
--- a/src/main/java/com/wordnik/swagger/codegen/CodegenOperation.java
+++ b/src/main/java/com/wordnik/swagger/codegen/CodegenOperation.java
@@ -18,6 +18,7 @@ public class CodegenOperation {
   public List<CodegenParameter> headerParams = new ArrayList<CodegenParameter>();
   public List<CodegenParameter> formParams = new ArrayList<CodegenParameter>();
   public List<String> tags;
+  public CodegenResponse successResponse;
   public List<CodegenResponse> responses = new ArrayList<CodegenResponse>();
   public final List<CodegenProperty> responseHeaders = new ArrayList<CodegenProperty>();
   public Set<String> imports = new HashSet<String>();

--- a/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -581,6 +581,10 @@ public class DefaultCodegen {
         Response response = operation.getResponses().get(responseCode);
         if("200".equals(responseCode)) {
           methodResponse = response;
+          op.successResponse = fromResponse(responseCode, response);
+          if(operation.getResponses().keySet().size() > 1) {
+            op.successResponse.hasMore = new Boolean(true);
+          }
         }
       }
       if(methodResponse == null && operation.getResponses().keySet().contains("default")) {

--- a/src/main/resources/JavaJaxRS/api.mustache
+++ b/src/main/resources/JavaJaxRS/api.mustache
@@ -22,9 +22,16 @@ public class {{classname}} {
   @{{httpMethod}}
   @Path("{{path}}")
   @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}})
-  @ApiResponses(value = { {{#responses}}
+  @ApiResponses(value = {
+{{#successResponse}}
     @ApiResponse(code = {{{code}}}, message = "{{{message}}}"){{#hasMore}},
-    {{/hasMore}}{{/responses}} })
+    {{/hasMore}}
+{{/successResponse}}
+{{#responses}}
+    @ApiResponse(code = {{{code}}}, message = "{{{message}}}"){{#hasMore}},
+    {{/hasMore}}
+{{/responses}}
+  })
 
   public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{#hasMore}},
     {{/hasMore}}{{/allParams}})


### PR DESCRIPTION
In my swagger spec I have the following case:

```
      responses:
        200:
          description: Success - Duplicate transaction detected and previous charge returned
          schema:
            $ref: '#/definitions/Charge'
```

When I generate JaxRS resources the @ApiResponse annotation for the 200 response code is not generated. 

My solution was to add a new field, successResponse, to CodegenOperation which contains the success response object (which is normally culled during DefaultCodegen.fromOperation()).

I then use successResponse in the JaxRS template. 