### PR TITLE
Scala api.mustache: allow easy basePath and ApiInvoker override

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/api.mustache
@@ -11,10 +11,9 @@ import java.util.Date
 import scala.collection.mutable.HashMap
 
 {{#operations}}
-class {{classname}} {
-  var basePath: String = "{{basePath}}"
-  var apiInvoker = ApiInvoker
-  
+class {{classname}}(val basePath: String = "{{basePath}}",
+                        apiInvoker: ApiInvoker = ApiInvoker) {
+
   def addHeader(key: String, value: String) = apiInvoker.defaultHeaders += key -> value 
 
   {{#operation}}


### PR DESCRIPTION
Gets rid of the smelly vars inside Scala api.mustache allowing the
override of default basePath and ApiInvoker on the constructor.

Previously the code for overriding was:

  val myApi = new MyApi()
  myApi.basePath = "http://myapi.endpoint.com"
  myApi.apiInvoker = new ApiInvoker(authScheme = "SPNEGO")

after the change everything can be simply declared in the constructor:

  val myApi = new MyApi("http://myapi.endpoint.com",
                         new ApiInvoker(authScheme = "SPNEGO"))