### PR TITLE
Fix StringIndexOutOfBoundsException on Windows

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PythonClientCodegen.java
@@ -54,7 +54,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
     supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
     supportingFiles.add(new SupportingFile("swagger.mustache", module, "swagger.py"));
     supportingFiles.add(new SupportingFile("__init__.mustache", module, "__init__.py"));
-    supportingFiles.add(new SupportingFile("__init__.mustache", modelPackage.replaceAll("\\.", File.separator), "__init__.py"));
+    supportingFiles.add(new SupportingFile("__init__.mustache", modelPackage.replace('.', File.separatorChar), "__init__.py"));
   }
 
   @Override


### PR DESCRIPTION
Running ./bin/java-petstore.sh on Windows fails with StringIndexOutOfBoundsException

```
Exception in thread "main" java.util.ServiceConfigurationError: com.wordnik.swagger.codegen.CodegenConfig: Provider com.wordnik.
swagger.codegen.languages.PythonClientCodegen could not be instantiated
        at java.util.ServiceLoader.fail(ServiceLoader.java:224)
        at java.util.ServiceLoader.access$100(ServiceLoader.java:181)
        at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:377)
        at java.util.ServiceLoader$1.next(ServiceLoader.java:445)
        at com.wordnik.swagger.codegen.Codegen.getExtensions(Codegen.java:111)
        at com.wordnik.swagger.codegen.Codegen.<clinit>(Codegen.java:19)
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: 1
        at java.lang.String.charAt(String.java:658)
        at java.util.regex.Matcher.appendReplacement(Matcher.java:762)
        at java.util.regex.Matcher.replaceAll(Matcher.java:906)
        at java.lang.String.replaceAll(String.java:2162)
        at com.wordnik.swagger.codegen.languages.PythonClientCodegen.<init>(PythonClientCodegen.java:57)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
        at java.lang.Class.newInstance(Class.java:374)
        at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:373)
        ... 3 more
```

Because backslashes in the replacement string (File.separator is "\\\\" on Windows)
> may cause the results to be different than if it were being treated as a literal replacement string

(from [String.replaceAll Javadoc](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Matcher.html#replaceAll(java.lang.String))).