### PR TITLE
Java: properly add request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can build a client against the swagger sample [petstore](http://petstore.swa
 This will run the generator with this command:
 
 ```
-java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.0-M1.jar \
+java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.2-M1.jar \
   -i http://petstore.swagger.io/v2/swagger.json \
   -l java \
   -o samples/client/petstore/java
@@ -189,7 +189,7 @@ You can also use the codegen to generate a server for a couple different framewo
 
 ### node.js
 ```
-java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.0-M1.jar \
+java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.2-M1.jar \
   -i http://petstore.swagger.io/v2/swagger.json \
   -l nodejs \
   -o samples/server/petstore/nodejs
@@ -201,7 +201,7 @@ java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distributi
 
 ### scala scalatra
 ```
-java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.0-M1.jar \
+java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.2-M1.jar \
   -i http://petstore.swagger.io/v2/swagger.json \
   -l scalatra \
   -o samples/server/petstore/scalatra
@@ -210,7 +210,7 @@ java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distributi
 ### java jax-rs
 
 ```
-java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.0-M1.jar \
+java -jar modules/swagger-codegen-distribution/target/swagger-codegen-distribution-2.1.2-M1.jar \
   -i http://petstore.swagger.io/v2/swagger.json \
   -l jaxrs \
   -o samples/server/petstore/jaxrs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Swagger Specification has undergone 3 revisions since initial creation in 20
 
 Swagger Codegen Version | Release Date | Swagger Spec compatability | Notes
 ----------------------- | ------------ | -------------------------- | -----
-2.1.2-M1                | 2015-02-23   | 1.0, 1.1, 1.2, 2.0   | [tag v2.1.0-M1](https://github.com/swagger-api/swagger-codegen)
+2.1.2-M1 (master)       | 2015-02-23   | 1.0, 1.1, 1.2, 2.0   | [tag v2.1.0-M1](https://github.com/swagger-api/swagger-codegen)
 2.0.17                  | 2014-08-22   | 1.1, 1.2      | [tag v2.0.17](https://github.com/swagger-api/swagger-codegen/tree/v2.0.17)
 1.0.4                   | 2012-04-12   | 1.0, 1.1      | [tag v1.0.4](https://github.com/swagger-api/swagger-codegen/tree/swagger-codegen_2.9.1-1.1)
 

--- a/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
@@ -106,12 +106,12 @@ public class ApiInvoker {
 
     Builder builder = client.resource(host + path + querystring).accept("application/json");
     for(String key : headerParams.keySet()) {
-      builder.header(key, headerParams.get(key));
+      builder = builder.header(key, headerParams.get(key));
     }
 
     for(String key : defaultHeaderMap.keySet()) {
       if(!headerParams.containsKey(key)) {
-        builder.header(key, defaultHeaderMap.get(key));
+        builder = builder.header(key, defaultHeaderMap.get(key));
       }
     }
     ClientResponse response = null;


### PR DESCRIPTION
We were running into issues with our headers not making it into our requests. Upon some research, it appears that Jersey's header() method returns the builder object, meaning we have to do this reassignment to properly construct the request. After making the change, our requests work as expected.

https://jersey.java.net/nonav/apidocs/1.8/jersey/com/sun/jersey/api/client/PartialRequestBuilder.html#header(java.lang.String, java.lang.Object)