### PR TITLE
Add support of optional parameters to Ruby codegen

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -4,55 +4,47 @@ require "uri"
 class {{classname}}
   basePath = "{{basePath}}"
   # apiInvoker = APIInvoker
-
 {{#operation}}
 {{newline}}
   # {{summary}}
   # {{notes}}
-{{#allParams}}{{^optional}}  # @param {{paramName}} {{description}}
-{{/optional}}{{/allParams}}{{#allParams}}{{#optional}}  # @option opts [{{dataType}}] :{{baseName}} {{description}}
-{{/optional}}{{/allParams}}  # @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
-  def self.{{nickname}} ({{#allParams}}{{paramName}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}, {{/allParams}}opts={})
-    query_param_keys = [{{#queryParams}}:{{paramName}}{{#hasMore}},{{/hasMore}}{{/queryParams}}]
-    headerParams = {}
+{{#allParams}}{{#required}}  # @param {{paramName}} {{description}}
+{{/required}}{{/allParams}}  # @param [Hash] opts the optional parameters
+{{#allParams}}{{^required}}  # @option opts [{{dataType}}] :{{baseName}} {{description}}
+{{/required}}{{/allParams}}  # @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
+  def self.{{nickname}}({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
+    # verify existence of params{{#allParams}}{{#required}}
+    raise "{{{paramName}}} is required" if {{{paramName}}}.nil?{{/required}}{{/allParams}}
 
-    {{#requiredParamCount}}
-    # verify existence of params
-    {{#requiredParams}}
-    raise "{{{paramName}}} is required" if {{{paramName}}}.nil?
-    {{/requiredParams}}
-    {{/requiredParamCount}}
-    
-    # set default values and merge with input
-    options = {
-      {{#allParams}}:'{{paramName}}' => {{paramName}}{{#hasMore}},{{/hasMore}}
-      {{/allParams}}
-    }.merge(opts)
+    # resource path
+    path = "{{path}}".sub('{format}','json'){{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
 
-    #resource path
-    path = "{{path}}".sub('{format}','json'){{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s)
-    {{/pathParams}}{{newline}}
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+    # query parameters
+    query_params = {}
+{{#queryParams}}{{#required}}
+    query_params[:'{{{baseName}}}'] = {{{paramName}}}{{/required}}{{/queryParams}}{{#queryParams}}{{^required}}
+    query_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'] if opts[:'{{{paramName}}}']{{/required}}{{/queryParams}}
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = '{{#produces}}{{mediaType}}{{#hasMore}}, {{/hasMore}}{{/produces}}'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = [{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}]
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    {{#headerParams}}{{#optional}}headers[:'{{{baseName}}}'] = options[:'{{{paramName}}}'] if options[:'{{{paramName}}}']{{/optional}}{{/headerParams}}
-    {{#headerParams}}{{^optional}}headers[:'{{{baseName}}}'] = {{{paramName}}}{{/optional}}{{/headerParams}}
+    _header_content_type = [{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}]
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+{{#headerParams}}{{#required}}
+    header_params[:'{{{baseName}}}'] = {{{paramName}}}{{/required}}{{/headerParams}}{{#headerParams}}{{^required}}
+    header_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'] if opts[:'{{{paramName}}}']{{/required}}{{/headerParams}}
+
+    # form parameters
+    form_params = {}
+{{#formParams}}{{#required}}
+    form_params["{{baseName}}"] = {{paramName}}{{/required}}{{/formParams}}{{#formParams}}{{^required}}
+    form_params["{{baseName}}"] = opts[:'{{paramName}}'] if opts[:'{{paramName}}']{{/required}}{{/formParams}}
+
     # http body (model)
-    post_body = nil
-    {{#bodyParam}}
+    post_body = nil{{#bodyParam}}
     if body != nil
       if body.is_a?(Array)
         array = Array.new
@@ -71,21 +63,11 @@ class {{classname}}
           post_body = body
         end
       end
-    end
-    {{/bodyParam}}
-    # form parameters
-    form_parameter_hash = {}
-    {{#formParams}}{{#optional}}form_parameter_hash["{{baseName}}"] = options[:'{{paramName}}'] if options[:'{{paramName}}']{{/optional}}
-    {{^optional}}form_parameter_hash["{{baseName}}"] = {{paramName}}{{/optional}}{{/formParams}}
-    {{#returnType}}
-    response = Swagger::Request.new(:{{httpMethod}}, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-    {{#returnContainer}}
-    response.map {|response|{{/returnContainer}} {{returnBaseType}}.new(response){{#returnContainer}} }{{/returnContainer}}
-    {{/returnType}}
-    {{^returnType}}
-    Swagger::Request.new(:{{httpMethod}}, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    {{/returnType}}
-  {{newline}}
+    end{{/bodyParam}}
+
+{{#returnType}}
+    response = Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
+    {{#returnContainer}}response.map {|response| {{/returnContainer}}{{returnBaseType}}.new(response){{#returnContainer}} }{{/returnContainer}}{{/returnType}}{{^returnType}}    Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make{{/returnType}}
   end
 {{/operation}}
 end

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -42,22 +42,23 @@ class {{classname}}
 
     # http body (model)
     post_body = nil{{#bodyParam}}
-    if body != nil
-      if body.is_a?(Array)
-        array = Array.new
-        body.each do |item|
-          if item.respond_to?("to_body".to_sym)
-            array.push item.to_body
+    _body_param = {{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}
+    if _body_param != nil
+      if _body_param.is_a?(Array)
+        _array = Array.new
+        _body_param.each do |item|
+          if item.respond_to?(:to_body)
+            _array.push item.to_body
           else
-            array.push item
+            _array.push item
           end
         end
-        post_body = array
+        post_body = _array
       else 
-        if body.respond_to?("to_body".to_sym)
-          post_body = body.to_body
+        if _body_param.respond_to?(:to_body)
+          post_body = _body_param.to_body
         else
-          post_body = body
+          post_body = _body_param
         end
       end
     end{{/bodyParam}}

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -10,7 +10,7 @@ class {{classname}}
   # {{notes}}
 {{#allParams}}{{#required}}  # @param {{paramName}} {{description}}
 {{/required}}{{/allParams}}  # @param [Hash] opts the optional parameters
-{{#allParams}}{{^required}}  # @option opts [{{dataType}}] :{{baseName}} {{description}}
+{{#allParams}}{{^required}}  # @option opts [{{dataType}}] :{{paramName}} {{description}}
 {{/required}}{{/allParams}}  # @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
   def self.{{nickname}}({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
     # verify existence of params{{#allParams}}{{#required}}
@@ -20,8 +20,7 @@ class {{classname}}
     path = "{{path}}".sub('{format}','json'){{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
 
     # query parameters
-    query_params = {}
-{{#queryParams}}{{#required}}
+    query_params = {}{{#queryParams}}{{#required}}
     query_params[:'{{{baseName}}}'] = {{{paramName}}}{{/required}}{{/queryParams}}{{#queryParams}}{{^required}}
     query_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'] if opts[:'{{{paramName}}}']{{/required}}{{/queryParams}}
 
@@ -32,14 +31,12 @@ class {{classname}}
     header_params['Accept'] = _header_accept if _header_accept != ''
 
     _header_content_type = [{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}]
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
-{{#headerParams}}{{#required}}
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'{{#headerParams}}{{#required}}
     header_params[:'{{{baseName}}}'] = {{{paramName}}}{{/required}}{{/headerParams}}{{#headerParams}}{{^required}}
     header_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'] if opts[:'{{{paramName}}}']{{/required}}{{/headerParams}}
 
     # form parameters
-    form_params = {}
-{{#formParams}}{{#required}}
+    form_params = {}{{#formParams}}{{#required}}
     form_params["{{baseName}}"] = {{paramName}}{{/required}}{{/formParams}}{{#formParams}}{{^required}}
     form_params["{{baseName}}"] = opts[:'{{paramName}}'] if opts[:'{{paramName}}']{{/required}}{{/formParams}}
 

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -18,7 +18,6 @@ class PetApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -28,10 +27,8 @@ class PetApi
     _header_content_type = ['application/json', 'application/xml', ]
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -72,7 +69,6 @@ class PetApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -82,10 +78,8 @@ class PetApi
     _header_content_type = ['application/json', 'application/xml', ]
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -125,7 +119,6 @@ class PetApi
 
     # query parameters
     query_params = {}
-
     query_params[:'status'] = opts[:'status'] if opts[:'status']
 
     # header parameters
@@ -137,10 +130,8 @@ class PetApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -162,7 +153,6 @@ class PetApi
 
     # query parameters
     query_params = {}
-
     query_params[:'tags'] = opts[:'tags'] if opts[:'tags']
 
     # header parameters
@@ -174,10 +164,8 @@ class PetApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -201,7 +189,6 @@ class PetApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -211,10 +198,8 @@ class PetApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -240,7 +225,6 @@ class PetApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -250,10 +234,8 @@ class PetApi
     _header_content_type = ['application/x-www-form-urlencoded', ]
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
     form_params["name"] = opts[:'name'] if opts[:'name']
     form_params["status"] = opts[:'status'] if opts[:'status']
 
@@ -279,7 +261,6 @@ class PetApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -288,12 +269,10 @@ class PetApi
 
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
-
     header_params[:'api_key'] = opts[:'api_key'] if opts[:'api_key']
 
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -305,7 +284,7 @@ class PetApi
   # 
   # @param pet_id ID of pet to update
   # @param [Hash] opts the optional parameters
-  # @option opts [string] :additionalMetadata Additional data to pass to server
+  # @option opts [string] :additional_metadata Additional data to pass to server
   # @option opts [file] :file file to upload
   # @return void
   def self.uploadFile(pet_id, opts = {})
@@ -318,7 +297,6 @@ class PetApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -328,10 +306,8 @@ class PetApi
     _header_content_type = ['multipart/form-data', ]
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
     form_params["additionalMetadata"] = opts[:'additional_metadata'] if opts[:'additional_metadata']
     form_params["file"] = opts[:'file'] if opts[:'file']
 

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -32,22 +32,23 @@ class PetApi
 
     # http body (model)
     post_body = nil
-    if body != nil
-      if body.is_a?(Array)
-        array = Array.new
-        body.each do |item|
-          if item.respond_to?("to_body".to_sym)
-            array.push item.to_body
+    _body_param = opts[:'body']
+    if _body_param != nil
+      if _body_param.is_a?(Array)
+        _array = Array.new
+        _body_param.each do |item|
+          if item.respond_to?(:to_body)
+            _array.push item.to_body
           else
-            array.push item
+            _array.push item
           end
         end
-        post_body = array
+        post_body = _array
       else 
-        if body.respond_to?("to_body".to_sym)
-          post_body = body.to_body
+        if _body_param.respond_to?(:to_body)
+          post_body = _body_param.to_body
         else
-          post_body = body
+          post_body = _body_param
         end
       end
     end
@@ -83,22 +84,23 @@ class PetApi
 
     # http body (model)
     post_body = nil
-    if body != nil
-      if body.is_a?(Array)
-        array = Array.new
-        body.each do |item|
-          if item.respond_to?("to_body".to_sym)
-            array.push item.to_body
+    _body_param = opts[:'body']
+    if _body_param != nil
+      if _body_param.is_a?(Array)
+        _array = Array.new
+        _body_param.each do |item|
+          if item.respond_to?(:to_body)
+            _array.push item.to_body
           else
-            array.push item
+            _array.push item
           end
         end
-        post_body = array
+        post_body = _array
       else 
-        if body.respond_to?("to_body".to_sym)
-          post_body = body.to_body
+        if _body_param.respond_to?(:to_body)
+          post_body = _body_param.to_body
         else
-          post_body = body
+          post_body = _body_param
         end
       end
     end

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -4,46 +4,37 @@ class PetApi
   basePath = "http://petstore.swagger.io/v2"
   # apiInvoker = APIInvoker
 
-
   # Update an existing pet
   # 
-  # @param body Pet object that needs to be added to the store
+  # @param [Hash] opts the optional parameters
+  # @option opts [Pet] :body Pet object that needs to be added to the store
   # @return void
-  def self.updatePet (body, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.updatePet(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'body' => body
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/pet".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = ['application/json', 'application/xml', ]
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = ['application/json', 'application/xml', ]
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
     if body != nil
       if body.is_a?(Array)
         array = Array.new
@@ -63,56 +54,41 @@ class PetApi
         end
       end
     end
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:PUT, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Add a new pet to the store
   # 
-  # @param body Pet object that needs to be added to the store
+  # @param [Hash] opts the optional parameters
+  # @option opts [Pet] :body Pet object that needs to be added to the store
   # @return void
-  def self.addPet (body, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.addPet(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'body' => body
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/pet".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = ['application/json', 'application/xml', ]
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = ['application/json', 'application/xml', ]
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
     if body != nil
       if body.is_a?(Array)
         array = Array.new
@@ -132,331 +108,236 @@ class PetApi
         end
       end
     end
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:POST, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Finds Pets by status
   # Multiple status values can be provided with comma seperated strings
-  # @param status Status values that need to be considered for filter
+  # @param [Hash] opts the optional parameters
+  # @option opts [array[string]] :status Status values that need to be considered for filter
   # @return array[Pet]
-  def self.findPetsByStatus (status, opts={})
-    query_param_keys = [:status]
-    headerParams = {}
+  def self.findPetsByStatus(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'status' => status
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/pet/findByStatus".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
+    query_params[:'status'] = opts[:'status'] if opts[:'status']
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    response = Swagger::Request.new(:GET, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-    
+
+    response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
     response.map {|response| Pet.new(response) }
-    
-    
-  
   end
 
   # Finds Pets by tags
   # Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
-  # @param tags Tags to filter by
+  # @param [Hash] opts the optional parameters
+  # @option opts [array[string]] :tags Tags to filter by
   # @return array[Pet]
-  def self.findPetsByTags (tags, opts={})
-    query_param_keys = [:tags]
-    headerParams = {}
+  def self.findPetsByTags(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'tags' => tags
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/pet/findByTags".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
+    query_params[:'tags'] = opts[:'tags'] if opts[:'tags']
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    response = Swagger::Request.new(:GET, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-    
+
+    response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
     response.map {|response| Pet.new(response) }
-    
-    
-  
   end
 
   # Find pet by ID
   # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
   # @param pet_id ID of pet that needs to be fetched
+  # @param [Hash] opts the optional parameters
   # @return Pet
-  def self.getPetById (pet_id, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.getPetById(pet_id, opts = {})
+    # verify existence of params
+    raise "pet_id is required" if pet_id.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'pet_id' => pet_id
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/pet/{petId}".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    response = Swagger::Request.new(:GET, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-     Pet.new(response)
-    
-    
-  
+
+    response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
+    Pet.new(response)
   end
 
   # Updates a pet in the store with form data
   # 
   # @param pet_id ID of pet that needs to be updated
-  # @param name Updated name of the pet
-  # @param status Updated status of the pet
+  # @param [Hash] opts the optional parameters
+  # @option opts [string] :name Updated name of the pet
+  # @option opts [string] :status Updated status of the pet
   # @return void
-  def self.updatePetWithForm (pet_id, name, status, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.updatePetWithForm(pet_id, opts = {})
+    # verify existence of params
+    raise "pet_id is required" if pet_id.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'pet_id' => pet_id,
-      :'name' => name,
-      :'status' => status
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/pet/{petId}".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = ['application/x-www-form-urlencoded', ]
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = ['application/x-www-form-urlencoded', ]
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+    form_params["name"] = opts[:'name'] if opts[:'name']
+    form_params["status"] = opts[:'status'] if opts[:'status']
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    form_parameter_hash["name"] = name
-    form_parameter_hash["status"] = status
-    
-    
-    Swagger::Request.new(:POST, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Deletes a pet
   # 
-  # @param api_key 
   # @param pet_id Pet id to delete
+  # @param [Hash] opts the optional parameters
+  # @option opts [string] :api_key 
   # @return void
-  def self.deletePet (api_key, pet_id, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.deletePet(pet_id, opts = {})
+    # verify existence of params
+    raise "pet_id is required" if pet_id.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'api_key' => api_key,
-      :'pet_id' => pet_id
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/pet/{petId}".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    headers[:'api_key'] = api_key
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+    header_params[:'api_key'] = opts[:'api_key'] if opts[:'api_key']
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:DELETE, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # uploads an image
   # 
   # @param pet_id ID of pet to update
-  # @param additional_metadata Additional data to pass to server
-  # @param file file to upload
+  # @param [Hash] opts the optional parameters
+  # @option opts [string] :additionalMetadata Additional data to pass to server
+  # @option opts [file] :file file to upload
   # @return void
-  def self.uploadFile (pet_id, additional_metadata, file, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.uploadFile(pet_id, opts = {})
+    # verify existence of params
+    raise "pet_id is required" if pet_id.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'pet_id' => pet_id,
-      :'additional_metadata' => additional_metadata,
-      :'file' => file
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/pet/{petId}/uploadImage".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = ['multipart/form-data', ]
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = ['multipart/form-data', ]
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+    form_params["additionalMetadata"] = opts[:'additional_metadata'] if opts[:'additional_metadata']
+    form_params["file"] = opts[:'file'] if opts[:'file']
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    form_parameter_hash["additionalMetadata"] = additional_metadata
-    form_parameter_hash["file"] = file
-    
-    
-    Swagger::Request.new(:POST, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 end

--- a/samples/client/petstore/ruby/lib/store_api.rb
+++ b/samples/client/petstore/ruby/lib/store_api.rb
@@ -17,7 +17,6 @@ class StoreApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -27,10 +26,8 @@ class StoreApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -53,7 +50,6 @@ class StoreApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -63,10 +59,8 @@ class StoreApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -109,7 +103,6 @@ class StoreApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -119,10 +112,8 @@ class StoreApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -146,7 +137,6 @@ class StoreApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -156,10 +146,8 @@ class StoreApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil

--- a/samples/client/petstore/ruby/lib/store_api.rb
+++ b/samples/client/petstore/ruby/lib/store_api.rb
@@ -64,22 +64,23 @@ class StoreApi
 
     # http body (model)
     post_body = nil
-    if body != nil
-      if body.is_a?(Array)
-        array = Array.new
-        body.each do |item|
-          if item.respond_to?("to_body".to_sym)
-            array.push item.to_body
+    _body_param = opts[:'body']
+    if _body_param != nil
+      if _body_param.is_a?(Array)
+        _array = Array.new
+        _body_param.each do |item|
+          if item.respond_to?(:to_body)
+            _array.push item.to_body
           else
-            array.push item
+            _array.push item
           end
         end
-        post_body = array
+        post_body = _array
       else 
-        if body.respond_to?("to_body".to_sym)
-          post_body = body.to_body
+        if _body_param.respond_to?(:to_body)
+          post_body = _body_param.to_body
         else
-          post_body = body
+          post_body = _body_param
         end
       end
     end

--- a/samples/client/petstore/ruby/lib/store_api.rb
+++ b/samples/client/petstore/ruby/lib/store_api.rb
@@ -4,95 +4,72 @@ class StoreApi
   basePath = "http://petstore.swagger.io/v2"
   # apiInvoker = APIInvoker
 
-
   # Returns pet inventories by status
   # Returns a map of status codes to quantities
+  # @param [Hash] opts the optional parameters
   # @return map[string,int]
-  def self.getInventory (opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.getInventory(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/store/inventory".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    response = Swagger::Request.new(:GET, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-    
+
+    response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
     response.map {|response| map.new(response) }
-    
-    
-  
   end
 
   # Place an order for a pet
   # 
-  # @param body order placed for purchasing the pet
+  # @param [Hash] opts the optional parameters
+  # @option opts [Order] :body order placed for purchasing the pet
   # @return Order
-  def self.placeOrder (body, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.placeOrder(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'body' => body
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/store/order".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
     if body != nil
       if body.is_a?(Array)
         array = Array.new
@@ -112,116 +89,81 @@ class StoreApi
         end
       end
     end
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    response = Swagger::Request.new(:POST, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-     Order.new(response)
-    
-    
-  
+
+    response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
+    Order.new(response)
   end
 
   # Find purchase order by ID
   # For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
   # @param order_id ID of pet that needs to be fetched
+  # @param [Hash] opts the optional parameters
   # @return Order
-  def self.getOrderById (order_id, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.getOrderById(order_id, opts = {})
+    # verify existence of params
+    raise "order_id is required" if order_id.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'order_id' => order_id
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/store/order/{orderId}".sub('{format}','json').sub('{' + 'orderId' + '}', order_id.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    response = Swagger::Request.new(:GET, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-     Order.new(response)
-    
-    
-  
+
+    response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
+    Order.new(response)
   end
 
   # Delete purchase order by ID
   # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
   # @param order_id ID of the order that needs to be deleted
+  # @param [Hash] opts the optional parameters
   # @return void
-  def self.deleteOrder (order_id, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.deleteOrder(order_id, opts = {})
+    # verify existence of params
+    raise "order_id is required" if order_id.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'order_id' => order_id
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/store/order/{orderId}".sub('{format}','json').sub('{' + 'orderId' + '}', order_id.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:DELETE, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 end

--- a/samples/client/petstore/ruby/lib/swagger.rb
+++ b/samples/client/petstore/ruby/lib/swagger.rb
@@ -7,6 +7,8 @@ require 'logger'
 
 module Swagger
     
+  @configuration = Configuration.new
+
   class << self
     attr_accessor :logger
     
@@ -27,7 +29,6 @@ module Swagger
     #   end
     #
     def configure
-      self.configuration ||= Configuration.new
       yield(configuration) if block_given?
 
       # Configure logger.  Default to use Rails

--- a/samples/client/petstore/ruby/lib/user_api.rb
+++ b/samples/client/petstore/ruby/lib/user_api.rb
@@ -4,46 +4,37 @@ class UserApi
   basePath = "http://petstore.swagger.io/v2"
   # apiInvoker = APIInvoker
 
-
   # Create user
   # This can only be done by the logged in user.
-  # @param body Created user object
+  # @param [Hash] opts the optional parameters
+  # @option opts [User] :body Created user object
   # @return void
-  def self.createUser (body, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.createUser(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'body' => body
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/user".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
     if body != nil
       if body.is_a?(Array)
         array = Array.new
@@ -63,56 +54,41 @@ class UserApi
         end
       end
     end
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:POST, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Creates list of users with given input array
   # 
-  # @param body List of user object
+  # @param [Hash] opts the optional parameters
+  # @option opts [array[User]] :body List of user object
   # @return void
-  def self.createUsersWithArrayInput (body, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.createUsersWithArrayInput(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'body' => body
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/user/createWithArray".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
     if body != nil
       if body.is_a?(Array)
         array = Array.new
@@ -132,56 +108,41 @@ class UserApi
         end
       end
     end
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:POST, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Creates list of users with given input array
   # 
-  # @param body List of user object
+  # @param [Hash] opts the optional parameters
+  # @option opts [array[User]] :body List of user object
   # @return void
-  def self.createUsersWithListInput (body, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.createUsersWithListInput(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'body' => body
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/user/createWithList".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
     if body != nil
       if body.is_a?(Array)
         array = Array.new
@@ -201,209 +162,153 @@ class UserApi
         end
       end
     end
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:POST, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Logs user into the system
   # 
-  # @param username The user name for login
-  # @param password The password for login in clear text
+  # @param [Hash] opts the optional parameters
+  # @option opts [string] :username The user name for login
+  # @option opts [string] :password The password for login in clear text
   # @return string
-  def self.loginUser (username, password, opts={})
-    query_param_keys = [:username,:password]
-    headerParams = {}
+  def self.loginUser(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'username' => username,
-      :'password' => password
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/user/login".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
+    query_params[:'username'] = opts[:'username'] if opts[:'username']
+    query_params[:'password'] = opts[:'password'] if opts[:'password']
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    response = Swagger::Request.new(:GET, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-     string.new(response)
-    
-    
-  
+
+    response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
+    string.new(response)
   end
 
   # Logs out current logged in user session
   # 
+  # @param [Hash] opts the optional parameters
   # @return void
-  def self.logoutUser (opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.logoutUser(opts = {})
+    # verify existence of params
 
-    
-    
-    # set default values and merge with input
-    options = {
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/user/logout".sub('{format}','json')
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:GET, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:GET, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Get user by user name
   # 
   # @param username The name that needs to be fetched. Use user1 for testing. 
+  # @param [Hash] opts the optional parameters
   # @return User
-  def self.getUserByName (username, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.getUserByName(username, opts = {})
+    # verify existence of params
+    raise "username is required" if username.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'username' => username
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/user/{username}".sub('{format}','json').sub('{' + 'username' + '}', username.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    response = Swagger::Request.new(:GET, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make.body
-     User.new(response)
-    
-    
-  
+
+    response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
+    User.new(response)
   end
 
   # Updated user
   # This can only be done by the logged in user.
   # @param username name that need to be deleted
-  # @param body Updated user object
+  # @param [Hash] opts the optional parameters
+  # @option opts [User] :body Updated user object
   # @return void
-  def self.updateUser (username, body, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.updateUser(username, opts = {})
+    # verify existence of params
+    raise "username is required" if username.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'username' => username,
-      :'body' => body
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/user/{username}".sub('{format}','json').sub('{' + 'username' + '}', username.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
     if body != nil
       if body.is_a?(Array)
         array = Array.new
@@ -423,64 +328,43 @@ class UserApi
         end
       end
     end
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:PUT, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Delete user
   # This can only be done by the logged in user.
   # @param username The name that needs to be deleted
+  # @param [Hash] opts the optional parameters
   # @return void
-  def self.deleteUser (username, opts={})
-    query_param_keys = []
-    headerParams = {}
+  def self.deleteUser(username, opts = {})
+    # verify existence of params
+    raise "username is required" if username.nil?
 
-    
-    
-    # set default values and merge with input
-    options = {
-      :'username' => username
-      
-    }.merge(opts)
-
-    #resource path
+    # resource path
     path = "/user/{username}".sub('{format}','json').sub('{' + 'username' + '}', username.to_s)
-    
-    
-    # pull querystring keys from options
-    queryopts = options.select do |key,value|
-      query_param_keys.include? key
-    end
+
+    # query parameters
+    query_params = {}
+
 
     # header parameters
-    headers = {}
+    header_params = {}
 
     _header_accept = 'application/json, application/xml'
-    if _header_accept != ''
-      headerParams['Accept'] = _header_accept
-    end 
-    _header_content_type = []
-    headerParams['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Accept'] = _header_accept if _header_accept != ''
 
-    
-    
+    _header_content_type = []
+    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+
+
+    # form parameters
+    form_params = {}
+
+
     # http body (model)
     post_body = nil
-    
-    # form parameters
-    form_parameter_hash = {}
-    
-    
-    
-    Swagger::Request.new(:DELETE, path, {:params=>queryopts,:headers=>headers, :body=>post_body, :form_params => form_parameter_hash }).make
-    
-  
+
+    Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 end

--- a/samples/client/petstore/ruby/lib/user_api.rb
+++ b/samples/client/petstore/ruby/lib/user_api.rb
@@ -32,22 +32,23 @@ class UserApi
 
     # http body (model)
     post_body = nil
-    if body != nil
-      if body.is_a?(Array)
-        array = Array.new
-        body.each do |item|
-          if item.respond_to?("to_body".to_sym)
-            array.push item.to_body
+    _body_param = opts[:'body']
+    if _body_param != nil
+      if _body_param.is_a?(Array)
+        _array = Array.new
+        _body_param.each do |item|
+          if item.respond_to?(:to_body)
+            _array.push item.to_body
           else
-            array.push item
+            _array.push item
           end
         end
-        post_body = array
+        post_body = _array
       else 
-        if body.respond_to?("to_body".to_sym)
-          post_body = body.to_body
+        if _body_param.respond_to?(:to_body)
+          post_body = _body_param.to_body
         else
-          post_body = body
+          post_body = _body_param
         end
       end
     end
@@ -83,22 +84,23 @@ class UserApi
 
     # http body (model)
     post_body = nil
-    if body != nil
-      if body.is_a?(Array)
-        array = Array.new
-        body.each do |item|
-          if item.respond_to?("to_body".to_sym)
-            array.push item.to_body
+    _body_param = opts[:'body']
+    if _body_param != nil
+      if _body_param.is_a?(Array)
+        _array = Array.new
+        _body_param.each do |item|
+          if item.respond_to?(:to_body)
+            _array.push item.to_body
           else
-            array.push item
+            _array.push item
           end
         end
-        post_body = array
+        post_body = _array
       else 
-        if body.respond_to?("to_body".to_sym)
-          post_body = body.to_body
+        if _body_param.respond_to?(:to_body)
+          post_body = _body_param.to_body
         else
-          post_body = body
+          post_body = _body_param
         end
       end
     end
@@ -134,22 +136,23 @@ class UserApi
 
     # http body (model)
     post_body = nil
-    if body != nil
-      if body.is_a?(Array)
-        array = Array.new
-        body.each do |item|
-          if item.respond_to?("to_body".to_sym)
-            array.push item.to_body
+    _body_param = opts[:'body']
+    if _body_param != nil
+      if _body_param.is_a?(Array)
+        _array = Array.new
+        _body_param.each do |item|
+          if item.respond_to?(:to_body)
+            _array.push item.to_body
           else
-            array.push item
+            _array.push item
           end
         end
-        post_body = array
+        post_body = _array
       else 
-        if body.respond_to?("to_body".to_sym)
-          post_body = body.to_body
+        if _body_param.respond_to?(:to_body)
+          post_body = _body_param.to_body
         else
-          post_body = body
+          post_body = _body_param
         end
       end
     end
@@ -288,22 +291,23 @@ class UserApi
 
     # http body (model)
     post_body = nil
-    if body != nil
-      if body.is_a?(Array)
-        array = Array.new
-        body.each do |item|
-          if item.respond_to?("to_body".to_sym)
-            array.push item.to_body
+    _body_param = opts[:'body']
+    if _body_param != nil
+      if _body_param.is_a?(Array)
+        _array = Array.new
+        _body_param.each do |item|
+          if item.respond_to?(:to_body)
+            _array.push item.to_body
           else
-            array.push item
+            _array.push item
           end
         end
-        post_body = array
+        post_body = _array
       else 
-        if body.respond_to?("to_body".to_sym)
-          post_body = body.to_body
+        if _body_param.respond_to?(:to_body)
+          post_body = _body_param.to_body
         else
-          post_body = body
+          post_body = _body_param
         end
       end
     end

--- a/samples/client/petstore/ruby/lib/user_api.rb
+++ b/samples/client/petstore/ruby/lib/user_api.rb
@@ -18,7 +18,6 @@ class UserApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -28,10 +27,8 @@ class UserApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -72,7 +69,6 @@ class UserApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -82,10 +78,8 @@ class UserApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -126,7 +120,6 @@ class UserApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -136,10 +129,8 @@ class UserApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -180,7 +171,6 @@ class UserApi
 
     # query parameters
     query_params = {}
-
     query_params[:'username'] = opts[:'username'] if opts[:'username']
     query_params[:'password'] = opts[:'password'] if opts[:'password']
 
@@ -193,10 +183,8 @@ class UserApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -218,7 +206,6 @@ class UserApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -228,10 +215,8 @@ class UserApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -254,7 +239,6 @@ class UserApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -264,10 +248,8 @@ class UserApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -292,7 +274,6 @@ class UserApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -302,10 +283,8 @@ class UserApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil
@@ -347,7 +326,6 @@ class UserApi
     # query parameters
     query_params = {}
 
-
     # header parameters
     header_params = {}
 
@@ -357,10 +335,8 @@ class UserApi
     _header_content_type = []
     header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
 
-
     # form parameters
     form_params = {}
-
 
     # http body (model)
     post_body = nil

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -15,17 +15,17 @@ describe "Pet" do
     end
 
     it "should find pets by status" do
-      pets = PetApi.findPetsByStatus('available')
+      pets = PetApi.findPetsByStatus(:status => 'available')
       pets.length.should >= 3
     end
     
     it "should not find a pet with invalid status" do
-      pets = PetApi.findPetsByStatus('invalid-status')
+      pets = PetApi.findPetsByStatus(:status => 'invalid-status')
       pets.length.should == 0
     end
 
     it "should find a pet by status" do
-      pets = PetApi.findPetsByStatus("available,sold")
+      pets = PetApi.findPetsByStatus(:status => "available,sold")
       pets.map {|pet| 
         if(pet.status != 'available' && pet.status != 'sold') 
           raise "pet status wasn't right"
@@ -35,7 +35,7 @@ describe "Pet" do
     
     it "should update a pet" do
       pet = Pet.new({'id' => 10002, 'status' => 'sold'})
-      PetApi.addPet(pet)
+      PetApi.addPet(:body => pet)
       
       fetched = PetApi.getPetById(10002)
       fetched.id.should == 10002
@@ -44,7 +44,7 @@ describe "Pet" do
 
     it "should create a pet" do 
       pet = Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING")
-      PetApi.addPet(pet)
+      PetApi.addPet(:body => pet)
 
       pet = PetApi.getPetById(10002)
       pet.id.should == 10002

--- a/samples/client/petstore/ruby/spec/spec_helper.rb
+++ b/samples/client/petstore/ruby/spec/spec_helper.rb
@@ -47,10 +47,10 @@ end
 # always delete and then re-create the pet object with 10002
 def prepare_pet
   # remove the pet
-  PetApi.deletePet('special-key', 10002)
+  PetApi.deletePet(10002, :api_key => 'special-key')
   # recreate the pet
   pet = Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING")
-  PetApi.addPet(pet)
+  PetApi.addPet(:body => pet)
 end
 
 # always delete and then re-create the store order 
@@ -61,7 +61,7 @@ def prepare_store
 		  "shipDate" => "2015-04-06T23:42:01.678Z",
 		  "status" => "placed",
 		  "complete" => false)
-  StoreApi.placeOrder(order)
+  StoreApi.placeOrder(:body => order)
 end
 
 configure_swagger


### PR DESCRIPTION
Assuming `name` and `status` are optional parameters (`required` is `false`), instead of having to pass those two parameters like this:

``` ruby
PetApi.updatePetWithForm(1, "pet name", "pet status")
```

this PR allows passing any parameters that is needed, e.g. only update the status:

``` ruby
PetApi.updatePetWithForm(1, :status => "pet status")
```

Complete changes:
* Pass optional parameters via the `opts` Hash
* Handle query parameters in a way similar to header/form parameters to
  support parameter name normalization, e.g. the "additional_metadata"
  key is used for "additionalMetadata"
* Rename variables to be consistent: `query_params`, `header_params` and
  `form_params`
* Remove unnecessary blank lines
* Rename local variable `body` to `_body_param` to avoid potential naming comflict