### PR TITLE
Python Binding Request Headers

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/swagger.mustache
@@ -28,23 +28,27 @@ class ApiClient:
     headerValue: a header value to pass when making calls to the API
   """
   def __init__(self, host=None, headerName=None, headerValue=None):
-    self.headerName = headerName
-    self.headerValue = headerValue
+    self.defaultHeaders = {}
+    if (headerName is not None):
+      self.defaultHeaders[headerName] = headerValue
     self.host = host
     self.cookie = None
     self.boundary = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(30))
+
+  def setDefaultHeader(headerName, headerValue):
+    self.defaultHeaders[headerName] = headerValue
 
   def callAPI(self, resourcePath, method, queryParams, postData,
               headerParams=None, files=None):
 
     url = self.host + resourcePath
+
+    mergedHeaderParams = self.defaultHeaders.copy()
+    mergedHeaderParams.update(headerParams)
     headers = {}
-    if headerParams:
+    if mergedHeaderParams:
       for param, value in headerParams.iteritems():
         headers[param] = value
-
-    if self.headerName:
-      headers[self.headerName] = self.headerValue
 
     if self.cookie:
       headers['Cookie'] = self.cookie


### PR DESCRIPTION
Modifying request headers in ApiClient to act like those in Java  and PHP