### PR TITLE
Set default User-Agent for Java and Android clients

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
@@ -53,6 +53,9 @@ public class ApiInvoker {
     // Use UTC as the default time zone.
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    // Set the default User-Agent header.
+    INSTANCE.addDefaultHeader("User-Agent", "Java-Swagger");
   }
 
   public static Date parseDateTime(String str) {

--- a/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
@@ -54,8 +54,12 @@ public class ApiInvoker {
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-    // Set the default User-Agent header.
-    INSTANCE.addDefaultHeader("User-Agent", "Java-Swagger");
+    // Set default User-Agent.
+    setUserAgent("Java-Swagger");
+  }
+
+  public static void setUserAgent(String userAgent) {
+    INSTANCE.addDefaultHeader("User-Agent", userAgent);
   }
 
   public static Date parseDateTime(String str) {

--- a/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
@@ -82,6 +82,9 @@ public class ApiInvoker {
     // Use UTC as the default time zone.
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    // Set the default User-Agent header.
+    INSTANCE.addDefaultHeader("User-Agent", "Android-Java-Swagger");
   }
 
   public static Date parseDateTime(String str) {

--- a/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
@@ -83,8 +83,12 @@ public class ApiInvoker {
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-    // Set the default User-Agent header.
-    INSTANCE.addDefaultHeader("User-Agent", "Android-Java-Swagger");
+    // Set default User-Agent.
+    setUserAgent("Android-Java-Swagger");
+  }
+
+  public static void setUserAgent(String userAgent) {
+    INSTANCE.addDefaultHeader("User-Agent", userAgent);
   }
 
   public static Date parseDateTime(String str) {

--- a/samples/client/petstore/android-java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android-java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -82,6 +82,9 @@ public class ApiInvoker {
     // Use UTC as the default time zone.
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    // Set the default User-Agent header.
+    INSTANCE.addDefaultHeader("User-Agent", "Android-Java-Swagger");
   }
 
   public static Date parseDateTime(String str) {

--- a/samples/client/petstore/android-java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android-java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -83,8 +83,12 @@ public class ApiInvoker {
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-    // Set the default User-Agent header.
-    INSTANCE.addDefaultHeader("User-Agent", "Android-Java-Swagger");
+    // Set default User-Agent.
+    setUserAgent("Android-Java-Swagger");
+  }
+
+  public static void setUserAgent(String userAgent) {
+    INSTANCE.addDefaultHeader("User-Agent", userAgent);
   }
 
   public static Date parseDateTime(String str) {

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -53,6 +53,9 @@ public class ApiInvoker {
     // Use UTC as the default time zone.
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    // Set the default User-Agent header.
+    INSTANCE.addDefaultHeader("User-Agent", "Java-Swagger");
   }
 
   public static Date parseDateTime(String str) {

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -54,8 +54,12 @@ public class ApiInvoker {
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-    // Set the default User-Agent header.
-    INSTANCE.addDefaultHeader("User-Agent", "Java-Swagger");
+    // Set default User-Agent.
+    setUserAgent("Java-Swagger");
+  }
+
+  public static void setUserAgent(String userAgent) {
+    INSTANCE.addDefaultHeader("User-Agent", userAgent);
   }
 
   public static Date parseDateTime(String str) {


### PR DESCRIPTION
* Java client uses e.g. `Java/1.7.0_51` as User-Agent, changing it to `Java-Swagger` by default.
* Android client uses e.g. `Apache-HttpClient/4.3.6 (java 1.5)`, changing it to `Android-Java-Swagger`.
* Provide the `ApiInvoker.setUserAgent` method to allow customizing User-Agent easily.