### PR TITLE
Switched SingleClientConnManager with ThreadSafeClientConnManager.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
@@ -16,6 +16,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.*;
 import org.apache.http.impl.conn.*;
+import org.apache.http.impl.conn.tsccm.*;
 import org.apache.http.params.*;
 import org.apache.http.util.EntityUtils;
 
@@ -364,7 +365,7 @@ public class ApiInvoker {
       schemeRegistry.register(httpsScheme);
       schemeRegistry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
 
-      ignoreSSLConnectionManager = new SingleClientConnManager(new BasicHttpParams(), schemeRegistry);
+      ignoreSSLConnectionManager = new ThreadSafeClientConnManager(new BasicHttpParams(), schemeRegistry);
     } catch (NoSuchAlgorithmException e) {
       // This will only be thrown if SSL isn't available for some reason.
     } catch (KeyManagementException e) {


### PR DESCRIPTION
 Switched `SingleClientConnManager` with `ThreadSafeClientConnManager`.

The `SingleClientConnManager` cannot be used safely in multi-threaded environments (see [this](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/SingleClientConnManager.html)),  and therefor should not be used.

This fix should be considered temporary since with the Apache HttpClient version bump in b5a4d5be040d9115063145a5923d7aafa17b3242, many of the classes in `ApiInvoker` have been deprecated 