### PR TITLE
Improve README for OS X Users with random Java versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ You need the following installed and available in your $PATH:
 * [Java 7](http://java.oracle.com)
 
 * [Apache maven 3.0.3 or greater](http://maven.apache.org/)
+ 
+#### OS X Users
+Don't forget to install Java 7. You probably have 1.6 or 1.8.
+
+Export JAVA_HOME in order to user proper Java version:
+```
+export JAVA_HOME=`/usr/libexec/java_home -v 1.7`
+export PATH=${JAVA_HOME}/bin:$PATH
+```
+
+#### Building
 
 After cloning the project, you can build it from source with this command:
 


### PR DESCRIPTION
Looks like I'm the one of users, who have missed "Requires Java 1.7". I suggest to add a section how to ensure, that you are running proper Java version. ... at least for OS X users (like me).

There are some issues, created because of this:

- https://github.com/swagger-api/swagger-codegen/issues/605
- https://github.com/swagger-api/swagger-codegen/issues/381