### PR TITLE
Defect (Issue #445) : change the call of initialCaps for getter and setter proper generation

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -4,14 +4,12 @@ import com.wordnik.swagger.models.*;
 import com.wordnik.swagger.models.parameters.*;
 import com.wordnik.swagger.models.properties.*;
 import com.wordnik.swagger.util.Json;
-
 import org.apache.commons.lang.StringUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
 import java.io.File;
+import java.util.*;
 
 public class DefaultCodegen {
   Logger LOGGER = LoggerFactory.getLogger(DefaultCodegen.class);
@@ -439,6 +437,19 @@ public class DefaultCodegen {
     return m;
   }
 
+    public static String getterAndSetterCapitalize(String name) {
+        if (name == null || name.length() == 0) {
+            return name;
+        }
+        if (name.length() > 1 && Character.isUpperCase(name.charAt(1)) &&
+                Character.isLowerCase(name.charAt(0))){
+            return name;
+        }
+        char chars[] = name.toCharArray();
+        chars[0] = Character.toUpperCase(chars[0]);
+        return new String(chars);
+    }
+
   public CodegenProperty fromProperty(String name, Property p) {
     if(p == null) {
       LOGGER.error("unexpected missing property for name " + null);
@@ -449,8 +460,8 @@ public class DefaultCodegen {
     property.name = toVarName(name);
     property.baseName = name;
     property.description = escapeText(p.getDescription());
-    property.getter = "get" + initialCaps(name);
-    property.setter = "set" + initialCaps(name);
+    property.getter = "get" + getterAndSetterCapitalize(name);
+    property.setter = "set" + getterAndSetterCapitalize(name);
     property.example = p.getExample();
     property.defaultValue = toDefaultValue(p);
 

--- a/modules/swagger-codegen/src/test/scala/Java/JavaModelTest.scala
+++ b/modules/swagger-codegen/src/test/scala/Java/JavaModelTest.scala
@@ -265,4 +265,30 @@ class JavaModelTest extends FlatSpec with Matchers {
     vars.get(0).required should equal (true)
     vars.get(0).isNotContainer should equal (true)
   }
+
+  it should "convert a model with a 2nd char upper-case property names" in {
+    val model = new ModelImpl()
+      .description("a model with a 2nd char upper-case property names")
+      .property("pId", new StringProperty())
+      .required("pId")
+
+    val codegen = new JavaClientCodegen()
+    val cm = codegen.fromModel("sample", model)
+
+    cm.name should be ("sample")
+    cm.classname should be ("Sample")
+    cm.vars.size should be (1)
+
+    val vars = cm.vars
+    vars.get(0).baseName should be ("pId")
+    vars.get(0).getter should be ("getpId")
+    vars.get(0).setter should be ("setpId")
+    vars.get(0).datatype should be ("String")
+    vars.get(0).name should be ("pId")
+    vars.get(0).defaultValue should be ("null")
+    vars.get(0).baseType should be ("String")
+    vars.get(0).hasMore should equal (null)
+    vars.get(0).required should equal (true)
+    vars.get(0).isNotContainer should equal (true)
+  }
 }


### PR DESCRIPTION
Getter and Setter with 2nd chars being uppercase are not generated following the Sun specification : http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf?AuthParam=1424762391_ef17a82335203d9fbf095a2f819eb317
Chapter 8.8.

When you generate a getter and setter, you should get : 
fooBah --> getFooBah
mAttr --> getmAttr

That was not the cas, we got previously, which is wrong.
fooBah --> getFooBah
mAttr --> getMAttr

I have made a new function called getterAndSetterCapitalize which takes a String and return the proper capitalized name for getter and setter.
