### PR TITLE
SPNEGO auth fix: Authentication scheme should be set as String

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
@@ -167,6 +167,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
     case true => {
       import org.sonatype.spice.jersey.client.ahc.config.DefaultAhcConfig
       import org.sonatype.spice.jersey.client.ahc.AhcHttpClient
+      import com.ning.http.client.Realm
 
       val config: DefaultAhcConfig = new DefaultAhcConfig()
       if (!authScheme.isEmpty) {
@@ -185,7 +186,7 @@ object ApiInvoker extends ApiInvoker(mapper = ScalaJsonUtil.getJsonMapper,
   httpHeaders = HashMap(),
   hostMap = HashMap(),
   asyncHttpClient = {{asyncHttpClient}},
-  authScheme = {{authScheme}},
+  authScheme = "{{authScheme}}",
   authPreemptive = {{authPreemptive}})
 
 class ApiException(val code: Int, msg: String) extends RuntimeException(msg)


### PR DESCRIPTION
Default authentication scheme is a String and must be later
on decoded as Realm enum