### PR TITLE
Added unit testing for PHP Petstore client

### DIFF
--- a/samples/client/petstore/php/SwaggerPetstore-php/README.md
+++ b/samples/client/petstore/php/SwaggerPetstore-php/README.md
@@ -1,0 +1,52 @@
+## Requirements
+
+PHP 5.3.3 and later.
+
+## Composer
+
+You can install the bindings via [Composer](http://getcomposer.org/). Add this to your `composer.json`:
+
+    {
+        "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/wing328/SwaggerPetstore-php.git"
+        }
+        ],
+        "require": {
+            "SwaggerPetstore/SwaggerPetstore-php": "*@dev"
+        }
+    }
+
+Then install via:
+
+    composer install
+
+To use the bindings, use Composer's [autoload](https://getcomposer.org/doc/00-intro.md#autoloading):
+
+    require_once('vendor/autoload.php');
+
+## Manual Installation
+
+If you do not wish to use Composer, you can download the latest release. Then, to use the bindings, include the `SwaggerPetstore.php` file.
+
+    require_once('/path/to/SwaggerPetstore-php/SwaggerPetstore.php');
+
+## Getting Started
+
+php test.php
+
+## Documentation
+
+TODO
+
+## Tests
+
+In order to run tests first install [PHPUnit](http://packagist.org/packages/phpunit/phpunit) via [Composer](http://getcomposer.org/):
+
+    composer update
+
+To run the test suite:
+
+    ./vendor/bin/phpunit tests
+

--- a/samples/client/petstore/php/SwaggerPetstore-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerPetstore-php/tests/PetApiTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require('SwaggerPetstore.php');
+require_once('SwaggerPetstore.php');
 
 class PetApiTest extends \PHPUnit_Framework_TestCase
 {

--- a/samples/client/petstore/php/SwaggerPetstore-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerPetstore-php/tests/PetApiTest.php
@@ -1,0 +1,19 @@
+<?php
+
+require('SwaggerPetstore.php');
+
+class PetApiTest extends \PHPUnit_Framework_TestCase
+{
+  public function testGetPetById()
+  {
+    // initialize the API client
+    $api_client = new SwaggerPetstore\APIClient('http://petstore.swagger.io/v2');
+    $petId = 5;  // ID of pet that needs to be fetched
+    $pet_api = new SwaggerPetstore\PetAPI($api_client);
+    // return Pet (model)
+    $response = $pet_api->getPetById($petId);
+    $this->assertSame($response->id, $petId);
+  }
+}
+
+?>


### PR DESCRIPTION
Added a unit test for PHP petstore client - getPetById, using PHPUnit_Framework_TestCase
Added a readme with instruction on how to perform testing.

Here is the test result

```
./vendor/bin/phpunit tests
PHPUnit 4.6.2 by Sebastian Bergmann and contributors.

.

Time: 2.45 seconds, Memory: 2.75Mb

OK (1 test, 1 assertion)
```

This PR is a starting point for PHP client unit testing. More tests will be added with reference to how other Petstore client (e.g. ruby, java) is tested.