### PR TITLE
Minor fix to cater for empty array in php

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
@@ -228,6 +228,7 @@ class APIClient {
       $deserialized = $values;
     } elseif (substr($class, 0, 6) == 'array[') {
       $subClass = substr($class, 6, -1);
+      $values = array();
       foreach ($data as $key => $value) {
         $values[] = self::deserialize($value, $subClass);
       }


### PR DESCRIPTION
When working with empty arrays in the php library, I was getting an error message "Undefined variable: values".