### PR TITLE
Rework generated PHP function comments.

### DIFF
--- a/src/main/resources/php/api.mustache
+++ b/src/main/resources/php/api.mustache
@@ -27,12 +27,12 @@ class {{classname}} {
 	}
 
   {{#operation}}
-	/**
-	 * {{nickname}}
-	 * {{summary}}
+  /**
+   * {{nickname}}
+   * {{summary}}
+   * 
    {{#allParams}}
-   * {{paramName}}, {{dataType}}: {{description}} {{^optional}}(required){{/optional}}{{#optional}}(optional){{/optional}}
-   {{newline}}
+   * @param {{dataType}} ${{paramName}} {{description}} ({{^optional}}required{{/optional}}{{#optional}}optional{{/optional}})
    {{/allParams}}
 	 * @return {{returnType}}
 	 */


### PR DESCRIPTION
Before this patch:

![Imgur](http://i.imgur.com/HO4JPrD.jpg)

After:

![Imgur](http://i.imgur.com/sPrlHbA.jpg)