### PR TITLE
Implements CodegenResponse, and return default response in Operaiton.Responses (#293)

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
@@ -6,5 +6,10 @@ public class CodegenResponse {
   public String code, message;
   public Boolean hasMore;
   public List<Map<String, String>> examples;
+  public String dataType, baseType, containerType;
+  public Boolean simpleType;
+  public Boolean primitiveType;
+  public Boolean isMapContainer;
+  public Boolean isListContainer;
   Object schema;
 }

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -752,6 +752,40 @@ public class DefaultCodegen {
     r.message = response.getDescription();
     r.schema = response.getSchema();
     r.examples = toExamples(response.getExamples());
+
+    if (r.schema != null) {
+      Property responseProperty = response.getSchema();
+      responseProperty.setRequired(true);
+      CodegenProperty cm = fromProperty("response", responseProperty);
+
+      if(responseProperty instanceof ArrayProperty) {
+        ArrayProperty ap = (ArrayProperty) responseProperty;
+        CodegenProperty innerProperty = fromProperty("response", ap.getItems());
+        r.baseType = innerProperty.baseType;
+      }
+      else {
+        if(cm.complexType != null)
+          r.baseType = cm.complexType;
+        else
+          r.baseType = cm.baseType;
+      }
+      r.dataType = cm.datatype;
+      if(cm.isContainer != null) {
+        r.simpleType = false;
+        r.containerType = cm.containerType;
+        r.isMapContainer = "map".equals(cm.containerType);
+        r.isListContainer = "list".equals(cm.containerType);
+      }
+      else
+        r.simpleType  = true;
+      r.primitiveType = (r.baseType == null ||languageSpecificPrimitives().contains(r.baseType));
+    }
+    if (r.baseType == null) {
+      r.isMapContainer = false;
+      r.isListContainer = false;
+      r.primitiveType = true;
+      r.simpleType = true;
+    }
     return r;
   }
 

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -541,6 +541,7 @@ public class DefaultCodegen {
   }
 
   private Response findMethodResponse(Map<String, Response> responses) {
+
     String code = null;
     for(String responseCode : responses.keySet()) {
       if (responseCode.startsWith("2") || responseCode.equals("default")) {
@@ -627,6 +628,11 @@ public class DefaultCodegen {
         Response response = entry.getValue();
         CodegenResponse r = fromResponse(entry.getKey(), response);
         r.hasMore = true;
+        if(r.baseType != null &&
+            !defaultIncludes.contains(r.baseType) &&
+            !languageSpecificPrimitives.contains(r.baseType))
+          imports.add(r.baseType);
+
         if (response == methodResponse)
           methodCodegenResponse = r;
         op.responses.add(r);
@@ -652,11 +658,6 @@ public class DefaultCodegen {
 
       }
     }
-
-    if(op.returnBaseType != null &&
-      !defaultIncludes.contains(op.returnBaseType) &&
-      !languageSpecificPrimitives.contains(op.returnBaseType))
-      imports.add(op.returnBaseType);
 
     List<Parameter> parameters = operation.getParameters();
     CodegenParameter bodyParam = null;

--- a/modules/swagger-codegen/src/test/resources/2_0/responseSelectionTest.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/responseSelectionTest.json
@@ -1,0 +1,139 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at <a href=\"http://swagger.io\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample, you can use the api key \"special-key\" to test the authorization filters",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "email": "apiteam@wordnik.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/tests/withTwoHundredAndDefault": {
+      "get": {
+        "summary": "Operation with several unordered 2XX results and one default",
+        "description": "",
+        "operationId": "withTwoHundredAndDefault",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "default": {
+            "description": "default response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "100": {
+            "description": "100 response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "202": {
+            "description": "201 response",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "203": {
+            "description": "202 response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "400": {
+            "description": "400 response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "201": {
+            "description": "200 response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/tests/withoutTwoHundredButDefault": {
+      "get": {
+        "summary": "Operation with several unordered 2XX results and one default",
+        "description": "",
+        "operationId": "withoutTwoHundredButDefault",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "default": {
+            "description": "default response",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "100": {
+            "description": "100 response",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "301": {
+            "description": "301 response",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    },
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
+      "flow": "implicit",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    }
+  },
+  "definitions": {
+    "CustomModel": {
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string",
+          "example": "doggie"
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-codegen/src/test/scala/CodegenTest.scala
+++ b/modules/swagger-codegen/src/test/scala/CodegenTest.scala
@@ -94,4 +94,31 @@ class CodegenTest extends FlatSpec with Matchers {
     statusParam.required should equal (false)    
     statusParam.hasMore should be (null)    
   }
+
+  it should "select main response from a 2.0 spec using the lowest 2XX code" in {
+    val model = new SwaggerParser()
+      .read("src/test/resources/2_0/responseSelectionTest.json")
+
+    val codegen = new DefaultCodegen()
+
+    val path = "/tests/withTwoHundredAndDefault"
+    val p = model.getPaths().get(path).getGet()
+    val op = codegen.fromOperation(path, "get", p)
+    op.returnType should be("String")
+
+  }
+
+  it should "select main response from a 2.0 spec using the default keyword when no 2XX code" in {
+    val model = new SwaggerParser()
+      .read("src/test/resources/2_0/responseSelectionTest.json")
+
+    val codegen = new DefaultCodegen()
+
+    val path = "/tests/withoutTwoHundredButDefault"
+    val p = model.getPaths().get(path).getGet()
+    val op = codegen.fromOperation(path, "get", p)
+    op.returnType should be("String")
+
+  }
+
 }


### PR DESCRIPTION
Hi,

In my clients, I want to be able to handle every response, not only the 200 (or default) one.
If order to achieve this, some more informations are required in CodegenResponse, ie dataType of each of them.

This pull request add the kind of type information (dataType, isPrimitive, map/list, ...) you find on an operation inside CodegenResponse.

In the same time, the fromOperation method has been refactored, in order to:
- add the default response to the CodegenOperation.responses list
- remove unnecessary loops and Map.get operations
- reduce code size and factorization of return type discovery

Tests have been added in CodegenTest, using new json files, in order to test default return type selection.