### PR TITLE
Scala api.mustache: make new constructor backward compatible

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/api.mustache
@@ -11,8 +11,10 @@ import java.util.Date
 import scala.collection.mutable.HashMap
 
 {{#operations}}
-class {{classname}}(val basePath: String = "{{basePath}}",
-                        apiInvoker: ApiInvoker = ApiInvoker) {
+class {{classname}}(val defBasePath: String = "{{basePath}}",
+                        defApiInvoker: ApiInvoker = ApiInvoker) {
+  var basePath = defBasePath
+  var apiInvoker = defApiInvoker
 
   def addHeader(key: String, value: String) = apiInvoker.defaultHeaders += key -> value 
 


### PR DESCRIPTION
When default values have been provided with the api.mustache
constructor, backward compatibility was broken because of the public
instance variables becoming immutable vals whilst they were vars before.

We can now use the constructor arguments as default values for the internal
vars and establish backward compatibility with existing code.