### PR TITLE
Fixing bug in new APIClientException

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
@@ -259,7 +259,7 @@ class APIClient {
 class APIClientException extends Exception {
   protected $response, $response_info;
 
-  public class __construct($message="", $code=0, $response_info=null, $response=null) {
+  public function __construct($message="", $code=0, $response_info=null, $response=null) {
     parent::__construct($message, $code);
     $this->response_info = $response_info;
     $this->response = $response;


### PR DESCRIPTION
This new exception had a typo in it for the construct class declaration.