### PR TITLE
small fix on CodegenConfig to bring back Threepane and Swift

### DIFF
--- a/modules/swagger-codegen/src/main/resources/META-INF/services/com.wordnik.swagger.codegen.CodegenConfig
+++ b/modules/swagger-codegen/src/main/resources/META-INF/services/com.wordnik.swagger.codegen.CodegenConfig
@@ -15,3 +15,5 @@ com.wordnik.swagger.codegen.languages.TizenClientCodegen
 com.wordnik.swagger.codegen.languages.PhpClientCodegen
 com.wordnik.swagger.codegen.languages.RubyClientCodegen
 com.wordnik.swagger.codegen.languages.PythonClientCodegen
+com.wordnik.swagger.codegen.languages.ThreePane
+com.wordnik.swagger.codegen.languages.SwiftGenerator


### PR DESCRIPTION
Since Threepane and Swift were not listed as languages