### PR TITLE
Python: fixing an issue in swagger python code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can build a client against the swagger sample [petstore](http://petstore.swa
 This will run the generator with this command:
 
 ```
-java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.0-M1.jar \
+java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.2-M1.jar \
   -i http://petstore.swagger.io/v2/swagger.json \
   -l java \
   -o samples/client/petstore/java
@@ -189,7 +189,7 @@ You can also use the codegen to generate a server for a couple different framewo
 
 ### node.js
 ```
-java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.0-M1.jar \
+java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.2-M1.jar \
   -i http://petstore.swagger.io/v2/swagger.json \
   -l nodejs \
   -o samples/server/petstore/nodejs
@@ -201,7 +201,7 @@ java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distributi
 
 ### scala scalatra
 ```
-java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.0-M1.jar \
+java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.2-M1.jar \
   -i http://petstore.swagger.io/v2/swagger.json \
   -l scalatra \
   -o samples/server/petstore/scalatra
@@ -210,7 +210,7 @@ java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distributi
 ### java jax-rs
 
 ```
-java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.0-M1.jar \
+java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.2-M1.jar \
   -i http://petstore.swagger.io/v2/swagger.json \
   -l jaxrs \
   -o samples/server/petstore/jaxrs

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ public class MyObjcCodegen extends ObjcClientCodegen {
 and specify the `classname` when running the generator:
 
 ```
--i com.mycompany.swagger.codegen.MyObjcCodegen
+-l com.mycompany.swagger.codegen.MyObjcCodegen
 ```
 
 Your subclass will now be loaded and overrides the `PREFIX` value in the superclass.

--- a/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
@@ -106,12 +106,12 @@ public class ApiInvoker {
 
     Builder builder = client.resource(host + path + querystring).accept("application/json");
     for(String key : headerParams.keySet()) {
-      builder.header(key, headerParams.get(key));
+      builder = builder.header(key, headerParams.get(key));
     }
 
     for(String key : defaultHeaderMap.keySet()) {
       if(!headerParams.containsKey(key)) {
-        builder.header(key, defaultHeaderMap.get(key));
+        builder = builder.header(key, defaultHeaderMap.get(key));
       }
     }
     ClientResponse response = null;

--- a/modules/swagger-codegen/src/main/resources/python/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/swagger.mustache
@@ -226,7 +226,7 @@ class ApiClient:
                 subValues.append(self.deserialize(subValue, subClass))
             setattr(instance, attr, subValues)
           else:
-            setattr(instance, attr, self.deserialize(value, objClass))
+            setattr(instance, attr, self.deserialize(value, attrType))
 
     return instance
 


### PR DESCRIPTION
Attribute classes weren't being respected and now they are.