### PR TITLE
use baseName for parameter name in PHP api

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -50,20 +50,20 @@ class {{classname}} {
 
       {{#queryParams}}// query params
       if(${{paramName}} !== null) {
-  		  $queryParams['{{paramName}}'] = $this->apiClient->toQueryValue(${{paramName}});
+  		  $queryParams['{{baseName}}'] = $this->apiClient->toQueryValue(${{paramName}});
   		}{{/queryParams}}
       {{#headerParams}}// header params
       if(${{paramName}} !== null) {
-  		 	$headerParams['{{paramName}}'] = $this->apiClient->toHeaderValue(${{paramName}});
+  		 	$headerParams['{{baseName}}'] = $this->apiClient->toHeaderValue(${{paramName}});
   		}{{/headerParams}}
       {{#pathParams}}// path params
       if(${{paramName}} !== null) {
-  			$resourcePath = str_replace("{" . "{{paramName}}" . "}",
+  			$resourcePath = str_replace("{" . "{{baseName}}" . "}",
   			                            $this->apiClient->toPathValue(${{paramName}}), $resourcePath);
   		}{{/pathParams}}
       {{#formParams}}
       if (${{paramName}} !== null) {
-        $formParams[{{paramName}}] = {{#isFile}}'@' . {{/isFile}}${{paramName}};
+        $formParams[{{baseName}}] = {{#isFile}}'@' . {{/isFile}}${{paramName}};
       }{{/formParams}}
       {{#bodyParams}}// body params
       $body = null;


### PR DESCRIPTION
use baseName for parameters (query, header, form) in PHP api method/function (other clients like Java also use baseName instead of paramName for query, header and form parameters in api method/function )