### PR TITLE
Java Model Template Fixes

### DIFF
--- a/src/main/resources/Java/model.mustache
+++ b/src/main/resources/Java/model.mustache
@@ -6,42 +6,54 @@ package {{package}};
 import com.wordnik.swagger.annotations.*;
 {{#models}}
 
-{{#model}}{{#description}}
+    {{#model}}
+{{#description}}
 /**
- * {{description}}
- **/{{/description}}
+* {{description}}
+**/
+{{/description}}
 @ApiModel(description = "{{{description}}}")
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} { {{#vars}}
-  private {{{datatype}}} {{name}} = {{{defaultValue}}};{{#allowableValues}}
-  
-  //{{^min}}public enum {{name}}Enum { {{#values}} {{.}}, {{/values}} }; 
-  {{/min}}{{/allowableValues}}{{/vars}}
-  
-  {{#vars}}
-  /**{{#description}}
-   * {{{description}}}{{/description}}{{#minimum}}
-   * minimum: {{minimum}}{{/minimum}}{{#maximum}}
-   * maximum: {{maximum}}{{/maximum}}
-   **/
-  @ApiModelProperty(required = {{required}}, value = "{{{description}}}")
-  public {{{datatype}}} {{getter}}() {
+public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} { 
+{{#vars}}
+    private {{{datatype}}} {{name}} = {{{defaultValue}}};
+{{#allowableValues}}
+{{#isEnum}}
+    public enum {{datatype}} { {{#values}} {{.}}, {{/values}} };
+{{/isEnum}}
+{{/allowableValues}}
+{{/vars}}
+
+{{#vars}}
+    /**
+{{#description}}
+     * {{{description}}}
+{{/description}}
+{{#minimum}}
+     * minimum: {{minimum}}
+{{/minimum}}
+{{#maximum}}
+     * maximum: {{maximum}}
+{{/maximum}}
+    **/
+    @ApiModelProperty(required = {{required}}, value = "{{{description}}}")
+    public {{{datatype}}} {{getter}}() {
     return {{name}};
-  }
-  public void {{setter}}({{{datatype}}} {{name}}) {
+    }
+    public void {{setter}}({{{datatype}}} {{name}}) {
     this.{{name}} = {{name}};
-  }
+    }
 
-  {{/vars}}
+{{/vars}}
 
-  @Override
-  public String toString()  {
+    @Override
+    public String toString()  {
     StringBuilder sb = new StringBuilder();
     sb.append("class {{classname}} {\n");
     {{#parent}}sb.append("  " + super.toString()).append("\n");{{/parent}}
     {{#vars}}sb.append("  {{name}}: ").append({{name}}).append("\n");
     {{/vars}}sb.append("}\n");
     return sb.toString();
-  }
-}
+    }
+    }
 {{/model}}
 {{/models}}


### PR DESCRIPTION
The current Java/model.mustache generates an empty enum class when your specify a numeric property because the template was using the "min" property to determine whether to generate an enum. I switched the template to use "isEnum" instead. Now only enum fields get an enum generated.

I also reformatted the template to take advantage of the the [newline trimming](https://github.com/samskivert/jmustache#newline-trimming) feature in jmustache. While this does increase the length of the template, i think it makes it more readable.
