### PR TITLE
Update model optional property in objc client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
@@ -9,6 +9,18 @@
   return [[JSONKeyMapper alloc] initWithDictionary:@{ {{#vars}}@"{{baseName}}": @"{{name}}"{{#hasMore}}, {{/hasMore}}{{/vars}} }];
 }
 
++ (BOOL)propertyIsOptional:(NSString *)propertyName
+{
+  NSArray *optionalProperties = @[{{#vars}}{{^required}}@"{{name}}"{{#hasMore}}, {{/hasMore}}{{/required}}{{/vars}}];
+
+  if ([optionalProperties containsObject:propertyName]) {
+    return YES;
+  }
+  else {
+    return NO;
+  }
+}
+
 {{/model}}
 @end
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/objc/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/model-header.mustache
@@ -14,7 +14,7 @@
 {{#vars}}
 {{#description}}/* {{{description}}} {{^required}}[optional]{{/required}}
  */{{/description}}
-@property(nonatomic) {{{ baseType }}}{{^required}}<Optional{{#complexType}}, {{complexType}}{{/complexType}}>{{/required}}* {{name}};
+@property(nonatomic) {{{ datatype }}} {{name}};
 {{/vars}}
 
 @end

--- a/samples/client/petstore/objc/client/SWGApiClient.m
+++ b/samples/client/petstore/objc/client/SWGApiClient.m
@@ -314,7 +314,7 @@ static bool loggingEnabled = true;
         NSString * urlString = [[NSURL URLWithString:path relativeToURL:self.baseURL] absoluteString];
 
         // request with multipart form
-        if(file != nil) {
+        if([requestContentType isEqualToString:@"multipart/form-data"]) {
             request = [self.requestSerializer multipartFormRequestWithMethod: @"POST"
                                                                    URLString: urlString
                                                                   parameters: nil
@@ -325,15 +325,17 @@ static bool loggingEnabled = true;
                                                            [formData appendPartWithFormData: data name: key];
                                                        }
 
-                                                       [formData appendPartWithFileData: [file data]
-                                                                                   name: [file paramName]
-                                                                               fileName: [file name]
-                                                                               mimeType: [file mimeType]];
+                                                       if (file) {
+                                                           [formData appendPartWithFileData: [file data]
+                                                                                       name: [file paramName]
+                                                                                   fileName: [file name]
+                                                                                   mimeType: [file mimeType]];
+                                                       }
 
                                                    }
                                                                        error:nil];
         }
-        // request with form parameters
+        // request with form parameters or json
         else {
             NSString* pathWithQueryParams = [self pathWithQueryParamsToString:path queryParams:queryParams];
             NSString* urlString = [[NSURL URLWithString:pathWithQueryParams relativeToURL:self.baseURL] absoluteString];
@@ -470,7 +472,7 @@ static bool loggingEnabled = true;
         NSString * urlString = [[NSURL URLWithString:path relativeToURL:self.baseURL] absoluteString];
 
         // request with multipart form
-        if(file != nil) {
+        if([requestContentType isEqualToString:@"multipart/form-data"]) {
             request = [self.requestSerializer multipartFormRequestWithMethod: @"POST"
                                                                    URLString: urlString
                                                                   parameters: nil
@@ -481,15 +483,17 @@ static bool loggingEnabled = true;
                                                            [formData appendPartWithFormData: data name: key];
                                                        }
 
-                                                       [formData appendPartWithFileData: [file data]
-                                                                                   name: [file paramName]
-                                                                               fileName: [file name]
-                                                                               mimeType: [file mimeType]];
+                                                       if (file) {
+                                                           [formData appendPartWithFileData: [file data]
+                                                                                       name: [file paramName]
+                                                                                   fileName: [file name]
+                                                                                   mimeType: [file mimeType]];
+                                                       }
 
                                                    }
                                                                        error:nil];
         }
-        // request with form parameters
+        // request with form parameters or json
         else {
             NSString* pathWithQueryParams = [self pathWithQueryParamsToString:path queryParams:queryParams];
             NSString* urlString = [[NSURL URLWithString:pathWithQueryParams relativeToURL:self.baseURL] absoluteString];
@@ -576,3 +580,11 @@ static bool loggingEnabled = true;
 }
 
 @end
+
+
+
+
+
+
+
+

--- a/samples/client/petstore/objc/client/SWGCategory.h
+++ b/samples/client/petstore/objc/client/SWGCategory.h
@@ -8,8 +8,8 @@
 @interface SWGCategory : SWGObject
 
 
-@property(nonatomic) NSNumber<Optional>* _id;
+@property(nonatomic) NSNumber* _id;
 
-@property(nonatomic) NSString<Optional>* name;
+@property(nonatomic) NSString* name;
 
 @end

--- a/samples/client/petstore/objc/client/SWGCategory.m
+++ b/samples/client/petstore/objc/client/SWGCategory.m
@@ -7,4 +7,16 @@
   return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"name": @"name" }];
 }
 
++ (BOOL)propertyIsOptional:(NSString *)propertyName
+{
+  NSArray *optionalProperties = @[@"_id", @"name"];
+
+  if ([optionalProperties containsObject:propertyName]) {
+    return YES;
+  }
+  else {
+    return NO;
+  }
+}
+
 @end

--- a/samples/client/petstore/objc/client/SWGOrder.h
+++ b/samples/client/petstore/objc/client/SWGOrder.h
@@ -8,17 +8,17 @@
 @interface SWGOrder : SWGObject
 
 
-@property(nonatomic) NSNumber<Optional>* _id;
+@property(nonatomic) NSNumber* _id;
 
-@property(nonatomic) NSNumber<Optional>* petId;
+@property(nonatomic) NSNumber* petId;
 
-@property(nonatomic) NSNumber<Optional>* quantity;
+@property(nonatomic) NSNumber* quantity;
 
-@property(nonatomic) NSDate<Optional>* shipDate;
+@property(nonatomic) NSDate* shipDate;
 /* Order Status [optional]
  */
-@property(nonatomic) NSString<Optional>* status;
+@property(nonatomic) NSString* status;
 
-@property(nonatomic) NSNumber<Optional>* complete;
+@property(nonatomic) NSNumber* complete;
 
 @end

--- a/samples/client/petstore/objc/client/SWGOrder.m
+++ b/samples/client/petstore/objc/client/SWGOrder.m
@@ -7,4 +7,16 @@
   return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"petId": @"petId", @"quantity": @"quantity", @"shipDate": @"shipDate", @"status": @"status", @"complete": @"complete" }];
 }
 
++ (BOOL)propertyIsOptional:(NSString *)propertyName
+{
+  NSArray *optionalProperties = @[@"_id", @"petId", @"quantity", @"shipDate", @"status", @"complete"];
+
+  if ([optionalProperties containsObject:propertyName]) {
+    return YES;
+  }
+  else {
+    return NO;
+  }
+}
+
 @end

--- a/samples/client/petstore/objc/client/SWGPet.h
+++ b/samples/client/petstore/objc/client/SWGPet.h
@@ -10,17 +10,17 @@
 @interface SWGPet : SWGObject
 
 
-@property(nonatomic) NSNumber<Optional>* _id;
+@property(nonatomic) NSNumber* _id;
 
-@property(nonatomic) SWGCategory<Optional, SWGCategory>* category;
+@property(nonatomic) SWGCategory* category;
 
 @property(nonatomic) NSString* name;
 
 @property(nonatomic) NSArray* photoUrls;
 
-@property(nonatomic) NSArray<Optional, SWGTag>* tags;
+@property(nonatomic) NSArray<SWGTag>* tags;
 /* pet status in the store [optional]
  */
-@property(nonatomic) NSString<Optional>* status;
+@property(nonatomic) NSString* status;
 
 @end

--- a/samples/client/petstore/objc/client/SWGPet.m
+++ b/samples/client/petstore/objc/client/SWGPet.m
@@ -7,4 +7,16 @@
   return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"category": @"category", @"name": @"name", @"photoUrls": @"photoUrls", @"tags": @"tags", @"status": @"status" }];
 }
 
++ (BOOL)propertyIsOptional:(NSString *)propertyName
+{
+  NSArray *optionalProperties = @[@"category", @"tags", @"status", @"photoUrls", @"_id"];
+
+  if ([optionalProperties containsObject:propertyName]) {
+    return YES;
+  }
+  else {
+    return NO;
+  }
+}
+
 @end

--- a/samples/client/petstore/objc/client/SWGTag.h
+++ b/samples/client/petstore/objc/client/SWGTag.h
@@ -8,8 +8,8 @@
 @interface SWGTag : SWGObject
 
 
-@property(nonatomic) NSNumber<Optional>* _id;
+@property(nonatomic) NSNumber* _id;
 
-@property(nonatomic) NSString<Optional>* name;
+@property(nonatomic) NSString* name;
 
 @end

--- a/samples/client/petstore/objc/client/SWGTag.m
+++ b/samples/client/petstore/objc/client/SWGTag.m
@@ -7,4 +7,16 @@
   return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"name": @"name" }];
 }
 
