### PR TITLE
Support unicode string in python client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 {{classname}}.py
 Copyright 2015 Reverb Technologies, Inc.

--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 Copyright 2015 Reverb Technologies, Inc.
 
@@ -39,7 +41,7 @@ class {{classname}}(object):
             {{#vars}}
             '{{name}}': '{{baseName}}'{{#hasMore}},{{/hasMore}}
             {{/vars}}
-        }       
+        }
 
         {{#vars}}
         {{#description}}#{{description}}

--- a/modules/swagger-codegen/src/main/resources/python/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/swagger.mustache
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """Swagger generic API client. This client handles the client-
 server communication, and is invariant across implementations. Specifics of
 the methods and models for each application are generated from the Swagger


### PR DESCRIPTION
Fixed issue that it will throw some errors if unicode string in the python client.