### PR TITLE
fix StringIndexOutOfBoundsException when tag is not provided

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -376,7 +376,10 @@ public class DefaultCodegen {
   }
 
   public String initialCaps(String name) {
-    return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    if (name.length()>0)
+      return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    else
+      return name;
   }
 
   public String getTypeDeclaration(String name) {

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -139,7 +139,7 @@ public class DefaultCodegen {
   }
 
   public String toApiFilename(String name) {
-    return initialCaps(name) + "Api";
+    return toApiName(name);
   }
 
   public String toApiVarName(String name) {
@@ -376,10 +376,7 @@ public class DefaultCodegen {
   }
 
   public String initialCaps(String name) {
-    if (name.length()>0)
-      return Character.toUpperCase(name.charAt(0)) + name.substring(1);
-    else
-      return name;
+    return StringUtils.capitalize(name);
   }
 
   public String getTypeDeclaration(String name) {


### PR DESCRIPTION
when tag is not provided a StringIndexOutOfBoundsException is generated 

java.lang.StringIndexOutOfBoundsException: String index out of range: 0
	at java.lang.String.charAt(String.java:646)
	at com.wordnik.swagger.codegen.DefaultCodegen.initialCaps(DefaultCodegen.java:379)
	at com.wordnik.swagger.codegen.DefaultCodegen.toApiFilename(DefaultCodegen.java:142)
	at com.wordnik.swagger.codegen.DefaultGenerator.generate(DefaultGenerator.java:144)
	at com.wordnik.swagger.codegen.Codegen.main(Codegen.java:99)
java.lang.StringIndexOutOfBoundsException: String index out of range: 0
	at java.lang.String.charAt(String.java:646)
	at com.wordnik.swagger.codegen.DefaultGenerator.generate(DefaultGenerator.java:144)
	at com.wordnik.swagger.codegen.Codegen.main(Codegen.java:99)
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1918)
	at com.wordnik.swagger.codegen.DefaultGenerator.generate(DefaultGenerator.java:144)
	at com.wordnik.swagger.codegen.Codegen.main(Codegen.java:99)

since tags are note required, the fix only try to capitalize non emply tags