### PR TITLE
Fix tests for Scala petstore sample

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,18 @@
       </modules>
     </profile>
     <profile>
+      <id>scala-client</id>
+      <activation>
+        <property>
+          <name>env</name>
+          <value>scala</value>
+        </property>
+      </activation>
+      <modules>
+        <module>samples/client/petstore/scala</module>
+      </modules>
+    </profile>
+    <profile>
       <id>objc-client</id>
       <activation>
         <property>
@@ -361,6 +373,7 @@
       <modules>
         <module>samples/client/petstore/android-java</module>
         <module>samples/client/petstore/java</module>
+        <module>samples/client/petstore/scala</module>
         <module>samples/server/petstore/jaxrs</module>
         <module>samples/server/petstore/spring-mvc</module>
         <module>samples/client/petstore/objc</module>

--- a/samples/client/petstore/scala/src/test/scala/PetApiTest.scala
+++ b/samples/client/petstore/scala/src/test/scala/PetApiTest.scala
@@ -15,17 +15,7 @@ class PetApiTest extends FlatSpec with Matchers {
   behavior of "PetApi"
   val api = new PetApi
 
-  it should "fetch a pet" in {
-    api.getPetById(1) match {
-      case Some(pet) => {
-        pet should not be (null)
-        pet.id should be(1)
-      }
-      case None => fail("didn't find pet 1")
-    }
-  }
-
-  it should "add a new pet" in {
+  it should "add and fetch a pet" in {
     val pet = Pet(
       1000,
       Category(1, "sold"),


### PR DESCRIPTION
Test results before the fixes:

```
Results :

Tests in error:
  PetApi should fetch a pet(PetApiTest): didn't find pet 1
  StoreApi should fetch an order(StoreApiTest): didn't find order
  StoreApi should place an order(StoreApiTest): false was not true
  StoreApi should delete an order(StoreApiTest): false was not true

Tests run: 15, Failures: 0, Errors: 4, Skipped: 0
```

Test results after the fixes:

```
Results :

Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```