### PR TITLE
PHP Bindings: exposing response and response info in Exceptions

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
@@ -127,19 +127,19 @@ class APIClient {
 
     // Handle the response
     if ($response_info['http_code'] == 0) {
-      throw new Exception("TIMEOUT: api call to " . $url .
-        " took more than 5s to return" );
+      throw new APIClientException("TIMEOUT: api call to " . $url .
+        " took more than 5s to return", 0, $response_info, $response);
     } else if ($response_info['http_code'] == 200) {
       $data = json_decode($response);
     } else if ($response_info['http_code'] == 401) {
-      throw new Exception("Unauthorized API request to " . $url .
-          ": ".json_decode($response)->message );
+      throw new APIClientException("Unauthorized API request to " . $url .
+          ": " . json_decode($response)->message, 0, $response_info, $response);
     } else if ($response_info['http_code'] == 404) {
       $data = null;
     } else {
-      throw new Exception("Can't connect to the api: " . $url .
+      throw new APIClientException("Can't connect to the api: " . $url .
         " response code: " .
-        $response_info['http_code']);
+        $response_info['http_code'], 0, $response_info, $response);
     }
     return $data;
   }
@@ -256,3 +256,20 @@ class APIClient {
 
 }
 
+class APIClientException extends Exception {
+  protected $response, $response_info;
+
+  public class __construct($message="", $code=0, $response_info=null, $response=null) {
+    parent::__construct($message, $code);
+    $this->response_info = $response_info;
+    $this->response = $response;
+  }
+
+  public function getResponse() {
+    return $this->response;
+  }
+
+  public function getResponseInfo() {
+    return $this->response_info;
+  }
+}


### PR DESCRIPTION
Adding a new exception so that the curl response and response info will be accessible to the main process in case additional information about the error is passed either through the response or response headers.