### PR TITLE
Fixed request content-type in objc client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/SWGApiClient.m
+++ b/modules/swagger-codegen/src/main/resources/objc/SWGApiClient.m
@@ -314,7 +314,7 @@ static bool loggingEnabled = true;
         NSString * urlString = [[NSURL URLWithString:path relativeToURL:self.baseURL] absoluteString];
 
         // request with multipart form
-        if(file != nil) {
+        if([requestContentType isEqualToString:@"multipart/form-data"]) {
             request = [self.requestSerializer multipartFormRequestWithMethod: @"POST"
                                                                    URLString: urlString
                                                                   parameters: nil
@@ -325,15 +325,17 @@ static bool loggingEnabled = true;
                                                            [formData appendPartWithFormData: data name: key];
                                                        }
 
-                                                       [formData appendPartWithFileData: [file data]
-                                                                                   name: [file paramName]
-                                                                               fileName: [file name]
-                                                                               mimeType: [file mimeType]];
+                                                       if (file) {
+                                                           [formData appendPartWithFileData: [file data]
+                                                                                       name: [file paramName]
+                                                                                   fileName: [file name]
+                                                                                   mimeType: [file mimeType]];
+                                                       }
 
                                                    }
                                                                        error:nil];
         }
-        // request with form parameters
+        // request with form parameters or json
         else {
             NSString* pathWithQueryParams = [self pathWithQueryParamsToString:path queryParams:queryParams];
             NSString* urlString = [[NSURL URLWithString:pathWithQueryParams relativeToURL:self.baseURL] absoluteString];
@@ -470,7 +472,7 @@ static bool loggingEnabled = true;
         NSString * urlString = [[NSURL URLWithString:path relativeToURL:self.baseURL] absoluteString];
 
         // request with multipart form
-        if(file != nil) {
+        if([requestContentType isEqualToString:@"multipart/form-data"]) {
             request = [self.requestSerializer multipartFormRequestWithMethod: @"POST"
                                                                    URLString: urlString
                                                                   parameters: nil
@@ -481,15 +483,17 @@ static bool loggingEnabled = true;
                                                            [formData appendPartWithFormData: data name: key];
                                                        }
 
-                                                       [formData appendPartWithFileData: [file data]
-                                                                                   name: [file paramName]
-                                                                               fileName: [file name]
-                                                                               mimeType: [file mimeType]];
+                                                       if (file) {
+                                                           [formData appendPartWithFileData: [file data]
+                                                                                       name: [file paramName]
+                                                                                   fileName: [file name]
+                                                                                   mimeType: [file mimeType]];
+                                                       }
 
                                                    }
                                                                        error:nil];
         }
-        // request with form parameters
+        // request with form parameters or json
         else {
             NSString* pathWithQueryParams = [self pathWithQueryParamsToString:path queryParams:queryParams];
             NSString* urlString = [[NSURL URLWithString:pathWithQueryParams relativeToURL:self.baseURL] absoluteString];
@@ -576,3 +580,11 @@ static bool loggingEnabled = true;
 }
 
 @end
+
+
+
+
+
+
+
+


### PR DESCRIPTION
* When call `uploadFile` method without file in objc client, the request content-type is `application/x-www-form-urlencoded` which is incorrect.
* After fixing, the request content-type is `multipart/form-data` and the tcpdump information is below:

```sh
POST /v2/pet/1/uploadImage HTTP/1.1
Host: petstore.swagger.io
Content-Type: multipart/form-data; boundary=Boundary+2262D22AF872FACC
Connection: keep-alive
Accept: */*
User-Agent: PetstoreClient/1.0 (iPhone Simulator; iOS 8.2; Scale/2.00)
Accept-Language: en;q=1, fr;q=0.9, de;q=0.8, zh-Hans;q=0.7, zh-Hant;q=0.6, ja;q=0.5
Content-Length: 130
Accept-Encoding: gzip, deflate
--Boundary+2262D22AF872FACC
Content-Disposition: form-data; name="additionalMetadata"
special
--Boundary+2262D22AF872FACC--
```