### PR TITLE
Eliminated warning related to response in CSharp API files

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -1,101 +1,113 @@
-  using System;
-  using System.Collections.Generic;
-  using {{invokerPackage}};
-  using {{modelPackage}};
-  {{#imports}}
-  {{/imports}}
+using System;
+using System.Collections.Generic;
+using {{invokerPackage}};
+using {{modelPackage}};
+{{#imports}}
+{{/imports}}
 
-  namespace {{package}} {
-    {{#operations}}
-    public class {{classname}} {
-      string basePath;
-      private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
+namespace {{package}} {
+  {{#operations}}
+  public class {{classname}} {
+    string basePath;
+    private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
 
-      public {{classname}}(String basePath = "{{basePath}}")
-      {
-        this.basePath = basePath;
+    public {{classname}}(String basePath = "{{basePath}}")
+    {
+      this.basePath = basePath;
+    }
+
+    public ApiInvoker getInvoker() {
+      return apiInvoker;
+    }
+
+    // Sets the endpoint base url for the services being accessed
+    public void setBasePath(string basePath) {
+      this.basePath = basePath;
+    }
+
+    // Gets the endpoint base url for the services being accessed
+    public String getBasePath() {
+      return basePath;
+    }
+
+    {{#operation}}
+
+    /// <summary>
+    /// {{summary}} {{notes}}
+    /// </summary>
+    {{#allParams}}/// <param name="{{paramName}}">{{description}}</param>
+    {{#hasMore}} {{/hasMore}}{{/allParams}}
+    /// <returns></returns>
+    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+      // create path and map variables
+      var path = "{{path}}".Replace("{format}","json"){{#pathParams}}.Replace("{" + "{{baseName}}" + "}", apiInvoker.escapeString({{{paramName}}}.ToString())){{/pathParams}};
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
+      {{#requiredParamCount}}
+      // verify required params are set
+      if ({{/requiredParamCount}}{{#requiredParams}} {{paramName}} == null {{#hasMore}}|| {{/hasMore}}{{/requiredParams}}{{#requiredParamCount}}) {
+         throw new ApiException(400, "missing required params");
       }
+      {{/requiredParamCount}}
 
-      public ApiInvoker getInvoker() {
-        return apiInvoker;
+      {{#queryParams}}if ({{paramName}} != null){
+        string paramStr = ({{paramName}} is DateTime) ? ((DateTime)(object){{paramName}}).ToString("u") : Convert.ToString({{paramName}});
+        queryParams.Add("{{baseName}}", paramStr);
       }
+      {{/queryParams}}
 
-      // Sets the endpoint base url for the services being accessed
-      public void setBasePath(string basePath) {
-        this.basePath = basePath;
-      }
+      {{#headerParams}}headerParams.Add("{{baseName}}", {{paramName}});
+      {{/headerParams}}
 
-      // Gets the endpoint base url for the services being accessed
-      public String getBasePath() {
-        return basePath;
-      }
-
-      {{#operation}}
-
-      /// <summary>
-      /// {{summary}} {{notes}}
-      /// </summary>
-      {{#allParams}}/// <param name="{{paramName}}">{{description}}</param>
-      {{#hasMore}} {{/hasMore}}{{/allParams}}
-      /// <returns></returns>
-      public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
-        // create path and map variables
-        var path = "{{path}}".Replace("{format}","json"){{#pathParams}}.Replace("{" + "{{baseName}}" + "}", apiInvoker.escapeString({{{paramName}}}.ToString())){{/pathParams}};
-
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
-
-        {{#requiredParamCount}}
-        // verify required params are set
-        if ({{/requiredParamCount}}{{#requiredParams}} {{paramName}} == null {{#hasMore}}|| {{/hasMore}}{{/requiredParams}}{{#requiredParamCount}}) {
-           throw new ApiException(400, "missing required params");
-        }
-        {{/requiredParamCount}}
-
-        {{#queryParams}}if ({{paramName}} != null){
+      {{#formParams}}if ({{paramName}} != null){
+        if({{paramName}} is byte[]) {
+          formParams.Add("{{baseName}}", {{paramName}});
+        } else {
           string paramStr = ({{paramName}} is DateTime) ? ((DateTime)(object){{paramName}}).ToString("u") : Convert.ToString({{paramName}});
-          queryParams.Add("{{baseName}}", paramStr);
-		}
-        {{/queryParams}}
+          formParams.Add("{{baseName}}", paramStr);
+        }
+      }
+      {{/formParams}}
 
-        {{#headerParams}}headerParams.Add("{{baseName}}", {{paramName}});
-        {{/headerParams}}
-
-        {{#formParams}}if ({{paramName}} != null){
-          if({{paramName}} is byte[]) {
-            formParams.Add("{{baseName}}", {{paramName}});
-          } else {
-            string paramStr = ({{paramName}} is DateTime) ? ((DateTime)(object){{paramName}}).ToString("u") : Convert.ToString({{paramName}});
-            formParams.Add("{{baseName}}", paramStr);
-          }
-		}
-        {{/formParams}}
-
-        try {
-          if (typeof({{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return {{#returnType}}((object)response) as {{{returnType}}}{{/returnType}};
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "{{httpMethod}}", queryParams, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, headerParams, formParams);
-            if(response != null){
-               return {{#returnType}}({{{returnType}}}) ApiInvoker.deserialize(response, typeof({{{returnType}}})){{/returnType}};
-            }
-            else {
-              return {{#returnType}}null{{/returnType}};
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return {{#returnType}}null{{/returnType}};
+      try {
+        if (typeof({{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}) == typeof(byte[])) {
+          {{#returnType}}
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as {{{returnType}}};
+          {{/returnType}}
+          {{^returnType}}
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          {{/returnType}}
+        } else {
+          {{#returnType}}
+          var response = apiInvoker.invokeAPI(basePath, path, "{{httpMethod}}", queryParams, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, headerParams, formParams);
+          if (response != null){
+             return ({{{returnType}}}) ApiInvoker.deserialize(response, typeof({{{returnType}}}));
           }
           else {
-            throw ex;
+            return null;
           }
+          {{/returnType}}
+          {{^returnType}}
+          apiInvoker.invokeAPI(basePath, path, "{{httpMethod}}", queryParams, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, headerParams, formParams);
+          return;
+          {{/returnType}}
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return {{#returnType}}null{{/returnType}};
+        }
+        else {
+          throw ex;
         }
       }
-      {{/operation}}
     }
-    {{/operations}}
+    {{/operation}}
   }
+  {{/operations}}
+}

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
@@ -1,461 +1,479 @@
-  using System;
-  using System.Collections.Generic;
-  using io.swagger.client;
-  using io.swagger.Model;
-  
-  
-  
-  
-  
+using System;
+using System.Collections.Generic;
+using io.swagger.client;
+using io.swagger.Model;
 
-  namespace io.swagger.Api {
+namespace io.swagger.Api {
+  
+  public class PetApi {
+    string basePath;
+    private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
+
+    public PetApi(String basePath = "http://petstore.swagger.io/v2")
+    {
+      this.basePath = basePath;
+    }
+
+    public ApiInvoker getInvoker() {
+      return apiInvoker;
+    }
+
+    // Sets the endpoint base url for the services being accessed
+    public void setBasePath(string basePath) {
+      this.basePath = basePath;
+    }
+
+    // Gets the endpoint base url for the services being accessed
+    public String getBasePath() {
+      return basePath;
+    }
+
     
-    public class PetApi {
-      string basePath;
-      private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
 
-      public PetApi(String basePath = "http://petstore.swagger.io/v2")
-      {
-        this.basePath = basePath;
-      }
+    /// <summary>
+    /// Update an existing pet 
+    /// </summary>
+    /// <param name="Body">Pet object that needs to be added to the store</param>
+    
+    /// <returns></returns>
+    public void  updatePet (Pet Body) {
+      // create path and map variables
+      var path = "/pet".Replace("{format}","json");
 
-      public ApiInvoker getInvoker() {
-        return apiInvoker;
-      }
-
-      // Sets the endpoint base url for the services being accessed
-      public void setBasePath(string basePath) {
-        this.basePath = basePath;
-      }
-
-      // Gets the endpoint base url for the services being accessed
-      public String getBasePath() {
-        return basePath;
-      }
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
 
       
 
-      /// <summary>
-      /// Update an existing pet 
-      /// </summary>
-      /// <param name="Body">Pet object that needs to be added to the store</param>
       
-      /// <returns></returns>
-      public void  updatePet (Pet Body) {
-        // create path and map variables
-        var path = "/pet".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "PUT", queryParams, Body, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "PUT", queryParams, Body, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
         }
       }
+    }
+    
+
+    /// <summary>
+    /// Add a new pet to the store 
+    /// </summary>
+    /// <param name="Body">Pet object that needs to be added to the store</param>
+    
+    /// <returns></returns>
+    public void  addPet (Pet Body) {
+      // create path and map variables
+      var path = "/pet".Replace("{format}","json");
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
 
-      /// <summary>
-      /// Add a new pet to the store 
-      /// </summary>
-      /// <param name="Body">Pet object that needs to be added to the store</param>
       
-      /// <returns></returns>
-      public void  addPet (Pet Body) {
-        // create path and map variables
-        var path = "/pet".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
+          return;
+          
         }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
+
+    /// <summary>
+    /// Finds Pets by status Multiple status values can be provided with comma seperated strings
+    /// </summary>
+    /// <param name="Status">Status values that need to be considered for filter</param>
+    
+    /// <returns></returns>
+    public List<Pet>  findPetsByStatus (List<string> Status) {
+      // create path and map variables
+      var path = "/pet/findByStatus".Replace("{format}","json");
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
+      
+
+      if (Status != null){
+        string paramStr = (Status is DateTime) ? ((DateTime)(object)Status).ToString("u") : Convert.ToString(Status);
+        queryParams.Add("status", paramStr);
       }
       
 
-      /// <summary>
-      /// Finds Pets by status Multiple status values can be provided with comma seperated strings
-      /// </summary>
-      /// <param name="Status">Status values that need to be considered for filter</param>
       
-      /// <returns></returns>
-      public List<Pet>  findPetsByStatus (List<string> Status) {
-        // create path and map variables
-        var path = "/pet/findByStatus".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      try {
+        if (typeof(List<Pet>) == typeof(byte[])) {
+          
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as List<Pet>;
+          
+          
+        } else {
+          
+          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          if (response != null){
+             return (List<Pet>) ApiInvoker.deserialize(response, typeof(List<Pet>));
+          }
+          else {
+            return null;
+          }
+          
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return null;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
 
-        if (Status != null){
+    /// <summary>
+    /// Finds Pets by tags Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
+    /// </summary>
+    /// <param name="Tags">Tags to filter by</param>
+    
+    /// <returns></returns>
+    public List<Pet>  findPetsByTags (List<string> Tags) {
+      // create path and map variables
+      var path = "/pet/findByTags".Replace("{format}","json");
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
+      
+
+      if (Tags != null){
+        string paramStr = (Tags is DateTime) ? ((DateTime)(object)Tags).ToString("u") : Convert.ToString(Tags);
+        queryParams.Add("tags", paramStr);
+      }
+      
+
+      
+
+      
+
+      try {
+        if (typeof(List<Pet>) == typeof(byte[])) {
+          
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as List<Pet>;
+          
+          
+        } else {
+          
+          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          if (response != null){
+             return (List<Pet>) ApiInvoker.deserialize(response, typeof(List<Pet>));
+          }
+          else {
+            return null;
+          }
+          
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return null;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
+
+    /// <summary>
+    /// Find pet by ID Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
+    /// </summary>
+    /// <param name="PetId">ID of pet that needs to be fetched</param>
+    
+    /// <returns></returns>
+    public Pet  getPetById (long? PetId) {
+      // create path and map variables
+      var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.escapeString(PetId.ToString()));
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
+      
+
+      
+
+      
+
+      
+
+      try {
+        if (typeof(Pet) == typeof(byte[])) {
+          
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as Pet;
+          
+          
+        } else {
+          
+          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          if (response != null){
+             return (Pet) ApiInvoker.deserialize(response, typeof(Pet));
+          }
+          else {
+            return null;
+          }
+          
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return null;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
+
+    /// <summary>
+    /// Updates a pet in the store with form data 
+    /// </summary>
+    /// <param name="PetId">ID of pet that needs to be updated</param>
+     /// <param name="Name">Updated name of the pet</param>
+     /// <param name="Status">Updated status of the pet</param>
+    
+    /// <returns></returns>
+    public void  updatePetWithForm (string PetId, string Name, string Status) {
+      // create path and map variables
+      var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.escapeString(PetId.ToString()));
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
+      
+
+      
+
+      
+
+      if (Name != null){
+        if(Name is byte[]) {
+          formParams.Add("name", Name);
+        } else {
+          string paramStr = (Name is DateTime) ? ((DateTime)(object)Name).ToString("u") : Convert.ToString(Name);
+          formParams.Add("name", paramStr);
+        }
+      }
+      if (Status != null){
+        if(Status is byte[]) {
+          formParams.Add("status", Status);
+        } else {
           string paramStr = (Status is DateTime) ? ((DateTime)(object)Status).ToString("u") : Convert.ToString(Status);
-          queryParams.Add("status", paramStr);
-		}
-        
-
-        
-
-        
-
-        try {
-          if (typeof(List<Pet>) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ((object)response) as List<Pet>;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return (List<Pet>) ApiInvoker.deserialize(response, typeof(List<Pet>));
-            }
-            else {
-              return null;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return null;
-          }
-          else {
-            throw ex;
-          }
+          formParams.Add("status", paramStr);
         }
       }
       
 
-      /// <summary>
-      /// Finds Pets by tags Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
-      /// </summary>
-      /// <param name="Tags">Tags to filter by</param>
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, null, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
+
+    /// <summary>
+    /// Deletes a pet 
+    /// </summary>
+    /// <param name="ApiKey"></param>
+     /// <param name="PetId">Pet id to delete</param>
+    
+    /// <returns></returns>
+    public void  deletePet (string ApiKey, long? PetId) {
+      // create path and map variables
+      var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.escapeString(PetId.ToString()));
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
-      /// <returns></returns>
-      public List<Pet>  findPetsByTags (List<string> Tags) {
-        // create path and map variables
-        var path = "/pet/findByTags".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      headerParams.Add("api_key", ApiKey);
+      
 
-        if (Tags != null){
-          string paramStr = (Tags is DateTime) ? ((DateTime)(object)Tags).ToString("u") : Convert.ToString(Tags);
-          queryParams.Add("tags", paramStr);
-		}
-        
+      
 
-        
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
 
-        
+    /// <summary>
+    /// uploads an image 
+    /// </summary>
+    /// <param name="PetId">ID of pet to update</param>
+     /// <param name="AdditionalMetadata">Additional data to pass to server</param>
+     /// <param name="File">file to upload</param>
+    
+    /// <returns></returns>
+    public void  uploadFile (long? PetId, string AdditionalMetadata, byte[] File) {
+      // create path and map variables
+      var path = "/pet/{petId}/uploadImage".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.escapeString(PetId.ToString()));
 
-        try {
-          if (typeof(List<Pet>) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ((object)response) as List<Pet>;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return (List<Pet>) ApiInvoker.deserialize(response, typeof(List<Pet>));
-            }
-            else {
-              return null;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return null;
-          }
-          else {
-            throw ex;
-          }
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
+      
+
+      
+
+      
+
+      if (AdditionalMetadata != null){
+        if(AdditionalMetadata is byte[]) {
+          formParams.Add("additionalMetadata", AdditionalMetadata);
+        } else {
+          string paramStr = (AdditionalMetadata is DateTime) ? ((DateTime)(object)AdditionalMetadata).ToString("u") : Convert.ToString(AdditionalMetadata);
+          formParams.Add("additionalMetadata", paramStr);
+        }
+      }
+      if (File != null){
+        if(File is byte[]) {
+          formParams.Add("file", File);
+        } else {
+          string paramStr = (File is DateTime) ? ((DateTime)(object)File).ToString("u") : Convert.ToString(File);
+          formParams.Add("file", paramStr);
         }
       }
       
 
-      /// <summary>
-      /// Find pet by ID Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
-      /// </summary>
-      /// <param name="PetId">ID of pet that needs to be fetched</param>
-      
-      /// <returns></returns>
-      public Pet  getPetById (long? PetId) {
-        // create path and map variables
-        var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.escapeString(PetId.ToString()));
-
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
-
-        
-
-        
-
-        
-
-        
-
-        try {
-          if (typeof(Pet) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ((object)response) as Pet;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return (Pet) ApiInvoker.deserialize(response, typeof(Pet));
-            }
-            else {
-              return null;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return null;
-          }
-          else {
-            throw ex;
-          }
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, null, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
         }
       }
-      
-
-      /// <summary>
-      /// Updates a pet in the store with form data 
-      /// </summary>
-      /// <param name="PetId">ID of pet that needs to be updated</param>
-       /// <param name="Name">Updated name of the pet</param>
-       /// <param name="Status">Updated status of the pet</param>
-      
-      /// <returns></returns>
-      public void  updatePetWithForm (string PetId, string Name, string Status) {
-        // create path and map variables
-        var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.escapeString(PetId.ToString()));
-
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
-
-        
-
-        
-
-        
-
-        if (Name != null){
-          if(Name is byte[]) {
-            formParams.Add("name", Name);
-          } else {
-            string paramStr = (Name is DateTime) ? ((DateTime)(object)Name).ToString("u") : Convert.ToString(Name);
-            formParams.Add("name", paramStr);
-          }
-		}
-        if (Status != null){
-          if(Status is byte[]) {
-            formParams.Add("status", Status);
-          } else {
-            string paramStr = (Status is DateTime) ? ((DateTime)(object)Status).ToString("u") : Convert.ToString(Status);
-            formParams.Add("status", paramStr);
-          }
-		}
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
-        }
-      }
-      
-
-      /// <summary>
-      /// Deletes a pet 
-      /// </summary>
-      /// <param name="ApiKey"></param>
-       /// <param name="PetId">Pet id to delete</param>
-      
-      /// <returns></returns>
-      public void  deletePet (string ApiKey, long? PetId) {
-        // create path and map variables
-        var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.escapeString(PetId.ToString()));
-
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
-
-        
-
-        
-
-        headerParams.Add("api_key", ApiKey);
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
-        }
-      }
-      
-
-      /// <summary>
-      /// uploads an image 
-      /// </summary>
-      /// <param name="PetId">ID of pet to update</param>
-       /// <param name="AdditionalMetadata">Additional data to pass to server</param>
-       /// <param name="File">file to upload</param>
-      
-      /// <returns></returns>
-      public void  uploadFile (long? PetId, string AdditionalMetadata, byte[] File) {
-        // create path and map variables
-        var path = "/pet/{petId}/uploadImage".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.escapeString(PetId.ToString()));
-
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
-
-        
-
-        
-
-        
-
-        if (AdditionalMetadata != null){
-          if(AdditionalMetadata is byte[]) {
-            formParams.Add("additionalMetadata", AdditionalMetadata);
-          } else {
-            string paramStr = (AdditionalMetadata is DateTime) ? ((DateTime)(object)AdditionalMetadata).ToString("u") : Convert.ToString(AdditionalMetadata);
-            formParams.Add("additionalMetadata", paramStr);
-          }
-		}
-        if (File != null){
-          if(File is byte[]) {
-            formParams.Add("file", File);
-          } else {
-            string paramStr = (File is DateTime) ? ((DateTime)(object)File).ToString("u") : Convert.ToString(File);
-            formParams.Add("file", paramStr);
-          }
-		}
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
-        }
-      }
-      
     }
     
   }
+  
+}

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
@@ -1,225 +1,240 @@
-  using System;
-  using System.Collections.Generic;
-  using io.swagger.client;
-  using io.swagger.Model;
-  
-  
-  
-  
+using System;
+using System.Collections.Generic;
+using io.swagger.client;
+using io.swagger.Model;
 
-  namespace io.swagger.Api {
+namespace io.swagger.Api {
+  
+  public class StoreApi {
+    string basePath;
+    private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
+
+    public StoreApi(String basePath = "http://petstore.swagger.io/v2")
+    {
+      this.basePath = basePath;
+    }
+
+    public ApiInvoker getInvoker() {
+      return apiInvoker;
+    }
+
+    // Sets the endpoint base url for the services being accessed
+    public void setBasePath(string basePath) {
+      this.basePath = basePath;
+    }
+
+    // Gets the endpoint base url for the services being accessed
+    public String getBasePath() {
+      return basePath;
+    }
+
     
-    public class StoreApi {
-      string basePath;
-      private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
 
-      public StoreApi(String basePath = "http://petstore.swagger.io/v2")
-      {
-        this.basePath = basePath;
-      }
+    /// <summary>
+    /// Returns pet inventories by status Returns a map of status codes to quantities
+    /// </summary>
+    
+    /// <returns></returns>
+    public Dictionary<String, int?>  getInventory () {
+      // create path and map variables
+      var path = "/store/inventory".Replace("{format}","json");
 
-      public ApiInvoker getInvoker() {
-        return apiInvoker;
-      }
-
-      // Sets the endpoint base url for the services being accessed
-      public void setBasePath(string basePath) {
-        this.basePath = basePath;
-      }
-
-      // Gets the endpoint base url for the services being accessed
-      public String getBasePath() {
-        return basePath;
-      }
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
 
       
 
-      /// <summary>
-      /// Returns pet inventories by status Returns a map of status codes to quantities
-      /// </summary>
       
-      /// <returns></returns>
-      public Dictionary<String, int?>  getInventory () {
-        // create path and map variables
-        var path = "/store/inventory".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(Dictionary<String, int?>) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ((object)response) as Dictionary<String, int?>;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return (Dictionary<String, int?>) ApiInvoker.deserialize(response, typeof(Dictionary<String, int?>));
-            }
-            else {
-              return null;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return null;
+      try {
+        if (typeof(Dictionary<String, int?>) == typeof(byte[])) {
+          
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as Dictionary<String, int?>;
+          
+          
+        } else {
+          
+          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          if (response != null){
+             return (Dictionary<String, int?>) ApiInvoker.deserialize(response, typeof(Dictionary<String, int?>));
           }
           else {
-            throw ex;
+            return null;
           }
+          
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return null;
+        }
+        else {
+          throw ex;
         }
       }
+    }
+    
+
+    /// <summary>
+    /// Place an order for a pet 
+    /// </summary>
+    /// <param name="Body">order placed for purchasing the pet</param>
+    
+    /// <returns></returns>
+    public Order  placeOrder (Order Body) {
+      // create path and map variables
+      var path = "/store/order".Replace("{format}","json");
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
 
-      /// <summary>
-      /// Place an order for a pet 
-      /// </summary>
-      /// <param name="Body">order placed for purchasing the pet</param>
       
-      /// <returns></returns>
-      public Order  placeOrder (Order Body) {
-        // create path and map variables
-        var path = "/store/order".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(Order) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ((object)response) as Order;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-            if(response != null){
-               return (Order) ApiInvoker.deserialize(response, typeof(Order));
-            }
-            else {
-              return null;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return null;
+      try {
+        if (typeof(Order) == typeof(byte[])) {
+          
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as Order;
+          
+          
+        } else {
+          
+          var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
+          if (response != null){
+             return (Order) ApiInvoker.deserialize(response, typeof(Order));
           }
           else {
-            throw ex;
+            return null;
           }
+          
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return null;
+        }
+        else {
+          throw ex;
         }
       }
+    }
+    
+
+    /// <summary>
+    /// Find purchase order by ID For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
+    /// </summary>
+    /// <param name="OrderId">ID of pet that needs to be fetched</param>
+    
+    /// <returns></returns>
+    public Order  getOrderById (string OrderId) {
+      // create path and map variables
+      var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.escapeString(OrderId.ToString()));
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
 
-      /// <summary>
-      /// Find purchase order by ID For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
-      /// </summary>
-      /// <param name="OrderId">ID of pet that needs to be fetched</param>
       
-      /// <returns></returns>
-      public Order  getOrderById (string OrderId) {
-        // create path and map variables
-        var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.escapeString(OrderId.ToString()));
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(Order) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ((object)response) as Order;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return (Order) ApiInvoker.deserialize(response, typeof(Order));
-            }
-            else {
-              return null;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return null;
+      try {
+        if (typeof(Order) == typeof(byte[])) {
+          
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as Order;
+          
+          
+        } else {
+          
+          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          if (response != null){
+             return (Order) ApiInvoker.deserialize(response, typeof(Order));
           }
           else {
-            throw ex;
+            return null;
           }
+          
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return null;
+        }
+        else {
+          throw ex;
         }
       }
+    }
+    
+
+    /// <summary>
+    /// Delete purchase order by ID For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+    /// </summary>
+    /// <param name="OrderId">ID of the order that needs to be deleted</param>
+    
+    /// <returns></returns>
+    public void  deleteOrder (string OrderId) {
+      // create path and map variables
+      var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.escapeString(OrderId.ToString()));
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
 
-      /// <summary>
-      /// Delete purchase order by ID For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
-      /// </summary>
-      /// <param name="OrderId">ID of the order that needs to be deleted</param>
       
-      /// <returns></returns>
-      public void  deleteOrder (string OrderId) {
-        // create path and map variables
-        var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.escapeString(OrderId.ToString()));
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
         }
       }
-      
     }
     
   }
+  
+}

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
@@ -1,423 +1,437 @@
-  using System;
-  using System.Collections.Generic;
-  using io.swagger.client;
-  using io.swagger.Model;
-  
-  
-  
-  
+using System;
+using System.Collections.Generic;
+using io.swagger.client;
+using io.swagger.Model;
 
-  namespace io.swagger.Api {
+namespace io.swagger.Api {
+  
+  public class UserApi {
+    string basePath;
+    private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
+
+    public UserApi(String basePath = "http://petstore.swagger.io/v2")
+    {
+      this.basePath = basePath;
+    }
+
+    public ApiInvoker getInvoker() {
+      return apiInvoker;
+    }
+
+    // Sets the endpoint base url for the services being accessed
+    public void setBasePath(string basePath) {
+      this.basePath = basePath;
+    }
+
+    // Gets the endpoint base url for the services being accessed
+    public String getBasePath() {
+      return basePath;
+    }
+
     
-    public class UserApi {
-      string basePath;
-      private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
 
-      public UserApi(String basePath = "http://petstore.swagger.io/v2")
-      {
-        this.basePath = basePath;
-      }
+    /// <summary>
+    /// Create user This can only be done by the logged in user.
+    /// </summary>
+    /// <param name="Body">Created user object</param>
+    
+    /// <returns></returns>
+    public void  createUser (User Body) {
+      // create path and map variables
+      var path = "/user".Replace("{format}","json");
 
-      public ApiInvoker getInvoker() {
-        return apiInvoker;
-      }
-
-      // Sets the endpoint base url for the services being accessed
-      public void setBasePath(string basePath) {
-        this.basePath = basePath;
-      }
-
-      // Gets the endpoint base url for the services being accessed
-      public String getBasePath() {
-        return basePath;
-      }
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
 
       
 
-      /// <summary>
-      /// Create user This can only be done by the logged in user.
-      /// </summary>
-      /// <param name="Body">Created user object</param>
       
-      /// <returns></returns>
-      public void  createUser (User Body) {
-        // create path and map variables
-        var path = "/user".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
         }
       }
+    }
+    
+
+    /// <summary>
+    /// Creates list of users with given input array 
+    /// </summary>
+    /// <param name="Body">List of user object</param>
+    
+    /// <returns></returns>
+    public void  createUsersWithArrayInput (List<User> Body) {
+      // create path and map variables
+      var path = "/user/createWithArray".Replace("{format}","json");
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
 
-      /// <summary>
-      /// Creates list of users with given input array 
-      /// </summary>
-      /// <param name="Body">List of user object</param>
       
-      /// <returns></returns>
-      public void  createUsersWithArrayInput (List<User> Body) {
-        // create path and map variables
-        var path = "/user/createWithArray".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
+          return;
+          
         }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
+
+    /// <summary>
+    /// Creates list of users with given input array 
+    /// </summary>
+    /// <param name="Body">List of user object</param>
+    
+    /// <returns></returns>
+    public void  createUsersWithListInput (List<User> Body) {
+      // create path and map variables
+      var path = "/user/createWithList".Replace("{format}","json");
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
+      
+
+      
+
+      
+
+      
+
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
+
+    /// <summary>
+    /// Logs user into the system 
+    /// </summary>
+    /// <param name="Username">The user name for login</param>
+     /// <param name="Password">The password for login in clear text</param>
+    
+    /// <returns></returns>
+    public string  loginUser (string Username, string Password) {
+      // create path and map variables
+      var path = "/user/login".Replace("{format}","json");
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
+      
+
+      if (Username != null){
+        string paramStr = (Username is DateTime) ? ((DateTime)(object)Username).ToString("u") : Convert.ToString(Username);
+        queryParams.Add("username", paramStr);
+      }
+      if (Password != null){
+        string paramStr = (Password is DateTime) ? ((DateTime)(object)Password).ToString("u") : Convert.ToString(Password);
+        queryParams.Add("password", paramStr);
       }
       
 
-      /// <summary>
-      /// Creates list of users with given input array 
-      /// </summary>
-      /// <param name="Body">List of user object</param>
       
-      /// <returns></returns>
-      public void  createUsersWithListInput (List<User> Body) {
-        // create path and map variables
-        var path = "/user/createWithList".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
-
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
+      try {
+        if (typeof(string) == typeof(byte[])) {
+          
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as string;
+          
+          
+        } else {
+          
+          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          if (response != null){
+             return (string) ApiInvoker.deserialize(response, typeof(string));
           }
           else {
-            throw ex;
+            return null;
           }
+          
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return null;
+        }
+        else {
+          throw ex;
         }
       }
+    }
+    
+
+    /// <summary>
+    /// Logs out current logged in user session 
+    /// </summary>
+    
+    /// <returns></returns>
+    public void  logoutUser () {
+      // create path and map variables
+      var path = "/user/logout".Replace("{format}","json");
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
 
-      /// <summary>
-      /// Logs user into the system 
-      /// </summary>
-      /// <param name="Username">The user name for login</param>
-       /// <param name="Password">The password for login in clear text</param>
       
-      /// <returns></returns>
-      public string  loginUser (string Username, string Password) {
-        // create path and map variables
-        var path = "/user/login".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        if (Username != null){
-          string paramStr = (Username is DateTime) ? ((DateTime)(object)Username).ToString("u") : Convert.ToString(Username);
-          queryParams.Add("username", paramStr);
-		}
-        if (Password != null){
-          string paramStr = (Password is DateTime) ? ((DateTime)(object)Password).ToString("u") : Convert.ToString(Password);
-          queryParams.Add("password", paramStr);
-		}
-        
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
+        }
+      }
+    }
+    
 
-        
+    /// <summary>
+    /// Get user by user name 
+    /// </summary>
+    /// <param name="Username">The name that needs to be fetched. Use user1 for testing. </param>
+    
+    /// <returns></returns>
+    public User  getUserByName (string Username) {
+      // create path and map variables
+      var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.escapeString(Username.ToString()));
 
-        
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
 
-        try {
-          if (typeof(string) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ((object)response) as string;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return (string) ApiInvoker.deserialize(response, typeof(string));
-            }
-            else {
-              return null;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return null;
+      
+
+      
+
+      
+
+      
+
+      try {
+        if (typeof(User) == typeof(byte[])) {
+          
+          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return ((object)response) as User;
+          
+          
+        } else {
+          
+          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          if (response != null){
+             return (User) ApiInvoker.deserialize(response, typeof(User));
           }
           else {
-            throw ex;
+            return null;
           }
+          
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return null;
+        }
+        else {
+          throw ex;
         }
       }
+    }
+    
+
+    /// <summary>
+    /// Updated user This can only be done by the logged in user.
+    /// </summary>
+    /// <param name="Username">name that need to be deleted</param>
+     /// <param name="Body">Updated user object</param>
+    
+    /// <returns></returns>
+    public void  updateUser (string Username, User Body) {
+      // create path and map variables
+      var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.escapeString(Username.ToString()));
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
 
-      /// <summary>
-      /// Logs out current logged in user session 
-      /// </summary>
       
-      /// <returns></returns>
-      public void  logoutUser () {
-        // create path and map variables
-        var path = "/user/logout".Replace("{format}","json");
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "PUT", queryParams, Body, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
         }
       }
+    }
+    
+
+    /// <summary>
+    /// Delete user This can only be done by the logged in user.
+    /// </summary>
+    /// <param name="Username">The name that needs to be deleted</param>
+    
+    /// <returns></returns>
+    public void  deleteUser (string Username) {
+      // create path and map variables
+      var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.escapeString(Username.ToString()));
+
+      // query params
+      var queryParams = new Dictionary<String, String>();
+      var headerParams = new Dictionary<String, String>();
+      var formParams = new Dictionary<String, object>();
+
       
 
-      /// <summary>
-      /// Get user by user name 
-      /// </summary>
-      /// <param name="Username">The name that needs to be fetched. Use user1 for testing. </param>
       
-      /// <returns></returns>
-      public User  getUserByName (string Username) {
-        // create path and map variables
-        var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.escapeString(Username.ToString()));
 
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
+      
 
-        
+      
 
-        
-
-        
-
-        
-
-        try {
-          if (typeof(User) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ((object)response) as User;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return (User) ApiInvoker.deserialize(response, typeof(User));
-            }
-            else {
-              return null;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return null;
-          }
-          else {
-            throw ex;
-          }
+      try {
+        if (typeof(void) == typeof(byte[])) {
+          
+          
+          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
+          return;
+          
+        } else {
+          
+          
+          apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
+          return;
+          
+        }
+      } catch (ApiException ex) {
+        if(ex.ErrorCode == 404) {
+          return ;
+        }
+        else {
+          throw ex;
         }
       }
-      
-
-      /// <summary>
-      /// Updated user This can only be done by the logged in user.
-      /// </summary>
-      /// <param name="Username">name that need to be deleted</param>
-       /// <param name="Body">Updated user object</param>
-      
-      /// <returns></returns>
-      public void  updateUser (string Username, User Body) {
-        // create path and map variables
-        var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.escapeString(Username.ToString()));
-
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
-
-        
-
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "PUT", queryParams, Body, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
-        }
-      }
-      
-
-      /// <summary>
-      /// Delete user This can only be done by the logged in user.
-      /// </summary>
-      /// <param name="Username">The name that needs to be deleted</param>
-      
-      /// <returns></returns>
-      public void  deleteUser (string Username) {
-        // create path and map variables
-        var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.escapeString(Username.ToString()));
-
-        // query params
-        var queryParams = new Dictionary<String, String>();
-        var headerParams = new Dictionary<String, String>();
-        var formParams = new Dictionary<String, object>();
-
-        
-
-        
-
-        
-
-        
-
-        try {
-          if (typeof(void) == typeof(byte[])) {
-            var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-            return ;
-          } else {
-            var response = apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
-            if(response != null){
-               return ;
-            }
-            else {
-              return ;
-            }
-          }
-        } catch (ApiException ex) {
-          if(ex.ErrorCode == 404) {
-          	return ;
-          }
-          else {
-            throw ex;
-          }
-        }
-      }
-      
     }
     
   }
+  
+}


### PR DESCRIPTION
Currently, IDE shows the following warnings:
```
Warning CS0219: The variable `response' is assigned but its value is never used (CS0219)
```

This is due to the variable response is defined even the return type is "void".

This PR updates the code to use {{#returnType}} and {{^returnType}} to correctly declare the variable response if needed (number of warnings down from 33 to 22)

This PR also updates code format of api.mustache: remove 2 leading spaces and replace tab with spaces

