### PR TITLE
PHP better naming convention

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -38,7 +38,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     reservedWords = new HashSet<String> (
       Arrays.asList(
-        "int")
+        "__halt_compiler", "abstract", "and", "array", "as", "break", "callable", "case", "catch", "class", "clone", "const", "continue", "declare", "default", "die", "do", "echo", "else", "elseif", "empty", "enddeclare", "endfor", "endforeach", "endif", "endswitch", "endwhile", "eval", "exit", "extends", "final", "for", "foreach", "function", "global", "goto", "if", "implements", "include", "include_once", "instanceof", "insteadof", "interface", "isset", "list", "namespace", "new", "or", "print", "private", "protected", "public", "require", "require_once", "return", "static", "switch", "throw", "trait", "try", "unset", "use", "var", "while", "xor")
     );
 
     additionalProperties.put("invokerPackage", invokerPackage);
@@ -66,7 +66,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
   public String escapeReservedWord(String name) {
     return "_" + name;
   }
-
+  
   @Override
   public String apiFileFolder() {
     return outputFolder + "/" + apiPackage().replace('.', File.separatorChar);
@@ -111,4 +111,42 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
   public String toDefaultValue(Property p) {
     return "null";
   }
+
+
+  @Override
+  public String toVarName(String name) {
+    // parameter name starting with number won't compile
+    // need to escape it by appending _ at the beginning
+    if (name.matches("^[0-9]")) {
+      name = "_" + name;
+    }
+    
+    // return the name in underscore style
+    // PhoneNumber => phone_number
+    return underscore(name);
+  }
+
+  @Override
+  public String toParamName(String name) {
+    // should be the same as variable name
+    return toVarName(name);
+  }
+
+  @Override
+  public String toModelName(String name) {
+    // model name cannot use reserved keyword
+    if(reservedWords.contains(name))
+      escapeReservedWord(name); // e.g. return => _return
+
+    // camelize the model name
+    // phone_number => PhoneNumber
+    return camelize(name);
+  }
+
+  @Override
+  public String toModelFilename(String name) {
+    // should be the same as the model name
+    return toModelName(name);
+  }
+
 }

