### PR TITLE
Java Template: Make ApiInvoker more pluggable

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -21,8 +21,12 @@ import java.util.HashMap;
 
 {{#operations}}
 public class {{classname}} {
-  String basePath = "{{basePath}}";
-  ApiInvoker apiInvoker = ApiInvoker.getInstance();
+  private String basePath = "{{basePath}}";
+  private ApiInvoker apiInvoker;
+
+  public {{classname}}(ApiInvoker apiInvoker) {
+      this.apiInvoker = apiInvoker;
+  }  
 
   public ApiInvoker getInvoker() {
     return apiInvoker;

--- a/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiInvoker.mustache
@@ -32,7 +32,6 @@ import java.text.SimpleDateFormat;
 import java.text.ParseException;
 
 public class ApiInvoker {
-  private static ApiInvoker INSTANCE = new ApiInvoker();
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private boolean isDebug = false;
@@ -52,14 +51,16 @@ public class ApiInvoker {
   static {
     // Use UTC as the default time zone.
     DATE_TIME_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));    
+  }
 
+  public ApiInvoker() {
     // Set default User-Agent.
     setUserAgent("Java-Swagger");
   }
 
-  public static void setUserAgent(String userAgent) {
-    INSTANCE.addDefaultHeader("User-Agent", userAgent);
+  public void setUserAgent(String userAgent) {
+    this.addDefaultHeader("User-Agent", userAgent);
   }
 
   public static Date parseDateTime(String str) {
@@ -106,10 +107,6 @@ public class ApiInvoker {
   }
   public void enableDebug() {
     isDebug = true;
-  }
-
-  public static ApiInvoker getInstance() {
-    return INSTANCE;
   }
 
   public void addDefaultHeader(String key, String value) {


### PR DESCRIPTION
We needed simple key authentication and with this change you can easily extend the ApiInvoker and e.g. hook into ApiInvoker.invokeAPI to modify the queryParams. And for header based authentication you could change the headers there too.

Example usage:
```java
ApiInvoker myInvoker = new ApiInvoker() {
  public String invokeAPI(String host, String path, String method, Map<String, String> queryParams, ...) {
    queryParams.put("key", someKey);
    super.invokeAPI(host, path, method, queryParams, ...);
  }
}

SomeApi api = new SomeApi(myInvoker);
```