### PR TITLE
Update method naming convention for csharp, ruby, python

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -838,7 +838,7 @@ public class DefaultCodegen {
     // op.cookieParams = cookieParams;
     op.formParams = addHasMore(formParams);
     // legacy support
-    op.nickname = operationId;
+    op.nickname = op.operationId;
 
     if(op.allParams.size() > 0) 
       op.hasParams = true;

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/CSharpClientCodegen.java
@@ -163,4 +163,14 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
       type = swaggerType;
     return type;
   }
+
+  @Override
+  public String toOperationId(String operationId) {
+    // method name cannot use reserved keyword, e.g. return
+    if(reservedWords.contains(operationId))
+      throw new RuntimeException(operationId + " (reserved word) cannot be used as method name");
+
+    return camelize(operationId);
+  }
+
 }

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PythonClientCodegen.java
@@ -187,4 +187,14 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
     return underscore(name) + "_api";
   }
 
+  public String toOperationId(String operationId) {
+    // method name cannot use reserved keyword, e.g. return
+    if(reservedWords.contains(operationId))
+      throw new RuntimeException(operationId + " (reserved word) cannot be used as method name");
+
+    return underscore(operationId);
+  }
+
+
+
 }

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/RubyClientCodegen.java
@@ -154,7 +154,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
   public String toModelName(String name) {
     // model name cannot use reserved keyword, e.g. return
     if(reservedWords.contains(name))
-      throw new RuntimeException(name + " (reserved word) cannot be used as a model name");
+      throw new RuntimeException(name + " (reserved word) cannot be used as model name");
  
     // camelize the model name
     // phone_number => PhoneNumber
@@ -165,7 +165,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
   public String toModelFilename(String name) {
     // model name cannot use reserved keyword, e.g. return
     if(reservedWords.contains(name))
-      throw new RuntimeException(name + " (reserved word) cannot be used as a model name");
+      throw new RuntimeException(name + " (reserved word) cannot be used as model name");
  
     // underscore the model file name
     // PhoneNumber.rb => phone_number.rb
@@ -187,6 +187,15 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
       return "DefaultApi";
     // e.g. phone_number_api => PhoneNumberApi 
     return camelize(name) + "Api";
+  }
+
+  @Override
+  public String toOperationId(String operationId) {
+    // method name cannot use reserved keyword, e.g. return
+    if(reservedWords.contains(operationId))
+      throw new RuntimeException(operationId + " (reserved word) cannot be used as method name");
+
+    return underscore(operationId); 
   }
 
 }

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
@@ -36,7 +36,7 @@ namespace io.swagger.Api {
     /// <param name="Body">Pet object that needs to be added to the store</param>
     
     /// <returns></returns>
-    public void  updatePet (Pet Body) {
+    public void  UpdatePet (Pet Body) {
       // create path and map variables
       var path = "/pet".Replace("{format}","json");
 
@@ -84,7 +84,7 @@ namespace io.swagger.Api {
     /// <param name="Body">Pet object that needs to be added to the store</param>
     
     /// <returns></returns>
-    public void  addPet (Pet Body) {
+    public void  AddPet (Pet Body) {
       // create path and map variables
       var path = "/pet".Replace("{format}","json");
 
@@ -132,7 +132,7 @@ namespace io.swagger.Api {
     /// <param name="Status">Status values that need to be considered for filter</param>
     
     /// <returns></returns>
-    public List<Pet>  findPetsByStatus (List<string> Status) {
+    public List<Pet>  FindPetsByStatus (List<string> Status) {
       // create path and map variables
       var path = "/pet/findByStatus".Replace("{format}","json");
 
@@ -188,7 +188,7 @@ namespace io.swagger.Api {
     /// <param name="Tags">Tags to filter by</param>
     
     /// <returns></returns>
-    public List<Pet>  findPetsByTags (List<string> Tags) {
+    public List<Pet>  FindPetsByTags (List<string> Tags) {
       // create path and map variables
       var path = "/pet/findByTags".Replace("{format}","json");
 
@@ -244,7 +244,7 @@ namespace io.swagger.Api {
     /// <param name="PetId">ID of pet that needs to be fetched</param>
     
     /// <returns></returns>
-    public Pet  getPetById (long? PetId) {
+    public Pet  GetPetById (long? PetId) {
       // create path and map variables
       var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
 
@@ -299,7 +299,7 @@ namespace io.swagger.Api {
      /// <param name="Status">Updated status of the pet</param>
     
     /// <returns></returns>
-    public void  updatePetWithForm (string PetId, string Name, string Status) {
+    public void  UpdatePetWithForm (string PetId, string Name, string Status) {
       // create path and map variables
       var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
 
@@ -362,7 +362,7 @@ namespace io.swagger.Api {
      /// <param name="PetId">Pet id to delete</param>
     
     /// <returns></returns>
-    public void  deletePet (string ApiKey, long? PetId) {
+    public void  DeletePet (string ApiKey, long? PetId) {
       // create path and map variables
       var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
 
@@ -413,7 +413,7 @@ namespace io.swagger.Api {
      /// <param name="File">file to upload</param>
     
     /// <returns></returns>
-    public void  uploadFile (long? PetId, string AdditionalMetadata, byte[] File) {
+    public void  UploadFile (long? PetId, string AdditionalMetadata, byte[] File) {
       // create path and map variables
       var path = "/pet/{petId}/uploadImage".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
 

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
@@ -35,7 +35,7 @@ namespace io.swagger.Api {
     /// </summary>
     
     /// <returns></returns>
-    public Dictionary<String, int?>  getInventory () {
+    public Dictionary<String, int?>  GetInventory () {
       // create path and map variables
       var path = "/store/inventory".Replace("{format}","json");
 
@@ -88,7 +88,7 @@ namespace io.swagger.Api {
     /// <param name="Body">order placed for purchasing the pet</param>
     
     /// <returns></returns>
-    public Order  placeOrder (Order Body) {
+    public Order  PlaceOrder (Order Body) {
       // create path and map variables
       var path = "/store/order".Replace("{format}","json");
 
@@ -141,7 +141,7 @@ namespace io.swagger.Api {
     /// <param name="OrderId">ID of pet that needs to be fetched</param>
     
     /// <returns></returns>
-    public Order  getOrderById (string OrderId) {
+    public Order  GetOrderById (string OrderId) {
       // create path and map variables
       var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.ParameterToString(OrderId));
 
@@ -194,7 +194,7 @@ namespace io.swagger.Api {
     /// <param name="OrderId">ID of the order that needs to be deleted</param>
     
     /// <returns></returns>
-    public void  deleteOrder (string OrderId) {
+    public void  DeleteOrder (string OrderId) {
       // create path and map variables
       var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.ParameterToString(OrderId));
 

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
@@ -36,7 +36,7 @@ namespace io.swagger.Api {
     /// <param name="Body">Created user object</param>
     
     /// <returns></returns>
-    public void  createUser (User Body) {
+    public void  CreateUser (User Body) {
       // create path and map variables
       var path = "/user".Replace("{format}","json");
 
@@ -84,7 +84,7 @@ namespace io.swagger.Api {
     /// <param name="Body">List of user object</param>
     
     /// <returns></returns>
-    public void  createUsersWithArrayInput (List<User> Body) {
+    public void  CreateUsersWithArrayInput (List<User> Body) {
       // create path and map variables
       var path = "/user/createWithArray".Replace("{format}","json");
 
@@ -132,7 +132,7 @@ namespace io.swagger.Api {
     /// <param name="Body">List of user object</param>
     
     /// <returns></returns>
-    public void  createUsersWithListInput (List<User> Body) {
+    public void  CreateUsersWithListInput (List<User> Body) {
       // create path and map variables
       var path = "/user/createWithList".Replace("{format}","json");
 
@@ -181,7 +181,7 @@ namespace io.swagger.Api {
      /// <param name="Password">The password for login in clear text</param>
     
     /// <returns></returns>
-    public string  loginUser (string Username, string Password) {
+    public string  LoginUser (string Username, string Password) {
       // create path and map variables
       var path = "/user/login".Replace("{format}","json");
 
@@ -239,7 +239,7 @@ namespace io.swagger.Api {
     /// </summary>
     
     /// <returns></returns>
-    public void  logoutUser () {
+    public void  LogoutUser () {
       // create path and map variables
       var path = "/user/logout".Replace("{format}","json");
 
@@ -287,7 +287,7 @@ namespace io.swagger.Api {
     /// <param name="Username">The name that needs to be fetched. Use user1 for testing. </param>
     
     /// <returns></returns>
-    public User  getUserByName (string Username) {
+    public User  GetUserByName (string Username) {
       // create path and map variables
       var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
 
@@ -341,7 +341,7 @@ namespace io.swagger.Api {
      /// <param name="Body">Updated user object</param>
     
     /// <returns></returns>
-    public void  updateUser (string Username, User Body) {
+    public void  UpdateUser (string Username, User Body) {
       // create path and map variables
       var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
 
@@ -389,7 +389,7 @@ namespace io.swagger.Api {
     /// <param name="Username">The name that needs to be deleted</param>
     
     /// <returns></returns>
-    public void  deleteUser (string Username) {
+    public void  DeleteUser (string Username) {
       // create path and map variables
       var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
 

--- a/samples/client/petstore/python/client/models/category.py
+++ b/samples/client/petstore/python/client/models/category.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 Copyright 2015 Reverb Technologies, Inc.
 
@@ -41,7 +43,7 @@ class Category(object):
             
             'name': 'name'
             
-        }       
+        }
 
         
         

--- a/samples/client/petstore/python/client/models/order.py
+++ b/samples/client/petstore/python/client/models/order.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 Copyright 2015 Reverb Technologies, Inc.
 
@@ -61,7 +63,7 @@ class Order(object):
             
             'complete': 'complete'
             
-        }       
+        }
 
         
         

--- a/samples/client/petstore/python/client/models/pet.py
+++ b/samples/client/petstore/python/client/models/pet.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 Copyright 2015 Reverb Technologies, Inc.
 
@@ -61,7 +63,7 @@ class Pet(object):
             
             'status': 'status'
             
-        }       
+        }
 
         
         

--- a/samples/client/petstore/python/client/models/tag.py
+++ b/samples/client/petstore/python/client/models/tag.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 Copyright 2015 Reverb Technologies, Inc.
 
@@ -41,7 +43,7 @@ class Tag(object):
             
             'name': 'name'
             
-        }       
+        }
 
         
         

--- a/samples/client/petstore/python/client/models/user.py
+++ b/samples/client/petstore/python/client/models/user.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 Copyright 2015 Reverb Technologies, Inc.
 
@@ -71,7 +73,7 @@ class User(object):
             
             'user_status': 'userStatus'
             
-        }       
+        }
 
         
         

--- a/samples/client/petstore/python/client/pet_api.py
+++ b/samples/client/petstore/python/client/pet_api.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 PetApi.py
 Copyright 2015 Reverb Technologies, Inc.
@@ -31,7 +33,7 @@ class PetApi(object):
 
     
     
-    def updatePet(self, **kwargs):
+    def update_pet(self, **kwargs):
         """Update an existing pet
 
         Args:
@@ -48,7 +50,7 @@ class PetApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method updatePet" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method update_pet" % key)
             params[key] = val
         del params['kwargs']
 
@@ -87,7 +89,7 @@ class PetApi(object):
         
         
     
-    def addPet(self, **kwargs):
+    def add_pet(self, **kwargs):
         """Add a new pet to the store
 
         Args:
@@ -104,7 +106,7 @@ class PetApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method addPet" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method add_pet" % key)
             params[key] = val
         del params['kwargs']
 
@@ -143,7 +145,7 @@ class PetApi(object):
         
         
     
-    def findPetsByStatus(self, **kwargs):
+    def find_pets_by_status(self, **kwargs):
         """Finds Pets by status
 
         Args:
@@ -160,7 +162,7 @@ class PetApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method findPetsByStatus" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method find_pets_by_status" % key)
             params[key] = val
         del params['kwargs']
 
@@ -205,7 +207,7 @@ class PetApi(object):
         
         
     
-    def findPetsByTags(self, **kwargs):
+    def find_pets_by_tags(self, **kwargs):
         """Finds Pets by tags
 
         Args:
@@ -222,7 +224,7 @@ class PetApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method findPetsByTags" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method find_pets_by_tags" % key)
             params[key] = val
         del params['kwargs']
 
@@ -267,7 +269,7 @@ class PetApi(object):
         
         
     
-    def getPetById(self, **kwargs):
+    def get_pet_by_id(self, **kwargs):
         """Find pet by ID
 
         Args:
@@ -284,7 +286,7 @@ class PetApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method getPetById" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method get_pet_by_id" % key)
             params[key] = val
         del params['kwargs']
 
@@ -332,7 +334,7 @@ class PetApi(object):
         
         
     
-    def updatePetWithForm(self, **kwargs):
+    def update_pet_with_form(self, **kwargs):
         """Updates a pet in the store with form data
 
         Args:
@@ -355,7 +357,7 @@ class PetApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method updatePetWithForm" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method update_pet_with_form" % key)
             params[key] = val
         del params['kwargs']
 
@@ -403,7 +405,7 @@ class PetApi(object):
         
         
     
-    def deletePet(self, **kwargs):
+    def delete_pet(self, **kwargs):
         """Deletes a pet
 
         Args:
@@ -423,7 +425,7 @@ class PetApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method deletePet" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method delete_pet" % key)
             params[key] = val
         del params['kwargs']
 
@@ -468,7 +470,7 @@ class PetApi(object):
         
         
     
-    def uploadFile(self, **kwargs):
+    def upload_file(self, **kwargs):
         """uploads an image
 
         Args:
@@ -491,7 +493,7 @@ class PetApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method uploadFile" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method upload_file" % key)
             params[key] = val
         del params['kwargs']
 

--- a/samples/client/petstore/python/client/store_api.py
+++ b/samples/client/petstore/python/client/store_api.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 StoreApi.py
 Copyright 2015 Reverb Technologies, Inc.
@@ -31,7 +33,7 @@ class StoreApi(object):
 
     
     
-    def getInventory(self, **kwargs):
+    def get_inventory(self, **kwargs):
         """Returns pet inventories by status
 
         Args:
@@ -45,7 +47,7 @@ class StoreApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method getInventory" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method get_inventory" % key)
             params[key] = val
         del params['kwargs']
 
@@ -87,7 +89,7 @@ class StoreApi(object):
         
         
     
-    def placeOrder(self, **kwargs):
+    def place_order(self, **kwargs):
         """Place an order for a pet
 
         Args:
@@ -104,7 +106,7 @@ class StoreApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method placeOrder" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method place_order" % key)
             params[key] = val
         del params['kwargs']
 
@@ -149,7 +151,7 @@ class StoreApi(object):
         
         
     
-    def getOrderById(self, **kwargs):
+    def get_order_by_id(self, **kwargs):
         """Find purchase order by ID
 
         Args:
@@ -166,7 +168,7 @@ class StoreApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method getOrderById" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method get_order_by_id" % key)
             params[key] = val
         del params['kwargs']
 
@@ -214,7 +216,7 @@ class StoreApi(object):
         
         
     
-    def deleteOrder(self, **kwargs):
+    def delete_order(self, **kwargs):
         """Delete purchase order by ID
 
         Args:
@@ -231,7 +233,7 @@ class StoreApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method deleteOrder" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method delete_order" % key)
             params[key] = val
         del params['kwargs']
 

--- a/samples/client/petstore/python/client/swagger.py
+++ b/samples/client/petstore/python/client/swagger.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """Swagger generic API client. This client handles the client-
 server communication, and is invariant across implementations. Specifics of
 the methods and models for each application are generated from the Swagger

--- a/samples/client/petstore/python/client/user_api.py
+++ b/samples/client/petstore/python/client/user_api.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding: utf-8
+
 """
 UserApi.py
 Copyright 2015 Reverb Technologies, Inc.
@@ -31,7 +33,7 @@ class UserApi(object):
 
     
     
-    def createUser(self, **kwargs):
+    def create_user(self, **kwargs):
         """Create user
 
         Args:
@@ -48,7 +50,7 @@ class UserApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method createUser" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method create_user" % key)
             params[key] = val
         del params['kwargs']
 
@@ -87,7 +89,7 @@ class UserApi(object):
         
         
     
-    def createUsersWithArrayInput(self, **kwargs):
+    def create_users_with_array_input(self, **kwargs):
         """Creates list of users with given input array
 
         Args:
@@ -104,7 +106,7 @@ class UserApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method createUsersWithArrayInput" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method create_users_with_array_input" % key)
             params[key] = val
         del params['kwargs']
 
@@ -143,7 +145,7 @@ class UserApi(object):
         
         
     
-    def createUsersWithListInput(self, **kwargs):
+    def create_users_with_list_input(self, **kwargs):
         """Creates list of users with given input array
 
         Args:
@@ -160,7 +162,7 @@ class UserApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method createUsersWithListInput" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method create_users_with_list_input" % key)
             params[key] = val
         del params['kwargs']
 
@@ -199,7 +201,7 @@ class UserApi(object):
         
         
     
-    def loginUser(self, **kwargs):
+    def login_user(self, **kwargs):
         """Logs user into the system
 
         Args:
@@ -219,7 +221,7 @@ class UserApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method loginUser" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method login_user" % key)
             params[key] = val
         del params['kwargs']
 
@@ -267,7 +269,7 @@ class UserApi(object):
         
         
     
-    def logoutUser(self, **kwargs):
+    def logout_user(self, **kwargs):
         """Logs out current logged in user session
 
         Args:
@@ -281,7 +283,7 @@ class UserApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method logoutUser" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method logout_user" % key)
             params[key] = val
         del params['kwargs']
 
@@ -317,7 +319,7 @@ class UserApi(object):
         
         
     
-    def getUserByName(self, **kwargs):
+    def get_user_by_name(self, **kwargs):
         """Get user by user name
 
         Args:
@@ -334,7 +336,7 @@ class UserApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method getUserByName" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method get_user_by_name" % key)
             params[key] = val
         del params['kwargs']
 
@@ -382,7 +384,7 @@ class UserApi(object):
         
         
     
-    def updateUser(self, **kwargs):
+    def update_user(self, **kwargs):
         """Updated user
 
         Args:
@@ -402,7 +404,7 @@ class UserApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method updateUser" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method update_user" % key)
             params[key] = val
         del params['kwargs']
 
@@ -447,7 +449,7 @@ class UserApi(object):
         
         
     
-    def deleteUser(self, **kwargs):
+    def delete_user(self, **kwargs):
         """Delete user
 
         Args:
@@ -464,7 +466,7 @@ class UserApi(object):
         params = locals()
         for (key, val) in params['kwargs'].iteritems():
             if key not in allParams:
-                raise TypeError("Got an unexpected keyword argument '%s' to method deleteUser" % key)
+                raise TypeError("Got an unexpected keyword argument '%s' to method delete_user" % key)
             params[key] = val
         del params['kwargs']
 

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -9,7 +9,7 @@ class PetApi
   # 
   # @param body Pet object that needs to be added to the store
   # @return void
-  def self.updatePet (body, opts={})
+  def self.update_pet (body, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -78,7 +78,7 @@ class PetApi
   # 
   # @param body Pet object that needs to be added to the store
   # @return void
-  def self.addPet (body, opts={})
+  def self.add_pet (body, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -147,7 +147,7 @@ class PetApi
   # Multiple status values can be provided with comma seperated strings
   # @param status Status values that need to be considered for filter
   # @return array[Pet]
-  def self.findPetsByStatus (status, opts={})
+  def self.find_pets_by_status (status, opts={})
     query_param_keys = [:status]
     headerParams = {}
 
@@ -198,7 +198,7 @@ class PetApi
   # Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
   # @param tags Tags to filter by
   # @return array[Pet]
-  def self.findPetsByTags (tags, opts={})
+  def self.find_pets_by_tags (tags, opts={})
     query_param_keys = [:tags]
     headerParams = {}
 
@@ -249,7 +249,7 @@ class PetApi
   # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
   # @param pet_id ID of pet that needs to be fetched
   # @return Pet
-  def self.getPetById (pet_id, opts={})
+  def self.get_pet_by_id (pet_id, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -302,7 +302,7 @@ class PetApi
   # @param name Updated name of the pet
   # @param status Updated status of the pet
   # @return void
-  def self.updatePetWithForm (pet_id, name, status, opts={})
+  def self.update_pet_with_form (pet_id, name, status, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -357,7 +357,7 @@ class PetApi
   # @param api_key 
   # @param pet_id Pet id to delete
   # @return void
-  def self.deletePet (api_key, pet_id, opts={})
+  def self.delete_pet (api_key, pet_id, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -410,7 +410,7 @@ class PetApi
   # @param additional_metadata Additional data to pass to server
   # @param file file to upload
   # @return void
-  def self.uploadFile (pet_id, additional_metadata, file, opts={})
+  def self.upload_file (pet_id, additional_metadata, file, opts={})
     query_param_keys = []
     headerParams = {}
 

--- a/samples/client/petstore/ruby/lib/store_api.rb
+++ b/samples/client/petstore/ruby/lib/store_api.rb
@@ -8,7 +8,7 @@ class StoreApi
   # Returns pet inventories by status
   # Returns a map of status codes to quantities
   # @return map[string,int]
-  def self.getInventory (opts={})
+  def self.get_inventory (opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -58,7 +58,7 @@ class StoreApi
   # 
   # @param body order placed for purchasing the pet
   # @return Order
-  def self.placeOrder (body, opts={})
+  def self.place_order (body, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -128,7 +128,7 @@ class StoreApi
   # For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
   # @param order_id ID of pet that needs to be fetched
   # @return Order
-  def self.getOrderById (order_id, opts={})
+  def self.get_order_by_id (order_id, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -179,7 +179,7 @@ class StoreApi
   # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
   # @param order_id ID of the order that needs to be deleted
   # @return void
-  def self.deleteOrder (order_id, opts={})
+  def self.delete_order (order_id, opts={})
     query_param_keys = []
     headerParams = {}
 

--- a/samples/client/petstore/ruby/lib/user_api.rb
+++ b/samples/client/petstore/ruby/lib/user_api.rb
@@ -9,7 +9,7 @@ class UserApi
   # This can only be done by the logged in user.
   # @param body Created user object
   # @return void
-  def self.createUser (body, opts={})
+  def self.create_user (body, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -78,7 +78,7 @@ class UserApi
   # 
   # @param body List of user object
   # @return void
-  def self.createUsersWithArrayInput (body, opts={})
+  def self.create_users_with_array_input (body, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -147,7 +147,7 @@ class UserApi
   # 
   # @param body List of user object
   # @return void
-  def self.createUsersWithListInput (body, opts={})
+  def self.create_users_with_list_input (body, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -217,7 +217,7 @@ class UserApi
   # @param username The user name for login
   # @param password The password for login in clear text
   # @return string
-  def self.loginUser (username, password, opts={})
+  def self.login_user (username, password, opts={})
     query_param_keys = [:username,:password]
     headerParams = {}
 
@@ -267,7 +267,7 @@ class UserApi
   # Logs out current logged in user session
   # 
   # @return void
-  def self.logoutUser (opts={})
+  def self.logout_user (opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -315,7 +315,7 @@ class UserApi
   # 
   # @param username The name that needs to be fetched. Use user1 for testing. 
   # @return User
-  def self.getUserByName (username, opts={})
+  def self.get_user_by_name (username, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -367,7 +367,7 @@ class UserApi
   # @param username name that need to be deleted
   # @param body Updated user object
   # @return void
-  def self.updateUser (username, body, opts={})
+  def self.update_user (username, body, opts={})
     query_param_keys = []
     headerParams = {}
 
@@ -438,7 +438,7 @@ class UserApi
   # This can only be done by the logged in user.
   # @param username The name that needs to be deleted
   # @return void
-  def self.deleteUser (username, opts={})
+  def self.delete_user (username, opts={})
     query_param_keys = []
     headerParams = {}
 

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -32,16 +32,15 @@ describe "Pet" do
     end
     
     it "should update a pet" do
-      pet = Pet.new({'id' => 99, 'name' => 'programmer', 'status' => 'coding'})
+      pet = Pet.new({'id' => 10002, 'status' => 'sold'})
       PetApi.add_pet(pet)
       
-      fetched = PetApi.get_pet_by_id(99)
-      fetched.id.should == 99
+      fetched = PetApi.get_pet_by_id(10002)
+      fetched.id.should == 10002
     end
 
     it "should create a pet" do 
       pet = Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING")
-      #raise pet.inspect
       PetApi.add_pet(pet)
 
       pet = PetApi.get_pet_by_id(10002)

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -2,11 +2,7 @@ require 'spec_helper'
 
 describe "Pet" do
   before do
-    Swagger.configure do |config|
-      config.api_key = 'special-key' 
-      config.host = 'petstore.swagger.io'
-      config.base_path = '/v2'
-    end
+    configure_swagger
   end
   
   describe "pet methods" do

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -11,16 +11,9 @@ describe "Pet" do
   
   describe "pet methods" do
     it "should fetch a pet object" do
-<<<<<<< HEAD
-      pet = PetApi.getPetById(5)
-      pet.should be_a(Pet)
-      pet.id.should == 5
-      pet.name.should == "panda"
-=======
       pet = PetApi.get_pet_by_id(10002)
       pet.id.should == 10002 
       pet.name.should == "RUBY UNIT TESTING"
->>>>>>> update method naming convention for csharp, ruby, python, fix rspec for
     end
 
     it "should find pets by status" do
@@ -29,11 +22,7 @@ describe "Pet" do
     end
     
     it "should not find a pet with invalid status" do
-<<<<<<< HEAD
-      pets = PetApi.findPetsByStatus('invalid-status')
-=======
       pets = PetApi.find_pets_by_status('invalid_status123')
->>>>>>> update method naming convention for csharp, ruby, python, fix rspec for
       pets.length.should == 0
     end
 

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -11,24 +11,34 @@ describe "Pet" do
   
   describe "pet methods" do
     it "should fetch a pet object" do
+<<<<<<< HEAD
       pet = PetApi.getPetById(5)
       pet.should be_a(Pet)
       pet.id.should == 5
       pet.name.should == "panda"
+=======
+      pet = PetApi.get_pet_by_id(10002)
+      pet.id.should == 10002 
+      pet.name.should == "RUBY UNIT TESTING"
+>>>>>>> update method naming convention for csharp, ruby, python, fix rspec for
     end
 
     it "should find pets by status" do
-      pets = PetApi.findPetsByStatus('available')
+      pets = PetApi.find_pets_by_status('available')
       pets.length.should >= 3
     end
     
     it "should not find a pet with invalid status" do
+<<<<<<< HEAD
       pets = PetApi.findPetsByStatus('invalid-status')
+=======
+      pets = PetApi.find_pets_by_status('invalid_status123')
+>>>>>>> update method naming convention for csharp, ruby, python, fix rspec for
       pets.length.should == 0
     end
 
     it "should find a pet by status" do
-      pets = PetApi.findPetsByStatus("available,sold")
+      pets = PetApi.find_pets_by_status("available,sold")
       pets.map {|pet| 
         if(pet.status != 'available' && pet.status != 'sold') 
           raise "pet status wasn't right"
@@ -38,35 +48,21 @@ describe "Pet" do
     
     it "should update a pet" do
       pet = Pet.new({'id' => 99, 'name' => 'programmer', 'status' => 'coding'})
-      PetApi.addPet(pet)
+      PetApi.add_pet(pet)
       
-      fetched = PetApi.getPetById(99)
+      fetched = PetApi.get_pet_by_id(99)
       fetched.id.should == 99
     end
 
     it "should create a pet" do 
-      pet = Pet.new('id' => 100, 'name' => "Gorilla")
+      pet = Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING")
       #raise pet.inspect
-      PetApi.addPet(pet)
+      PetApi.add_pet(pet)
 
-      pet = PetApi.getPetById(100)
-      pet.id.should == 100
-      pet.name.should == "Gorilla"
+      pet = PetApi.get_pet_by_id(10002)
+      pet.id.should == 10002
+      pet.name.should == "RUBY UNIT TESTING"
     end
   end
 end
 
-describe "Store" do
-  before do
-    Swagger.configure do |config|
-      config.api_key = 'special-key' 
-      config.host = 'petstore.swagger.io'
-      config.base_path = '/v2'
-    end
-  end
-
-  it "should fetch an order" do
-    item = StoreApi.getOrderById(5)
-    item.id.should == 5
-  end
-end

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe "Pet" do
   before do
     configure_swagger
+    prepare_pet
   end
   
   describe "pet methods" do

--- a/samples/client/petstore/ruby/spec/request_spec.rb
+++ b/samples/client/petstore/ruby/spec/request_spec.rb
@@ -3,12 +3,7 @@ require 'spec_helper'
 describe Swagger::Request do
 
   before(:each) do 
-    Swagger.configure do |config|
-      inject_format = true
-      config.api_key = 'special-key'
-      config.host = 'petstore.swagger.io'
-      config.base_path = '/v2'
-    end
+    configure_swagger
 
     @default_http_method = :get
     @default_path = "pet.{format}/fancy"

--- a/samples/client/petstore/ruby/spec/response_spec.rb
+++ b/samples/client/petstore/ruby/spec/response_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 describe Swagger::Response do
 
+  before do
+    configure_swagger
+    prepare_pet
+  end
+
   before(:each) do
 
     VCR.use_cassette('pet_resource', :record => :new_episodes) do

--- a/samples/client/petstore/ruby/spec/response_spec.rb
+++ b/samples/client/petstore/ruby/spec/response_spec.rb
@@ -5,7 +5,7 @@ describe Swagger::Response do
   before(:each) do
 
     VCR.use_cassette('pet_resource', :record => :new_episodes) do
-      @raw = Typhoeus::Request.get("http://petstore.swagger.io/v2/pet/5")
+      @raw = Typhoeus::Request.get("http://petstore.swagger.io/v2/pet/10002")
     end
 
     @response = Swagger::Response.new(@raw)
@@ -35,7 +35,7 @@ describe Swagger::Response do
 
     it "recognizes xml" do
       VCR.use_cassette('xml_response_request', :record => :new_episodes) do
-        @raw = Typhoeus::Request.get("http://petstore.swagger.io/v2/pet/5",
+        @raw = Typhoeus::Request.get("http://petstore.swagger.io/v2/pet/10002",
                                     :headers => {'Accept'=> "application/xml"})
       end
       @response = Swagger::Response.new(@raw)

--- a/samples/client/petstore/ruby/spec/spec_helper.rb
+++ b/samples/client/petstore/ruby/spec/spec_helper.rb
@@ -28,22 +28,40 @@ def help
   exit
 end
 
+# COMMENT OUT AS CREDENTIALS ARE NOT USED AT THE MOMENT (20150410)
 # Parse ~/.swagger.yml for user credentials
-begin
-  CREDENTIALS = YAML::load_file(File.join(ENV['HOME'], ".swagger.yml")).symbolize_keys
-rescue
-  help
-end
+#begin
+#  CREDENTIALS = YAML::load_file(File.join(ENV['HOME'], ".swagger.yml")).symbolize_keys
+#rescue
+#  help
+#end
 
 def configure_swagger
   Swagger.configure do |config|
-    config.api_key = "special-key"
-    config.username = ""
-    config.password = ""
-
-    config.host = 'petstore.swagger.wordnik.com'
-    config.base_path = '/api'
+    config.api_key = 'special-key'
+    config.host = 'petstore.swagger.io'
+    config.base_path = '/v2'
   end
+end
+
+# always delete and then re-create the pet object with 10002
+def prepare_pet
+  # remove the pet
+  PetApi.delete_pet('special-key', 10002)
+  # recreate the pet
+  pet = Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING")
+  PetApi.add_pet(pet)
+end
+
+# always delete and then re-create the store order 
+def prepare_store
+  order = Order.new("id" => 10002,
+		  "petId" => 10002,
+		  "quantity" => 789,
+		  "shipDate" => "2015-04-06T23:42:01.678Z",
+		  "status" => "placed",
+		  "complete" => false)
+  StoreApi.place_order(order)
 end
 
 configure_swagger

--- a/samples/client/petstore/ruby/spec/store_spec.rb
+++ b/samples/client/petstore/ruby/spec/store_spec.rb
@@ -2,15 +2,11 @@ require 'spec_helper'
 
 describe "Store" do
   before do
-    Swagger.configure do |config|
-      config.api_key = 'special-key' 
-      config.host = 'petstore.swagger.io'
-      config.base_path = '/v2'
-    end
+    configure_swagger
   end
 
   it "should fetch an order" do
-    item = StoreApi.get_order_by_id(5)
-    item.id.should == 5
+    item = StoreApi.get_order_by_id(10002)
+    item.id.should == 10002
   end
 end

--- a/samples/client/petstore/ruby/spec/store_spec.rb
+++ b/samples/client/petstore/ruby/spec/store_spec.rb
@@ -10,7 +10,7 @@ describe "Store" do
   end
 
   it "should fetch an order" do
-    item = StoreApi.getOrderById(5)
+    item = StoreApi.get_order_by_id(5)
     item.id.should == 5
   end
 end

--- a/samples/client/petstore/ruby/spec/store_spec.rb
+++ b/samples/client/petstore/ruby/spec/store_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe "Store" do
   before do
     configure_swagger
+    prepare_store
   end
 
   it "should fetch an order" do


### PR DESCRIPTION
Update method naming convention for:
- Ruby: addPet => add_pet
- CSharp: addPet => AddPet
- Python: addPet => add_pet

NO change to PHP, Java and Android since the current method naming (e.g. addPet) already conforms to the convention.