--- a/modules/swagger-codegen/src/test/scala/php/PhpModelTest.scala
+++ b/modules/swagger-codegen/src/test/scala/php/PhpModelTest.scala
@@ -58,7 +58,7 @@ class PhpModelTest extends FlatSpec with Matchers {
     vars.get(2).baseName should be ("createdAt")
     vars.get(2).complexType should be (null)
     vars.get(2).datatype should be ("DateTime")
-    vars.get(2).name should be ("createdAt")
+    vars.get(2).name should be ("created_at")
     vars.get(2).defaultValue should be ("null")
     vars.get(2).baseType should be ("DateTime")
     vars.get(2).hasMore should equal (null)

--- a/samples/client/petstore/php/PetApi.php
+++ b/samples/client/petstore/php/PetApi.php
@@ -224,12 +224,12 @@ class PetApi {
 	 * getPetById
    *
 	 * Find pet by ID
-   * petId, int: ID of pet that needs to be fetched (required)
+   * pet_id, int: ID of pet that needs to be fetched (required)
    * 
 	 * @return Pet
 	 */
 
-   public function getPetById($petId) {
+   public function getPetById($pet_id) {
 
   		// parse inputs
   		$resourcePath = "/pet/{petId}";
@@ -244,9 +244,9 @@ class PetApi {
       
       
       // path params
-      if($petId !== null) {
+      if($pet_id !== null) {
   			$resourcePath = str_replace("{" . "petId" . "}",
-  			                            $this->apiClient->toPathValue($petId), $resourcePath);
+  			                            $this->apiClient->toPathValue($pet_id), $resourcePath);
   		}
       
       
@@ -276,14 +276,14 @@ class PetApi {
 	 * updatePetWithForm
    *
 	 * Updates a pet in the store with form data
-   * petId, string: ID of pet that needs to be updated (required)
+   * pet_id, string: ID of pet that needs to be updated (required)
    * * name, string: Updated name of the pet (required)
    * * status, string: Updated status of the pet (required)
    * 
 	 * @return 
 	 */
 
-   public function updatePetWithForm($petId, $name, $status) {
+   public function updatePetWithForm($pet_id, $name, $status) {
 
   		// parse inputs
   		$resourcePath = "/pet/{petId}";
@@ -298,9 +298,9 @@ class PetApi {
       
       
       // path params
-      if($petId !== null) {
+      if($pet_id !== null) {
   			$resourcePath = str_replace("{" . "petId" . "}",
-  			                            $this->apiClient->toPathValue($petId), $resourcePath);
+  			                            $this->apiClient->toPathValue($pet_id), $resourcePath);
   		}
       // form params
       if ($name !== null) {
@@ -331,12 +331,12 @@ class PetApi {
    *
 	 * Deletes a pet
    * api_key, string:  (required)
-   * * petId, int: Pet id to delete (required)
+   * * pet_id, int: Pet id to delete (required)
    * 
 	 * @return 
 	 */
 
-   public function deletePet($api_key, $petId) {
+   public function deletePet($api_key, $pet_id) {
 
   		// parse inputs
   		$resourcePath = "/pet/{petId}";
@@ -354,9 +354,9 @@ class PetApi {
   		 	$headerParams['api_key'] = $this->apiClient->toHeaderValue($api_key);
   		}
       // path params
-      if($petId !== null) {
+      if($pet_id !== null) {
   			$resourcePath = str_replace("{" . "petId" . "}",
-  			                            $this->apiClient->toPathValue($petId), $resourcePath);
+  			                            $this->apiClient->toPathValue($pet_id), $resourcePath);
   		}
       
       
@@ -380,14 +380,14 @@ class PetApi {
 	 * uploadFile
    *
 	 * uploads an image
-   * petId, int: ID of pet to update (required)
-   * * additionalMetadata, string: Additional data to pass to server (required)
+   * pet_id, int: ID of pet to update (required)
+   * * additional_metadata, string: Additional data to pass to server (required)
    * * file, file: file to upload (required)
    * 
 	 * @return 
 	 */
 
-   public function uploadFile($petId, $additionalMetadata, $file) {
+   public function uploadFile($pet_id, $additional_metadata, $file) {
 
   		// parse inputs
   		$resourcePath = "/pet/{petId}/uploadImage";
@@ -402,13 +402,13 @@ class PetApi {
       
       
       // path params
-      if($petId !== null) {
+      if($pet_id !== null) {
   			$resourcePath = str_replace("{" . "petId" . "}",
-  			                            $this->apiClient->toPathValue($petId), $resourcePath);
+  			                            $this->apiClient->toPathValue($pet_id), $resourcePath);
   		}
       // form params
-      if ($additionalMetadata !== null) {
-        $formParams['additionalMetadata'] = $this->apiClient->toFormValue($additionalMetadata);
+      if ($additional_metadata !== null) {
+        $formParams['additionalMetadata'] = $this->apiClient->toFormValue($additional_metadata);
       }// form params
       if ($file !== null) {
         $formParams['file'] = '@' . $this->apiClient->toFormValue($file);

--- a/samples/client/petstore/php/StoreApi.php
+++ b/samples/client/petstore/php/StoreApi.php
@@ -129,12 +129,12 @@ class StoreApi {
 	 * getOrderById
    *
 	 * Find purchase order by ID
-   * orderId, string: ID of pet that needs to be fetched (required)
+   * order_id, string: ID of pet that needs to be fetched (required)
    * 
 	 * @return Order
 	 */
 
-   public function getOrderById($orderId) {
+   public function getOrderById($order_id) {
 
   		// parse inputs
   		$resourcePath = "/store/order/{orderId}";
@@ -149,9 +149,9 @@ class StoreApi {
       
       
       // path params
-      if($orderId !== null) {
+      if($order_id !== null) {
   			$resourcePath = str_replace("{" . "orderId" . "}",
-  			                            $this->apiClient->toPathValue($orderId), $resourcePath);
+  			                            $this->apiClient->toPathValue($order_id), $resourcePath);
   		}
       
       
@@ -181,12 +181,12 @@ class StoreApi {
 	 * deleteOrder
    *
 	 * Delete purchase order by ID
-   * orderId, string: ID of the order that needs to be deleted (required)
+   * order_id, string: ID of the order that needs to be deleted (required)
    * 
 	 * @return 
 	 */
 
-   public function deleteOrder($orderId) {
+   public function deleteOrder($order_id) {
 
   		// parse inputs
   		$resourcePath = "/store/order/{orderId}";
@@ -201,9 +201,9 @@ class StoreApi {
       
       
       // path params
-      if($orderId !== null) {
+      if($order_id !== null) {
   			$resourcePath = str_replace("{" . "orderId" . "}",
-  			                            $this->apiClient->toPathValue($orderId), $resourcePath);
+  			                            $this->apiClient->toPathValue($order_id), $resourcePath);
   		}
       
       

--- a/samples/client/petstore/php/models/Pet.php
+++ b/samples/client/petstore/php/models/Pet.php
@@ -27,7 +27,7 @@ class Pet implements ArrayAccess {
       'id' => 'int',
       'category' => 'Category',
       'name' => 'string',
-      'photoUrls' => 'array[string]',
+      'photo_urls' => 'array[string]',
       'tags' => 'array[Tag]',
       'status' => 'string'
   );
@@ -36,7 +36,7 @@ class Pet implements ArrayAccess {
       'id' => 'id',
       'category' => 'category',
       'name' => 'name',
-      'photoUrls' => 'photoUrls',
+      'photo_urls' => 'photoUrls',
       'tags' => 'tags',
       'status' => 'status'
   );
@@ -45,7 +45,7 @@ class Pet implements ArrayAccess {
   public $id; /* int */
   public $category; /* Category */
   public $name; /* string */
-  public $photoUrls; /* array[string] */
+  public $photo_urls; /* array[string] */
   public $tags; /* array[Tag] */
   /**
   * pet status in the store
@@ -56,7 +56,7 @@ class Pet implements ArrayAccess {
     $this->id = $data["id"];
     $this->category = $data["category"];
     $this->name = $data["name"];
-    $this->photoUrls = $data["photoUrls"];
+    $this->photo_urls = $data["photo_urls"];
     $this->tags = $data["tags"];
     $this->status = $data["status"];
   }

--- a/samples/client/petstore/php/models/User.php
+++ b/samples/client/petstore/php/models/User.php
@@ -26,47 +26,47 @@ class User implements ArrayAccess {
   static $swaggerTypes = array(
       'id' => 'int',
       'username' => 'string',
-      'firstName' => 'string',
-      'lastName' => 'string',
+      'first_name' => 'string',
+      'last_name' => 'string',
       'email' => 'string',
       'password' => 'string',
       'phone' => 'string',
-      'userStatus' => 'int'
+      'user_status' => 'int'
   );
 
   static $attributeMap = array(
       'id' => 'id',
       'username' => 'username',
-      'firstName' => 'firstName',
-      'lastName' => 'lastName',
+      'first_name' => 'firstName',
+      'last_name' => 'lastName',
       'email' => 'email',
       'password' => 'password',
       'phone' => 'phone',
-      'userStatus' => 'userStatus'
+      'user_status' => 'userStatus'
   );
 
   
   public $id; /* int */
   public $username; /* string */
-  public $firstName; /* string */
-  public $lastName; /* string */
+  public $first_name; /* string */
+  public $last_name; /* string */
   public $email; /* string */
   public $password; /* string */
   public $phone; /* string */
   /**
   * User Status
   */
-  public $userStatus; /* int */
+  public $user_status; /* int */
 
   public function __construct(array $data) {
     $this->id = $data["id"];
     $this->username = $data["username"];
-    $this->firstName = $data["firstName"];
-    $this->lastName = $data["lastName"];
+    $this->first_name = $data["first_name"];
+    $this->last_name = $data["last_name"];
     $this->email = $data["email"];
     $this->password = $data["password"];
     $this->phone = $data["phone"];
-    $this->userStatus = $data["userStatus"];
+    $this->user_status = $data["user_status"];
   }
 
   public function offsetExists($offset) {

--- a/samples/client/petstore/php/models/category.php
+++ b/samples/client/petstore/php/models/category.php
@@ -22,43 +22,24 @@
  *
  */
 
-class Order implements ArrayAccess {
+class category implements ArrayAccess {
   static $swaggerTypes = array(
       'id' => 'int',
-      'pet_id' => 'int',
-      'quantity' => 'int',
-      'ship_date' => 'DateTime',
-      'status' => 'string',
-      'complete' => 'boolean'
+      'name' => 'string'
   );
 
   static $attributeMap = array(
       'id' => 'id',
-      'pet_id' => 'petId',
-      'quantity' => 'quantity',
-      'ship_date' => 'shipDate',
-      'status' => 'status',
-      'complete' => 'complete'
+      'name' => 'name'
   );
 
   
   public $id; /* int */
-  public $pet_id; /* int */
-  public $quantity; /* int */
-  public $ship_date; /* DateTime */
-  /**
-  * Order Status
-  */
-  public $status; /* string */
-  public $complete; /* boolean */
+  public $name; /* string */
 
   public function __construct(array $data) {
     $this->id = $data["id"];
-    $this->pet_id = $data["pet_id"];
-    $this->quantity = $data["quantity"];
-    $this->ship_date = $data["ship_date"];
-    $this->status = $data["status"];
-    $this->complete = $data["complete"];
+    $this->name = $data["name"];
   }
 
   public function offsetExists($offset) {

--- a/samples/client/petstore/php/models/order.php
+++ b/samples/client/petstore/php/models/order.php
@@ -22,7 +22,7 @@
  *
  */
 
-class Order implements ArrayAccess {
+class order implements ArrayAccess {
   static $swaggerTypes = array(
       'id' => 'int',
       'pet_id' => 'int',

--- a/samples/client/petstore/php/models/pet.php
+++ b/samples/client/petstore/php/models/pet.php
@@ -22,43 +22,43 @@
  *
  */
 
-class Order implements ArrayAccess {
+class pet implements ArrayAccess {
   static $swaggerTypes = array(
       'id' => 'int',
-      'pet_id' => 'int',
-      'quantity' => 'int',
-      'ship_date' => 'DateTime',
-      'status' => 'string',
-      'complete' => 'boolean'
+      'category' => 'Category',
+      'name' => 'string',
+      'photo_urls' => 'array[string]',
+      'tags' => 'array[Tag]',
+      'status' => 'string'
   );
 
   static $attributeMap = array(
       'id' => 'id',
-      'pet_id' => 'petId',
-      'quantity' => 'quantity',
-      'ship_date' => 'shipDate',
-      'status' => 'status',
-      'complete' => 'complete'
+      'category' => 'category',
+      'name' => 'name',
+      'photo_urls' => 'photoUrls',
+      'tags' => 'tags',
+      'status' => 'status'
   );
 
   
   public $id; /* int */
-  public $pet_id; /* int */
-  public $quantity; /* int */
-  public $ship_date; /* DateTime */
+  public $category; /* Category */
+  public $name; /* string */
+  public $photo_urls; /* array[string] */
+  public $tags; /* array[Tag] */
   /**
-  * Order Status
+  * pet status in the store
   */
   public $status; /* string */
-  public $complete; /* boolean */
 
   public function __construct(array $data) {
     $this->id = $data["id"];
-    $this->pet_id = $data["pet_id"];
-    $this->quantity = $data["quantity"];
-    $this->ship_date = $data["ship_date"];
+    $this->category = $data["category"];
+    $this->name = $data["name"];
+    $this->photo_urls = $data["photo_urls"];
+    $this->tags = $data["tags"];
     $this->status = $data["status"];
-    $this->complete = $data["complete"];
   }
 
   public function offsetExists($offset) {

--- a/samples/client/petstore/php/models/tag.php
+++ b/samples/client/petstore/php/models/tag.php
@@ -22,43 +22,24 @@
  *
  */
 
-class Order implements ArrayAccess {
+class tag implements ArrayAccess {
   static $swaggerTypes = array(
       'id' => 'int',
-      'pet_id' => 'int',
-      'quantity' => 'int',
-      'ship_date' => 'DateTime',
-      'status' => 'string',
-      'complete' => 'boolean'
+      'name' => 'string'
   );
 
   static $attributeMap = array(
       'id' => 'id',
-      'pet_id' => 'petId',
-      'quantity' => 'quantity',
-      'ship_date' => 'shipDate',
-      'status' => 'status',
-      'complete' => 'complete'
+      'name' => 'name'
   );
 
   
   public $id; /* int */
-  public $pet_id; /* int */
-  public $quantity; /* int */
-  public $ship_date; /* DateTime */
-  /**
-  * Order Status
-  */
-  public $status; /* string */
-  public $complete; /* boolean */
+  public $name; /* string */
 
   public function __construct(array $data) {
     $this->id = $data["id"];
-    $this->pet_id = $data["pet_id"];
-    $this->quantity = $data["quantity"];
-    $this->ship_date = $data["ship_date"];
-    $this->status = $data["status"];
-    $this->complete = $data["complete"];
+    $this->name = $data["name"];
   }
 
   public function offsetExists($offset) {

--- a/samples/client/petstore/php/models/user.php
+++ b/samples/client/petstore/php/models/user.php
@@ -22,43 +22,51 @@
  *
  */
 
-class Order implements ArrayAccess {
+class user implements ArrayAccess {
   static $swaggerTypes = array(
       'id' => 'int',
-      'pet_id' => 'int',
-      'quantity' => 'int',
-      'ship_date' => 'DateTime',
-      'status' => 'string',
-      'complete' => 'boolean'
+      'username' => 'string',
+      'first_name' => 'string',
+      'last_name' => 'string',
+      'email' => 'string',
+      'password' => 'string',
+      'phone' => 'string',
+      'user_status' => 'int'
   );
 
   static $attributeMap = array(
       'id' => 'id',
-      'pet_id' => 'petId',
-      'quantity' => 'quantity',
-      'ship_date' => 'shipDate',
-      'status' => 'status',
-      'complete' => 'complete'
+      'username' => 'username',
+      'first_name' => 'firstName',
+      'last_name' => 'lastName',
+      'email' => 'email',
+      'password' => 'password',
+      'phone' => 'phone',
+      'user_status' => 'userStatus'
   );
 
   
   public $id; /* int */
-  public $pet_id; /* int */
-  public $quantity; /* int */
-  public $ship_date; /* DateTime */
+  public $username; /* string */
+  public $first_name; /* string */
+  public $last_name; /* string */
+  public $email; /* string */
+  public $password; /* string */
+  public $phone; /* string */
   /**
-  * Order Status
+  * User Status
   */
-  public $status; /* string */
-  public $complete; /* boolean */
+  public $user_status; /* int */
 
   public function __construct(array $data) {
     $this->id = $data["id"];
-    $this->pet_id = $data["pet_id"];
-    $this->quantity = $data["quantity"];
-    $this->ship_date = $data["ship_date"];
-    $this->status = $data["status"];
-    $this->complete = $data["complete"];
+    $this->username = $data["username"];
+    $this->first_name = $data["first_name"];
+    $this->last_name = $data["last_name"];
+    $this->email = $data["email"];
+    $this->password = $data["password"];
+    $this->phone = $data["phone"];
+    $this->user_status = $data["user_status"];
   }
 
   public function offsetExists($offset) {


### PR DESCRIPTION
Update PHP codegen as follows:

- model property in underscore format (createAt => create_at)
- method argument in underscore format (additionalMeta => additiona_meta)
- model name (class name) in camelized format (mobile_phone => MobilePhone)
- escape invalid  name (e.g. reserved word, 123testing) with _ at the beginning (e.g. 123number => _123number, return => _return)
- update reserved word list
- update test case for php and php petstore sample
- add string utility function (camelize, underscore) to default codegen (ref: https://github.com/twitter/elephant-bird/blob/master/core/src/main/java/com/twitter/elephantbird/util/Strings.java)


