### PR TITLE
Making default PHP namespace generic and fix issues 628 and 635

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -28,8 +28,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
   public PhpClientCodegen() {
     super();
 
-    //TODO determine hte package name from host name
-    invokerPackage = camelize("SwaggerPetstore"); 
+    invokerPackage = camelize("SwaggerClient"); 
 
     String packagePath = invokerPackage + "-php";
 

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -289,8 +289,8 @@ class APIClient {
       $class = "{{invokerPackage}}\\models\\".$class;
       $instance = new $class();
       foreach ($instance::$swaggerTypes as $property => $type) {
-        if (isset($data->$property)) {
-          $original_property_name = $instance::$attributeMap[$property];
+        $original_property_name = $instance::$attributeMap[$property];
+        if (isset($original_property_name)) {
           $instance->$property = self::deserialize($data->$original_property_name, $type);
         }
       }

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -73,14 +73,14 @@ class {{classname}} {
         $formParams['{{baseName}}'] = {{#isFile}}'@' . {{/isFile}}$this->apiClient->toFormValue(${{paramName}});
       }{{/formParams}}
       {{#bodyParams}}// body params
-      $body = null;
+      $_tempBody = null;
       if (isset(${{paramName}})) {
-        $body = ${{paramName}};
+        $_tempBody = ${{paramName}};
       }{{/bodyParams}}
 
       // for model (json/xml)
-      if (isset($body)) {
-        $httpBody = $body; // $body is the method argument, if present
+      if (isset($_tempBody)) {
+        $httpBody = $_tempBody; // $_tempBody is the method argument, if present
       }
       
       // for HTTP post (form)


### PR DESCRIPTION
This fixes issue https://github.com/swagger-api/swagger-codegen/issues/628, which causes name collision.