### PR TITLE
Fixed "double" response type in PHP client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -282,7 +282,7 @@ class APIClient {
       $deserialized = $values;
     } elseif ($class == 'DateTime') {
       $deserialized = new \DateTime($data);
-    } elseif (in_array($class, array('string', 'int', 'float', 'bool'))) {
+    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool'))) {
       settype($data, $class);
       $deserialized = $data;
     } else {

--- a/samples/client/petstore/php/SwaggerPetstore-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerPetstore-php/lib/APIClient.php
@@ -282,7 +282,7 @@ class APIClient {
       $deserialized = $values;
     } elseif ($class == 'DateTime') {
       $deserialized = new \DateTime($data);
-    } elseif (in_array($class, array('string', 'int', 'float', 'bool'))) {
+    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool'))) {
       settype($data, $class);
       $deserialized = $data;
     } else {


### PR DESCRIPTION
Currently, the PHP API client only looks for the following primitive types:
```
    } elseif (in_array($class, array('string', 'int', 'float', 'bool'))) {
```
This PR updates the check to include "double":
```
    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool'))) {
```