### PR TITLE
Add defined response headers in CodegenResponse. at this time, only the ...

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
@@ -6,7 +6,7 @@ public class CodegenResponse {
   public String code, message;
   public Boolean hasMore;
   public List<Map<String, String>> examples;
-  public List<CodegenProperty> headers;
+  public final List<CodegenProperty> headers = new ArrayList<CodegenProperty>();
   public String dataType, baseType, containerType;
   public Boolean simpleType;
   public Boolean primitiveType;

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
@@ -6,6 +6,7 @@ public class CodegenResponse {
   public String code, message;
   public Boolean hasMore;
   public List<Map<String, String>> examples;
+  public List<CodegenProperty> headers;
   public String dataType, baseType, containerType;
   public Boolean simpleType;
   public Boolean primitiveType;

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -765,6 +765,7 @@ public class DefaultCodegen {
     r.schema = response.getSchema();
     r.examples = toExamples(response.getExamples());
     r.jsonSchema = Json.pretty(response);
+    addHeaders(response, r.headers);
 
     if (r.schema != null) {
       Property responseProperty = response.getSchema();


### PR DESCRIPTION
Simply adds the list of the headers a reponse can contain to CodegenResponse.
Right now, CodegenOperation contains the list of the headers described by the 'defaut' response (200).