++ (BOOL)propertyIsOptional:(NSString *)propertyName
+{
+  NSArray *optionalProperties = @[@"_id", @"name"];
+
+  if ([optionalProperties containsObject:propertyName]) {
+    return YES;
+  }
+  else {
+    return NO;
+  }
+}
+
 @end

--- a/samples/client/petstore/objc/client/SWGUser.h
+++ b/samples/client/petstore/objc/client/SWGUser.h
@@ -8,21 +8,21 @@
 @interface SWGUser : SWGObject
 
 
-@property(nonatomic) NSNumber<Optional>* _id;
+@property(nonatomic) NSNumber* _id;
 
-@property(nonatomic) NSString<Optional>* username;
+@property(nonatomic) NSString* username;
 
-@property(nonatomic) NSString<Optional>* firstName;
+@property(nonatomic) NSString* firstName;
 
-@property(nonatomic) NSString<Optional>* lastName;
+@property(nonatomic) NSString* lastName;
 
-@property(nonatomic) NSString<Optional>* email;
+@property(nonatomic) NSString* email;
 
-@property(nonatomic) NSString<Optional>* password;
+@property(nonatomic) NSString* password;
 
-@property(nonatomic) NSString<Optional>* phone;
+@property(nonatomic) NSString* phone;
 /* User Status [optional]
  */
