### PR TITLE
Bug fixes for Swagger.php deserialize function

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
@@ -223,13 +223,14 @@ class APIClient {
       $inner = substr($class, 4, -1);
       $values = array();
       if(strrpos($inner, ",") !== false) {
-        $subClass = explode(',', $inner, 2)[1];
+        $subClass_array = explode(',', $inner, 2);
+        $subClass = $subClass_array[1];
         foreach ($data as $key => $value) {
           $values[] = array($key => self::deserialize($value, $subClass));
         }        
       }
       $deserialized = $values;
-    } elseif (substr($class, 0, 6) == 'array[') {
+    } elseif (strcasecmp(substr($class, 0, 6),'array[') == 0) {
       $subClass = substr($class, 6, -1);
       $values = array();
       foreach ($data as $key => $value) {

--- a/samples/client/petstore/php/Swagger.php
+++ b/samples/client/petstore/php/Swagger.php
@@ -107,6 +107,9 @@ class APIClient {
     if ($method == self::$POST) {
       curl_setopt($curl, CURLOPT_POST, true);
       curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
+    } else if ($method == self::$PATCH) {
+      curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PATCH");
+      curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
     } else if ($method == self::$PUT) {
       curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
       curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
@@ -220,13 +223,14 @@ class APIClient {
       $inner = substr($class, 4, -1);
       $values = array();
       if(strrpos($inner, ",") !== false) {
-        $subClass = explode(',', $inner, 2)[1];
+        $subClass_array = explode(',', $inner, 2);
+        $subClass = $subClass_array[1];
         foreach ($data as $key => $value) {
           $values[] = array($key => self::deserialize($value, $subClass));
         }        
       }
       $deserialized = $values;
-    } elseif (substr($class, 0, 6) == 'array[') {
+    } elseif (strcasecmp(substr($class, 0, 6),'array[') == 0) {
       $subClass = substr($class, 6, -1);
       $values = array();
       foreach ($data as $key => $value) {


### PR DESCRIPTION
1) syntax error `PHP Parse error:  syntax error, unexpected '[' in Swagger.php on line 223` due to the following:
`$subClass = explode(',', $inner, 2)[1];`

not sure if it's due to me not using the latest version of php, I workaround the issue by moving the [1] to the next line with a temporary variable so that php5.3 can compile it without syntax error

2) updated array comparison to case insensitive so that it works for both array of primitive type and array of model

3) updated PHP sample