### PR TITLE
Adding defintion of security schemes in CodegenSecurity

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenSecurity.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenSecurity.java
@@ -3,5 +3,9 @@ package com.wordnik.swagger.codegen;
 public class CodegenSecurity {
   String name;
   String type;
-  Boolean hasMore;
+  Boolean hasMore, isBasic, isOAuth, isApiKey;
+  // ApiKey specific
+  String keyParamName;
+  Boolean isKeyInQuery, isKeyInHeader;
+
 }

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -1,6 +1,9 @@
 package com.wordnik.swagger.codegen;
 
 import com.wordnik.swagger.models.*;
+import com.wordnik.swagger.models.auth.ApiKeyAuthDefinition;
+import com.wordnik.swagger.models.auth.BasicAuthDefinition;
+import com.wordnik.swagger.models.auth.In;
 import com.wordnik.swagger.models.auth.SecuritySchemeDefinition;
 import com.wordnik.swagger.models.parameters.*;
 import com.wordnik.swagger.models.properties.*;
@@ -888,10 +891,25 @@ public class DefaultCodegen {
     List<CodegenSecurity> secs = new ArrayList<CodegenSecurity>();
     for(Iterator entries = schemes.entrySet().iterator(); entries.hasNext(); ) {
       Map.Entry<String, SecuritySchemeDefinition> entry = (Map.Entry<String, SecuritySchemeDefinition>) entries.next();
+      final SecuritySchemeDefinition schemeDefinition = entry.getValue();
 
       CodegenSecurity sec = CodegenModelFactory.newInstance(CodegenModelType.SECURITY);
       sec.name = entry.getKey();
-      sec.type = entry.getValue().getType();
+      sec.type = schemeDefinition.getType();
+
+      if (schemeDefinition instanceof ApiKeyAuthDefinition) {
+        final ApiKeyAuthDefinition apiKeyDefinition = (ApiKeyAuthDefinition) schemeDefinition;
+        sec.isBasic = sec.isOAuth = false;
+        sec.isApiKey = true;
+        sec.keyParamName = apiKeyDefinition.getName();
+        sec.isKeyInHeader = apiKeyDefinition.getIn() == In.HEADER;
+        sec.isKeyInQuery = !sec.isKeyInHeader;
+      } else {
+        sec.isKeyInHeader = sec.isKeyInQuery = sec.isApiKey = false;
+        sec.isBasic = schemeDefinition instanceof BasicAuthDefinition;
+        sec.isOAuth = !sec.isBasic;
+      }
+
       sec.hasMore = entries.hasNext();
       secs.add(sec);
     }


### PR DESCRIPTION
Hi,
This PR allows one to access definitions of security schemes.
The following members are available : 
```
- isBasic
- isApiKey
- isOAuth
```

In case of ApiKey scheme, the following members can be used : 
```
- apiKeyParamName
- isKeyInQuery
- isKeyInParam
```
