### PR TITLE
Allow SPNEGO security to be enforced as system level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ crossScalaVersions := Seq("2.10.4", "2.11.4", "2.11.5")
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
-  "org.json4s"                  %% "json4s-jackson"     % "3.2.10",
+  "org.json4s"                  %% "json4s-jackson"     % "3.2.5",
   "io.backchat.inflector"       %% "scala-inflector"    % "1.3.5",
   "commons-io"                   % "commons-io"         % "2.3",
   "net.iharder"                  % "base64"             % "2.3.8",

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.wordnik"
 
 name := "swagger-codegen"
 
-version := "2.0.18-SNAPSHOT"
+version := "2.0.17.spnego"
 
 crossVersion := CrossVersion.full
 
@@ -13,7 +13,7 @@ javacOptions ++= Seq("-target", "1.6", "-source", "1.6", "-Xlint:unchecked", "-X
 
 scalacOptions ++= Seq("-optimize", "-unchecked", "-deprecation", "-Xcheckinit", "-encoding", "utf8")
 
-crossScalaVersions := Seq("2.10.4", "2.11.0", "2.11.1")
+crossScalaVersions := Seq("2.10.4", "2.11.4", "2.11.5")
 
 scalaVersion := "2.10.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.wordnik"
 
 name := "swagger-codegen"
 
-version := "2.0.17.spnego"
+version := "2.0.18.spnego"
 
 crossVersion := CrossVersion.full
 

--- a/src/main/resources/scala/api.mustache
+++ b/src/main/resources/scala/api.mustache
@@ -11,8 +11,10 @@ import java.util.Date
 import scala.collection.mutable.HashMap
 
 {{#operations}}
-class {{classname}}(val basePath: String = "{{basePath}}",
-                        apiInvoker: ApiInvoker = ApiInvoker) {
+class {{classname}}(val defBasePath: String = "{{basePath}}",
+                        defApiInvoker: ApiInvoker = ApiInvoker) {
+  var basePath = defBasePath
+  var apiInvoker = defApiInvoker
 
   def addHeader(key: String, value: String) = apiInvoker.defaultHeaders += key -> value 
 

--- a/src/main/resources/scala/api.mustache
+++ b/src/main/resources/scala/api.mustache
@@ -11,10 +11,9 @@ import java.util.Date
 import scala.collection.mutable.HashMap
 
 {{#operations}}
-class {{classname}} {
-  var basePath: String = "{{basePath}}"
-  var apiInvoker = ApiInvoker
-  
+class {{classname}}(val basePath: String = "{{basePath}}",
+                        apiInvoker: ApiInvoker = ApiInvoker) {
+
   def addHeader(key: String, value: String) = apiInvoker.defaultHeaders += key -> value 
 
   {{#operation}}

--- a/src/main/resources/scala/apiInvoker.mustache
+++ b/src/main/resources/scala/apiInvoker.mustache
@@ -167,6 +167,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
     case true => {
       import org.sonatype.spice.jersey.client.ahc.config.DefaultAhcConfig
       import org.sonatype.spice.jersey.client.ahc.AhcHttpClient
+      import com.ning.http.client.Realm
 
       val config: DefaultAhcConfig = new DefaultAhcConfig()
       if (!authScheme.isEmpty) {
@@ -185,7 +186,7 @@ object ApiInvoker extends ApiInvoker(mapper = ScalaJsonUtil.getJsonMapper,
   httpHeaders = HashMap(),
   hostMap = HashMap(),
   asyncHttpClient = {{asyncHttpClient}},
-  authScheme = {{authScheme}},
+  authScheme = "{{authScheme}}",
   authPreemptive = {{authPreemptive}})
 
 class ApiException(val code: Int, msg: String) extends RuntimeException(msg)

--- a/src/main/resources/scala/apiInvoker.mustache
+++ b/src/main/resources/scala/apiInvoker.mustache
@@ -41,6 +41,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
                  asyncHttpClient: Boolean = false,
                  authScheme: String = "",
                  authPreemptive: Boolean = false) {
+  val SystemEnforcedAuthSchemeProperty = "apiInvokerAuthScheme"
 
   var defaultHeaders: HashMap[String, String] = httpHeaders
 
@@ -170,11 +171,14 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
       import com.ning.http.client.Realm
 
       val config: DefaultAhcConfig = new DefaultAhcConfig()
-      if (!authScheme.isEmpty) {
-        val authSchemeEnum = Realm.AuthScheme.valueOf(authScheme)
+      val enforcedAuthScheme = System.getProperty(SystemEnforcedAuthSchemeProperty)
+      val scheme = if(enforcedAuthScheme == null) authScheme else enforcedAuthScheme
+      val preemptive = if(enforcedAuthScheme == null) authPreemptive else true
+      if (!scheme.isEmpty) {
+        val authSchemeEnum = Realm.AuthScheme.valueOf(scheme)
         config.getAsyncHttpClientConfigBuilder
           .setRealm(new Realm.RealmBuilder().setScheme(authSchemeEnum)
-          .setUsePreemptiveAuth(authPreemptive).build)
+          .setUsePreemptiveAuth(preemptive).build)
       }
       AhcHttpClient.create(config)
     }

--- a/src/main/resources/scala/apiInvoker.mustache
+++ b/src/main/resources/scala/apiInvoker.mustache
@@ -38,7 +38,9 @@ object ScalaJsonUtil {
 class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
                  httpHeaders: HashMap[String, String] = HashMap(),
                  hostMap: HashMap[String, Client] = HashMap(),
-                 asyncHttpClient: Boolean = false) {
+                 asyncHttpClient: Boolean = false,
+                 authScheme: String = "",
+                 authPreemptive: Boolean = false) {
 
   var defaultHeaders: HashMap[String, String] = httpHeaders
 
@@ -167,6 +169,12 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
       import org.sonatype.spice.jersey.client.ahc.AhcHttpClient
 
       val config: DefaultAhcConfig = new DefaultAhcConfig()
+      if (!authScheme.isEmpty) {
+        val authSchemeEnum = Realm.AuthScheme.valueOf(authScheme)
+        config.getAsyncHttpClientConfigBuilder
+          .setRealm(new Realm.RealmBuilder().setScheme(authSchemeEnum)
+          .setUsePreemptiveAuth(authPreemptive).build)
+      }
       AhcHttpClient.create(config)
     }
     case _ => Client.create()
@@ -176,7 +184,9 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
 object ApiInvoker extends ApiInvoker(mapper = ScalaJsonUtil.getJsonMapper,
   httpHeaders = HashMap(),
   hostMap = HashMap(),
-  asyncHttpClient = {{asyncHttpClient}})
+  asyncHttpClient = {{asyncHttpClient}},
+  authScheme = {{authScheme}},
+  authPreemptive = {{authPreemptive}})
 
 class ApiException(val code: Int, msg: String) extends RuntimeException(msg)
 

--- a/src/main/scala/com/wordnik/swagger/codegen/BasicScalaGenerator.scala
+++ b/src/main/scala/com/wordnik/swagger/codegen/BasicScalaGenerator.scala
@@ -23,6 +23,10 @@ object BasicScalaGenerator extends BasicScalaGenerator {
 }
 
 class BasicScalaGenerator extends BasicGenerator {
+  def authScheme: String = ""
+  def authPreemptive: Boolean = false
+  def asyncHttpClient: Boolean = !authScheme.isEmpty
+  
   override def defaultIncludes = Set(
     "Int",
     "String",
@@ -213,7 +217,9 @@ class BasicScalaGenerator extends BasicGenerator {
     "artifactId" -> "scala-client", 
     "artifactVersion" -> "1.0.0",
     "groupId" -> "com.wordnik",
-    "asyncHttpClient" -> "false")
+    "asyncHttpClient" -> asyncHttpClient.toString,
+    "authScheme" -> authScheme,
+    "authPreemptive" -> authPreemptive.toString)
 
   // supporting classes
   override def supportingFiles = List(


### PR DESCRIPTION
By introducing the Java system property -DapiInvokerAuthScheme=SPNEGO
    it is now possible to make sure that security is enforced regardless
    of the client settings provided by the client.
    
    This is sometimes needed as the Security Officer requires policies to
    be enforced regardless of what the client code is actually going to
    provide as parameters.
