### PR TITLE
Fix User-Agent in Ruby API cleint

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/swagger/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger/configuration.mustache
@@ -3,7 +3,7 @@ module Swagger
   class Configuration
     require 'swagger/version'    
     
-    attr_accessor :format, :api_key, :username, :password, :auth_token, :scheme, :host, :base_path, :user_agent, :logger, :inject_format, :force_ending_format, :camelize_params
+    attr_accessor :format, :api_key, :username, :password, :auth_token, :scheme, :host, :base_path, :user_agent, :logger, :inject_format, :force_ending_format, :camelize_params, :user_agent
     
     # Defaults go in here..
     def initialize
@@ -11,7 +11,7 @@ module Swagger
       @scheme = 'http'
       @host = 'api.wordnik.com'
       @base_path = '/v4'
-      @user_agent = "ruby-#{Swagger::VERSION}"
+      @user_agent = "ruby-swagger-#{Swagger::VERSION}"
       @inject_format = true
       @force_ending_format = false
       @camelize_params = true

--- a/modules/swagger-codegen/src/main/resources/ruby/swagger/request.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger/request.mustache
@@ -19,7 +19,8 @@ module Swagger
       # Set default headers
       default_headers = {
         'Content-Type' => "application/#{attributes[:format].downcase}",
-        :api_key => Swagger.configuration.api_key
+        :api_key => Swagger.configuration.api_key,
+        'User-Agent' => Swagger.configuration.user_agent
       }
 
       # api_key from headers hash trumps the default, even if its value is blank

--- a/samples/client/petstore/ruby/lib/PetApi.rb
+++ b/samples/client/petstore/ruby/lib/PetApi.rb
@@ -16,7 +16,7 @@ class PetApi
     
     # set default values and merge with input
     options = {
-      :body => body
+      :'body' => body
       
     }.merge(opts)
 
@@ -77,7 +77,7 @@ class PetApi
     
     # set default values and merge with input
     options = {
-      :body => body
+      :'body' => body
       
     }.merge(opts)
 
@@ -138,7 +138,7 @@ class PetApi
     
     # set default values and merge with input
     options = {
-      :status => status
+      :'status' => status
       
     }.merge(opts)
 
@@ -180,7 +180,7 @@ class PetApi
     
     # set default values and merge with input
     options = {
-      :tags => tags
+      :'tags' => tags
       
     }.merge(opts)
 
@@ -222,7 +222,7 @@ class PetApi
     
     # set default values and merge with input
     options = {
-      :petId => petId
+      :'petId' => petId
       
     }.merge(opts)
 
@@ -264,9 +264,9 @@ class PetApi
     
     # set default values and merge with input
     options = {
-      :petId => petId,
-      :name => name,
-      :status => status
+      :'petId' => petId,
+      :'name' => name,
+      :'status' => status
       
     }.merge(opts)
 
@@ -309,8 +309,8 @@ class PetApi
     
     # set default values and merge with input
     options = {
-      :api_key => api_key,
-      :petId => petId
+      :'api_key' => api_key,
+      :'petId' => petId
       
     }.merge(opts)
 
@@ -351,9 +351,9 @@ class PetApi
     
     # set default values and merge with input
     options = {
-      :petId => petId,
-      :additionalMetadata => additionalMetadata,
-      :file => file
+      :'petId' => petId,
+      :'additionalMetadata' => additionalMetadata,
+      :'file' => file
       
     }.merge(opts)
 

--- a/samples/client/petstore/ruby/lib/StoreApi.rb
+++ b/samples/client/petstore/ruby/lib/StoreApi.rb
@@ -57,7 +57,7 @@ class StoreApi
     
     # set default values and merge with input
     options = {
-      :body => body
+      :'body' => body
       
     }.merge(opts)
 
@@ -119,7 +119,7 @@ class StoreApi
     
     # set default values and merge with input
     options = {
-      :orderId => orderId
+      :'orderId' => orderId
       
     }.merge(opts)
 
@@ -161,7 +161,7 @@ class StoreApi
     
     # set default values and merge with input
     options = {
-      :orderId => orderId
+      :'orderId' => orderId
       
     }.merge(opts)
 

--- a/samples/client/petstore/ruby/lib/UserApi.rb
+++ b/samples/client/petstore/ruby/lib/UserApi.rb
@@ -16,7 +16,7 @@ class UserApi
     
     # set default values and merge with input
     options = {
-      :body => body
+      :'body' => body
       
     }.merge(opts)
 
@@ -77,7 +77,7 @@ class UserApi
     
     # set default values and merge with input
     options = {
-      :body => body
+      :'body' => body
       
     }.merge(opts)
 
@@ -138,7 +138,7 @@ class UserApi
     
     # set default values and merge with input
     options = {
-      :body => body
+      :'body' => body
       
     }.merge(opts)
 
@@ -199,8 +199,8 @@ class UserApi
     
     # set default values and merge with input
     options = {
-      :username => username,
-      :password => password
+      :'username' => username,
+      :'password' => password
       
     }.merge(opts)
 
@@ -280,7 +280,7 @@ class UserApi
     
     # set default values and merge with input
     options = {
-      :username => username
+      :'username' => username
       
     }.merge(opts)
 
@@ -322,8 +322,8 @@ class UserApi
     
     # set default values and merge with input
     options = {
-      :username => username,
-      :body => body
+      :'username' => username,
+      :'body' => body
       
     }.merge(opts)
 
@@ -385,7 +385,7 @@ class UserApi
     
     # set default values and merge with input
     options = {
-      :username => username
+      :'username' => username
       
     }.merge(opts)
 

--- a/samples/client/petstore/ruby/lib/swagger/configuration.rb
+++ b/samples/client/petstore/ruby/lib/swagger/configuration.rb
@@ -3,7 +3,7 @@ module Swagger
   class Configuration
     require 'swagger/version'    
     
-    attr_accessor :format, :api_key, :username, :password, :auth_token, :scheme, :host, :base_path, :user_agent, :logger, :inject_format, :force_ending_format, :camelize_params
+    attr_accessor :format, :api_key, :username, :password, :auth_token, :scheme, :host, :base_path, :user_agent, :logger, :inject_format, :force_ending_format, :camelize_params, :user_agent
     
     # Defaults go in here..
     def initialize
@@ -11,7 +11,7 @@ module Swagger
       @scheme = 'http'
       @host = 'api.wordnik.com'
       @base_path = '/v4'
-      @user_agent = "ruby-#{Swagger::VERSION}"
+      @user_agent = "ruby-swagger-#{Swagger::VERSION}"
       @inject_format = true
       @force_ending_format = false
       @camelize_params = true

--- a/samples/client/petstore/ruby/lib/swagger/request.rb
+++ b/samples/client/petstore/ruby/lib/swagger/request.rb
@@ -19,7 +19,8 @@ module Swagger
       # Set default headers
       default_headers = {
         'Content-Type' => "application/#{attributes[:format].downcase}",
-        :api_key => Swagger.configuration.api_key
+        :api_key => Swagger.configuration.api_key,
+        'User-Agent' => Swagger.configuration.user_agent
       }
 
       # api_key from headers hash trumps the default, even if its value is blank


### PR DESCRIPTION
currently, the user-agent is not set in Ruby API client. this PR will

- add user_agent to attr_accessor (so that developers can customize it)
- add user-agent to the default_headers
- update user-agent to "ruby-swagger-#{Swagger::VERSION}"