### PR TITLE
Fixed The html.sh Sample Generation Script

### DIFF
--- a/bin/html.sh
+++ b/bin/html.sh
@@ -31,6 +31,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ -i http://petstore.swagger.wordnik.com/v2/swagger.json -l html  -o samples/swagger-html"
+ags="$@ -i http://petstore.swagger.io/v2/swagger.json -l html  -o samples/swagger-html"
 
 java $JAVA_OPTS -jar $executable $ags


### PR DESCRIPTION
I fixed/updated the swagger.json example URL in the html.sh script so that it would be able to generate a sample again.

Previously it was breaking:

![image](https://cloud.githubusercontent.com/assets/6859/6177846/14f60fe4-b2c7-11e4-9e75-15f708a1c500.png)
