### PR TITLE
Fixes #646: Example field handling has been fixed.

### DIFF
--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -6,11 +6,9 @@
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.wordnik</groupId>
   <artifactId>swagger-codegen</artifactId>
   <packaging>jar</packaging>
   <name>swagger-codegen (core library)</name>
-  <version>2.1.1-M2-SNAPSHOT</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenResponse.java
@@ -1,11 +1,13 @@
 package com.wordnik.swagger.codegen;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class CodegenResponse {
   public String code, message;
   public Boolean hasMore;
-  public List<Map<String, String>> examples;
+  public List<Map<String, Object>> examples;
   public final List<CodegenProperty> headers = new ArrayList<CodegenProperty>();
   public String dataType, baseType, containerType;
   public Boolean simpleType;

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -1,25 +1,57 @@
 package com.wordnik.swagger.codegen;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.wordnik.swagger.codegen.examples.ExampleGenerator;
-import com.wordnik.swagger.models.*;
+import com.wordnik.swagger.models.ArrayModel;
+import com.wordnik.swagger.models.Model;
+import com.wordnik.swagger.models.ModelImpl;
+import com.wordnik.swagger.models.Operation;
+import com.wordnik.swagger.models.RefModel;
+import com.wordnik.swagger.models.Response;
+import com.wordnik.swagger.models.Swagger;
 import com.wordnik.swagger.models.auth.ApiKeyAuthDefinition;
 import com.wordnik.swagger.models.auth.BasicAuthDefinition;
 import com.wordnik.swagger.models.auth.In;
 import com.wordnik.swagger.models.auth.SecuritySchemeDefinition;
-import com.wordnik.swagger.models.parameters.*;
-import com.wordnik.swagger.models.properties.*;
+import com.wordnik.swagger.models.parameters.BodyParameter;
+import com.wordnik.swagger.models.parameters.CookieParameter;
+import com.wordnik.swagger.models.parameters.FormParameter;
+import com.wordnik.swagger.models.parameters.HeaderParameter;
+import com.wordnik.swagger.models.parameters.Parameter;
+import com.wordnik.swagger.models.parameters.PathParameter;
+import com.wordnik.swagger.models.parameters.QueryParameter;
+import com.wordnik.swagger.models.parameters.SerializableParameter;
+import com.wordnik.swagger.models.properties.AbstractNumericProperty;
+import com.wordnik.swagger.models.properties.ArrayProperty;
+import com.wordnik.swagger.models.properties.BooleanProperty;
+import com.wordnik.swagger.models.properties.DateProperty;
+import com.wordnik.swagger.models.properties.DateTimeProperty;
+import com.wordnik.swagger.models.properties.DecimalProperty;
+import com.wordnik.swagger.models.properties.DoubleProperty;
+import com.wordnik.swagger.models.properties.FloatProperty;
+import com.wordnik.swagger.models.properties.IntegerProperty;
+import com.wordnik.swagger.models.properties.LongProperty;
+import com.wordnik.swagger.models.properties.MapProperty;
+import com.wordnik.swagger.models.properties.Property;
+import com.wordnik.swagger.models.properties.PropertyBuilder;
+import com.wordnik.swagger.models.properties.RefProperty;
+import com.wordnik.swagger.models.properties.StringProperty;
 import com.wordnik.swagger.util.Json;
-
-import org.apache.commons.lang.StringUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.*;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class DefaultCodegen {
   Logger LOGGER = LoggerFactory.getLogger(DefaultCodegen.class);
@@ -996,9 +1028,9 @@ public class DefaultCodegen {
     if(schemes == null)
       return null;
 
-    List<CodegenSecurity> secs = new ArrayList<CodegenSecurity>();
-    for(Iterator entries = schemes.entrySet().iterator(); entries.hasNext(); ) {
-      Map.Entry<String, SecuritySchemeDefinition> entry = (Map.Entry<String, SecuritySchemeDefinition>) entries.next();
+    List<CodegenSecurity> secs = new ArrayList<CodegenSecurity>(schemes.size());
+    for (Iterator<Map.Entry<String, SecuritySchemeDefinition>> it = schemes.entrySet().iterator(); it.hasNext();) {
+      final Map.Entry<String, SecuritySchemeDefinition> entry = it.next();
       final SecuritySchemeDefinition schemeDefinition = entry.getValue();
 
       CodegenSecurity sec = CodegenModelFactory.newInstance(CodegenModelType.SECURITY);
@@ -1018,23 +1050,22 @@ public class DefaultCodegen {
         sec.isOAuth = !sec.isBasic;
       }
 
-      sec.hasMore = entries.hasNext();
+      sec.hasMore = it.hasNext();
       secs.add(sec);
     }
     return secs;
   }
 
-  protected List<Map<String, String>> toExamples(Map<String, String> examples) {
+  protected List<Map<String, Object>> toExamples(Map<String, Object> examples) {
     if(examples == null)
       return null;
 
-    List<Map<String, String>> output = new ArrayList<Map<String, String>>();
-    for(String key: examples.keySet()) {
-      String value = examples.get(key);
+    final List<Map<String, Object>> output = new ArrayList<Map<String, Object>>(examples.size());
+    for(Map.Entry<String, Object> entry : examples.entrySet()) {
 
-      Map<String, String> kv = new HashMap<String, String>();
-      kv.put("contentType", key);
-      kv.put("example", value);
+      final Map<String, Object> kv = new HashMap<String, Object>();
+      kv.put("contentType", entry.getKey());
+      kv.put("example", entry.getValue());
       output.add(kv);
     }
     return output;

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/examples/ExampleGenerator.java
@@ -1,19 +1,33 @@
 package com.wordnik.swagger.codegen.examples;
 
-import com.wordnik.swagger.models.*;
-import com.wordnik.swagger.models.properties.*;
-import com.wordnik.swagger.util.Json;
-
-import java.text.SimpleDateFormat;
-
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
- 
-
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.wordnik.swagger.models.Model;
+import com.wordnik.swagger.models.ModelImpl;
+import com.wordnik.swagger.models.properties.ArrayProperty;
+import com.wordnik.swagger.models.properties.BooleanProperty;
+import com.wordnik.swagger.models.properties.DateProperty;
+import com.wordnik.swagger.models.properties.DateTimeProperty;
+import com.wordnik.swagger.models.properties.DecimalProperty;
+import com.wordnik.swagger.models.properties.DoubleProperty;
+import com.wordnik.swagger.models.properties.FileProperty;
+import com.wordnik.swagger.models.properties.FloatProperty;
+import com.wordnik.swagger.models.properties.IntegerProperty;
+import com.wordnik.swagger.models.properties.LongProperty;
+import com.wordnik.swagger.models.properties.MapProperty;
+import com.wordnik.swagger.models.properties.ObjectProperty;
+import com.wordnik.swagger.models.properties.Property;
+import com.wordnik.swagger.models.properties.RefProperty;
+import com.wordnik.swagger.models.properties.StringProperty;
+import com.wordnik.swagger.models.properties.UUIDProperty;
+import com.wordnik.swagger.util.Json;
 
 public class ExampleGenerator {
   protected Map<String, Model> examples;
@@ -22,7 +36,7 @@ public class ExampleGenerator {
     this.examples = examples;
   }
 
-  public List<Map<String, String>> generate(Map<String, String> examples, List<String> mediaTypes, Property property) {
+  public List<Map<String, String>> generate(Map<String, Object> examples, List<String> mediaTypes, Property property) {
     List<Map<String, String>> output = new ArrayList<Map<String, String>>();
     Set<String> processedModels = new HashSet<String>();
     if(examples == null ) {
@@ -37,7 +51,6 @@ public class ExampleGenerator {
           String example = Json.pretty(resolvePropertyToExample(mediaType, property, processedModels));
 
           if(example != null) {
-            example = example.replaceAll("\n", "\\\\n");
             kv.put("example", example);
             output.add(kv);
           }
@@ -45,7 +58,6 @@ public class ExampleGenerator {
         else if(property != null && mediaType.startsWith("application/xml")) {
           String example = new XmlExampleGenerator(this.examples).toXml(property);
           if(example != null) {
-            example = example.replaceAll("\n", "\\\\n");
             kv.put("example", example);
             output.add(kv);
           }
@@ -53,12 +65,10 @@ public class ExampleGenerator {
       }
     }
     else {
-      for(String key: examples.keySet()) {
-        String value = examples.get(key);
-
-        Map<String, String> kv = new HashMap<String, String>();
-        kv.put("contentType", key);
-        kv.put("example", value);
+      for(Map.Entry<String, Object> entry: examples.entrySet()) {
+        final Map<String, String> kv = new HashMap<String, String>();
+        kv.put("contentType", entry.getKey());
+        kv.put("example", Json.pretty(entry.getValue()));
         output.add(kv);
       }
     }

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -1,11 +1,19 @@
 package com.wordnik.swagger.codegen.languages;
 
-import com.wordnik.swagger.codegen.*;
-import com.wordnik.swagger.util.Json;
-import com.wordnik.swagger.models.properties.*;
-
-import java.util.*;
 import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.wordnik.swagger.codegen.CodegenConfig;
+import com.wordnik.swagger.codegen.CodegenOperation;
+import com.wordnik.swagger.codegen.CodegenParameter;
+import com.wordnik.swagger.codegen.CodegenResponse;
+import com.wordnik.swagger.codegen.CodegenType;
+import com.wordnik.swagger.codegen.DefaultCodegen;
+import com.wordnik.swagger.codegen.SupportingFile;
 
 public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig {
   protected String apiVersion = "1.0.0";
@@ -156,8 +164,10 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
 
   @Override
   public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
-    Map<String, Object> objectMap = (Map<String, Object>)objs.get("operations");
-    List<CodegenOperation> operations = (List<CodegenOperation>)objectMap.get("operation");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> objectMap = (Map<String, Object>) objs.get("operations");
+    @SuppressWarnings("unchecked")
+    List<CodegenOperation> operations = (List<CodegenOperation>) objectMap.get("operation");
     for(CodegenOperation operation : operations) {
       operation.httpMethod = operation.httpMethod.toLowerCase();
       List<CodegenParameter> params = operation.allParams;
@@ -170,20 +180,14 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
             resp.code = "default";
         }
       }
-      if(operation.examples != null && operation.examples.size() > 0) {
-        List<Map<String, String>> examples = operation.examples;
-        for(int i = examples.size() - 1; i >= 0; i--) {
-          Map<String, String> example = examples.get(i);
-          String contentType = example.get("contentType");
-          if(contentType != null && contentType.indexOf("application/json") == 0) {
-            String jsonExample = example.get("example");
-            if(jsonExample != null) {
-              jsonExample = jsonExample.replaceAll("\\\\n", "\n");
-              example.put("example", jsonExample);
-            }            
+      if(operation.examples != null && !operation.examples.isEmpty()) {
+        // Leave application/json* items only
+        for (Iterator<Map<String, String>> it = operation.examples.iterator(); it.hasNext();) {
+          final Map<String, String> example = it.next();
+          final String contentType = example.get("contentType");
+          if (contentType == null || !contentType.startsWith("application/json")) {
+            it.remove();
           }
-          else
-            examples.remove(i);
         }
       }
     }

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
@@ -35,7 +35,7 @@
     {{#examples}}
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: {{{contentType}}}</div>
-    <pre class="example"><code>{{{example}}}</code></pre>
+    <pre class="example"><code>{{example}}</code></pre>
     {{/examples}}
   </div> <!-- method -->
   <hr>

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -720,6 +720,18 @@
             "description": "successful operation",
             "schema": {
               "$ref": "#/definitions/User"
+            },
+            "examples": {
+              "application/json": {
+                "id": 1,
+                "username": "johnp",
+                "firstName": "John",
+                "lastName": "Public",
+                "email": "johnp@swagger.io",
+                "password": "-secret-",
+                "phone": "0123456789",
+                "userStatus": 0
+              }
             }
           },
           "400": {

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -6,11 +6,9 @@
     <version>2.1.1-M2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
-  <groupId>com.wordnik</groupId>
   <artifactId>swagger-generator</artifactId>
   <packaging>war</packaging>
   <name>swagger-generator</name>
-  <version>2.1.1-M2-SNAPSHOT</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
     <swagger-parser-version>1.0.6-SNAPSHOT</swagger-parser-version>
     <scala-version>2.10.4</scala-version>
     <felix-version>2.3.4</felix-version>
-    <swagger-core-version>1.5.1-M2</swagger-core-version>
+    <swagger-core-version>1.5.2-M2-SNAPSHOT</swagger-core-version>
     <scala-test-version>2.1.4</scala-test-version>
     <commons-io-version>2.3</commons-io-version>
     <commons-cli-version>1.2</commons-cli-version>


### PR DESCRIPTION
Fixes #646: Example field handling has been fixed.
The swagger-api/swagger-core/pull/1002 has to be accepted first.

I would suggest to remove escaping of '\n' (i.e. example = example.replaceAll("\n", "\\\\n") in [ExampleGenerator](https://github.com/swagger-api/swagger-codegen/pull/676/files#diff-08b7ea6b5aaa485f71bcf31aec901b5dL40) and jsonExample = jsonExample.replaceAll("\\\\n", "\n") in [NodeJSServerCodegen](https://github.com/swagger-api/swagger-codegen/pull/676/files#diff-7a12f5f8b19af3ab6e9ee4867476611bL181)) and leave this on behalf of particular descendants of the DefaultCodegen class.
As for now only `html` and `nodejs` generators use examples, while the first outputs examples as is and has the issue reported [here](https://github.com/swagger-api/swagger-codegen/pull/654#issuecomment-93792558), and the former handles escaped '\n' properly