### PR TITLE
Fix hard-coded values in Ruby client: scheme, host and base_path

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultGenerator.java
@@ -93,12 +93,14 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
       }
 
       StringBuilder hostBuilder = new StringBuilder();
+      String scheme;
       if (swagger.getSchemes() != null && swagger.getSchemes().size() > 0) {
-        hostBuilder.append(swagger.getSchemes().get(0).toValue());
-        hostBuilder.append("://");
+        scheme = swagger.getSchemes().get(0).toValue();
       } else {
-        hostBuilder.append("https://");
+        scheme = "https";
       }
+      hostBuilder.append(scheme);
+      hostBuilder.append("://");
       if (swagger.getHost() != null) {
         hostBuilder.append(swagger.getHost());
       } else {
@@ -209,6 +211,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         bundle.put("host", swagger.getHost());
       }
       bundle.put("basePath", basePath);
+      bundle.put("scheme", scheme);
       bundle.put("contextPath", contextPath);
       bundle.put("apiInfo", apis);
       bundle.put("models", allModels);

--- a/modules/swagger-codegen/src/main/resources/ruby/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger.mustache
@@ -7,6 +7,8 @@ require 'logger'
 
 module Swagger
     
+  @configuration = Configuration.new
+
   class << self
     attr_accessor :logger
     
@@ -27,7 +29,6 @@ module Swagger
     #   end
     #
     def configure
-      self.configuration ||= Configuration.new
       yield(configuration) if block_given?
 
       # Configure logger.  Default to use Rails

--- a/modules/swagger-codegen/src/main/resources/ruby/swagger/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger/configuration.mustache
@@ -8,9 +8,9 @@ module Swagger
     # Defaults go in here..
     def initialize
       @format = 'json'
-      @scheme = 'http'
-      @host = 'petstore.swagger.io'
-      @base_path = '/v2'
+      @scheme = '{{scheme}}'
+      @host = '{{host}}'
+      @base_path = '{{contextPath}}'
       @user_agent = "ruby-swagger-#{Swagger::VERSION}"
       @inject_format = false
       @force_ending_format = false


### PR DESCRIPTION
* Fix hard-coded values in Ruby client: scheme, host and base_path, i.e. fill them with default values
* Initialize a default configuration object so that the client can be used without being configured explicitly