### PR TITLE
PHP Generated Models

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -37,7 +37,8 @@ class {{classname}} implements ArrayAccess {
   public ${{name}}; /* {{{datatype}}} */{{/vars}}
 
   public function __construct(array $data) {
-    {{#vars}}$this->{{name}} = $data["{{name}}"]{{/vars}}
+    {{#vars}}$this->{{name}} = $data["{{name}}"];{{#hasMore}},
+    {{/hasMore}}{{/vars}}
   }
 
   public function offsetExists($offset) {

--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -24,7 +24,7 @@
 {{#models}}
 {{#model}}
 
-class {{classname}} {
+class {{classname}} implements ArrayAccess {
   static $swaggerTypes = array(
       {{#vars}}'{{name}}' => '{{{datatype}}}'{{#hasMore}},
       {{/hasMore}}{{/vars}}
@@ -35,6 +35,26 @@ class {{classname}} {
   * {{{description}}}
   */{{/description}}
   public ${{name}}; /* {{{datatype}}} */{{/vars}}
+
+  public function __construct(array $data) {
+    {{#vars}}$this->{{name}} = $data["{{name}}"]{{/vars}}
+  }
+
+  public function offsetExists($offset) {
+    return isset($this->$offset);
+  }
+
+  public function offsetGet($offset) {
+    return $this->$offset;
+  }
+
+  public function offsetSet($offset, $value) {
+    $this->$offset = $value;
+  }
+
+  public function offsetUnset($offset) {
+    unset($this->$offset);
+  }
 }
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -37,7 +37,7 @@ class {{classname}} implements ArrayAccess {
   public ${{name}}; /* {{{datatype}}} */{{/vars}}
 
   public function __construct(array $data) {
-    {{#vars}}$this->{{name}} = $data["{{name}}"];{{#hasMore}},
+    {{#vars}}$this->{{name}} = $data["{{name}}"];{{#hasMore}}
     {{/hasMore}}{{/vars}}
   }
 


### PR DESCRIPTION
Adding in the ability to access and generate models as/from arrays.  This makes it easier to generate response and requests models for testing binding usage as well as creating request models in subsequent code.