### PR TITLE
#443 - Handling required parameters during swagger type discovery

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
@@ -6,5 +6,10 @@ public class CodegenResponse {
   public String code, message;
   public Boolean hasMore;
   public List<Map<String, String>> examples;
+  public String dataType, baseType, containerType;
+  public Boolean simpleType;
+  public Boolean primitiveType;
+  public Boolean isMapContainer;
+  public Boolean isListContainer;
   Object schema;
 }

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -142,6 +142,8 @@ public class DefaultCodegen {
     return name;
   }
 
+  public String toOperationId(String operationId) { return operationId; }
+
   public String toVarName(String name) {
     if(reservedWords.contains(name))
       return escapeReservedWord(name);
@@ -155,6 +157,7 @@ public class DefaultCodegen {
     }
     return name;
   }
+
 
   public String escapeReservedWord(String name) {
     throw new RuntimeException("reserved word " + name + " not allowed");
@@ -537,6 +540,20 @@ public class DefaultCodegen {
     return property;
   }
 
+  private Response findMethodResponse(Map<String, Response> responses) {
+    String code = null;
+    for(String responseCode : responses.keySet()) {
+      if (responseCode.startsWith("2") || responseCode.equals("default")) {
+        if (code == null || code.compareTo(responseCode) > 0) {
+          code = responseCode;
+        }
+      }
+    }
+    if (code == null)
+      return null;
+    return responses.get(code);
+  }
+
   public CodegenOperation fromOperation(String path, String httpMethod, Operation operation){
     CodegenOperation op = CodegenModelFactory.newInstance(CodegenModelType.OPERATION);
     Set<String> imports = new HashSet<String>();
@@ -566,12 +583,10 @@ public class DefaultCodegen {
       LOGGER.warn("generated operationId " + operationId);
     }
     op.path = path;
-    op.operationId = operationId;
+    op.operationId = toOperationId(operationId);
     op.summary = escapeText(operation.getSummary());
     op.notes = escapeText(operation.getDescription());
     op.tags = operation.getTags();
-
-    Response methodResponse = null;
 
     if(operation.getConsumes() != null && operation.getConsumes().size() > 0) {
       List<Map<String, String>> c = new ArrayList<Map<String, String>>();
@@ -603,69 +618,39 @@ public class DefaultCodegen {
       op.hasProduces = true;
     }
 
-    if(operation.getResponses() != null) {
-      for(String responseCode: new TreeSet<String>(operation.getResponses().keySet())) {
-        Response response = operation.getResponses().get(responseCode);
-        if (responseCode.startsWith("2")) {
-          // use the first, i.e. the smallest 2xx response status as methodResponse
-          methodResponse = response;
-          break;
-        }
-      }
-      if(methodResponse == null && operation.getResponses().keySet().contains("default")) {
-        methodResponse = operation.getResponses().get("default");
-      }
-      for(String responseCode: operation.getResponses().keySet()) {
-        Response response = operation.getResponses().get(responseCode);
-        if(response != methodResponse) {
-          CodegenResponse r = fromResponse(responseCode, response);
-          op.responses.add(r);
-        }
-        for(int i = 0; i < op.responses.size() - 1; i++) {
-          CodegenResponse r = op.responses.get(i);
-          r.hasMore = new Boolean(true);
-        }
-      }
-    }
+    if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {
 
-    if(methodResponse != null) {
-     if (methodResponse.getSchema() != null) {
-      Property responseProperty = methodResponse.getSchema();
-      responseProperty.setRequired(true);
-      CodegenProperty cm = fromProperty("response", responseProperty);
+      Response methodResponse = findMethodResponse(operation.getResponses());
+      CodegenResponse methodCodegenResponse = null;
 
-      if(responseProperty instanceof ArrayProperty) {
-        ArrayProperty ap = (ArrayProperty) responseProperty;
-        CodegenProperty innerProperty = fromProperty("response", ap.getItems());
-        op.returnBaseType = innerProperty.baseType;
+      for (Map.Entry<String, Response> entry : operation.getResponses().entrySet()) {
+        Response response = entry.getValue();
+        CodegenResponse r = fromResponse(entry.getKey(), response);
+        r.hasMore = true;
+        if (response == methodResponse)
+          methodCodegenResponse = r;
+        op.responses.add(r);
       }
-      else {
-        if(cm.complexType != null)
-          op.returnBaseType = cm.complexType;
-        else
-          op.returnBaseType = cm.baseType;
-      }
-      op.examples = toExamples(methodResponse.getExamples());
-      op.defaultResponse = toDefaultValue(responseProperty);
-      op.returnType = cm.datatype;
-      if(cm.isContainer != null) {
-        op.returnContainer = cm.containerType;
-        if("map".equals(cm.containerType))
-          op.isMapContainer = Boolean.TRUE;
-        else if ("list".equalsIgnoreCase(cm.containerType))
-          op.isListContainer = Boolean.TRUE;
-      }
-      else
-        op.returnSimpleType = true;
-      if (languageSpecificPrimitives().contains(op.returnBaseType) || op.returnBaseType == null)
-        op.returnTypeIsPrimitive = true;
-     }
-     addHeaders(methodResponse, op.responseHeaders);
-    }
+      op.responses.get(op.responses.size() - 1).hasMore = false;
 
-    if(op.returnBaseType == null) {
-      op.returnTypeIsPrimitive = true;
-      op.returnSimpleType = true;
+      if (methodResponse != null) {
+        op.returnType = methodCodegenResponse.dataType;
+        op.returnBaseType = methodCodegenResponse.baseType;
+        op.returnSimpleType = methodCodegenResponse.simpleType;
+        op.returnTypeIsPrimitive = methodCodegenResponse.primitiveType;
+        op.returnContainer = methodCodegenResponse.containerType;
+        op.isListContainer = methodCodegenResponse.isListContainer;
+        op.isMapContainer = methodCodegenResponse.isMapContainer;
+        if (methodResponse.getSchema() != null) {
+          Property responseProperty = methodResponse.getSchema();
+          responseProperty.setRequired(true);
+          CodegenProperty cm = fromProperty("response", responseProperty);
+          op.examples = toExamples(methodResponse.getExamples());
+          op.defaultResponse = toDefaultValue(responseProperty);
+          addHeaders(methodResponse, op.responseHeaders);
+        }
+
+      }
     }
 
     if(op.returnBaseType != null &&

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -630,9 +630,9 @@ public class DefaultCodegen {
 
     if(methodResponse != null) {
      if (methodResponse.getSchema() != null) {
-      CodegenProperty cm = fromProperty("response", methodResponse.getSchema());
-
       Property responseProperty = methodResponse.getSchema();
+      responseProperty.setRequired(true);
+      CodegenProperty cm = fromProperty("response", responseProperty);
 
       if(responseProperty instanceof ArrayProperty) {
         ArrayProperty ap = (ArrayProperty) responseProperty;
@@ -783,6 +783,7 @@ public class DefaultCodegen {
         LOGGER.warn("warning!  Property type \"" + qp.getType() + "\" not found for parameter \"" + param.getName() + "\", using String");
         property = new StringProperty().description("//TODO automatically added by swagger-codegen.  Type was " + qp.getType() + " but not supported");
       }
+      property.setRequired(param.getRequired());
       CodegenProperty model = fromProperty(qp.getName(), property);
       p.collectionFormat = collectionFormat;
       p.dataType = model.datatype;
@@ -806,6 +807,7 @@ public class DefaultCodegen {
         else {
           // TODO: missing format, so this will not always work
           Property prop = PropertyBuilder.build(impl.getType(), null, null);
+          prop.setRequired(bp.getRequired());
           CodegenProperty cp = fromProperty("property", prop);
           if(cp != null) {
             p.dataType = cp.datatype;
@@ -819,6 +821,7 @@ public class DefaultCodegen {
         CodegenModel cm = fromModel(bp.getName(), impl);
         // get the single property
         ArrayProperty ap = new ArrayProperty().items(impl.getItems());
+        ap.setRequired(param.getRequired());
         CodegenProperty cp = fromProperty("inner", ap);
         if(cp.complexType != null) {
           imports.add(cp.complexType);

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -752,6 +752,40 @@ public class DefaultCodegen {
     r.message = response.getDescription();
     r.schema = response.getSchema();
     r.examples = toExamples(response.getExamples());
+
+    if (r.schema != null) {
+      Property responseProperty = response.getSchema();
+      responseProperty.setRequired(true);
+      CodegenProperty cm = fromProperty("response", responseProperty);
+
+      if(responseProperty instanceof ArrayProperty) {
+        ArrayProperty ap = (ArrayProperty) responseProperty;
+        CodegenProperty innerProperty = fromProperty("response", ap.getItems());
+        r.baseType = innerProperty.baseType;
+      }
+      else {
+        if(cm.complexType != null)
+          r.baseType = cm.complexType;
+        else
+          r.baseType = cm.baseType;
+      }
+      r.dataType = cm.datatype;
+      if(cm.isContainer != null) {
+        r.simpleType = false;
+        r.containerType = cm.containerType;
+        r.isMapContainer = "map".equals(cm.containerType);
+        r.isListContainer = "list".equals(cm.containerType);
+      }
+      else
+        r.simpleType  = true;
+      r.primitiveType = (r.baseType == null ||languageSpecificPrimitives().contains(r.baseType));
+    }
+    if (r.baseType == null) {
+      r.isMapContainer = false;
+      r.isListContainer = false;
+      r.primitiveType = true;
+      r.simpleType = true;
+    }
     return r;
   }
 

--- a/modules/swagger-codegen/src/test/resources/2_0/requiredTest.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/requiredTest.json
@@ -1,0 +1,93 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at <a href=\"http://swagger.io\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample, you can use the api key \"special-key\" to test the authorization filters",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "email": "apiteam@wordnik.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/tests/requiredParams": {
+      "get": {
+        "tags": [
+          "tests"
+        ],
+        "summary": "Operation with required parameters",
+        "description": "",
+        "operationId": "requiredParams",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "param1",
+            "in": "formData",
+            "description": "Some required parameter",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "param2",
+            "in": "formData",
+            "description": "Some optional parameter",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation. Retuning a simple int.",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    },
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    }
+  },
+  "definitions": {
+    "CustomModel": {
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string",
+          "example": "doggie"
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-codegen/src/test/resources/2_0/responseSelectionTest.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/responseSelectionTest.json
@@ -1,0 +1,139 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at <a href=\"http://swagger.io\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample, you can use the api key \"special-key\" to test the authorization filters",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "email": "apiteam@wordnik.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/tests/withTwoHundredAndDefault": {
+      "get": {
+        "summary": "Operation with several unordered 2XX results and one default",
+        "description": "",
+        "operationId": "withTwoHundredAndDefault",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "default": {
+            "description": "default response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "100": {
+            "description": "100 response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "202": {
+            "description": "201 response",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "203": {
+            "description": "202 response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "400": {
+            "description": "400 response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "201": {
+            "description": "200 response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/tests/withoutTwoHundredButDefault": {
+      "get": {
+        "summary": "Operation with several unordered 2XX results and one default",
+        "description": "",
+        "operationId": "withoutTwoHundredButDefault",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "default": {
+            "description": "default response",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "100": {
+            "description": "100 response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "301": {
+            "description": "301 response",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    },
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    }
+  },
+  "definitions": {
+    "CustomModel": {
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string",
+          "example": "doggie"
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-codegen/src/test/scala/CodegenTest.scala
+++ b/modules/swagger-codegen/src/test/scala/CodegenTest.scala
@@ -107,13 +107,40 @@ class CodegenTest extends FlatSpec with Matchers {
     val op = codegen.fromOperation(path, "get", p)
 
     val formParams = op.formParams
-    formParams.size should be (2)
+    formParams.size should be(2)
     val requiredParam = formParams.get(0)
-    requiredParam.dataType should be ("Long")
+    requiredParam.dataType should be("Long")
 
     val optionalParam = formParams.get(1)
-    optionalParam.dataType should be ("Optional<string>")
+    optionalParam.dataType should be("Optional<string>")
 
-    op.returnType should be ("Long")
+    op.returnType should be("Long")
   }
+
+  it should "select main response from a 2.0 spec using the lowest 2XX code" in {
+    val model = new SwaggerParser()
+      .read("src/test/resources/2_0/responseSelectionTest.json")
+
+    val codegen = new DefaultCodegen()
+
+    val path = "/tests/withTwoHundredAndDefault"
+    val p = model.getPaths().get(path).getGet()
+    val op = codegen.fromOperation(path, "get", p)
+    op.returnType should be("String")
+
+  }
+
+  it should "select main response from a 2.0 spec using the default keyword when no 2XX code" in {
+    val model = new SwaggerParser()
+      .read("src/test/resources/2_0/responseSelectionTest.json")
+
+    val codegen = new DefaultCodegen()
+
+    val path = "/tests/withoutTwoHundredButDefault"
+    val p = model.getPaths().get(path).getGet()
+    val op = codegen.fromOperation(path, "get", p)
+    op.returnType should be("String")
+
+  }
+
 }


### PR DESCRIPTION
The problem fixed by this patch occurs when one tries to do some computation on the "requireness" of a parameter, in the DefaultCodegen.getSwaggerType.
Indeed, this method takes a Property as single parameter, and the 'required' field of this property is always set to false.
It should be true when the parameter is required (cptn obvious), and during computation of the operation.

Important note : overriding getSwaggerType (as done in the test) is definitely not the best way to handle required parameters. If one wants to add Option[...] or Optional<...> to any type, the easiest and best way is to modify the templete using {{required}}.
But this doesn't change the fact the property passed to the method is 'invalid'.
