### PR TITLE
update null comparison for query params in Java

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -58,7 +58,7 @@ public class {{classname}} {
     Map<String, String> headerParams = new HashMap<String, String>();
     Map<String, String> formParams = new HashMap<String, String>();
 
-    {{#queryParams}}if(!"null".equals(String.valueOf({{paramName}})))
+    {{#queryParams}}if ({{paramName}} != null)
       queryParams.put("{{baseName}}", String.valueOf({{paramName}}));
     {{/queryParams}}
     {{#headerParams}}headerParams.put("{{baseName}}", {{paramName}});


### PR DESCRIPTION
to make it clear and also allow a query parameter to be set with string value: "null" (4 characters string)