### PR TITLE
Fix {{basePath}} value in support files.

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultGenerator.java
@@ -150,7 +150,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
       Map<String, Object> apis = new HashMap<String, Object>();
       apis.put("apis", allOperations);
       if(swagger.getBasePath() != null) {
-        bundle.put("basePath", swagger.getBasePath());
+        bundle.put("basePath", basePath);
       }
       bundle.put("apiInfo", apis);
       bundle.put("models", allModels);


### PR DESCRIPTION
Make {{basePath}} value in support files be the
same as in operation files, aka host/path, instead of /path.