### PR TITLE
Fixed Ruby header: "Accept", "Content-Type"

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -41,8 +41,17 @@ class {{classname}}
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = '{{#produces}}{{mediaType}}{{#hasMore}}, {{/hasMore}}{{/produces}}';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+      _header_content_type = [{{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}}];
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     {{#headerParams}}{{#optional}}headers[:'{{{baseName}}}'] = options[:'{{{paramName}}}'] if options[:'{{{paramName}}}']{{/optional}}{{/headerParams}}
     {{#headerParams}}{{^optional}}headers[:'{{{baseName}}}'] = {{{paramName}}}{{/optional}}{{/headerParams}}
     # http body (model)

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -44,13 +44,12 @@ class {{classname}}
     # header parameters
     headers = {}
 
-    _header_accept = '{{#produces}}{{mediaType}}{{#hasMore}}, {{/hasMore}}{{/produces}}';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-      _header_content_type = [{{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}}];
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = '{{#produces}}{{mediaType}}{{#hasMore}}, {{/hasMore}}{{/produces}}'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = [{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}]
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     {{#headerParams}}{{#optional}}headers[:'{{{baseName}}}'] = options[:'{{{paramName}}}'] if options[:'{{{paramName}}}']{{/optional}}{{/headerParams}}
     {{#headerParams}}{{^optional}}headers[:'{{{baseName}}}'] = {{{paramName}}}{{/optional}}{{/headerParams}}

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -32,8 +32,17 @@ class PetApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [('application/json','application/xml',);
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -92,8 +101,17 @@ class PetApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [('application/json','application/xml',);
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -152,8 +170,17 @@ class PetApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -194,8 +221,17 @@ class PetApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -237,8 +273,17 @@ class PetApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -283,8 +328,17 @@ class PetApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [('application/x-www-form-urlencoded',);
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -328,8 +382,17 @@ class PetApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     headers[:'api_key'] = api_key
     # http body (model)
@@ -373,8 +436,17 @@ class PetApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [('multipart/form-data',);
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -35,13 +35,12 @@ class PetApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [('application/json','application/xml',);
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = ['application/json', 'application/xml', ]
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -104,13 +103,12 @@ class PetApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [('application/json','application/xml',);
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = ['application/json', 'application/xml', ]
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -173,13 +171,12 @@ class PetApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -224,13 +221,12 @@ class PetApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -276,13 +272,12 @@ class PetApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -331,13 +326,12 @@ class PetApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [('application/x-www-form-urlencoded',);
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = ['application/x-www-form-urlencoded', ]
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -385,13 +379,12 @@ class PetApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     headers[:'api_key'] = api_key
@@ -439,13 +432,12 @@ class PetApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [('multipart/form-data',);
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = ['multipart/form-data', ]
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     

--- a/samples/client/petstore/ruby/lib/store_api.rb
+++ b/samples/client/petstore/ruby/lib/store_api.rb
@@ -30,8 +30,17 @@ class StoreApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -72,8 +81,17 @@ class StoreApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -134,8 +152,17 @@ class StoreApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -176,8 +203,17 @@ class StoreApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)

--- a/samples/client/petstore/ruby/lib/store_api.rb
+++ b/samples/client/petstore/ruby/lib/store_api.rb
@@ -33,13 +33,12 @@ class StoreApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -84,13 +83,12 @@ class StoreApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -155,13 +153,12 @@ class StoreApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -206,13 +203,12 @@ class StoreApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     

--- a/samples/client/petstore/ruby/lib/user_api.rb
+++ b/samples/client/petstore/ruby/lib/user_api.rb
@@ -35,13 +35,12 @@ class UserApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -104,13 +103,12 @@ class UserApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -173,13 +171,12 @@ class UserApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -244,13 +241,12 @@ class UserApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -292,13 +288,12 @@ class UserApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -342,13 +337,12 @@ class UserApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -395,13 +389,12 @@ class UserApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     
@@ -465,13 +458,12 @@ class UserApi
     # header parameters
     headers = {}
 
-    _header_accept = 'application/json, application/xml';
-    if (_header_accept != '') {
-      headerParams['Accept'] = _header_accept;
-    }
-    _header_content_type = [();
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
-
+    _header_accept = 'application/json, application/xml'
+    if _header_accept != ''
+      headerParams['Accept'] = _header_accept
+    end 
+    _header_content_type = []
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
     
     

--- a/samples/client/petstore/ruby/lib/user_api.rb
+++ b/samples/client/petstore/ruby/lib/user_api.rb
@@ -32,8 +32,17 @@ class UserApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -92,8 +101,17 @@ class UserApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -152,8 +170,17 @@ class UserApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -214,8 +241,17 @@ class UserApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -253,8 +289,17 @@ class UserApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -294,8 +339,17 @@ class UserApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -338,8 +392,17 @@ class UserApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)
@@ -399,8 +462,17 @@ class UserApi
       query_param_keys.include? key
     end
 
-    # header parameters, if any
+    # header parameters
     headers = {}
+
+    _header_accept = 'application/json, application/xml';
+    if (_header_accept != '') {
+      headerParams['Accept'] = _header_accept;
+    }
+    _header_content_type = [();
+    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json';
+
+
     
     
     # http body (model)


### PR DESCRIPTION
- set "Accept" only if it's defined in the Swagger spec
- set Content-Type to the first value in "Consumes" or use "application/json" as default
- updated petstore ruby samples (files compiled without issue using ruby -c)