### PR TITLE
Support for HTTP Async client transport for Jersey on Scala (legacy master)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ javacOptions ++= Seq("-target", "1.6", "-source", "1.6", "-Xlint:unchecked", "-X
 
 scalacOptions ++= Seq("-optimize", "-unchecked", "-deprecation", "-Xcheckinit", "-encoding", "utf8")
 
-crossScalaVersions := Seq("2.10.0", "2.10.1", "2.10.2", "2.10.3", "2.10.4", "2.11.0", "2.11.1")
+crossScalaVersions := Seq("2.10.4", "2.11.0", "2.11.1")
 
 scalaVersion := "2.10.4"
 

--- a/sbt
+++ b/sbt
@@ -128,7 +128,7 @@ declare -r default_jvm_opts="-Dfile.encoding=UTF8 -XX:MaxPermSize=256m -Xms512m 
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"
-declare -r latest_210="2.10.0"
+declare -r latest_210="2.10.4"
 
 declare -r script_path=$(get_script_path "$BASH_SOURCE")
 declare -r script_dir="$(dirname $script_path)"

--- a/src/main/resources/scala/apiInvoker.mustache
+++ b/src/main/resources/scala/apiInvoker.mustache
@@ -35,10 +35,12 @@ object ScalaJsonUtil {
   }
 }
 
-object ApiInvoker {
-  val mapper = ScalaJsonUtil.getJsonMapper
-  val defaultHeaders: HashMap[String, String] = HashMap()
-  val hostMap: HashMap[String, Client] = HashMap()
+class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
+                 httpHeaders: HashMap[String, String] = HashMap(),
+                 hostMap: HashMap[String, Client] = HashMap(),
+                 asyncHttpClient: Boolean = false) {
+
+  var defaultHeaders: HashMap[String, String] = httpHeaders
 
   def escape(value: String): String = {
     URLEncoder.encode(value, "utf-8").replaceAll("\\+", "%20")
@@ -151,14 +153,30 @@ object ApiInvoker {
     hostMap.contains(host) match {
       case true => hostMap(host)
       case false => {
-        val client = Client.create()
+        val client = newClient(host)
         // client.addFilter(new LoggingFilter())
         hostMap += host -> client
         client
       }
     }
   }
+  
+  def newClient(host: String): Client = asyncHttpClient match {
+    case true => {
+      import org.sonatype.spice.jersey.client.ahc.config.DefaultAhcConfig
+      import org.sonatype.spice.jersey.client.ahc.AhcHttpClient
+
+      val config: DefaultAhcConfig = new DefaultAhcConfig()
+      AhcHttpClient.create(config)
+    }
+    case _ => Client.create()
+  }
 }
+
+object ApiInvoker extends ApiInvoker(mapper = ScalaJsonUtil.getJsonMapper,
+  httpHeaders = HashMap(),
+  hostMap = HashMap(),
+  asyncHttpClient = {{asyncHttpClient}})
 
 class ApiException(val code: Int, msg: String) extends RuntimeException(msg)
 

--- a/src/main/resources/scala/pom.mustache
+++ b/src/main/resources/scala/pom.mustache
@@ -163,6 +163,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.jfarcand</groupId>
+      <artifactId>jersey-ahc-client</artifactId>
+      <version>${jersey-async-version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala-version}</version>
@@ -221,6 +227,7 @@
     </profiles>
   <properties>
     <jersey-version>1.7</jersey-version>
+    <jersey-async-version>1.0.5</jersey-async-version>
     <junit-version>4.8.1</junit-version>
     <maven-plugin.version>1.0.0</maven-plugin.version>
     <junit-version>4.8.1</junit-version>

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicScalaGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicScalaGenerator.scala
@@ -212,7 +212,8 @@ class BasicScalaGenerator extends BasicGenerator {
   additionalParams ++= Map(
     "artifactId" -> "scala-client", 
     "artifactVersion" -> "1.0.0",
-    "groupId" -> "com.wordnik")
+    "groupId" -> "com.wordnik",
+    "asyncHttpClient" -> "false")
 
   // supporting classes
   override def supportingFiles = List(


### PR DESCRIPTION
When generating Scala client, the ApiInvoker is a class with
overridable options, avoiding the need of public vars to be
manually modified.

Additionally it is possible to plug the AsyncHttp protocol
for Jersey in order to achieve Netty support and maximum scalability.