-@property(nonatomic) NSNumber<Optional>* userStatus;
+@property(nonatomic) NSNumber* userStatus;
 
 @end

--- a/samples/client/petstore/objc/client/SWGUser.m
+++ b/samples/client/petstore/objc/client/SWGUser.m
@@ -7,4 +7,16 @@
   return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"username": @"username", @"firstName": @"firstName", @"lastName": @"lastName", @"email": @"email", @"password": @"password", @"phone": @"phone", @"userStatus": @"userStatus" }];
 }
 
++ (BOOL)propertyIsOptional:(NSString *)propertyName
+{
+  NSArray *optionalProperties = @[@"_id", @"username", @"firstName", @"lastName", @"email", @"password", @"phone", @"userStatus"];
+
+  if ([optionalProperties containsObject:propertyName]) {
+    return YES;
+  }
+  else {
+    return NO;
+  }
+}
+
 @end


### PR DESCRIPTION
Use `propertyIsOptional`(https://github.com/icanzilb/JSONModel#make-all-model-properties-optional-avoid-if-possible) to implement optional property instead of using `Optional` protocol in objc client.

If use `Optional` protocol to implement optional property, the generated code will be`BOOL<Optional>` when the data type is `BOOL`.
But the BOOL does not support protocol, so we use `propertyIsOptional` method instead of `Optiona` protocol.