### PR TITLE
Support for HTTP Async client transport for Jersey on Scala

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/ScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/ScalaClientCodegen.java
@@ -43,6 +43,7 @@ public class ScalaClientCodegen extends DefaultCodegen implements CodegenConfig 
     additionalProperties.put("groupId", groupId);
     additionalProperties.put("artifactId", artifactId);
     additionalProperties.put("artifactVersion", artifactVersion);
+    additionalProperties.put("asyncHttpClient", false);
 
     supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
     supportingFiles.add(new SupportingFile("apiInvoker.mustache", 

--- a/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
@@ -35,10 +35,12 @@ object ScalaJsonUtil {
   }
 }
 
-object ApiInvoker {
-  val mapper = ScalaJsonUtil.getJsonMapper
-  val defaultHeaders: HashMap[String, String] = HashMap()
-  val hostMap: HashMap[String, Client] = HashMap()
+class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
+                 httpHeaders: HashMap[String, String] = HashMap(),
+                 hostMap: HashMap[String, Client] = HashMap(),
+                 asyncHttpClient: Boolean = false) {
+
+  var defaultHeaders: HashMap[String, String] = httpHeaders
 
   def escape(value: String): String = {
     URLEncoder.encode(value, "utf-8").replaceAll("\\+", "%20")
@@ -151,14 +153,30 @@ object ApiInvoker {
     hostMap.contains(host) match {
       case true => hostMap(host)
       case false => {
-        val client = Client.create()
+        val client = newClient(host)
         // client.addFilter(new LoggingFilter())
         hostMap += host -> client
         client
       }
     }
   }
+  
+  def newClient(host: String): Client = asyncHttpClient match {
+    case true => {
+      import org.sonatype.spice.jersey.client.ahc.config.DefaultAhcConfig
+      import org.sonatype.spice.jersey.client.ahc.AhcHttpClient
+
+      val config: DefaultAhcConfig = new DefaultAhcConfig()
+      AhcHttpClient.create(config)
+    }
+    case _ => Client.create()
+  }
 }
+
+object ApiInvoker extends ApiInvoker(mapper = ScalaJsonUtil.getJsonMapper,
+  httpHeaders = HashMap(),
+  hostMap = HashMap(),
+  asyncHttpClient = {{asyncHttpClient}})
 
 class ApiException(val code: Int, msg: String) extends RuntimeException(msg)
 

--- a/modules/swagger-codegen/src/main/resources/scala/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/pom.mustache
@@ -166,6 +166,12 @@
       <version>${jersey-version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jfarcand</groupId>
+      <artifactId>jersey-ahc-client</artifactId>
+      <version>${jersey-async-version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala-version}</version>
@@ -204,6 +210,7 @@
     <joda-time-version>2.2</joda-time-version>
     <jersey-version>1.7</jersey-version>
     <swagger-core-version>1.5.0-M1</swagger-core-version>
+    <jersey-async-version>1.0.5</jersey-async-version>
     <maven-plugin.version>1.0.0</maven-plugin.version>
     <jackson-version>2.4.2</jackson-version>
 


### PR DESCRIPTION
When generating Scala client, the ApiInvoker is a class with
overridable options, avoiding the need of public vars to be
manually modified.

Additionally it is possible to plug the AsyncHttp protocol
for Jersey in order to achieve Netty support and maximum scalability.

NOTE: Support for Scala 2.10.0-3 removed as largely obsolete