### PR TITLE
[PHP Templates] Fixing a bug which was preventing payloads to serialize into JSON

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -94,7 +94,7 @@ class APIClient {
       $headers[] = $this->headerName . ": " . $this->headerValue;
     }
 
-    if ((isset($headers['Content-Type']) and strpos($headers['Content-Type'], "multipart/form-data") === FALSE) and (is_object($postData) or is_array($postData))) {
+    if ((isset($headerName['Content-Type']) and strpos($headerName['Content-Type'], "multipart/form-data") === FALSE) and (is_object($postData) or is_array($postData))) {
       $postData = json_encode($this->sanitizeForSerialization($postData));
     }
 


### PR DESCRIPTION
We found and fixed a bug in the PHP template which was causing PHP arrays to never serialize down to JSON.