### PR TITLE
Fixed user agent in python client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/swagger.mustache
@@ -34,6 +34,16 @@ class ApiClient(object):
     self.host = host
     self.cookie = None
     self.boundary = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(30))
+    # Set default User-Agent.
+    self.user_agent = 'Python-Swagger'
+
+  @property
+  def user_agent(self):
+    return self.defaultHeaders['User-Agent']
+
+  @user_agent.setter
+  def user_agent(self, value):
+    self.defaultHeaders['User-Agent'] = value
 
   def setDefaultHeader(self, headerName, headerValue):
     self.defaultHeaders[headerName] = headerValue

--- a/samples/client/petstore/python/client/PetApi.py
+++ b/samples/client/petstore/python/client/PetApi.py
@@ -63,7 +63,7 @@ class PetApi(object):
         bodyParam = None
 
         headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = 'application/json,application/xml'
+        headerParams['Content-Type'] = 'application/json,application/xml,'
 
         
 
@@ -119,7 +119,7 @@ class PetApi(object):
         bodyParam = None
 
         headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = 'application/json,application/xml'
+        headerParams['Content-Type'] = 'application/json,application/xml,'
 
         
 
@@ -370,7 +370,7 @@ class PetApi(object):
         bodyParam = None
 
         headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = 'application/x-www-form-urlencoded'
+        headerParams['Content-Type'] = 'application/x-www-form-urlencoded,'
 
         
 
@@ -506,7 +506,7 @@ class PetApi(object):
         bodyParam = None
 
         headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = 'multipart/form-data'
+        headerParams['Content-Type'] = 'multipart/form-data,'
 
         
 

--- a/samples/client/petstore/python/client/swagger.py
+++ b/samples/client/petstore/python/client/swagger.py
@@ -34,6 +34,16 @@ class ApiClient(object):
     self.host = host
     self.cookie = None
     self.boundary = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(30))
+    # Set default User-Agent.
+    self.user_agent = 'Python-Swagger'
+
+  @property
+  def user_agent(self):
+    return self.defaultHeaders['User-Agent']
+
+  @user_agent.setter
+  def user_agent(self, value):
+    self.defaultHeaders['User-Agent'] = value
 
   def setDefaultHeader(self, headerName, headerValue):
     self.defaultHeaders[headerName] = headerValue


### PR DESCRIPTION
* Changed default User-Agent to `Python-Swagger` in python client.
* Added the `user_agent` property to allow customizing User-Agent easily.
* Updated Python Petstore client and tested without issue.