### PR TITLE
PythonGenerator api args

### DIFF
--- a/src/main/resources/python/api.mustache
+++ b/src/main/resources/python/api.mustache
@@ -31,7 +31,7 @@ class {{classname}}(object):
 
     {{newline}}
     {{#operation}}
-    def {{nickname}}(self, {{#requiredParams}}{{paramName}}{{#defaultValue}} = None{{/defaultValue}}, {{/requiredParams}}**kwargs):
+    def {{nickname}}(self, {{#requiredParams}}{{paramName}}{{#defaultValue}}={{{defaultValue}}}{{/defaultValue}}, {{/requiredParams}}**kwargs):
         """{{summary}}
 
         Args:

--- a/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/Codegen.scala
@@ -240,6 +240,16 @@ class Codegen(config: CodegenConfig) {
       }
     }
 
+    val sortedParams = {
+      requiredParams.toList.sortBy(_.get("defaultValue") match{
+        case Some(defaultValue) => defaultValue match{
+          case Some(value) => 1
+          case None => 0
+        }
+        case None => 0
+      })
+    }
+
     val writeMethods = Set("POST", "PUT", "PATCH")
     val properties =
       HashMap[String, AnyRef](
@@ -257,7 +267,7 @@ class Codegen(config: CodegenConfig) {
         "queryParams" -> queryParams.toList,
         "headerParams" -> headerParams.toList,
         "formParams" -> formParams.toList,
-        "requiredParams" -> requiredParams.toList,
+        "requiredParams" -> sortedParams,
         "errorList" -> errorList,
         "httpMethod" -> operation.method.toUpperCase,
         "httpMethodLowerCase" -> operation.method.toLowerCase,


### PR DESCRIPTION
This patch addresses the order of arguments with default values within a function and what `defaultValue` is set to in the generated code. If we have a `Foo` function that takes three arguments: `bar, quz, and baz` but `baz` has a defaultValue of "Something". Currently, the output looks like this:

```
def Foo(self, bar, baz=None, quz, **kwargs):
    ...
```

Any values with default values should go at the end of the arguments list and the default should be "Something" rather than null. This patch explicitly orders `requiredParams` by defaultValue and puts that value in the mustache template. Below is the resulting output

```
def Foo(self, bar, quz, baz="Something", **kwargs):
    ...
```