### PR TITLE
Java: properly add request headers

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
@@ -106,12 +106,12 @@ public class ApiInvoker {
 
     Builder builder = client.resource(host + path + querystring).accept("application/json");
     for(String key : headerParams.keySet()) {
-      builder.header(key, headerParams.get(key));
+      builder = builder.header(key, headerParams.get(key));
     }
 
     for(String key : defaultHeaderMap.keySet()) {
       if(!headerParams.containsKey(key)) {
-        builder.header(key, defaultHeaderMap.get(key));
+        builder = builder.header(key, defaultHeaderMap.get(key));
       }
     }
     ClientResponse response = null;


### PR DESCRIPTION
We were running into issues with our headers not making it into our requests.  Upon some research, it appears that Jersey's header() method returns the builder object, meaning we have to do this reassignment to properly construct the request.  After making the change, our requests work as expected.

https://jersey.java.net/nonav/apidocs/1.8/jersey/com/sun/jersey/api/client/PartialRequestBuilder.html#header(java.lang.String, java.lang.Object)