### PR TITLE
Bug fix for ruby header parameter and better code format

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -23,10 +23,8 @@ class {{classname}}
     
     # set default values and merge with input
     options = {
-    {{#allParams}}
-      :{{paramName}} => {{paramName}}{{#hasMore}},
-      {{/hasMore}}
-    {{/allParams}}
+      {{#allParams}}:'{{paramName}}' => {{paramName}}{{#hasMore}},{{/hasMore}}
+      {{/allParams}}
     }.merge(opts)
 
     #resource path
@@ -38,12 +36,10 @@ class {{classname}}
       query_param_keys.include? key
     end
 
-    {{#headerParams}}headers = {
-      {{{paramName}}}: {{{paramName}}},
-    }
-    {{/headerParams}}
-    {{^headerParams}}headers = nil
-    {{/headerParams}}
+    # header parameters, if any
+    headers = {}
+    {{#headerParams}}{{#optional}}headers[:'{{{baseName}}}'] = options[:'{{{paramName}}}'] if options[:'{{{paramName}}}']{{/optional}}{{/headerParams}}
+    {{#headerParams}}{{^optional}}headers[:'{{{baseName}}}'] = {{{paramName}}}{{/optional}}{{/headerParams}}
 
     # http body (model)
     post_body = nil

--- a/modules/swagger-codegen/src/main/resources/ruby/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/model.mustache
@@ -6,8 +6,7 @@ class {{classname}}
   # :internal => :external
   def self.attribute_map
     {
-      {{#vars}}
-      :{{{name}}} => :{{{baseName}}}{{#hasMore}},{{/hasMore}}
+      {{#vars}}:{{{name}}} => :'{{{baseName}}}'{{#hasMore}},{{/hasMore}}
       {{/vars}}
     }
   end
@@ -17,13 +16,9 @@ class {{classname}}
     # Morph attribute keys into undescored rubyish style
     {{#vars}}
     if self.class.attribute_map[:"{{{name}}}"]
-      {{#isContainer}}
-      if (value = attributes["{{{baseName}}}"]).is_a?(Array)
-        @{{{name}}} = value{{#complexType}}.map{ |v| {{complexType}}.new(v) }{{/complexType}}{{newline}}
-      end
-      {{/isContainer}}{{^isContainer}}
-      @{{{name}}} = attributes["{{{baseName}}}"]
-      {{/isContainer}}
+      {{#isContainer}}if (value = attributes["{{{baseName}}}"]).is_a?(Array)
+        @{{{name}}} = value{{#complexType}}.map{ |v| {{complexType}}.new(v) }{{/complexType}}
+      end{{/isContainer}}{{^isContainer}}@{{{name}}} = attributes["{{{baseName}}}"]{{/isContainer}}
     end
     {{/vars}}
   end

--- a/samples/client/petstore/ruby/lib/PetApi.rb
+++ b/samples/client/petstore/ruby/lib/PetApi.rb
@@ -16,9 +16,8 @@ class PetApi
     
     # set default values and merge with input
     options = {
-    
       :body => body
-    
+      
     }.merge(opts)
 
     #resource path
@@ -29,8 +28,9 @@ class PetApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -77,9 +77,8 @@ class PetApi
     
     # set default values and merge with input
     options = {
-    
       :body => body
-    
+      
     }.merge(opts)
 
     #resource path
@@ -90,8 +89,9 @@ class PetApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -138,9 +138,8 @@ class PetApi
     
     # set default values and merge with input
     options = {
-    
       :status => status
-    
+      
     }.merge(opts)
 
     #resource path
@@ -151,8 +150,9 @@ class PetApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -180,9 +180,8 @@ class PetApi
     
     # set default values and merge with input
     options = {
-    
       :tags => tags
-    
+      
     }.merge(opts)
 
     #resource path
@@ -193,8 +192,9 @@ class PetApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -222,9 +222,8 @@ class PetApi
     
     # set default values and merge with input
     options = {
-    
       :petId => petId
-    
+      
     }.merge(opts)
 
     #resource path
@@ -236,8 +235,9 @@ class PetApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -264,15 +264,10 @@ class PetApi
     
     # set default values and merge with input
     options = {
-    
       :petId => petId,
-      
-    
       :name => name,
-      
-    
       :status => status
-    
+      
     }.merge(opts)
 
     #resource path
@@ -284,8 +279,9 @@ class PetApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -313,12 +309,9 @@ class PetApi
     
     # set default values and merge with input
     options = {
-    
       :api_key => api_key,
-      
-    
       :petId => petId
-    
+      
     }.merge(opts)
 
     #resource path
@@ -330,11 +323,10 @@ class PetApi
       query_param_keys.include? key
     end
 
-    headers = {
-      api_key: api_key,
-    }
+    # header parameters, if any
+    headers = {}
     
-    
+    headers[:'api_key'] = api_key
 
     # http body (model)
     post_body = nil
@@ -359,15 +351,10 @@ class PetApi
     
     # set default values and merge with input
     options = {
-    
       :petId => petId,
-      
-    
       :additionalMetadata => additionalMetadata,
-      
-    
       :file => file
-    
+      
     }.merge(opts)
 
     #resource path
@@ -379,8 +366,9 @@ class PetApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)

--- a/samples/client/petstore/ruby/lib/StoreApi.rb
+++ b/samples/client/petstore/ruby/lib/StoreApi.rb
@@ -16,7 +16,7 @@ class StoreApi
     
     # set default values and merge with input
     options = {
-    
+      
     }.merge(opts)
 
     #resource path
@@ -27,8 +27,9 @@ class StoreApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -56,9 +57,8 @@ class StoreApi
     
     # set default values and merge with input
     options = {
-    
       :body => body
-    
+      
     }.merge(opts)
 
     #resource path
@@ -69,8 +69,9 @@ class StoreApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -118,9 +119,8 @@ class StoreApi
     
     # set default values and merge with input
     options = {
-    
       :orderId => orderId
-    
+      
     }.merge(opts)
 
     #resource path
@@ -132,8 +132,9 @@ class StoreApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -160,9 +161,8 @@ class StoreApi
     
     # set default values and merge with input
     options = {
-    
       :orderId => orderId
-    
+      
     }.merge(opts)
 
     #resource path
@@ -174,8 +174,9 @@ class StoreApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)

--- a/samples/client/petstore/ruby/lib/UserApi.rb
+++ b/samples/client/petstore/ruby/lib/UserApi.rb
@@ -16,9 +16,8 @@ class UserApi
     
     # set default values and merge with input
     options = {
-    
       :body => body
-    
+      
     }.merge(opts)
 
     #resource path
@@ -29,8 +28,9 @@ class UserApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -77,9 +77,8 @@ class UserApi
     
     # set default values and merge with input
     options = {
-    
       :body => body
-    
+      
     }.merge(opts)
 
     #resource path
@@ -90,8 +89,9 @@ class UserApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -138,9 +138,8 @@ class UserApi
     
     # set default values and merge with input
     options = {
-    
       :body => body
-    
+      
     }.merge(opts)
 
     #resource path
@@ -151,8 +150,9 @@ class UserApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -199,12 +199,9 @@ class UserApi
     
     # set default values and merge with input
     options = {
-    
       :username => username,
-      
-    
       :password => password
-    
+      
     }.merge(opts)
 
     #resource path
@@ -215,8 +212,9 @@ class UserApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -243,7 +241,7 @@ class UserApi
     
     # set default values and merge with input
     options = {
-    
+      
     }.merge(opts)
 
     #resource path
@@ -254,8 +252,9 @@ class UserApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -281,9 +280,8 @@ class UserApi
     
     # set default values and merge with input
     options = {
-    
       :username => username
-    
+      
     }.merge(opts)
 
     #resource path
@@ -295,8 +293,9 @@ class UserApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -323,12 +322,9 @@ class UserApi
     
     # set default values and merge with input
     options = {
-    
       :username => username,
-      
-    
       :body => body
-    
+      
     }.merge(opts)
 
     #resource path
@@ -340,8 +336,9 @@ class UserApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)
@@ -388,9 +385,8 @@ class UserApi
     
     # set default values and merge with input
     options = {
-    
       :username => username
-    
+      
     }.merge(opts)
 
     #resource path
@@ -402,8 +398,9 @@ class UserApi
       query_param_keys.include? key
     end
 
+    # header parameters, if any
+    headers = {}
     
-    headers = nil
     
 
     # http body (model)

--- a/samples/client/petstore/ruby/models/Category.rb
+++ b/samples/client/petstore/ruby/models/Category.rb
@@ -4,10 +4,8 @@ class Category
   # :internal => :external
   def self.attribute_map
     {
-      
-      :id => :id,
-      
-      :name => :name
+      :id => :'id',
+      :name => :'name'
       
     }
   end
@@ -17,15 +15,11 @@ class Category
     # Morph attribute keys into undescored rubyish style
     
     if self.class.attribute_map[:"id"]
-      
       @id = attributes["id"]
-      
     end
     
     if self.class.attribute_map[:"name"]
-      
       @name = attributes["name"]
-      
     end
     
   end

--- a/samples/client/petstore/ruby/models/Order.rb
+++ b/samples/client/petstore/ruby/models/Order.rb
@@ -4,18 +4,12 @@ class Order
   # :internal => :external
   def self.attribute_map
     {
-      
-      :id => :id,
-      
-      :petId => :petId,
-      
-      :quantity => :quantity,
-      
-      :shipDate => :shipDate,
-      
-      :status => :status,
-      
-      :complete => :complete
+      :id => :'id',
+      :petId => :'petId',
+      :quantity => :'quantity',
+      :shipDate => :'shipDate',
+      :status => :'status',
+      :complete => :'complete'
       
     }
   end
@@ -25,39 +19,27 @@ class Order
     # Morph attribute keys into undescored rubyish style
     
     if self.class.attribute_map[:"id"]
-      
       @id = attributes["id"]
-      
     end
     
     if self.class.attribute_map[:"petId"]
-      
       @petId = attributes["petId"]
-      
     end
     
     if self.class.attribute_map[:"quantity"]
-      
       @quantity = attributes["quantity"]
-      
     end
     
     if self.class.attribute_map[:"shipDate"]
-      
       @shipDate = attributes["shipDate"]
-      
     end
     
     if self.class.attribute_map[:"status"]
-      
       @status = attributes["status"]
-      
     end
     
     if self.class.attribute_map[:"complete"]
-      
       @complete = attributes["complete"]
-      
     end
     
   end

--- a/samples/client/petstore/ruby/models/Pet.rb
+++ b/samples/client/petstore/ruby/models/Pet.rb
@@ -4,18 +4,12 @@ class Pet
   # :internal => :external
   def self.attribute_map
     {
-      
-      :id => :id,
-      
-      :category => :category,
-      
-      :name => :name,
-      
-      :photoUrls => :photoUrls,
-      
-      :tags => :tags,
-      
-      :status => :status
+      :id => :'id',
+      :category => :'category',
+      :name => :'name',
+      :photoUrls => :'photoUrls',
+      :tags => :'tags',
+      :status => :'status'
       
     }
   end
@@ -25,43 +19,31 @@ class Pet
     # Morph attribute keys into undescored rubyish style
     
     if self.class.attribute_map[:"id"]
-      
       @id = attributes["id"]
-      
     end
     
     if self.class.attribute_map[:"category"]
-      
       @category = attributes["category"]
-      
     end
     
     if self.class.attribute_map[:"name"]
-      
       @name = attributes["name"]
-      
     end
     
     if self.class.attribute_map[:"photoUrls"]
-      
       if (value = attributes["photoUrls"]).is_a?(Array)
         @photoUrls = value
       end
-      
     end
     
     if self.class.attribute_map[:"tags"]
-      
       if (value = attributes["tags"]).is_a?(Array)
         @tags = value.map{ |v| Tag.new(v) }
       end
-      
     end
     
     if self.class.attribute_map[:"status"]
-      
       @status = attributes["status"]
-      
     end
     
   end

--- a/samples/client/petstore/ruby/models/Tag.rb
+++ b/samples/client/petstore/ruby/models/Tag.rb
@@ -4,10 +4,8 @@ class Tag
   # :internal => :external
   def self.attribute_map
     {
-      
-      :id => :id,
-      
-      :name => :name
+      :id => :'id',
+      :name => :'name'
       
     }
   end
@@ -17,15 +15,11 @@ class Tag
     # Morph attribute keys into undescored rubyish style
     
     if self.class.attribute_map[:"id"]
-      
       @id = attributes["id"]
-      
     end
     
     if self.class.attribute_map[:"name"]
-      
       @name = attributes["name"]
-      
     end
     
   end

--- a/samples/client/petstore/ruby/models/User.rb
+++ b/samples/client/petstore/ruby/models/User.rb
@@ -4,22 +4,14 @@ class User
   # :internal => :external
   def self.attribute_map
     {
-      
-      :id => :id,
-      
-      :username => :username,
-      
-      :firstName => :firstName,
-      
-      :lastName => :lastName,
-      
-      :email => :email,
-      
-      :password => :password,
-      
-      :phone => :phone,
-      
-      :userStatus => :userStatus
+      :id => :'id',
+      :username => :'username',
+      :firstName => :'firstName',
+      :lastName => :'lastName',
+      :email => :'email',
+      :password => :'password',
+      :phone => :'phone',
+      :userStatus => :'userStatus'
       
     }
   end
@@ -29,51 +21,35 @@ class User
     # Morph attribute keys into undescored rubyish style
     
     if self.class.attribute_map[:"id"]
-      
       @id = attributes["id"]
-      
     end
     
     if self.class.attribute_map[:"username"]
-      
       @username = attributes["username"]
-      
     end
     
     if self.class.attribute_map[:"firstName"]
-      
       @firstName = attributes["firstName"]
-      
     end
     
     if self.class.attribute_map[:"lastName"]
-      
       @lastName = attributes["lastName"]
-      
     end
     
     if self.class.attribute_map[:"email"]
-      
       @email = attributes["email"]
-      
     end
     
     if self.class.attribute_map[:"password"]
-      
       @password = attributes["password"]
-      
     end
     
     if self.class.attribute_map[:"phone"]
-      
       @phone = attributes["phone"]
-      
     end
     
     if self.class.attribute_map[:"userStatus"]
-      
       @userStatus = attributes["userStatus"]
-      
     end
     
   end


### PR DESCRIPTION
- Bug fix for Ruby header parameter: the current code will only set the *last* header parameter if there're more than one header parameter

```
    {{#headerParams}}headers = {
      {{{paramName}}}: {{{paramName}}},
    }
    {{/headerParams}}
    {{^headerParams}}headers = nil
    {{/headerParams}}
```

- remove extra line break in api.mustache and model.mustache so that the code format looks better

- put single quote in parameter name to avoid special character from causing failure in compiling the auto-generated Ruby code


