### PR TITLE
Fix for java client codegen for array-type responses

### DIFF
--- a/src/main/java/com/wordnik/swagger/codegen/languages/JavaClientCodegen.java
+++ b/src/main/java/com/wordnik/swagger/codegen/languages/JavaClientCodegen.java
@@ -1,10 +1,10 @@
 package com.wordnik.swagger.codegen.languages;
 
+import java.io.*;
+import java.util.*;
+
 import com.wordnik.swagger.codegen.*;
 import com.wordnik.swagger.models.properties.*;
-
-import java.util.*;
-import java.io.File;
 
 public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
   protected String invokerPackage = "com.wordnik.client";
@@ -111,5 +111,20 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
     else
       type = swaggerType;
     return toModelName(type);
+  }
+
+  public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
+    Map<String, Object> operations = (Map<String, Object>)objs.get("operations");
+    if(operations != null) {
+      List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
+      for(CodegenOperation operation : ops) {
+    	if (operation.returnType == null)
+    	  continue;
+        if(operation.returnType.startsWith("List<")) {
+          operation.returnContainer = "List";
+        }
+      }
+    }
+    return objs;
   }
 }


### PR DESCRIPTION
Hi,
this fixes generated Java client code for array type responses. Before the fix the resulting client would have the following as the method result statement
```java 
(List<ResultClassname>) ApiInvoker.deserialize(response, "ResultClassname", ResultClassname.class);
```
Which led to an error when actually using this method (Innstance of RsultClassname was created from JSON array but could not be casted to List<ResultClassname>).
After the fix this is the result statement:
```java 
(List<ResultClassname>) ApiInvoker.deserialize(response, "List", ResultClassname.class);
```
However, I'm not sure whether this change is done at the correct location or whether it should be somewhere more basic. I've adapted the way something similar was done for `JaxRSServerCodegen`.

Best regards
Fleque