### PR TITLE
Fix date time format for Android client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
@@ -41,7 +41,7 @@ public class ApiInvoker {
    * ISO 8601 date time format.
    * @see https://en.wikipedia.org/wiki/ISO_8601
    */
-  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   /**
    * ISO 8601 date format.

--- a/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
@@ -70,7 +70,7 @@ public class ApiInvoker {
    * ISO 8601 date time format.
    * @see https://en.wikipedia.org/wiki/ISO_8601
    */
-  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   /**
    * ISO 8601 date format.

--- a/samples/client/petstore/android-java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android-java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -70,7 +70,7 @@ public class ApiInvoker {
    * ISO 8601 date time format.
    * @see https://en.wikipedia.org/wiki/ISO_8601
    */
-  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   /**
    * ISO 8601 date format.

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -41,7 +41,7 @@ public class ApiInvoker {
    * ISO 8601 date time format.
    * @see https://en.wikipedia.org/wiki/ISO_8601
    */
-  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   /**
    * ISO 8601 date format.


### PR DESCRIPTION
According to Android's docs (https://developer.android.com/reference/java/text/SimpleDateFormat.html)
the `SimpleDateFormat` class in Android does not accept `XXX` as the timezone, it uses `Z` instead.

Also updated the date time format of Android and Java clients to include milliseconds and to be consistent.