### PR TITLE
Fixed bug that prevented Objective-C code from compiling when using a Sw...

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -528,16 +528,20 @@ public class DefaultCodegen {
         property.isPrimitiveType = true;
     }
     else {
-      property.isNotContainer = true;
-      if(languageSpecificPrimitives().contains(type))
-        property.isPrimitiveType = true;
-      else
-        property.complexType = property.baseType;
+        setNonArrayMapProperty(property, type);
     }
     return property;
   }
 
-  public CodegenOperation fromOperation(String path, String httpMethod, Operation operation){
+    protected void setNonArrayMapProperty(CodegenProperty property, String type) {
+        property.isNotContainer = true;
+        if(languageSpecificPrimitives().contains(type))
+          property.isPrimitiveType = true;
+        else
+          property.complexType = property.baseType;
+    }
+
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation){
     CodegenOperation op = CodegenModelFactory.newInstance(CodegenModelType.OPERATION);
     Set<String> imports = new HashSet<String>();
 

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/ObjcClientCodegen.java
@@ -168,7 +168,18 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     }
   }
 
-  @Override
+    @Override
+    protected void setNonArrayMapProperty(CodegenProperty property, String type) {
+        super.setNonArrayMapProperty(property, type);
+        if("NSDictionary".equals(type)) {
+            property.setter = "initWithDictionary";
+        }
+        else {
+            property.setter = "initWithValues";
+        }
+    }
+
+    @Override
   public String toModelImport(String name) {
     if("".equals(modelPackage()))
       return name;

--- a/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
@@ -39,7 +39,7 @@
         }
         {{/isContainer}}{{#isNotContainer}}
         if({{name}}_dict != nil)
-            _{{name}} = [[{{#instantiationType}}NSClassFromString(@"{{{instantiationType}}}") {{/instantiationType}}{{^instantiationType}}{{{complexType}}} {{/instantiationType}} alloc]initWithValues:{{name}}_dict];
+            _{{name}} = [[{{#instantiationType}}NSClassFromString(@"{{{instantiationType}}}") {{/instantiationType}}{{^instantiationType}}{{{complexType}}} {{/instantiationType}} alloc]{{setter}}:{{name}}_dict];
         {{/isNotContainer}}
         {{/complexType}}
         {{/vars}}{{newline}}


### PR DESCRIPTION
...agger 'map' type.

In the current code, when one uses `map` as a type in the Swagger model, the Objective-C code produced uses `initWithValues` which is not corrent since `NSDictionary` does not inherit from `SWGObject`.
The correct behavior in this case seems to be to use `initWithDictionary`.

During the creation of this fix I tried to limit the impact of the code changes as much as possible.
Therefor I have not added any new values to `CodegenProperty` (instead opted for using `setter` which is unused in the case of Objective-C), nor have I altered the code flow of the other clients in any way. 
All that I did is add a new method to `DefaultCodegen` that is only called when producing Objective-C code and only when a Swagger `map` or custom user type is used.