### PR TITLE
Adding first and hasRequiredParams parameters to Codegen

### DIFF
--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -202,7 +202,10 @@ class Codegen(config: CodegenConfig) {
 
     queryParams.size match {
       case 0 =>
-      case _ => queryParams.last.asInstanceOf[HashMap[String, String]] -= "hasMore"
+      case _ => {
+        queryParams.head.asInstanceOf[HashMap[String, String]] += "first" -> "true"
+        queryParams.last.asInstanceOf[HashMap[String, String]] -= "hasMore"
+      }
     }
 
     pathParams.size match {
@@ -390,7 +393,10 @@ class Codegen(config: CodegenConfig) {
           "description" -> propertyDocSchema.description,
           "notes" -> propertyDocSchema.description,
           "allowableValues" -> rawAllowableValuesToString(propertyDocSchema.allowableValues),
-          (if(propertyDocSchema.required) "required" else "isNotRequired") -> "true",
+          (if(propertyDocSchema.required) {
+            data += "hasRequiredParams" -> "true"
+            "required"
+          } else "isNotRequired") -> "true",
           "getter" -> config.toGetter(prop._1, config.toDeclaration(propertyDocSchema)._1),
           "setter" -> config.toSetter(prop._1, config.toDeclaration(propertyDocSchema)._1),
           "isList" -> isList,

--- a/src/test/scala/CodegenTest.scala
+++ b/src/test/scala/CodegenTest.scala
@@ -24,6 +24,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers 
 
 import scala.beans.BeanProperty
+import scala.collection.mutable.{ HashMap, LinkedHashMap }
 
 @RunWith(classOf[JUnitRunner])
 class CodegenTest extends FlatSpec with Matchers {
@@ -40,8 +41,18 @@ class CodegenTest extends FlatSpec with Matchers {
       List.empty,
       List.empty,
       List.empty,
+      //query param
+      List(new Parameter("Name", Some("name"), Some("null"), false, false, "String", AnyAllowableValues, "query", None)),
       List.empty,
-      List.empty,
+      None)
+
+  val testModel = new Model("Contact",
+      "Contact",
+      "Contact",
+      //required field
+      LinkedHashMap("Name" -> new ModelProperty("String", "String", 0, true, None, AnyAllowableValues, None)),
+      None,
+      None,
       None)
 
   behavior of "Codegen"
@@ -52,4 +63,21 @@ class CodegenTest extends FlatSpec with Matchers {
     val map = subject.apiToMap("/contacts", testOp)
     map("returnContainer") should be (Some("List"))
   }
+
+  /*
+   * Field first on the query param should be true
+   */
+  it should "have a first field on first query param and should be true" in {
+    val map = subject.apiToMap("/contacts", testOp)
+    map("queryParams").asInstanceOf[List[HashMap[String, String]]].head("first") should be ("true")
+  }
+
+  /*
+   * Field hasRequiredParams should be true
+   */
+  it should "have a hasRequiredParams field and should be true" in {
+    val map = subject.modelToMap("Contact", testModel)
+    map("hasRequiredParams") should be ("true")
+  }
 }
+


### PR DESCRIPTION
I found that I needed two extra variables in the generator/mustache templates. I thought other people might find these useful as well.

"first" - the first query param, this could also be aded for the other types of params
"hasRequiredParams" - a flag to indicate the presence of required params