### PR TITLE
Add Attribute Mapping to PHP model

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/Swagger.mustache
@@ -182,7 +182,7 @@ class APIClient {
     } else if (is_object($data)) {
       $values = array();
       foreach (array_keys($data::$swaggerTypes) as $property) {
-        $values[$property] = $this->sanitizeForSerialization($data->$property);
+        $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$property);
       }
       $sanitized = $values;
     } else {
@@ -295,7 +295,8 @@ class APIClient {
       $instance = new $class();
       foreach ($instance::$swaggerTypes as $property => $type) {
         if (isset($data->$property)) {
-          $instance->$property = self::deserialize($data->$property, $type);
+          $original_property_name = $instance::$attributeMap[$property];
+          $instance->$property = self::deserialize($data->$original_property_name, $type);
         }
       }
       $deserialized = $instance;

--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -28,7 +28,12 @@ class {{classname}} implements ArrayAccess {
   static $swaggerTypes = array(
       {{#vars}}'{{name}}' => '{{{datatype}}}'{{#hasMore}},
       {{/hasMore}}{{/vars}}
-    );
+  );
+
+  static $attributeMap = array(
+      {{#vars}}'{{name}}' => '{{baseName}}'{{#hasMore}},
+      {{/hasMore}}{{/vars}}
+  );
 
   {{#vars}}{{#description}}
   /**

--- a/samples/client/petstore/php/Swagger.php
+++ b/samples/client/petstore/php/Swagger.php
@@ -182,7 +182,7 @@ class APIClient {
     } else if (is_object($data)) {
       $values = array();
       foreach (array_keys($data::$swaggerTypes) as $property) {
-        $values[$property] = $this->sanitizeForSerialization($data->$property);
+        $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$property);
       }
       $sanitized = $values;
     } else {
@@ -295,7 +295,8 @@ class APIClient {
       $instance = new $class();
       foreach ($instance::$swaggerTypes as $property => $type) {
         if (isset($data->$property)) {
-          $instance->$property = self::deserialize($data->$property, $type);
+          $original_property_name = $instance::$attributeMap[$property];
+          $instance->$property = self::deserialize($data->$original_property_name, $type);
         }
       }
       $deserialized = $instance;

--- a/samples/client/petstore/php/models/Category.php
+++ b/samples/client/petstore/php/models/Category.php
@@ -26,7 +26,12 @@ class Category implements ArrayAccess {
   static $swaggerTypes = array(
       'id' => 'int',
       'name' => 'string'
-    );
+  );
+
+  static $attributeMap = array(
+      'id' => 'id',
+      'name' => 'name'
+  );
 
   
   public $id; /* int */

--- a/samples/client/petstore/php/models/Order.php
+++ b/samples/client/petstore/php/models/Order.php
@@ -30,7 +30,16 @@ class Order implements ArrayAccess {
       'shipDate' => 'DateTime',
       'status' => 'string',
       'complete' => 'boolean'
-    );
+  );
+
+  static $attributeMap = array(
+      'id' => 'id',
+      'petId' => 'petId',
+      'quantity' => 'quantity',
+      'shipDate' => 'shipDate',
+      'status' => 'status',
+      'complete' => 'complete'
+  );
 
   
   public $id; /* int */

--- a/samples/client/petstore/php/models/Pet.php
+++ b/samples/client/petstore/php/models/Pet.php
@@ -30,7 +30,16 @@ class Pet implements ArrayAccess {
       'photoUrls' => 'array[string]',
       'tags' => 'array[Tag]',
       'status' => 'string'
-    );
+  );
+
+  static $attributeMap = array(
+      'id' => 'id',
+      'category' => 'category',
+      'name' => 'name',
+      'photoUrls' => 'photoUrls',
+      'tags' => 'tags',
+      'status' => 'status'
+  );
 
   
   public $id; /* int */

--- a/samples/client/petstore/php/models/Tag.php
+++ b/samples/client/petstore/php/models/Tag.php
@@ -26,7 +26,12 @@ class Tag implements ArrayAccess {
   static $swaggerTypes = array(
       'id' => 'int',
       'name' => 'string'
-    );
+  );
+
+  static $attributeMap = array(
+      'id' => 'id',
+      'name' => 'name'
+  );
 
   
   public $id; /* int */

--- a/samples/client/petstore/php/models/User.php
+++ b/samples/client/petstore/php/models/User.php
@@ -32,7 +32,18 @@ class User implements ArrayAccess {
       'password' => 'string',
       'phone' => 'string',
       'userStatus' => 'int'
-    );
+  );
+
+  static $attributeMap = array(
+      'id' => 'id',
+      'username' => 'username',
+      'firstName' => 'firstName',
+      'lastName' => 'lastName',
+      'email' => 'email',
+      'password' => 'password',
+      'phone' => 'phone',
+      'userStatus' => 'userStatus'
+  );
 
   
   public $id; /* int */


### PR DESCRIPTION
Add attribute mapping to PHP model to handle property key with special characters (e.g. -).

Ruby API client already has an attribute map and the PHP's attribute map is implemented with referenced to the Ruby implementation.