### PR TITLE
Fixed encoding issue for request json body in python client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/swagger.mustache
@@ -85,6 +85,8 @@ class ApiClient(object):
         if 'Content-Type' not in headers:
           headers['Content-Type'] = 'application/json'
           data = json.dumps(postData)
+        elif headers['Content-Type'] == 'application/json':
+          data = json.dumps(postData)
         elif headers['Content-Type'] == 'multipart/form-data':
           data = self.buildMultipartFormData(postData, files)
           headers['Content-Type'] = 'multipart/form-data; boundary={0}'.format(self.boundary)

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/swagger.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/swagger.py
@@ -85,6 +85,8 @@ class ApiClient(object):
         if 'Content-Type' not in headers:
           headers['Content-Type'] = 'application/json'
           data = json.dumps(postData)
+        elif headers['Content-Type'] == 'application/json':
+          data = json.dumps(postData)
         elif headers['Content-Type'] == 'multipart/form-data':
           data = self.buildMultipartFormData(postData, files)
           headers['Content-Type'] = 'multipart/form-data; boundary={0}'.format(self.boundary)


### PR DESCRIPTION
If the request content type is `application/json`, 
it will execute `data = urllib.urlencode(postData)` in the else part which is incorrect.