### PR TITLE
Fixed bug that did not allow json arrays to be deserialized by Jackson

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
@@ -51,8 +51,11 @@ public class ApiInvoker {
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {
+    if(null != containerType) {
+        containerType = containerType.toLowerCase();
+    }
     try{
-      if("List".equals(containerType)) {
+      if("list".equals(containerType) || "array".equals(containerType)) {
         JavaType typeInfo = JsonUtil.getJsonMapper().getTypeFactory().constructCollectionType(List.class, cls);
         List response = (List<?>) JsonUtil.getJsonMapper().readValue(json, typeInfo);
         return response;


### PR DESCRIPTION
The way the code is written currently, Jackson cannot deserialize 'array' types. This simple pull request fixed the problem