### PR TITLE
This is a fix for issue: https://github.com/swagger-api/swagger-codegen/issues/577

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -346,7 +346,7 @@ public class DefaultCodegen {
       m.name = escapeReservedWord(name);
     else
       m.name = name;
-    m.description = model.getDescription();
+    m.description = escapeText(model.getDescription());
     m.classname = toModelName(name);
     m.classVarName = toVarName(name);
     m.modelJson = Json.pretty(model);


### PR DESCRIPTION
Fixed the compile time error in the generated code caused due to unescaped new line characters.

Since the description text is not being escaped, if there is a new line character, it will cause a new line to be added to the source code. This can cause compile time error if the new line character is part of a string (e.g. java string) and there is no '+' sign explicitly added to the code. Note: The code was doing escapeText for properties but not for models. This patch fixes that.