### PR TITLE
Expose Security schemes of operations.

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenConfig.java
@@ -1,6 +1,7 @@
 package com.wordnik.swagger.codegen;
 
 import com.wordnik.swagger.models.*;
+import com.wordnik.swagger.models.auth.SecuritySchemeDefinition;
 import com.wordnik.swagger.models.properties.*;
 
 import java.util.*;
@@ -35,6 +36,8 @@ public interface CodegenConfig {
 
   CodegenModel fromModel(String name, Model model);
   CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation);
+  List<CodegenSecurity> fromSecurity(Map<String, SecuritySchemeDefinition> schemes);
+
   Set<String> defaultIncludes();
   Map<String, String> typeMapping();
   Map<String, String> instantiationTypes();

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenModelType.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenModelType.java
@@ -6,7 +6,8 @@ public enum CodegenModelType {
   OPERATION(CodegenOperation.class),
   PARAMETER(CodegenParameter.class),
   PROPERTY(CodegenProperty.class),
-  RESPONSE(CodegenResponse.class);
+  RESPONSE(CodegenResponse.class),
+  SECURITY(CodegenSecurity.class);
 
   private final Class<?> defaultImplementation;
 

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenOperation.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenOperation.java
@@ -18,6 +18,7 @@ public class CodegenOperation {
   public List<CodegenParameter> queryParams = new ArrayList<CodegenParameter>();
   public List<CodegenParameter> headerParams = new ArrayList<CodegenParameter>();
   public List<CodegenParameter> formParams = new ArrayList<CodegenParameter>();
+  public List<CodegenSecurity> authMethods;
   public List<String> tags;
   public List<CodegenResponse> responses = new ArrayList<CodegenResponse>();
   public final List<CodegenProperty> responseHeaders = new ArrayList<CodegenProperty>();

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenSecurity.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenSecurity.java
@@ -1,0 +1,7 @@
+package com.wordnik.swagger.codegen;
+
+public class CodegenSecurity {
+  String name;
+  String type;
+  Boolean hasMore;
+}

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -1,6 +1,7 @@
 package com.wordnik.swagger.codegen;
 
 import com.wordnik.swagger.models.*;
+import com.wordnik.swagger.models.auth.SecuritySchemeDefinition;
 import com.wordnik.swagger.models.parameters.*;
 import com.wordnik.swagger.models.properties.*;
 import com.wordnik.swagger.util.Json;
@@ -878,6 +879,23 @@ public class DefaultCodegen {
       p.paramName = toParamName(bp.getName());
     }
     return p;
+  }
+
+  public List<CodegenSecurity> fromSecurity(Map<String, SecuritySchemeDefinition> schemes) {
+    if(schemes == null)
+      return null;
+
+    List<CodegenSecurity> secs = new ArrayList<CodegenSecurity>();
+    for(Iterator entries = schemes.entrySet().iterator(); entries.hasNext(); ) {
+      Map.Entry<String, SecuritySchemeDefinition> entry = (Map.Entry<String, SecuritySchemeDefinition>) entries.next();
+
+      CodegenSecurity sec = CodegenModelFactory.newInstance(CodegenModelType.SECURITY);
+      sec.name = entry.getKey();
+      sec.type = entry.getValue().getType();
+      sec.hasMore = entries.hasNext();
+      secs.add(sec);
+    }
+    return secs;
   }
 
   protected List<Map<String, String>> toExamples(Map<String, String> examples) {


### PR DESCRIPTION
A template can now refer to the type ( oath2.0, apiKey, basic )
as well as the name of the security schemes it rquires.

Usage :

{{#operations}}
{{#authMethods}}
{{type}}  {{name}}
{{/authMethods}}
{{/operations}}