### PR TITLE
Fix for the selection of the methodResponse during code-generation

### DIFF
--- a/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -4,6 +4,7 @@ import com.wordnik.swagger.models.*;
 import com.wordnik.swagger.models.parameters.*;
 import com.wordnik.swagger.models.properties.*;
 import com.wordnik.swagger.util.Json;
+
 import org.apache.commons.lang.StringUtils;
 
 import java.util.*;
@@ -577,10 +578,12 @@ public class DefaultCodegen {
     }
 
     if(operation.getResponses() != null) {
-      for(String responseCode: operation.getResponses().keySet()) {
+      for(String responseCode: new TreeSet<String>(operation.getResponses().keySet())) {
         Response response = operation.getResponses().get(responseCode);
-        if("200".equals(responseCode)) {
+        if (responseCode.startsWith("2")) {
+          // use the first, i.e. the smallest 2xx response status as methodResponse
           methodResponse = response;
+          break;
         }
       }
       if(methodResponse == null && operation.getResponses().keySet().contains("default")) {


### PR DESCRIPTION
Hi.

This fixes the selection of methodResponse for code generation. Before the change only responses with statusCode 200 were considered. If none present (fore example for a post-request to create a new resource responding with 201) this was not used and the "default" if present was used instead.

This fixes the selection in the way that it will use the response definition with the smalles 2xx value present as method result.

Best regards
Fleque