### PR TITLE
better naming convention for android-java codegen

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/AndroidClientCodegen.java
@@ -118,4 +118,49 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
       type = swaggerType;
     return toModelName(type);
   }
+
+  @Override
+  public String toVarName(String name) {
+    // replace - with _ e.g. created-at => created_at
+    name = name.replaceAll("-", "_");
+
+    // if it's all uppper case, do nothing
+    if (name.matches("^[A-Z_]*$"))
+      return name;
+
+    // camelize (lower first character) the variable name
+    // pet_id => petId
+    name = camelize(name, true);
+
+    // for reserved word or word starting with number, append _
+    if(reservedWords.contains(name) || name.matches("^\\d.*"))
+      name = escapeReservedWord(name);
+
+    return name;
+  }
+
+  @Override
+  public String toParamName(String name) {
+    // should be the same as variable name
+    return toVarName(name);
+  }
+ 
+  @Override
+  public String toModelName(String name) {
+    // model name cannot use reserved keyword, e.g. return
+    if(reservedWords.contains(name))
+      throw new RuntimeException(name + " (reserved word) cannot be used as a model name");
+ 
+    // camelize the model name
+    // phone_number => PhoneNumber
+    return camelize(name);
+  }
+
+  @Override
+  public String toModelFilename(String name) {
+    // should be the same as the model name
+    return toModelName(name);
+  }
+
+
 }

--- a/modules/swagger-codegen/src/main/resources/android-java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/model.mustache
@@ -27,7 +27,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * maximum: {{maximum}}{{/maximum}}
    **/
   @ApiModelProperty(required = {{required}}, value = "{{{description}}}")
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/samples/client/petstore/android-java/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/android-java/src/main/java/io/swagger/client/api/PetApi.java
@@ -383,7 +383,7 @@ public class PetApi {
   }
   
   
-  public void  deletePet (String api_key, Long petId) throws ApiException {
+  public void  deletePet (String apiKey, Long petId) throws ApiException {
     Object postBody = null;
 
     
@@ -400,7 +400,7 @@ public class PetApi {
 
     
 
-    headerParams.put("api_key", ApiInvoker.parameterToString(api_key));
+    headerParams.put("api_key", ApiInvoker.parameterToString(apiKey));
     
 
     String[] contentTypes = {


### PR DESCRIPTION
This PR is very similar to #535 (Better variable and model property naming for Java): update android-java codegen with better naming convention:

- in model template, use {{baseName}} instead of {{name}} for @JsonProperty (since we need the original name as the JSON key)
- camelized model name (e.g. phone_number => PhoneNumber)
- for property and variable name, camelize with lower first character (e.g. phone_number => phoneNumber)
- for reserved words or word starting with number, append _ (e.g. return => _return, 123number => _123number)
- update test case and Petstore sample for android-java