### PR TITLE
Fixed request content-type in python client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -65,8 +65,11 @@ class {{classname}}(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = '{{#produces}}{{mediaType}}{{#hasMore}},{{/hasMore}}{{/produces}}'
-        headerParams['Content-Type'] = '{{#consumes}}{{mediaType}}{{#hasMore}},{{/hasMore}}{{/consumes}}'
+        accepts = [{{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}]
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = [{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}]
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         {{#queryParams}}
         if ('{{paramName}}' in params):

--- a/modules/swagger-codegen/src/main/resources/python/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/swagger.mustache
@@ -82,12 +82,12 @@ class ApiClient(object):
     elif method in ['POST', 'PUT', 'DELETE']:
       if postData:
         postData = ApiClient.sanitizeForSerialization(postData)
-        if 'Content-type' not in headers:
-          headers['Content-type'] = 'application/json'
+        if 'Content-Type' not in headers:
+          headers['Content-Type'] = 'application/json'
           data = json.dumps(postData)
-        elif headers['Content-type'] == 'multipart/form-data':
+        elif headers['Content-Type'] == 'multipart/form-data':
           data = self.buildMultipartFormData(postData, files)
-          headers['Content-type'] = 'multipart/form-data; boundary={0}'.format(self.boundary)
+          headers['Content-Type'] = 'multipart/form-data; boundary={0}'.format(self.boundary)
           headers['Content-length'] = str(len(data))
         else:
             data = urllib.urlencode(postData)

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/pet_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/pet_api.py
@@ -64,8 +64,11 @@ class PetApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = 'application/json,application/xml,'
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = ['application/json', 'application/xml', ]
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -120,8 +123,11 @@ class PetApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = 'application/json,application/xml,'
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = ['application/json', 'application/xml', ]
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -176,8 +182,11 @@ class PetApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
         if ('status' in params):
@@ -238,8 +247,11 @@ class PetApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
         if ('tags' in params):
@@ -300,8 +312,11 @@ class PetApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -371,8 +386,11 @@ class PetApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = 'application/x-www-form-urlencoded,'
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = ['application/x-www-form-urlencoded', ]
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -439,8 +457,11 @@ class PetApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -507,8 +528,11 @@ class PetApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = 'multipart/form-data,'
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = ['multipart/form-data', ]
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/store_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/store_api.py
@@ -61,8 +61,11 @@ class StoreApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -120,8 +123,11 @@ class StoreApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -182,8 +188,11 @@ class StoreApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -247,8 +256,11 @@ class StoreApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/swagger.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/swagger.py
@@ -82,12 +82,12 @@ class ApiClient(object):
     elif method in ['POST', 'PUT', 'DELETE']:
       if postData:
         postData = ApiClient.sanitizeForSerialization(postData)
-        if 'Content-type' not in headers:
-          headers['Content-type'] = 'application/json'
+        if 'Content-Type' not in headers:
+          headers['Content-Type'] = 'application/json'
           data = json.dumps(postData)
-        elif headers['Content-type'] == 'multipart/form-data':
+        elif headers['Content-Type'] == 'multipart/form-data':
           data = self.buildMultipartFormData(postData, files)
-          headers['Content-type'] = 'multipart/form-data; boundary={0}'.format(self.boundary)
+          headers['Content-Type'] = 'multipart/form-data; boundary={0}'.format(self.boundary)
           headers['Content-length'] = str(len(data))
         else:
             data = urllib.urlencode(postData)

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/user_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/user_api.py
@@ -64,8 +64,11 @@ class UserApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -120,8 +123,11 @@ class UserApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -176,8 +182,11 @@ class UserApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -235,8 +244,11 @@ class UserApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
         if ('username' in params):
@@ -297,8 +309,11 @@ class UserApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -350,8 +365,11 @@ class UserApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -418,8 +436,11 @@ class UserApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 
@@ -480,8 +501,11 @@ class UserApi(object):
         files = {}
         bodyParam = None
 
-        headerParams['Accept'] = 'application/json,application/xml'
-        headerParams['Content-Type'] = ''
+        accepts = ['application/json', 'application/xml']
+        headerParams['Accept'] = ', '.join(accepts)
+
+        content_types = []
+        headerParams['Content-Type'] = content_types[0] if len(content_types) > 0 else 'application/json'
 
         
 


### PR DESCRIPTION
In `api.mustache`, the content-type key in the headerParams is `Content-Type`, `headerParams['Content-Type']`.
But in `swagger.mustache`, the content-type key in the headers hash is `Content-type`,
`headers['Content-type']`.
This will result the `content-type` in request headers always be `application/json`.
https://github.com/swagger-api/swagger-codegen/pull/625/files#diff-7356954fd07cc52ba5ac73153eb27cd8R85