### PR TITLE
Use RestSharp for CSharp API client

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/CSharpClientCodegen.java
@@ -7,7 +7,7 @@ import java.util.*;
 import java.io.File;
 
 public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig {
-  protected String invokerPackage = "io.swagger.client";
+  protected String invokerPackage = "IO.Swagger.Client";
   protected String groupId = "io.swagger";
   protected String artifactId = "swagger-csharp-client";
   protected String artifactVersion = "1.0.0";
@@ -31,8 +31,8 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
     modelTemplateFiles.put("model.mustache", ".cs");
     apiTemplateFiles.put("api.mustache", ".cs");
     templateDir = "csharp";
-    apiPackage = "io.swagger.Api";
-    modelPackage = "io.swagger.Model";
+    apiPackage = "IO.Swagger.Api";
+    modelPackage = "IO.Swagger.Model";
 
     reservedWords = new HashSet<String> (
       Arrays.asList(

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/CSharpClientCodegen.java
@@ -80,7 +80,7 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
     typeMapping.put("double", "double?");
     typeMapping.put("number", "double?");
     typeMapping.put("Date", "DateTime");
-    typeMapping.put("file", "byte[]");
+    typeMapping.put("file", "string"); // path to file
     typeMapping.put("array", "List");
     typeMapping.put("map", "Dictionary");
 

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -70,19 +70,13 @@ namespace {{package}} {
       {{#bodyParam}}_request.AddParameter("application/json", ApiInvoker.Serialize({{paramName}}), ParameterType.RequestBody); // http body (model) parameter
       {{/bodyParam}}
 
-      try {
-        // make the HTTP request
-        {{#returnType}}IRestResponse response = restClient.Execute(_request);
-        return ({{{returnType}}}) ApiInvoker.Deserialize(response.Content, typeof({{{returnType}}}));{{/returnType}}{{^returnType}}restClient.Execute(_request);
-        return;{{/returnType}}
-      } catch (Exception ex) {
-        if(ex != null) {
-          return {{#returnType}}null{{/returnType}};
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling {{nickname}}: " + response.Content);
       }
+      {{#returnType}}return ({{{returnType}}}) ApiInvoker.Deserialize(response.Content, typeof({{{returnType}}}));{{/returnType}}{{^returnType}}
+      return;{{/returnType}}
     }
     {{/operation}}
   }

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -41,15 +41,16 @@ namespace {{package}} {
     /// {{summary}} {{notes}}
     /// </summary>
 {{#allParams}}    /// <param name="{{paramName}}">{{description}}</param>
-{{/allParams}}    /// <returns>{{#returnType}}{{{returnType}}}{{/returnType}}</returns>
+{{/allParams}}
+    /// <returns>{{#returnType}}{{{returnType}}}{{/returnType}}</returns>
     public {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
 
       var _request = new RestRequest("{{path}}", Method.{{httpMethod}});
 
-      {{#requiredParams}}
-      // verify required param {{paramName}} is set
-      if ({{paramName}} == null) throw new ApiException(400, "missing required params {{paramName}}");
-      {{/requiredParams}}
+      {{#allParams}}{{#required}}
+      // verify the required parameter '{{paramName}}' is set
+      if ({{paramName}} == null) throw new ApiException(400, "Missing required parameter '{{paramName}}' when calling {{nickname}}");
+      {{/required}}{{/allParams}}
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       {{#pathParams}}_request.AddUrlSegment("{{baseName}}", ApiInvoker.ParameterToString({{{paramName}}})); // path (url segment) parameter
@@ -58,17 +59,15 @@ namespace {{package}} {
       {{/queryParams}}
       {{#headerParams}} if ({{paramName}} != null) _request.AddHeader("{{baseName}}", ApiInvoker.ParameterToString({{paramName}})); // header parameter
       {{/headerParams}}
-      {{#formParams}}if ({{paramName}} != null) {{#isFile}}_request.AddFile("{{baseName}}", {{paramName}});{{/isFile}}{{^isFile}}_request.AddParameter("{{baseName}}", ApiInvoker.ParameterToString({{paramName}}));{{/isFile}} // form parameter
+      {{#formParams}}if ({{paramName}} != null) {{#isFile}}_request.AddFile("{{baseName}}", {{paramName}});{{/isFile}}{{^isFile}}_request.AddParameter("{{baseName}}", ApiInvoker.ParameterToString({{paramName}})); // form parameter{{/isFile}}
       {{/formParams}}
-      {{#bodyParam}}
-      _request.AddParameter("application/json", ApiInvoker.Serialize({{paramName}}), ParameterType.RequestBody); // HTTP request body (model)
+      {{#bodyParam}}_request.AddParameter("application/json", ApiInvoker.Serialize({{paramName}}), ParameterType.RequestBody); // http body (model) parameter
       {{/bodyParam}}
 
       try {
+        // make the HTTP request
         {{#returnType}}IRestResponse response = restClient.Execute(_request);
-        return ({{{returnType}}}) ApiInvoker.Deserialize(response.Content, typeof({{{returnType}}}));
-        //return ((object)response) as {{{returnType}}};{{/returnType}}
-        {{^returnType}}restClient.Execute(_request);
+        return ({{{returnType}}}) ApiInvoker.Deserialize(response.Content, typeof({{{returnType}}}));{{/returnType}}{{^returnType}}restClient.Execute(_request);
         return;{{/returnType}}
       } catch (Exception ex) {
         if(ex != null) {

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -40,10 +40,9 @@ namespace {{package}} {
     /// <summary>
     /// {{summary}} {{notes}}
     /// </summary>
-    {{#allParams}}/// <param name="{{paramName}}">{{description}}</param>
-    {{/allParams}}
-    /// <returns></returns>
-    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+{{#allParams}}    /// <param name="{{paramName}}">{{description}}</param>
+{{/allParams}}    /// <returns>{{#returnType}}{{{returnType}}}{{/returnType}}</returns>
+    public {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
 
       var _request = new RestRequest("{{path}}", Method.{{httpMethod}});
 
@@ -52,18 +51,17 @@ namespace {{package}} {
       if ({{paramName}} == null) throw new ApiException(400, "missing required params {{paramName}}");
       {{/requiredParams}}
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      {{#pathParams}}_request.AddUrlSegment("{{baseName}}", ApiInvoker.ParameterToString({{{paramName}}}));{{/pathParams}}
-      // query parameters, if any
-      {{#queryParams}} if ({{paramName}} != null) _request.AddParameter("{{baseName}}", {{paramName}});{{/queryParams}}
-      // header parameters, if any
-      {{#headerParams}} if ({{paramName}} != null) _request.AddHeader("{{baseName}}", {{paramName}});{{/headerParams}}
-      // form parameters, if any
-      {{#formParams}}if ({{paramName}} != null) {{#isFile}}_request.AddFile("{{baseName}}", {{paramName}});{{/isFile}}{{^isFile}}_request.AddParameter("{{baseName}}", {{paramName}});{{/isFile}}
+      {{#pathParams}}_request.AddUrlSegment("{{baseName}}", ApiInvoker.ParameterToString({{{paramName}}})); // path (url segment) parameter
+      {{/pathParams}}
+      {{#queryParams}} if ({{paramName}} != null) _request.AddParameter("{{baseName}}", ApiInvoker.ParameterToString({{paramName}})); // query parameter
+      {{/queryParams}}
+      {{#headerParams}} if ({{paramName}} != null) _request.AddHeader("{{baseName}}", ApiInvoker.ParameterToString({{paramName}})); // header parameter
+      {{/headerParams}}
+      {{#formParams}}if ({{paramName}} != null) {{#isFile}}_request.AddFile("{{baseName}}", {{paramName}});{{/isFile}}{{^isFile}}_request.AddParameter("{{baseName}}", ApiInvoker.ParameterToString({{paramName}}));{{/isFile}} // form parameter
       {{/formParams}}
       {{#bodyParam}}
-      _request.AddParameter("application/json", ApiInvoker.Serialize({{paramName}}), ParameterType.RequestBody);
+      _request.AddParameter("application/json", ApiInvoker.Serialize({{paramName}}), ParameterType.RequestBody); // HTTP request body (model)
       {{/bodyParam}}
 
       try {

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using RestSharp;
 using {{invokerPackage}};
 using {{modelPackage}};
 {{#imports}}
@@ -10,10 +11,12 @@ namespace {{package}} {
   public class {{classname}} {
     string basePath;
     private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
+    protected RestClient _client;
 
     public {{classname}}(String basePath = "{{basePath}}")
     {
       this.basePath = basePath;
+      _client = new RestClient(basePath);
     }
 
     public ApiInvoker getInvoker() {
@@ -39,65 +42,33 @@ namespace {{package}} {
     {{#hasMore}} {{/hasMore}}{{/allParams}}
     /// <returns></returns>
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
-      // create path and map variables
-      var path = "{{path}}".Replace("{format}","json"){{#pathParams}}.Replace("{" + "{{baseName}}" + "}", apiInvoker.ParameterToString({{{paramName}}})){{/pathParams}};
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("{{path}}", Method.{{httpMethod}});
 
-      {{#requiredParamCount}}
-      // verify required params are set
-      if ({{/requiredParamCount}}{{#requiredParams}} {{paramName}} == null {{#hasMore}}|| {{/hasMore}}{{/requiredParams}}{{#requiredParamCount}}) {
-         throw new ApiException(400, "missing required params");
-      }
-      {{/requiredParamCount}}
+      {{#requiredParams}}
+      // verify required param {{paramName}} is set
+      if ({{paramName}} == null) throw new ApiException(400, "missing required params {{paramName}}");
+      {{/requiredParams}}
 
-      {{#queryParams}}if ({{paramName}} != null){
-        queryParams.Add("{{baseName}}", apiInvoker.ParameterToString({{paramName}}));
-      }
-      {{/queryParams}}
-
-      {{#headerParams}}headerParams.Add("{{baseName}}", apiInvoker.ParameterToString({{paramName}}));
-      {{/headerParams}}
-
-      {{#formParams}}if ({{paramName}} != null){
-        if({{paramName}} is byte[]) {
-          formParams.Add("{{baseName}}", {{paramName}});
-        } else {
-          formParams.Add("{{baseName}}", apiInvoker.ParameterToString({{paramName}}));
-        }
-      }
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      {{#pathParams}}_request.AddUrlSegment("{{baseName}}", apiInvoker.ParameterToString({{{paramName}}}));{{/pathParams}}
+      // query parameters, if any
+      {{#queryParams}} if ({{paramName}} != null) _request.AddParameter("{{baseName}}", {{paramName}});{{/queryParams}}
+      // header parameters, if any
+      {{#headerParams}} if ({{paramName}} != null) _request.AddHeader("{{baseName}}", {{paramName}});{{/headerParams}}
+      // form parameters, if any
+      {{#formParams}}if ({{paramName}} != null) {{#isFile}}_request.AddParameter("{{baseName}}", {{paramName}});{{/isFile}}{{^isFile}}_request.AddFile("{{baseName}}", {{paramName}});{{/isFile}}
       {{/formParams}}
 
       try {
-        if (typeof({{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}) == typeof(byte[])) {
-          {{#returnType}}
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as {{{returnType}}};
-          {{/returnType}}
-          {{^returnType}}
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          {{/returnType}}
-        } else {
-          {{#returnType}}
-          var response = apiInvoker.invokeAPI(basePath, path, "{{httpMethod}}", queryParams, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, headerParams, formParams);
-          if (response != null){
-             return ({{{returnType}}}) ApiInvoker.deserialize(response, typeof({{{returnType}}}));
-          }
-          else {
-            return null;
-          }
-          {{/returnType}}
-          {{^returnType}}
-          apiInvoker.invokeAPI(basePath, path, "{{httpMethod}}", queryParams, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, headerParams, formParams);
-          return;
-          {{/returnType}}
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        {{#returnType}}IRestResponse response = _client.Execute(_request);
+        return ({{{returnType}}}) ApiInvoker.deserialize(response.Content, typeof({{{returnType}}}));
+        //return ((object)response) as {{{returnType}}};{{/returnType}}
+        {{^returnType}}_client.Execute(_request);
+        return;{{/returnType}}
+      } catch (Exception ex) {
+        if(ex != null) {
           return {{#returnType}}null{{/returnType}};
         }
         else {

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -52,6 +52,12 @@ namespace {{package}} {
       if ({{paramName}} == null) throw new ApiException(400, "Missing required parameter '{{paramName}}' when calling {{nickname}}");
       {{/required}}{{/allParams}}
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       {{#pathParams}}_request.AddUrlSegment("{{baseName}}", ApiInvoker.ParameterToString({{{paramName}}})); // path (url segment) parameter
       {{/pathParams}}

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -10,36 +10,38 @@ namespace {{package}} {
   {{#operations}}
   public class {{classname}} {
     string basePath;
-    private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
-    protected RestClient _client;
+    protected RestClient restClient;
 
     public {{classname}}(String basePath = "{{basePath}}")
     {
       this.basePath = basePath;
-      _client = new RestClient(basePath);
+      this.restClient = new RestClient(basePath);
     }
 
-    public ApiInvoker getInvoker() {
-      return apiInvoker;
-    }
-
-    // Sets the endpoint base url for the services being accessed
-    public void setBasePath(string basePath) {
+    /// <summary>
+    /// Sets the endpoint base url for the services being accessed
+    /// </summary>
+    /// <param name="basePath"> Base URL
+    /// <returns></returns>
+    public void SetBasePath(string basePath) {
       this.basePath = basePath;
     }
 
-    // Gets the endpoint base url for the services being accessed
-    public String getBasePath() {
-      return basePath;
+    /// <summary>
+    /// Gets the endpoint base url for the services being accessed
+    /// <returns>Base URL</returns>
+    /// </summary>
+    public String GetBasePath() {
+      return this.basePath;
     }
 
     {{#operation}}
-
+    
     /// <summary>
     /// {{summary}} {{notes}}
     /// </summary>
     {{#allParams}}/// <param name="{{paramName}}">{{description}}</param>
-    {{#hasMore}} {{/hasMore}}{{/allParams}}
+    {{/allParams}}
     /// <returns></returns>
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
 
@@ -52,20 +54,23 @@ namespace {{package}} {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      {{#pathParams}}_request.AddUrlSegment("{{baseName}}", apiInvoker.ParameterToString({{{paramName}}}));{{/pathParams}}
+      {{#pathParams}}_request.AddUrlSegment("{{baseName}}", ApiInvoker.ParameterToString({{{paramName}}}));{{/pathParams}}
       // query parameters, if any
       {{#queryParams}} if ({{paramName}} != null) _request.AddParameter("{{baseName}}", {{paramName}});{{/queryParams}}
       // header parameters, if any
       {{#headerParams}} if ({{paramName}} != null) _request.AddHeader("{{baseName}}", {{paramName}});{{/headerParams}}
       // form parameters, if any
-      {{#formParams}}if ({{paramName}} != null) {{#isFile}}_request.AddParameter("{{baseName}}", {{paramName}});{{/isFile}}{{^isFile}}_request.AddFile("{{baseName}}", {{paramName}});{{/isFile}}
+      {{#formParams}}if ({{paramName}} != null) {{#isFile}}_request.AddFile("{{baseName}}", {{paramName}});{{/isFile}}{{^isFile}}_request.AddParameter("{{baseName}}", {{paramName}});{{/isFile}}
       {{/formParams}}
+      {{#bodyParam}}
+      _request.AddParameter("application/json", ApiInvoker.Serialize({{paramName}}), ParameterType.RequestBody);
+      {{/bodyParam}}
 
       try {
-        {{#returnType}}IRestResponse response = _client.Execute(_request);
-        return ({{{returnType}}}) ApiInvoker.deserialize(response.Content, typeof({{{returnType}}}));
+        {{#returnType}}IRestResponse response = restClient.Execute(_request);
+        return ({{{returnType}}}) ApiInvoker.Deserialize(response.Content, typeof({{{returnType}}}));
         //return ((object)response) as {{{returnType}}};{{/returnType}}
-        {{^returnType}}_client.Execute(_request);
+        {{^returnType}}restClient.Execute(_request);
         return;{{/returnType}}
       } catch (Exception ex) {
         if(ex != null) {

--- a/modules/swagger-codegen/src/main/resources/csharp/apiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/apiException.mustache
@@ -1,21 +1,17 @@
 using System;
 
 namespace {{invokerPackage}} {
+
   public class ApiException : Exception {
-    
-  	private int errorCode = 0;
+
+    public int ErrorCode { get; set; }
 
     public ApiException() {}
 
-    public int ErrorCode { 
-    	get
-    	{
-    		return errorCode;
-    	}
+    public ApiException(int errorCode, string message) : base(message) {
+      this.ErrorCode = errorCode;
     }
 
-    public ApiException(int errorCode, string message) : base(message) {
-    	this.errorCode = errorCode;
-    }
   }
+
 }

--- a/modules/swagger-codegen/src/main/resources/csharp/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/apiInvoker.mustache
@@ -1,235 +1,81 @@
-  using System;
-  using System.Collections.Generic;
-  using System.IO;
-  using System.Linq;
-  using System.Net;
-  using System.Text;
-  using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
 
-  namespace {{invokerPackage}} {
-    public class ApiInvoker {
-      private static readonly ApiInvoker _instance = new ApiInvoker();
-      private Dictionary<String, String> defaultHeaderMap = new Dictionary<String, String>();
+namespace {{invokerPackage}} {
+  public class ApiInvoker {
+    private static Dictionary<String, String> defaultHeaderMap = new Dictionary<String, String>();
 
-      public static ApiInvoker GetInstance() {
-        return _instance;
-      }
+    /// <summary>
+    /// Add default header
+    /// </summary>
+    /// <param name="key">  Header field name
+    /// <param name="value"> Header field value
+    /// <returns></returns>
+    public static void AddDefaultHeader(string key, string value) {
+       defaultHeaderMap.Add(key, value);
+    }
 
-      /// <summary>
-      /// Add default header
-      /// </summary>
-      /// <param name="key">  Header field name
-      /// <param name="value"> Header field value
-      /// <returns></returns>
-      public void addDefaultHeader(string key, string value) {
-         defaultHeaderMap.Add(key, value);
-      }
+    /// <summary>
+    /// Get default header
+    /// </summary>
+    /// <returns>Dictionary of default header</returns>
+    public static Dictionary<String, String> GetDefaultHeader() {
+       return defaultHeaderMap;
+    }
 
-      /// <summary>
-      /// escape string (url-encoded)
-      /// </summary>
-      /// <param name="str"> String to be escaped
-      /// <returns>Escaped string</returns>
-      public string escapeString(string str) {
-        return str;
-      }
+    /// <summary>
+    /// escape string (url-encoded)
+    /// </summary>
+    /// <param name="str"> String to be escaped
+    /// <returns>Escaped string</returns>
+    public static string EscapeString(string str) {
+      return str;
+    }
 
-      /// <summary>
-      /// if parameter is DateTime, output in ISO8601 format, otherwise just return the string
-      /// </summary>
-      /// <param name="obj"> The parameter (header, path, query, form)
-      /// <returns>Formatted string</returns>
-      public string ParameterToString(object obj)
+    /// <summary>
+    /// if parameter is DateTime, output in ISO8601 format, otherwise just return the string
+    /// </summary>
+    /// <param name="obj"> The parameter (header, path, query, form)
+    /// <returns>Formatted string</returns>
+    public static string ParameterToString(object obj)
+    {
+      return (obj is DateTime) ? ((DateTime)obj).ToString ("u") : Convert.ToString (obj);
+    }
+
+    /// <summary>
+    /// Deserialize the JSON string into a proper object
+    /// </summary>
+    /// <param name="json"> JSON string
+    /// <param name="type"> Object type
+    /// <returns>Object representation of the JSON string</returns>
+    public static object Deserialize(string json, Type type) {
+      try
       {
-        return (obj is DateTime) ? ((DateTime)obj).ToString ("u") : Convert.ToString (obj);
+          return JsonConvert.DeserializeObject(json, type);
       }
-
-      /// <summary>
-      /// Deserialize the JSON string into a proper object
-      /// </summary>
-      /// <param name="json"> JSON string
-      /// <param name="type"> Object type
-      /// <returns>Object representation of the JSON string</returns>
-      public static object deserialize(string json, Type type) {
-        try
-        {
-            return JsonConvert.DeserializeObject(json, type);
-        }
-        catch (IOException e) {
-          throw new ApiException(500, e.Message);
-        }
-
+      catch (IOException e) {
+        throw new ApiException(500, e.Message);
       }
+    }
 
-      public static string serialize(object obj) {
-        try
-        {
-            return obj != null ? JsonConvert.SerializeObject(obj) : null;
-        }
-        catch (Exception e) {
-          throw new ApiException(500, e.Message);
-        }
-      }
-
-      public string invokeAPI(string host, string path, string method, Dictionary<String, String> queryParams, object body, Dictionary<String, String> headerParams, Dictionary<String, object> formParams)
+    /// <summary>
+    /// Serialize an object into JSON string
+    /// </summary>
+    /// <param name="obj"> Object 
+    /// <returns>JSON string</returns>
+    public static string Serialize(object obj) {
+      try
       {
-          return invokeAPIInternal(host, path, method, false, queryParams, body, headerParams, formParams) as string;
+          return obj != null ? JsonConvert.SerializeObject(obj) : null;
       }
-
-      public byte[] invokeBinaryAPI(string host, string path, string method, Dictionary<String, String> queryParams, object body, Dictionary<String, String> headerParams, Dictionary<String, object> formParams)
-      {
-          return invokeAPIInternal(host, path, method, true, queryParams, body, headerParams, formParams) as byte[];
-      }
-
-      private object invokeAPIInternal(string host, string path, string method, bool binaryResponse, Dictionary<String, String> queryParams, object body, Dictionary<String, String> headerParams, Dictionary<String, object> formParams) {
-        var b = new StringBuilder();
-
-        foreach (var queryParamItem in queryParams)
-        {
-            var value = queryParamItem.Value;
-            if (value == null) continue;
-            b.Append(b.ToString().Length == 0 ? "?" : "&");
-            b.Append(escapeString(queryParamItem.Key)).Append("=").Append(escapeString(value));
-        }
-
-        var querystring = b.ToString();
-
-          host = host.EndsWith("/") ? host.Substring(0, host.Length - 1) : host;
-
-          var client = WebRequest.Create(host + path + querystring);
-          client.Method = method;
-
-          byte[] formData = null;
-          if (formParams.Count > 0)
-          {
-              string formDataBoundary = String.Format("----------{0:N}", Guid.NewGuid());
-              client.ContentType = "multipart/form-data; boundary=" + formDataBoundary;
-              formData = GetMultipartFormData(formParams, formDataBoundary);
-              client.ContentLength = formData.Length;
-          }
-          else
-          {
-              client.ContentType = "application/json";
-          }
-
-          foreach (var headerParamsItem in headerParams)
-          {
-              client.Headers.Add(headerParamsItem.Key, headerParamsItem.Value);
-          }
-          foreach (var defaultHeaderMapItem in defaultHeaderMap.Where(defaultHeaderMapItem => !headerParams.ContainsKey(defaultHeaderMapItem.Key)))
-          {
-              client.Headers.Add(defaultHeaderMapItem.Key, defaultHeaderMapItem.Value);
-          }
-
-          switch (method)
-          {
-              case "GET":
-                  break;
-              case "POST":
-              case "PATCH":
-              case "PUT":
-              case "DELETE":
-                  using (Stream requestStream = client.GetRequestStream())
-                  {
-                      if (formData != null)
-                      {
-                          requestStream.Write(formData, 0, formData.Length);
-                      }
-
-                      var swRequestWriter = new StreamWriter(requestStream);
-                      swRequestWriter.Write(serialize(body));
-                      swRequestWriter.Close();
-                  }
-                  break;
-              default:
-                  throw new ApiException(500, "unknown method type " + method);
-          }
-
-          try
-          {
-              var webResponse = (HttpWebResponse)client.GetResponse();
-              if (webResponse.StatusCode != HttpStatusCode.OK)
-              {
-                  webResponse.Close();
-                  throw new ApiException((int)webResponse.StatusCode, webResponse.StatusDescription);
-              }
-
-              if (binaryResponse)
-              {
-                  using (var memoryStream = new MemoryStream())
-                  {
-                      webResponse.GetResponseStream().CopyTo(memoryStream);
-                      return memoryStream.ToArray();
-                  }
-              }
-              else
-              {
-                  using (var responseReader = new StreamReader(webResponse.GetResponseStream()))
-                  {
-                      var responseData = responseReader.ReadToEnd();
-                      return responseData;
-                  }
-              }
-          }
-          catch(WebException ex)
-          {
-              var response = ex.Response as HttpWebResponse;
-              int statusCode = 0;
-              if (response != null)
-              {
-                  statusCode = (int)response.StatusCode;
-                  response.Close();
-              }
-              throw new ApiException(statusCode, ex.Message);
-          }
-      }
-
-      private static byte[] GetMultipartFormData(Dictionary<string, object> postParameters, string boundary)
-      {
-          Stream formDataStream = new System.IO.MemoryStream();
-          bool needsCLRF = false;
-
-          foreach (var param in postParameters)
-          {
-              // Thanks to feedback from commenters, add a CRLF to allow multiple parameters to be added.
-              // Skip it on the first parameter, add it to subsequent parameters.
-              if (needsCLRF)
-                  formDataStream.Write(Encoding.UTF8.GetBytes("\r\n"), 0, Encoding.UTF8.GetByteCount("\r\n"));
-
-              needsCLRF = true;
-
-              if (param.Value is byte[])
-              {
-                  string postData = string.Format("--{0}\r\nContent-Disposition: form-data; name=\"{1}\"; filename=\"{1}\"\r\nContent-Type: {2}\r\n\r\n",
-                      boundary,
-                      param.Key,
-                      "application/octet-stream");
-                  formDataStream.Write(Encoding.UTF8.GetBytes(postData), 0, Encoding.UTF8.GetByteCount(postData));
-
-                  // Write the file data directly to the Stream, rather than serializing it to a string.
-                  formDataStream.Write((param.Value as byte[]), 0, (param.Value as byte[]).Length);
-              }
-              else
-              {
-                  string postData = string.Format("--{0}\r\nContent-Disposition: form-data; name=\"{1}\"\r\n\r\n{2}",
-                      boundary,
-                      param.Key,
-                      param.Value);
-                  formDataStream.Write(Encoding.UTF8.GetBytes(postData), 0, Encoding.UTF8.GetByteCount(postData));
-              }
-          }
-
-          // Add the end of the request.  Start with a newline
-          string footer = "\r\n--" + boundary + "--\r\n";
-          formDataStream.Write(Encoding.UTF8.GetBytes(footer), 0, Encoding.UTF8.GetByteCount(footer));
-
-          // Dump the Stream into a byte[]
-          formDataStream.Position = 0;
-          byte[] formData = new byte[formDataStream.Length];
-          formDataStream.Read(formData, 0, formData.Length);
-          formDataStream.Close();
-
-          return formData;
+      catch (Exception e) {
+        throw new ApiException(500, e.Message);
       }
     }
   }
+}

--- a/modules/swagger-codegen/src/main/resources/csharp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model.mustache
@@ -2,19 +2,19 @@ using System;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 {{#models}}
 {{#model}}
 namespace {{package}} {
+  [DataContract]
   public class {{classname}} {
     {{#vars}}
-
-    {{#description}}/* {{{description}}} */
-    {{/description}}
+    {{#description}}/* {{{description}}} */{{/description}}
+    [DataMember(Name="{{baseName}}", EmitDefaultValue=false)]
     public {{{datatype}}} {{name}} { get; set; }
 
     {{/vars}}
-
     public override string ToString()  {
       var sb = new StringBuilder();
       sb.Append("class {{classname}} {\n");

--- a/samples/client/petstore/csharp/compile.bat
+++ b/samples/client/petstore/csharp/compile.bat
@@ -1,2 +1,2 @@
 SET CSCPATH=%SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319
-%CSCPATH%\csc /reference:bin/Newtonsoft.Json.dll /target:library /out:bin/io.swagger.client.dll /recurse:src\*.cs /doc:bin/io.swagger.client.xml
+%CSCPATH%\csc /reference:bin/Newtonsoft.Json.dll /target:library /out:bin/IO.Swagger.Client.dll /recurse:src\*.cs /doc:bin/IO.Swagger.Client.xml

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
@@ -60,18 +60,13 @@ namespace IO.Swagger.Api {
       _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling UpdatePet: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -100,18 +95,13 @@ namespace IO.Swagger.Api {
       _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling AddPet: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -140,18 +130,12 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        IRestResponse response = restClient.Execute(_request);
-        return (List<Pet>) ApiInvoker.Deserialize(response.Content, typeof(List<Pet>));
-      } catch (Exception ex) {
-        if(ex != null) {
-          return null;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling FindPetsByStatus: " + response.Content);
       }
+      return (List<Pet>) ApiInvoker.Deserialize(response.Content, typeof(List<Pet>));
     }
     
     
@@ -180,18 +164,12 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        IRestResponse response = restClient.Execute(_request);
-        return (List<Pet>) ApiInvoker.Deserialize(response.Content, typeof(List<Pet>));
-      } catch (Exception ex) {
-        if(ex != null) {
-          return null;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling FindPetsByTags: " + response.Content);
       }
+      return (List<Pet>) ApiInvoker.Deserialize(response.Content, typeof(List<Pet>));
     }
     
     
@@ -223,18 +201,12 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        IRestResponse response = restClient.Execute(_request);
-        return (Pet) ApiInvoker.Deserialize(response.Content, typeof(Pet));
-      } catch (Exception ex) {
-        if(ex != null) {
-          return null;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling GetPetById: " + response.Content);
       }
+      return (Pet) ApiInvoker.Deserialize(response.Content, typeof(Pet));
     }
     
     
@@ -270,18 +242,13 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling UpdatePetWithForm: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -315,18 +282,13 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling DeletePet: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -362,18 +324,13 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling UploadFile: " + response.Content);
       }
+      
+      return;
     }
     
   }

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using RestSharp;
 using io.swagger.client;
 using io.swagger.Model;
 
@@ -8,10 +9,12 @@ namespace io.swagger.Api {
   public class PetApi {
     string basePath;
     private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
+    protected RestClient _client;
 
     public PetApi(String basePath = "http://petstore.swagger.io/v2")
     {
       this.basePath = basePath;
+      _client = new RestClient(basePath);
     }
 
     public ApiInvoker getInvoker() {
@@ -40,35 +43,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/pet".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/pet", Method.PUT);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
       
-
+      // header parameters, if any
+      
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "PUT", queryParams, Body, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -88,35 +82,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/pet".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/pet", Method.POST);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
       
-
+      // header parameters, if any
+      
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -136,43 +121,27 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/pet/findByStatus".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/pet/findByStatus", Method.GET);
 
       
 
-      if (Status != null){
-        queryParams.Add("status", apiInvoker.ParameterToString(Status));
-      }
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
+       if (Status != null) _request.AddParameter("status", Status);
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(List<Pet>) == typeof(byte[])) {
-          
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as List<Pet>;
-          
-          
-        } else {
-          
-          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          if (response != null){
-             return (List<Pet>) ApiInvoker.deserialize(response, typeof(List<Pet>));
-          }
-          else {
-            return null;
-          }
-          
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        IRestResponse response = _client.Execute(_request);
+        return (List<Pet>) ApiInvoker.deserialize(response.Content, typeof(List<Pet>));
+        //return ((object)response) as List<Pet>;
+        
+      } catch (Exception ex) {
+        if(ex != null) {
           return null;
         }
         else {
@@ -192,43 +161,27 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/pet/findByTags".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/pet/findByTags", Method.GET);
 
       
 
-      if (Tags != null){
-        queryParams.Add("tags", apiInvoker.ParameterToString(Tags));
-      }
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
+       if (Tags != null) _request.AddParameter("tags", Tags);
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(List<Pet>) == typeof(byte[])) {
-          
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as List<Pet>;
-          
-          
-        } else {
-          
-          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          if (response != null){
-             return (List<Pet>) ApiInvoker.deserialize(response, typeof(List<Pet>));
-          }
-          else {
-            return null;
-          }
-          
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        IRestResponse response = _client.Execute(_request);
+        return (List<Pet>) ApiInvoker.deserialize(response.Content, typeof(List<Pet>));
+        //return ((object)response) as List<Pet>;
+        
+      } catch (Exception ex) {
+        if(ex != null) {
           return null;
         }
         else {
@@ -248,40 +201,27 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/pet/{petId}", Method.GET);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("petId", apiInvoker.ParameterToString(PetId));
+      // query parameters, if any
       
-
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(Pet) == typeof(byte[])) {
-          
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as Pet;
-          
-          
-        } else {
-          
-          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          if (response != null){
-             return (Pet) ApiInvoker.deserialize(response, typeof(Pet));
-          }
-          else {
-            return null;
-          }
-          
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        IRestResponse response = _client.Execute(_request);
+        return (Pet) ApiInvoker.deserialize(response.Content, typeof(Pet));
+        //return ((object)response) as Pet;
+        
+      } catch (Exception ex) {
+        if(ex != null) {
           return null;
         }
         else {
@@ -303,49 +243,28 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/pet/{petId}", Method.POST);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("petId", apiInvoker.ParameterToString(PetId));
+      // query parameters, if any
       
-
+      // header parameters, if any
       
-
-      if (Name != null){
-        if(Name is byte[]) {
-          formParams.Add("name", Name);
-        } else {
-          formParams.Add("name", apiInvoker.ParameterToString(Name));
-        }
-      }
-      if (Status != null){
-        if(Status is byte[]) {
-          formParams.Add("status", Status);
-        } else {
-          formParams.Add("status", apiInvoker.ParameterToString(Status));
-        }
-      }
+      // form parameters, if any
+      if (Name != null) _request.AddFile("name", Name);
+      if (Status != null) _request.AddFile("status", Status);
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, null, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -366,36 +285,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/pet/{petId}", Method.DELETE);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("petId", apiInvoker.ParameterToString(PetId));
+      // query parameters, if any
       
-
-      headerParams.Add("api_key", apiInvoker.ParameterToString(ApiKey));
-      
-
+      // header parameters, if any
+       if (ApiKey != null) _request.AddHeader("api_key", ApiKey);
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -417,49 +326,28 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/pet/{petId}/uploadImage".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/pet/{petId}/uploadImage", Method.POST);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("petId", apiInvoker.ParameterToString(PetId));
+      // query parameters, if any
       
-
+      // header parameters, if any
       
-
-      if (AdditionalMetadata != null){
-        if(AdditionalMetadata is byte[]) {
-          formParams.Add("additionalMetadata", AdditionalMetadata);
-        } else {
-          formParams.Add("additionalMetadata", apiInvoker.ParameterToString(AdditionalMetadata));
-        }
-      }
-      if (File != null){
-        if(File is byte[]) {
-          formParams.Add("file", File);
-        } else {
-          formParams.Add("file", apiInvoker.ParameterToString(File));
-        }
-      }
+      // form parameters, if any
+      if (AdditionalMetadata != null) _request.AddFile("additionalMetadata", AdditionalMetadata);
+      if (File != null) _request.AddParameter("file", File);
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, null, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
@@ -39,7 +39,6 @@ namespace io.swagger.Api {
     /// Update an existing pet 
     /// </summary>
     /// <param name="Body">Pet object that needs to be added to the store</param>
-    
     /// <returns></returns>
     public void  UpdatePet (Pet Body) {
       // create path and map variables
@@ -49,17 +48,13 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-      
-      // header parameters, if any
-      
-      // form parameters, if any
       
       
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
       
 
       try {
@@ -81,7 +76,6 @@ namespace io.swagger.Api {
     /// Add a new pet to the store 
     /// </summary>
     /// <param name="Body">Pet object that needs to be added to the store</param>
-    
     /// <returns></returns>
     public void  AddPet (Pet Body) {
       // create path and map variables
@@ -91,17 +85,13 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-      
-      // header parameters, if any
-      
-      // form parameters, if any
       
       
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
       
 
       try {
@@ -123,7 +113,6 @@ namespace io.swagger.Api {
     /// Finds Pets by status Multiple status values can be provided with comma seperated strings
     /// </summary>
     /// <param name="Status">Status values that need to be considered for filter</param>
-    
     /// <returns></returns>
     public List<Pet>  FindPetsByStatus (List<string> Status) {
       // create path and map variables
@@ -133,14 +122,11 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-       if (Status != null) _request.AddParameter("status", Status);
-      // header parameters, if any
+       if (Status != null) _request.AddParameter("status", ApiInvoker.ParameterToString(Status)); // query parameter
       
-      // form parameters, if any
+      
       
       
 
@@ -164,7 +150,6 @@ namespace io.swagger.Api {
     /// Finds Pets by tags Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
     /// </summary>
     /// <param name="Tags">Tags to filter by</param>
-    
     /// <returns></returns>
     public List<Pet>  FindPetsByTags (List<string> Tags) {
       // create path and map variables
@@ -174,14 +159,11 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-       if (Tags != null) _request.AddParameter("tags", Tags);
-      // header parameters, if any
+       if (Tags != null) _request.AddParameter("tags", ApiInvoker.ParameterToString(Tags)); // query parameter
       
-      // form parameters, if any
+      
       
       
 
@@ -205,7 +187,6 @@ namespace io.swagger.Api {
     /// Find pet by ID Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
     /// </summary>
     /// <param name="PetId">ID of pet that needs to be fetched</param>
-    
     /// <returns></returns>
     public Pet  GetPetById (long? PetId) {
       // create path and map variables
@@ -215,14 +196,11 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId));
-      // query parameters, if any
+      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId)); // path (url segment) parameter
       
-      // header parameters, if any
       
-      // form parameters, if any
+      
       
       
 
@@ -248,7 +226,6 @@ namespace io.swagger.Api {
     /// <param name="PetId">ID of pet that needs to be updated</param>
     /// <param name="Name">Updated name of the pet</param>
     /// <param name="Status">Updated status of the pet</param>
-    
     /// <returns></returns>
     public void  UpdatePetWithForm (string PetId, string Name, string Status) {
       // create path and map variables
@@ -258,16 +235,13 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId));
-      // query parameters, if any
+      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId)); // path (url segment) parameter
       
-      // header parameters, if any
       
-      // form parameters, if any
-      if (Name != null) _request.AddParameter("name", Name);
-      if (Status != null) _request.AddParameter("status", Status);
+      
+      if (Name != null) _request.AddParameter("name", ApiInvoker.ParameterToString(Name)); // form parameter
+      if (Status != null) _request.AddParameter("status", ApiInvoker.ParameterToString(Status)); // form parameter
       
       
 
@@ -291,7 +265,6 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="ApiKey"></param>
     /// <param name="PetId">Pet id to delete</param>
-    
     /// <returns></returns>
     public void  DeletePet (string ApiKey, long? PetId) {
       // create path and map variables
@@ -301,14 +274,12 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId));
-      // query parameters, if any
+      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId)); // path (url segment) parameter
       
-      // header parameters, if any
-       if (ApiKey != null) _request.AddHeader("api_key", ApiKey);
-      // form parameters, if any
+      
+       if (ApiKey != null) _request.AddHeader("api_key", ApiInvoker.ParameterToString(ApiKey)); // header parameter
+      
       
       
 
@@ -333,7 +304,6 @@ namespace io.swagger.Api {
     /// <param name="PetId">ID of pet to update</param>
     /// <param name="AdditionalMetadata">Additional data to pass to server</param>
     /// <param name="File">file to upload</param>
-    
     /// <returns></returns>
     public void  UploadFile (long? PetId, string AdditionalMetadata, byte[] File) {
       // create path and map variables
@@ -343,16 +313,13 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId));
-      // query parameters, if any
+      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId)); // path (url segment) parameter
       
-      // header parameters, if any
       
-      // form parameters, if any
-      if (AdditionalMetadata != null) _request.AddParameter("additionalMetadata", AdditionalMetadata);
-      if (File != null) _request.AddFile("file", File);
+      
+      if (AdditionalMetadata != null) _request.AddParameter("additionalMetadata", ApiInvoker.ParameterToString(AdditionalMetadata)); // form parameter
+      if (File != null) _request.AddFile("file", File); // form parameter
       
       
 

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using RestSharp;
-using io.swagger.client;
-using io.swagger.Model;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
 
-namespace io.swagger.Api {
+namespace IO.Swagger.Api {
   
   public class PetApi {
     string basePath;
@@ -46,6 +46,12 @@ namespace io.swagger.Api {
 
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
       
@@ -79,6 +85,12 @@ namespace io.swagger.Api {
       var _request = new RestRequest("/pet", Method.POST);
 
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
@@ -114,6 +126,12 @@ namespace io.swagger.Api {
 
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
        if (Status != null) _request.AddParameter("status", ApiInvoker.ParameterToString(Status)); // query parameter
@@ -147,6 +165,12 @@ namespace io.swagger.Api {
       var _request = new RestRequest("/pet/findByTags", Method.GET);
 
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
@@ -184,6 +208,12 @@ namespace io.swagger.Api {
       // verify the required parameter 'PetId' is set
       if (PetId == null) throw new ApiException(400, "Missing required parameter 'PetId' when calling GetPetById");
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId)); // path (url segment) parameter
@@ -223,6 +253,12 @@ namespace io.swagger.Api {
       // verify the required parameter 'PetId' is set
       if (PetId == null) throw new ApiException(400, "Missing required parameter 'PetId' when calling UpdatePetWithForm");
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId)); // path (url segment) parameter
@@ -264,6 +300,12 @@ namespace io.swagger.Api {
       if (PetId == null) throw new ApiException(400, "Missing required parameter 'PetId' when calling DeletePet");
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId)); // path (url segment) parameter
       
@@ -303,6 +345,12 @@ namespace io.swagger.Api {
       // verify the required parameter 'PetId' is set
       if (PetId == null) throw new ApiException(400, "Missing required parameter 'PetId' when calling UploadFile");
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId)); // path (url segment) parameter

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
@@ -40,9 +40,7 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="Body">Pet object that needs to be added to the store</param>
     /// <returns></returns>
-    public void  UpdatePet (Pet Body) {
-      // create path and map variables
-      var path = "/pet".Replace("{format}","json");
+    public void UpdatePet (Pet Body) {
 
       var _request = new RestRequest("/pet", Method.PUT);
 
@@ -53,12 +51,11 @@ namespace io.swagger.Api {
       
       
       
-      
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -77,9 +74,7 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="Body">Pet object that needs to be added to the store</param>
     /// <returns></returns>
-    public void  AddPet (Pet Body) {
-      // create path and map variables
-      var path = "/pet".Replace("{format}","json");
+    public void AddPet (Pet Body) {
 
       var _request = new RestRequest("/pet", Method.POST);
 
@@ -90,12 +85,11 @@ namespace io.swagger.Api {
       
       
       
-      
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -113,10 +107,8 @@ namespace io.swagger.Api {
     /// Finds Pets by status Multiple status values can be provided with comma seperated strings
     /// </summary>
     /// <param name="Status">Status values that need to be considered for filter</param>
-    /// <returns></returns>
-    public List<Pet>  FindPetsByStatus (List<string> Status) {
-      // create path and map variables
-      var path = "/pet/findByStatus".Replace("{format}","json");
+    /// <returns>List<Pet></returns>
+    public List<Pet> FindPetsByStatus (List<string> Status) {
 
       var _request = new RestRequest("/pet/findByStatus", Method.GET);
 
@@ -131,10 +123,9 @@ namespace io.swagger.Api {
       
 
       try {
+        // make the HTTP request
         IRestResponse response = restClient.Execute(_request);
         return (List<Pet>) ApiInvoker.Deserialize(response.Content, typeof(List<Pet>));
-        //return ((object)response) as List<Pet>;
-        
       } catch (Exception ex) {
         if(ex != null) {
           return null;
@@ -150,10 +141,8 @@ namespace io.swagger.Api {
     /// Finds Pets by tags Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
     /// </summary>
     /// <param name="Tags">Tags to filter by</param>
-    /// <returns></returns>
-    public List<Pet>  FindPetsByTags (List<string> Tags) {
-      // create path and map variables
-      var path = "/pet/findByTags".Replace("{format}","json");
+    /// <returns>List<Pet></returns>
+    public List<Pet> FindPetsByTags (List<string> Tags) {
 
       var _request = new RestRequest("/pet/findByTags", Method.GET);
 
@@ -168,10 +157,9 @@ namespace io.swagger.Api {
       
 
       try {
+        // make the HTTP request
         IRestResponse response = restClient.Execute(_request);
         return (List<Pet>) ApiInvoker.Deserialize(response.Content, typeof(List<Pet>));
-        //return ((object)response) as List<Pet>;
-        
       } catch (Exception ex) {
         if(ex != null) {
           return null;
@@ -187,13 +175,14 @@ namespace io.swagger.Api {
     /// Find pet by ID Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
     /// </summary>
     /// <param name="PetId">ID of pet that needs to be fetched</param>
-    /// <returns></returns>
-    public Pet  GetPetById (long? PetId) {
-      // create path and map variables
-      var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
+    /// <returns>Pet</returns>
+    public Pet GetPetById (long? PetId) {
 
       var _request = new RestRequest("/pet/{petId}", Method.GET);
 
+      
+      // verify the required parameter 'PetId' is set
+      if (PetId == null) throw new ApiException(400, "Missing required parameter 'PetId' when calling GetPetById");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -205,10 +194,9 @@ namespace io.swagger.Api {
       
 
       try {
+        // make the HTTP request
         IRestResponse response = restClient.Execute(_request);
         return (Pet) ApiInvoker.Deserialize(response.Content, typeof(Pet));
-        //return ((object)response) as Pet;
-        
       } catch (Exception ex) {
         if(ex != null) {
           return null;
@@ -227,12 +215,13 @@ namespace io.swagger.Api {
     /// <param name="Name">Updated name of the pet</param>
     /// <param name="Status">Updated status of the pet</param>
     /// <returns></returns>
-    public void  UpdatePetWithForm (string PetId, string Name, string Status) {
-      // create path and map variables
-      var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
+    public void UpdatePetWithForm (string PetId, string Name, string Status) {
 
       var _request = new RestRequest("/pet/{petId}", Method.POST);
 
+      
+      // verify the required parameter 'PetId' is set
+      if (PetId == null) throw new ApiException(400, "Missing required parameter 'PetId' when calling UpdatePetWithForm");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -246,7 +235,7 @@ namespace io.swagger.Api {
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -266,12 +255,13 @@ namespace io.swagger.Api {
     /// <param name="ApiKey"></param>
     /// <param name="PetId">Pet id to delete</param>
     /// <returns></returns>
-    public void  DeletePet (string ApiKey, long? PetId) {
-      // create path and map variables
-      var path = "/pet/{petId}".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
+    public void DeletePet (string ApiKey, long? PetId) {
 
       var _request = new RestRequest("/pet/{petId}", Method.DELETE);
 
+      
+      // verify the required parameter 'PetId' is set
+      if (PetId == null) throw new ApiException(400, "Missing required parameter 'PetId' when calling DeletePet");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -284,7 +274,7 @@ namespace io.swagger.Api {
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -305,12 +295,13 @@ namespace io.swagger.Api {
     /// <param name="AdditionalMetadata">Additional data to pass to server</param>
     /// <param name="File">file to upload</param>
     /// <returns></returns>
-    public void  UploadFile (long? PetId, string AdditionalMetadata, byte[] File) {
-      // create path and map variables
-      var path = "/pet/{petId}/uploadImage".Replace("{format}","json").Replace("{" + "petId" + "}", apiInvoker.ParameterToString(PetId));
+    public void UploadFile (long? PetId, string AdditionalMetadata, string File) {
 
       var _request = new RestRequest("/pet/{petId}/uploadImage", Method.POST);
 
+      
+      // verify the required parameter 'PetId' is set
+      if (PetId == null) throw new ApiException(400, "Missing required parameter 'PetId' when calling UploadFile");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -319,12 +310,12 @@ namespace io.swagger.Api {
       
       
       if (AdditionalMetadata != null) _request.AddParameter("additionalMetadata", ApiInvoker.ParameterToString(AdditionalMetadata)); // form parameter
-      if (File != null) _request.AddFile("file", File); // form parameter
+      if (File != null) _request.AddFile("file", File);
       
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/PetApi.cs
@@ -8,31 +8,33 @@ namespace io.swagger.Api {
   
   public class PetApi {
     string basePath;
-    private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
-    protected RestClient _client;
+    protected RestClient restClient;
 
     public PetApi(String basePath = "http://petstore.swagger.io/v2")
     {
       this.basePath = basePath;
-      _client = new RestClient(basePath);
+      this.restClient = new RestClient(basePath);
     }
 
-    public ApiInvoker getInvoker() {
-      return apiInvoker;
-    }
-
-    // Sets the endpoint base url for the services being accessed
-    public void setBasePath(string basePath) {
+    /// <summary>
+    /// Sets the endpoint base url for the services being accessed
+    /// </summary>
+    /// <param name="basePath"> Base URL
+    /// <returns></returns>
+    public void SetBasePath(string basePath) {
       this.basePath = basePath;
     }
 
-    // Gets the endpoint base url for the services being accessed
-    public String getBasePath() {
-      return basePath;
+    /// <summary>
+    /// Gets the endpoint base url for the services being accessed
+    /// <returns>Base URL</returns>
+    /// </summary>
+    public String GetBasePath() {
+      return this.basePath;
     }
 
     
-
+    
     /// <summary>
     /// Update an existing pet 
     /// </summary>
@@ -56,10 +58,13 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -71,7 +76,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Add a new pet to the store 
     /// </summary>
@@ -95,10 +100,13 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -110,7 +118,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Finds Pets by status Multiple status values can be provided with comma seperated strings
     /// </summary>
@@ -134,10 +142,11 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
 
       try {
-        IRestResponse response = _client.Execute(_request);
-        return (List<Pet>) ApiInvoker.deserialize(response.Content, typeof(List<Pet>));
+        IRestResponse response = restClient.Execute(_request);
+        return (List<Pet>) ApiInvoker.Deserialize(response.Content, typeof(List<Pet>));
         //return ((object)response) as List<Pet>;
         
       } catch (Exception ex) {
@@ -150,7 +159,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Finds Pets by tags Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
     /// </summary>
@@ -174,10 +183,11 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
 
       try {
-        IRestResponse response = _client.Execute(_request);
-        return (List<Pet>) ApiInvoker.deserialize(response.Content, typeof(List<Pet>));
+        IRestResponse response = restClient.Execute(_request);
+        return (List<Pet>) ApiInvoker.Deserialize(response.Content, typeof(List<Pet>));
         //return ((object)response) as List<Pet>;
         
       } catch (Exception ex) {
@@ -190,7 +200,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Find pet by ID Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
     /// </summary>
@@ -207,17 +217,18 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("petId", apiInvoker.ParameterToString(PetId));
+      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId));
       // query parameters, if any
       
       // header parameters, if any
       
       // form parameters, if any
       
+      
 
       try {
-        IRestResponse response = _client.Execute(_request);
-        return (Pet) ApiInvoker.deserialize(response.Content, typeof(Pet));
+        IRestResponse response = restClient.Execute(_request);
+        return (Pet) ApiInvoker.Deserialize(response.Content, typeof(Pet));
         //return ((object)response) as Pet;
         
       } catch (Exception ex) {
@@ -230,13 +241,13 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Updates a pet in the store with form data 
     /// </summary>
     /// <param name="PetId">ID of pet that needs to be updated</param>
-     /// <param name="Name">Updated name of the pet</param>
-     /// <param name="Status">Updated status of the pet</param>
+    /// <param name="Name">Updated name of the pet</param>
+    /// <param name="Status">Updated status of the pet</param>
     
     /// <returns></returns>
     public void  UpdatePetWithForm (string PetId, string Name, string Status) {
@@ -249,19 +260,20 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("petId", apiInvoker.ParameterToString(PetId));
+      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId));
       // query parameters, if any
       
       // header parameters, if any
       
       // form parameters, if any
-      if (Name != null) _request.AddFile("name", Name);
-      if (Status != null) _request.AddFile("status", Status);
+      if (Name != null) _request.AddParameter("name", Name);
+      if (Status != null) _request.AddParameter("status", Status);
+      
       
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -273,12 +285,12 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Deletes a pet 
     /// </summary>
     /// <param name="ApiKey"></param>
-     /// <param name="PetId">Pet id to delete</param>
+    /// <param name="PetId">Pet id to delete</param>
     
     /// <returns></returns>
     public void  DeletePet (string ApiKey, long? PetId) {
@@ -291,17 +303,18 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("petId", apiInvoker.ParameterToString(PetId));
+      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId));
       // query parameters, if any
       
       // header parameters, if any
        if (ApiKey != null) _request.AddHeader("api_key", ApiKey);
       // form parameters, if any
       
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -313,13 +326,13 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// uploads an image 
     /// </summary>
     /// <param name="PetId">ID of pet to update</param>
-     /// <param name="AdditionalMetadata">Additional data to pass to server</param>
-     /// <param name="File">file to upload</param>
+    /// <param name="AdditionalMetadata">Additional data to pass to server</param>
+    /// <param name="File">file to upload</param>
     
     /// <returns></returns>
     public void  UploadFile (long? PetId, string AdditionalMetadata, byte[] File) {
@@ -332,19 +345,20 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("petId", apiInvoker.ParameterToString(PetId));
+      _request.AddUrlSegment("petId", ApiInvoker.ParameterToString(PetId));
       // query parameters, if any
       
       // header parameters, if any
       
       // form parameters, if any
-      if (AdditionalMetadata != null) _request.AddFile("additionalMetadata", AdditionalMetadata);
-      if (File != null) _request.AddParameter("file", File);
+      if (AdditionalMetadata != null) _request.AddParameter("additionalMetadata", AdditionalMetadata);
+      if (File != null) _request.AddFile("file", File);
+      
       
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
@@ -58,18 +58,12 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        IRestResponse response = restClient.Execute(_request);
-        return (Dictionary<String, int?>) ApiInvoker.Deserialize(response.Content, typeof(Dictionary<String, int?>));
-      } catch (Exception ex) {
-        if(ex != null) {
-          return null;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling GetInventory: " + response.Content);
       }
+      return (Dictionary<String, int?>) ApiInvoker.Deserialize(response.Content, typeof(Dictionary<String, int?>));
     }
     
     
@@ -98,18 +92,12 @@ namespace IO.Swagger.Api {
       _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
-      try {
-        // make the HTTP request
-        IRestResponse response = restClient.Execute(_request);
-        return (Order) ApiInvoker.Deserialize(response.Content, typeof(Order));
-      } catch (Exception ex) {
-        if(ex != null) {
-          return null;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling PlaceOrder: " + response.Content);
       }
+      return (Order) ApiInvoker.Deserialize(response.Content, typeof(Order));
     }
     
     
@@ -141,18 +129,12 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        IRestResponse response = restClient.Execute(_request);
-        return (Order) ApiInvoker.Deserialize(response.Content, typeof(Order));
-      } catch (Exception ex) {
-        if(ex != null) {
-          return null;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling GetOrderById: " + response.Content);
       }
+      return (Order) ApiInvoker.Deserialize(response.Content, typeof(Order));
     }
     
     
@@ -184,18 +166,13 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling DeleteOrder: " + response.Content);
       }
+      
+      return;
     }
     
   }

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using RestSharp;
-using io.swagger.client;
-using io.swagger.Model;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
 
-namespace io.swagger.Api {
+namespace IO.Swagger.Api {
   
   public class StoreApi {
     string basePath;
@@ -45,6 +45,12 @@ namespace io.swagger.Api {
 
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
       
@@ -77,6 +83,12 @@ namespace io.swagger.Api {
       var _request = new RestRequest("/store/order", Method.POST);
 
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
@@ -115,6 +127,12 @@ namespace io.swagger.Api {
       if (OrderId == null) throw new ApiException(400, "Missing required parameter 'OrderId' when calling GetOrderById");
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("orderId", ApiInvoker.ParameterToString(OrderId)); // path (url segment) parameter
       
@@ -151,6 +169,12 @@ namespace io.swagger.Api {
       // verify the required parameter 'OrderId' is set
       if (OrderId == null) throw new ApiException(400, "Missing required parameter 'OrderId' when calling DeleteOrder");
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("orderId", ApiInvoker.ParameterToString(OrderId)); // path (url segment) parameter

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
@@ -8,31 +8,33 @@ namespace io.swagger.Api {
   
   public class StoreApi {
     string basePath;
-    private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
-    protected RestClient _client;
+    protected RestClient restClient;
 
     public StoreApi(String basePath = "http://petstore.swagger.io/v2")
     {
       this.basePath = basePath;
-      _client = new RestClient(basePath);
+      this.restClient = new RestClient(basePath);
     }
 
-    public ApiInvoker getInvoker() {
-      return apiInvoker;
-    }
-
-    // Sets the endpoint base url for the services being accessed
-    public void setBasePath(string basePath) {
+    /// <summary>
+    /// Sets the endpoint base url for the services being accessed
+    /// </summary>
+    /// <param name="basePath"> Base URL
+    /// <returns></returns>
+    public void SetBasePath(string basePath) {
       this.basePath = basePath;
     }
 
-    // Gets the endpoint base url for the services being accessed
-    public String getBasePath() {
-      return basePath;
+    /// <summary>
+    /// Gets the endpoint base url for the services being accessed
+    /// <returns>Base URL</returns>
+    /// </summary>
+    public String GetBasePath() {
+      return this.basePath;
     }
 
     
-
+    
     /// <summary>
     /// Returns pet inventories by status Returns a map of status codes to quantities
     /// </summary>
@@ -55,10 +57,11 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
 
       try {
-        IRestResponse response = _client.Execute(_request);
-        return (Dictionary<String, int?>) ApiInvoker.deserialize(response.Content, typeof(Dictionary<String, int?>));
+        IRestResponse response = restClient.Execute(_request);
+        return (Dictionary<String, int?>) ApiInvoker.Deserialize(response.Content, typeof(Dictionary<String, int?>));
         //return ((object)response) as Dictionary<String, int?>;
         
       } catch (Exception ex) {
@@ -71,7 +74,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Place an order for a pet 
     /// </summary>
@@ -95,10 +98,13 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
 
       try {
-        IRestResponse response = _client.Execute(_request);
-        return (Order) ApiInvoker.deserialize(response.Content, typeof(Order));
+        IRestResponse response = restClient.Execute(_request);
+        return (Order) ApiInvoker.Deserialize(response.Content, typeof(Order));
         //return ((object)response) as Order;
         
       } catch (Exception ex) {
@@ -111,7 +117,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Find purchase order by ID For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
     /// </summary>
@@ -128,17 +134,18 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("orderId", apiInvoker.ParameterToString(OrderId));
+      _request.AddUrlSegment("orderId", ApiInvoker.ParameterToString(OrderId));
       // query parameters, if any
       
       // header parameters, if any
       
       // form parameters, if any
       
+      
 
       try {
-        IRestResponse response = _client.Execute(_request);
-        return (Order) ApiInvoker.deserialize(response.Content, typeof(Order));
+        IRestResponse response = restClient.Execute(_request);
+        return (Order) ApiInvoker.Deserialize(response.Content, typeof(Order));
         //return ((object)response) as Order;
         
       } catch (Exception ex) {
@@ -151,7 +158,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Delete purchase order by ID For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     /// </summary>
@@ -168,17 +175,18 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("orderId", apiInvoker.ParameterToString(OrderId));
+      _request.AddUrlSegment("orderId", ApiInvoker.ParameterToString(OrderId));
       // query parameters, if any
       
       // header parameters, if any
       
       // form parameters, if any
       
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
@@ -38,7 +38,6 @@ namespace io.swagger.Api {
     /// <summary>
     /// Returns pet inventories by status Returns a map of status codes to quantities
     /// </summary>
-    
     /// <returns></returns>
     public Dictionary<String, int?>  GetInventory () {
       // create path and map variables
@@ -48,14 +47,10 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
       
-      // header parameters, if any
       
-      // form parameters, if any
       
       
 
@@ -79,7 +74,6 @@ namespace io.swagger.Api {
     /// Place an order for a pet 
     /// </summary>
     /// <param name="Body">order placed for purchasing the pet</param>
-    
     /// <returns></returns>
     public Order  PlaceOrder (Order Body) {
       // create path and map variables
@@ -89,17 +83,13 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-      
-      // header parameters, if any
-      
-      // form parameters, if any
       
       
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
       
 
       try {
@@ -122,7 +112,6 @@ namespace io.swagger.Api {
     /// Find purchase order by ID For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
     /// </summary>
     /// <param name="OrderId">ID of pet that needs to be fetched</param>
-    
     /// <returns></returns>
     public Order  GetOrderById (string OrderId) {
       // create path and map variables
@@ -132,14 +121,11 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("orderId", ApiInvoker.ParameterToString(OrderId));
-      // query parameters, if any
+      _request.AddUrlSegment("orderId", ApiInvoker.ParameterToString(OrderId)); // path (url segment) parameter
       
-      // header parameters, if any
       
-      // form parameters, if any
+      
       
       
 
@@ -163,7 +149,6 @@ namespace io.swagger.Api {
     /// Delete purchase order by ID For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     /// </summary>
     /// <param name="OrderId">ID of the order that needs to be deleted</param>
-    
     /// <returns></returns>
     public void  DeleteOrder (string OrderId) {
       // create path and map variables
@@ -173,14 +158,11 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("orderId", ApiInvoker.ParameterToString(OrderId));
-      // query parameters, if any
+      _request.AddUrlSegment("orderId", ApiInvoker.ParameterToString(OrderId)); // path (url segment) parameter
       
-      // header parameters, if any
       
-      // form parameters, if any
+      
       
       
 

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
@@ -38,10 +38,8 @@ namespace io.swagger.Api {
     /// <summary>
     /// Returns pet inventories by status Returns a map of status codes to quantities
     /// </summary>
-    /// <returns></returns>
-    public Dictionary<String, int?>  GetInventory () {
-      // create path and map variables
-      var path = "/store/inventory".Replace("{format}","json");
+    /// <returns>Dictionary<String, int?></returns>
+    public Dictionary<String, int?> GetInventory () {
 
       var _request = new RestRequest("/store/inventory", Method.GET);
 
@@ -55,10 +53,9 @@ namespace io.swagger.Api {
       
 
       try {
+        // make the HTTP request
         IRestResponse response = restClient.Execute(_request);
         return (Dictionary<String, int?>) ApiInvoker.Deserialize(response.Content, typeof(Dictionary<String, int?>));
-        //return ((object)response) as Dictionary<String, int?>;
-        
       } catch (Exception ex) {
         if(ex != null) {
           return null;
@@ -74,10 +71,8 @@ namespace io.swagger.Api {
     /// Place an order for a pet 
     /// </summary>
     /// <param name="Body">order placed for purchasing the pet</param>
-    /// <returns></returns>
-    public Order  PlaceOrder (Order Body) {
-      // create path and map variables
-      var path = "/store/order".Replace("{format}","json");
+    /// <returns>Order</returns>
+    public Order PlaceOrder (Order Body) {
 
       var _request = new RestRequest("/store/order", Method.POST);
 
@@ -88,15 +83,13 @@ namespace io.swagger.Api {
       
       
       
-      
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
       try {
+        // make the HTTP request
         IRestResponse response = restClient.Execute(_request);
         return (Order) ApiInvoker.Deserialize(response.Content, typeof(Order));
-        //return ((object)response) as Order;
-        
       } catch (Exception ex) {
         if(ex != null) {
           return null;
@@ -112,13 +105,14 @@ namespace io.swagger.Api {
     /// Find purchase order by ID For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
     /// </summary>
     /// <param name="OrderId">ID of pet that needs to be fetched</param>
-    /// <returns></returns>
-    public Order  GetOrderById (string OrderId) {
-      // create path and map variables
-      var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.ParameterToString(OrderId));
+    /// <returns>Order</returns>
+    public Order GetOrderById (string OrderId) {
 
       var _request = new RestRequest("/store/order/{orderId}", Method.GET);
 
+      
+      // verify the required parameter 'OrderId' is set
+      if (OrderId == null) throw new ApiException(400, "Missing required parameter 'OrderId' when calling GetOrderById");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -130,10 +124,9 @@ namespace io.swagger.Api {
       
 
       try {
+        // make the HTTP request
         IRestResponse response = restClient.Execute(_request);
         return (Order) ApiInvoker.Deserialize(response.Content, typeof(Order));
-        //return ((object)response) as Order;
-        
       } catch (Exception ex) {
         if(ex != null) {
           return null;
@@ -150,12 +143,13 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="OrderId">ID of the order that needs to be deleted</param>
     /// <returns></returns>
-    public void  DeleteOrder (string OrderId) {
-      // create path and map variables
-      var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.ParameterToString(OrderId));
+    public void DeleteOrder (string OrderId) {
 
       var _request = new RestRequest("/store/order/{orderId}", Method.DELETE);
 
+      
+      // verify the required parameter 'OrderId' is set
+      if (OrderId == null) throw new ApiException(400, "Missing required parameter 'OrderId' when calling DeleteOrder");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -167,7 +161,7 @@ namespace io.swagger.Api {
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/StoreApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using RestSharp;
 using io.swagger.client;
 using io.swagger.Model;
 
@@ -8,10 +9,12 @@ namespace io.swagger.Api {
   public class StoreApi {
     string basePath;
     private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
+    protected RestClient _client;
 
     public StoreApi(String basePath = "http://petstore.swagger.io/v2")
     {
       this.basePath = basePath;
+      _client = new RestClient(basePath);
     }
 
     public ApiInvoker getInvoker() {
@@ -39,40 +42,27 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/store/inventory".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/store/inventory", Method.GET);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
       
-
+      // header parameters, if any
+      
+      // form parameters, if any
       
 
       try {
-        if (typeof(Dictionary<String, int?>) == typeof(byte[])) {
-          
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as Dictionary<String, int?>;
-          
-          
-        } else {
-          
-          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          if (response != null){
-             return (Dictionary<String, int?>) ApiInvoker.deserialize(response, typeof(Dictionary<String, int?>));
-          }
-          else {
-            return null;
-          }
-          
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        IRestResponse response = _client.Execute(_request);
+        return (Dictionary<String, int?>) ApiInvoker.deserialize(response.Content, typeof(Dictionary<String, int?>));
+        //return ((object)response) as Dictionary<String, int?>;
+        
+      } catch (Exception ex) {
+        if(ex != null) {
           return null;
         }
         else {
@@ -92,40 +82,27 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/store/order".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/store/order", Method.POST);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
       
-
+      // header parameters, if any
+      
+      // form parameters, if any
       
 
       try {
-        if (typeof(Order) == typeof(byte[])) {
-          
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as Order;
-          
-          
-        } else {
-          
-          var response = apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-          if (response != null){
-             return (Order) ApiInvoker.deserialize(response, typeof(Order));
-          }
-          else {
-            return null;
-          }
-          
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        IRestResponse response = _client.Execute(_request);
+        return (Order) ApiInvoker.deserialize(response.Content, typeof(Order));
+        //return ((object)response) as Order;
+        
+      } catch (Exception ex) {
+        if(ex != null) {
           return null;
         }
         else {
@@ -145,40 +122,27 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.ParameterToString(OrderId));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/store/order/{orderId}", Method.GET);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("orderId", apiInvoker.ParameterToString(OrderId));
+      // query parameters, if any
       
-
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(Order) == typeof(byte[])) {
-          
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as Order;
-          
-          
-        } else {
-          
-          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          if (response != null){
-             return (Order) ApiInvoker.deserialize(response, typeof(Order));
-          }
-          else {
-            return null;
-          }
-          
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        IRestResponse response = _client.Execute(_request);
+        return (Order) ApiInvoker.deserialize(response.Content, typeof(Order));
+        //return ((object)response) as Order;
+        
+      } catch (Exception ex) {
+        if(ex != null) {
           return null;
         }
         else {
@@ -198,35 +162,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/store/order/{orderId}".Replace("{format}","json").Replace("{" + "orderId" + "}", apiInvoker.ParameterToString(OrderId));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/store/order/{orderId}", Method.DELETE);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("orderId", apiInvoker.ParameterToString(OrderId));
+      // query parameters, if any
       
-
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
@@ -60,18 +60,13 @@ namespace IO.Swagger.Api {
       _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling CreateUser: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -100,18 +95,13 @@ namespace IO.Swagger.Api {
       _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling CreateUsersWithArrayInput: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -140,18 +130,13 @@ namespace IO.Swagger.Api {
       _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling CreateUsersWithListInput: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -182,18 +167,12 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        IRestResponse response = restClient.Execute(_request);
-        return (string) ApiInvoker.Deserialize(response.Content, typeof(string));
-      } catch (Exception ex) {
-        if(ex != null) {
-          return null;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling LoginUser: " + response.Content);
       }
+      return (string) ApiInvoker.Deserialize(response.Content, typeof(string));
     }
     
     
@@ -220,18 +199,13 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling LogoutUser: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -263,18 +237,12 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        IRestResponse response = restClient.Execute(_request);
-        return (User) ApiInvoker.Deserialize(response.Content, typeof(User));
-      } catch (Exception ex) {
-        if(ex != null) {
-          return null;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling GetUserByName: " + response.Content);
       }
+      return (User) ApiInvoker.Deserialize(response.Content, typeof(User));
     }
     
     
@@ -308,18 +276,13 @@ namespace IO.Swagger.Api {
       _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling UpdateUser: " + response.Content);
       }
+      
+      return;
     }
     
     
@@ -351,18 +314,13 @@ namespace IO.Swagger.Api {
       
       
 
-      try {
-        // make the HTTP request
-        restClient.Execute(_request);
-        return;
-      } catch (Exception ex) {
-        if(ex != null) {
-          return ;
-        }
-        else {
-          throw ex;
-        }
+      // make the HTTP request
+      IRestResponse response = restClient.Execute(_request);
+      if (((int)response.StatusCode) >= 400) {
+        throw new ApiException ((int)response.StatusCode, "Error calling DeleteUser: " + response.Content);
       }
+      
+      return;
     }
     
   }

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using RestSharp;
-using io.swagger.client;
-using io.swagger.Model;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
 
-namespace io.swagger.Api {
+namespace IO.Swagger.Api {
   
   public class UserApi {
     string basePath;
@@ -46,6 +46,12 @@ namespace io.swagger.Api {
 
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
       
@@ -80,6 +86,12 @@ namespace io.swagger.Api {
 
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
       
@@ -113,6 +125,12 @@ namespace io.swagger.Api {
       var _request = new RestRequest("/user/createWithList", Method.POST);
 
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
@@ -149,6 +167,12 @@ namespace io.swagger.Api {
 
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
        if (Username != null) _request.AddParameter("username", ApiInvoker.ParameterToString(Username)); // query parameter
@@ -182,6 +206,12 @@ namespace io.swagger.Api {
       var _request = new RestRequest("/user/logout", Method.GET);
 
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
@@ -218,6 +248,12 @@ namespace io.swagger.Api {
       // verify the required parameter 'Username' is set
       if (Username == null) throw new ApiException(400, "Missing required parameter 'Username' when calling GetUserByName");
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username)); // path (url segment) parameter
@@ -257,6 +293,12 @@ namespace io.swagger.Api {
       if (Username == null) throw new ApiException(400, "Missing required parameter 'Username' when calling UpdateUser");
       
 
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
+
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username)); // path (url segment) parameter
       
@@ -294,6 +336,12 @@ namespace io.swagger.Api {
       // verify the required parameter 'Username' is set
       if (Username == null) throw new ApiException(400, "Missing required parameter 'Username' when calling DeleteUser");
       
+
+      // add default header, if any
+      foreach(KeyValuePair<string, string> defaultHeader in ApiInvoker.GetDefaultHeader())
+      {
+        _request.AddHeader(defaultHeader.Key, defaultHeader.Value);
+      }
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
       _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username)); // path (url segment) parameter

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
@@ -40,9 +40,7 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="Body">Created user object</param>
     /// <returns></returns>
-    public void  CreateUser (User Body) {
-      // create path and map variables
-      var path = "/user".Replace("{format}","json");
+    public void CreateUser (User Body) {
 
       var _request = new RestRequest("/user", Method.POST);
 
@@ -53,12 +51,11 @@ namespace io.swagger.Api {
       
       
       
-      
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -77,9 +74,7 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="Body">List of user object</param>
     /// <returns></returns>
-    public void  CreateUsersWithArrayInput (List<User> Body) {
-      // create path and map variables
-      var path = "/user/createWithArray".Replace("{format}","json");
+    public void CreateUsersWithArrayInput (List<User> Body) {
 
       var _request = new RestRequest("/user/createWithArray", Method.POST);
 
@@ -90,12 +85,11 @@ namespace io.swagger.Api {
       
       
       
-      
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -114,9 +108,7 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="Body">List of user object</param>
     /// <returns></returns>
-    public void  CreateUsersWithListInput (List<User> Body) {
-      // create path and map variables
-      var path = "/user/createWithList".Replace("{format}","json");
+    public void CreateUsersWithListInput (List<User> Body) {
 
       var _request = new RestRequest("/user/createWithList", Method.POST);
 
@@ -127,12 +119,11 @@ namespace io.swagger.Api {
       
       
       
-      
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -151,11 +142,8 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="Username">The user name for login</param>
     /// <param name="Password">The password for login in clear text</param>
-    
-    /// <returns></returns>
-    public string  LoginUser (string Username, string Password) {
-      // create path and map variables
-      var path = "/user/login".Replace("{format}","json");
+    /// <returns>string</returns>
+    public string LoginUser (string Username, string Password) {
 
       var _request = new RestRequest("/user/login", Method.GET);
 
@@ -171,10 +159,9 @@ namespace io.swagger.Api {
       
 
       try {
+        // make the HTTP request
         IRestResponse response = restClient.Execute(_request);
         return (string) ApiInvoker.Deserialize(response.Content, typeof(string));
-        //return ((object)response) as string;
-        
       } catch (Exception ex) {
         if(ex != null) {
           return null;
@@ -190,9 +177,7 @@ namespace io.swagger.Api {
     /// Logs out current logged in user session 
     /// </summary>
     /// <returns></returns>
-    public void  LogoutUser () {
-      // create path and map variables
-      var path = "/user/logout".Replace("{format}","json");
+    public void LogoutUser () {
 
       var _request = new RestRequest("/user/logout", Method.GET);
 
@@ -206,7 +191,7 @@ namespace io.swagger.Api {
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -224,12 +209,14 @@ namespace io.swagger.Api {
     /// Get user by user name 
     /// </summary>
     /// <param name="Username">The name that needs to be fetched. Use user1 for testing. </param>
-    public User  GetUserByName (string Username) {
-      // create path and map variables
-      var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
+    /// <returns>User</returns>
+    public User GetUserByName (string Username) {
 
       var _request = new RestRequest("/user/{username}", Method.GET);
 
+      
+      // verify the required parameter 'Username' is set
+      if (Username == null) throw new ApiException(400, "Missing required parameter 'Username' when calling GetUserByName");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -241,10 +228,9 @@ namespace io.swagger.Api {
       
 
       try {
+        // make the HTTP request
         IRestResponse response = restClient.Execute(_request);
         return (User) ApiInvoker.Deserialize(response.Content, typeof(User));
-        //return ((object)response) as User;
-        
       } catch (Exception ex) {
         if(ex != null) {
           return null;
@@ -262,12 +248,13 @@ namespace io.swagger.Api {
     /// <param name="Username">name that need to be deleted</param>
     /// <param name="Body">Updated user object</param>
     /// <returns></returns>
-    public void  UpdateUser (string Username, User Body) {
-      // create path and map variables
-      var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
+    public void UpdateUser (string Username, User Body) {
 
       var _request = new RestRequest("/user/{username}", Method.PUT);
 
+      
+      // verify the required parameter 'Username' is set
+      if (Username == null) throw new ApiException(400, "Missing required parameter 'Username' when calling UpdateUser");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -276,12 +263,11 @@ namespace io.swagger.Api {
       
       
       
-      
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // http body (model) parameter
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {
@@ -300,12 +286,13 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="Username">The name that needs to be deleted</param>
     /// <returns></returns>
-    public void  DeleteUser (string Username) {
-      // create path and map variables
-      var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
+    public void DeleteUser (string Username) {
 
       var _request = new RestRequest("/user/{username}", Method.DELETE);
 
+      
+      // verify the required parameter 'Username' is set
+      if (Username == null) throw new ApiException(400, "Missing required parameter 'Username' when calling DeleteUser");
       
 
       _request.AddUrlSegment("format", "json"); // set format to json by default
@@ -317,7 +304,7 @@ namespace io.swagger.Api {
       
 
       try {
-        
+        // make the HTTP request
         restClient.Execute(_request);
         return;
       } catch (Exception ex) {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
@@ -8,31 +8,33 @@ namespace io.swagger.Api {
   
   public class UserApi {
     string basePath;
-    private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
-    protected RestClient _client;
+    protected RestClient restClient;
 
     public UserApi(String basePath = "http://petstore.swagger.io/v2")
     {
       this.basePath = basePath;
-      _client = new RestClient(basePath);
+      this.restClient = new RestClient(basePath);
     }
 
-    public ApiInvoker getInvoker() {
-      return apiInvoker;
-    }
-
-    // Sets the endpoint base url for the services being accessed
-    public void setBasePath(string basePath) {
+    /// <summary>
+    /// Sets the endpoint base url for the services being accessed
+    /// </summary>
+    /// <param name="basePath"> Base URL
+    /// <returns></returns>
+    public void SetBasePath(string basePath) {
       this.basePath = basePath;
     }
 
-    // Gets the endpoint base url for the services being accessed
-    public String getBasePath() {
-      return basePath;
+    /// <summary>
+    /// Gets the endpoint base url for the services being accessed
+    /// <returns>Base URL</returns>
+    /// </summary>
+    public String GetBasePath() {
+      return this.basePath;
     }
 
     
-
+    
     /// <summary>
     /// Create user This can only be done by the logged in user.
     /// </summary>
@@ -56,10 +58,13 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -71,7 +76,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Creates list of users with given input array 
     /// </summary>
@@ -95,10 +100,13 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -110,7 +118,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Creates list of users with given input array 
     /// </summary>
@@ -134,10 +142,13 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -149,12 +160,12 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Logs user into the system 
     /// </summary>
     /// <param name="Username">The user name for login</param>
-     /// <param name="Password">The password for login in clear text</param>
+    /// <param name="Password">The password for login in clear text</param>
     
     /// <returns></returns>
     public string  LoginUser (string Username, string Password) {
@@ -174,10 +185,11 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
 
       try {
-        IRestResponse response = _client.Execute(_request);
-        return (string) ApiInvoker.deserialize(response.Content, typeof(string));
+        IRestResponse response = restClient.Execute(_request);
+        return (string) ApiInvoker.Deserialize(response.Content, typeof(string));
         //return ((object)response) as string;
         
       } catch (Exception ex) {
@@ -190,7 +202,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Logs out current logged in user session 
     /// </summary>
@@ -213,10 +225,11 @@ namespace io.swagger.Api {
       
       // form parameters, if any
       
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -228,7 +241,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Get user by user name 
     /// </summary>
@@ -245,17 +258,18 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("username", apiInvoker.ParameterToString(Username));
+      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username));
       // query parameters, if any
       
       // header parameters, if any
       
       // form parameters, if any
       
+      
 
       try {
-        IRestResponse response = _client.Execute(_request);
-        return (User) ApiInvoker.deserialize(response.Content, typeof(User));
+        IRestResponse response = restClient.Execute(_request);
+        return (User) ApiInvoker.Deserialize(response.Content, typeof(User));
         //return ((object)response) as User;
         
       } catch (Exception ex) {
@@ -268,12 +282,12 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Updated user This can only be done by the logged in user.
     /// </summary>
     /// <param name="Username">name that need to be deleted</param>
-     /// <param name="Body">Updated user object</param>
+    /// <param name="Body">Updated user object</param>
     
     /// <returns></returns>
     public void  UpdateUser (string Username, User Body) {
@@ -286,17 +300,20 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("username", apiInvoker.ParameterToString(Username));
+      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username));
       // query parameters, if any
       
       // header parameters, if any
       
       // form parameters, if any
       
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {
@@ -308,7 +325,7 @@ namespace io.swagger.Api {
       }
     }
     
-
+    
     /// <summary>
     /// Delete user This can only be done by the logged in user.
     /// </summary>
@@ -325,17 +342,18 @@ namespace io.swagger.Api {
 
       // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("username", apiInvoker.ParameterToString(Username));
+      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username));
       // query parameters, if any
       
       // header parameters, if any
       
       // form parameters, if any
       
+      
 
       try {
         
-        _client.Execute(_request);
+        restClient.Execute(_request);
         return;
       } catch (Exception ex) {
         if(ex != null) {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
@@ -39,7 +39,6 @@ namespace io.swagger.Api {
     /// Create user This can only be done by the logged in user.
     /// </summary>
     /// <param name="Body">Created user object</param>
-    
     /// <returns></returns>
     public void  CreateUser (User Body) {
       // create path and map variables
@@ -49,17 +48,13 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-      
-      // header parameters, if any
-      
-      // form parameters, if any
       
       
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
       
 
       try {
@@ -81,7 +76,6 @@ namespace io.swagger.Api {
     /// Creates list of users with given input array 
     /// </summary>
     /// <param name="Body">List of user object</param>
-    
     /// <returns></returns>
     public void  CreateUsersWithArrayInput (List<User> Body) {
       // create path and map variables
@@ -91,17 +85,13 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-      
-      // header parameters, if any
-      
-      // form parameters, if any
       
       
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
       
 
       try {
@@ -123,7 +113,6 @@ namespace io.swagger.Api {
     /// Creates list of users with given input array 
     /// </summary>
     /// <param name="Body">List of user object</param>
-    
     /// <returns></returns>
     public void  CreateUsersWithListInput (List<User> Body) {
       // create path and map variables
@@ -133,17 +122,13 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-      
-      // header parameters, if any
-      
-      // form parameters, if any
       
       
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
       
 
       try {
@@ -176,14 +161,12 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
-       if (Username != null) _request.AddParameter("username", Username); if (Password != null) _request.AddParameter("password", Password);
-      // header parameters, if any
+       if (Username != null) _request.AddParameter("username", ApiInvoker.ParameterToString(Username)); // query parameter
+       if (Password != null) _request.AddParameter("password", ApiInvoker.ParameterToString(Password)); // query parameter
       
-      // form parameters, if any
+      
       
       
 
@@ -206,7 +189,6 @@ namespace io.swagger.Api {
     /// <summary>
     /// Logs out current logged in user session 
     /// </summary>
-    
     /// <returns></returns>
     public void  LogoutUser () {
       // create path and map variables
@@ -216,14 +198,10 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
       
-      // query parameters, if any
       
-      // header parameters, if any
       
-      // form parameters, if any
       
       
 
@@ -246,8 +224,6 @@ namespace io.swagger.Api {
     /// Get user by user name 
     /// </summary>
     /// <param name="Username">The name that needs to be fetched. Use user1 for testing. </param>
-    
-    /// <returns></returns>
     public User  GetUserByName (string Username) {
       // create path and map variables
       var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
@@ -256,14 +232,11 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username));
-      // query parameters, if any
+      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username)); // path (url segment) parameter
       
-      // header parameters, if any
       
-      // form parameters, if any
+      
       
       
 
@@ -288,7 +261,6 @@ namespace io.swagger.Api {
     /// </summary>
     /// <param name="Username">name that need to be deleted</param>
     /// <param name="Body">Updated user object</param>
-    
     /// <returns></returns>
     public void  UpdateUser (string Username, User Body) {
       // create path and map variables
@@ -298,17 +270,14 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username));
-      // query parameters, if any
-      
-      // header parameters, if any
-      
-      // form parameters, if any
+      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username)); // path (url segment) parameter
       
       
-      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody);
+      
+      
+      
+      _request.AddParameter("application/json", ApiInvoker.Serialize(Body), ParameterType.RequestBody); // HTTP request body (model)
       
 
       try {
@@ -330,7 +299,6 @@ namespace io.swagger.Api {
     /// Delete user This can only be done by the logged in user.
     /// </summary>
     /// <param name="Username">The name that needs to be deleted</param>
-    
     /// <returns></returns>
     public void  DeleteUser (string Username) {
       // create path and map variables
@@ -340,14 +308,11 @@ namespace io.swagger.Api {
 
       
 
-      // path (url segment) parameters
       _request.AddUrlSegment("format", "json"); // set format to json by default
-      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username));
-      // query parameters, if any
+      _request.AddUrlSegment("username", ApiInvoker.ParameterToString(Username)); // path (url segment) parameter
       
-      // header parameters, if any
       
-      // form parameters, if any
+      
       
       
 

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Api/UserApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using RestSharp;
 using io.swagger.client;
 using io.swagger.Model;
 
@@ -8,10 +9,12 @@ namespace io.swagger.Api {
   public class UserApi {
     string basePath;
     private readonly ApiInvoker apiInvoker = ApiInvoker.GetInstance();
+    protected RestClient _client;
 
     public UserApi(String basePath = "http://petstore.swagger.io/v2")
     {
       this.basePath = basePath;
+      _client = new RestClient(basePath);
     }
 
     public ApiInvoker getInvoker() {
@@ -40,35 +43,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/user".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/user", Method.POST);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
       
-
+      // header parameters, if any
+      
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -88,35 +82,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/user/createWithArray".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/user/createWithArray", Method.POST);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
       
-
+      // header parameters, if any
+      
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -136,35 +121,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/user/createWithList".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/user/createWithList", Method.POST);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
       
-
+      // header parameters, if any
+      
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "POST", queryParams, Body, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -185,46 +161,27 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/user/login".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/user/login", Method.GET);
 
       
 
-      if (Username != null){
-        queryParams.Add("username", apiInvoker.ParameterToString(Username));
-      }
-      if (Password != null){
-        queryParams.Add("password", apiInvoker.ParameterToString(Password));
-      }
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
+       if (Username != null) _request.AddParameter("username", Username); if (Password != null) _request.AddParameter("password", Password);
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(string) == typeof(byte[])) {
-          
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as string;
-          
-          
-        } else {
-          
-          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          if (response != null){
-             return (string) ApiInvoker.deserialize(response, typeof(string));
-          }
-          else {
-            return null;
-          }
-          
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        IRestResponse response = _client.Execute(_request);
+        return (string) ApiInvoker.deserialize(response.Content, typeof(string));
+        //return ((object)response) as string;
+        
+      } catch (Exception ex) {
+        if(ex != null) {
           return null;
         }
         else {
@@ -243,35 +200,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/user/logout".Replace("{format}","json");
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/user/logout", Method.GET);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
       
-
+      // query parameters, if any
       
-
+      // header parameters, if any
+      
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -291,40 +239,27 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/user/{username}", Method.GET);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("username", apiInvoker.ParameterToString(Username));
+      // query parameters, if any
       
-
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(User) == typeof(byte[])) {
-          
-          var response = apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return ((object)response) as User;
-          
-          
-        } else {
-          
-          var response = apiInvoker.invokeAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          if (response != null){
-             return (User) ApiInvoker.deserialize(response, typeof(User));
-          }
-          else {
-            return null;
-          }
-          
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        IRestResponse response = _client.Execute(_request);
+        return (User) ApiInvoker.deserialize(response.Content, typeof(User));
+        //return ((object)response) as User;
+        
+      } catch (Exception ex) {
+        if(ex != null) {
           return null;
         }
         else {
@@ -345,35 +280,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/user/{username}", Method.PUT);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("username", apiInvoker.ParameterToString(Username));
+      // query parameters, if any
       
-
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "PUT", queryParams, Body, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {
@@ -393,35 +319,26 @@ namespace io.swagger.Api {
       // create path and map variables
       var path = "/user/{username}".Replace("{format}","json").Replace("{" + "username" + "}", apiInvoker.ParameterToString(Username));
 
-      // query params
-      var queryParams = new Dictionary<String, String>();
-      var headerParams = new Dictionary<String, String>();
-      var formParams = new Dictionary<String, object>();
+      var _request = new RestRequest("/user/{username}", Method.DELETE);
 
       
 
+      // path (url segment) parameters
+      _request.AddUrlSegment("format", "json"); // set format to json by default
+      _request.AddUrlSegment("username", apiInvoker.ParameterToString(Username));
+      // query parameters, if any
       
-
+      // header parameters, if any
       
-
+      // form parameters, if any
       
 
       try {
-        if (typeof(void) == typeof(byte[])) {
-          
-          
-          apiInvoker.invokeBinaryAPI(basePath, path, "GET", queryParams, null, headerParams, formParams);
-          return;
-          
-        } else {
-          
-          
-          apiInvoker.invokeAPI(basePath, path, "DELETE", queryParams, null, headerParams, formParams);
-          return;
-          
-        }
-      } catch (ApiException ex) {
-        if(ex.ErrorCode == 404) {
+        
+        _client.Execute(_request);
+        return;
+      } catch (Exception ex) {
+        if(ex != null) {
           return ;
         }
         else {

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Category.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Category.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace io.swagger.Model {
+namespace IO.Swagger.Model {
   [DataContract]
   public class Category {
     

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Category.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Category.cs
@@ -2,21 +2,22 @@ using System;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace io.swagger.Model {
+  [DataContract]
   public class Category {
     
-
     
+    [DataMember(Name="id", EmitDefaultValue=false)]
     public long? Id { get; set; }
 
     
-
     
+    [DataMember(Name="name", EmitDefaultValue=false)]
     public string Name { get; set; }
 
     
-
     public override string ToString()  {
       var sb = new StringBuilder();
       sb.Append("class Category {\n");

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Order.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Order.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace io.swagger.Model {
+namespace IO.Swagger.Model {
   [DataContract]
   public class Order {
     

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Order.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Order.cs
@@ -2,42 +2,42 @@ using System;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace io.swagger.Model {
+  [DataContract]
   public class Order {
     
-
     
+    [DataMember(Name="id", EmitDefaultValue=false)]
     public long? Id { get; set; }
 
     
-
     
+    [DataMember(Name="petId", EmitDefaultValue=false)]
     public long? PetId { get; set; }
 
     
-
     
+    [DataMember(Name="quantity", EmitDefaultValue=false)]
     public int? Quantity { get; set; }
 
     
-
     
+    [DataMember(Name="shipDate", EmitDefaultValue=false)]
     public DateTime ShipDate { get; set; }
 
     
-
     /* Order Status */
-    
+    [DataMember(Name="status", EmitDefaultValue=false)]
     public string Status { get; set; }
 
     
-
     
+    [DataMember(Name="complete", EmitDefaultValue=false)]
     public bool? Complete { get; set; }
 
     
-
     public override string ToString()  {
       var sb = new StringBuilder();
       sb.Append("class Order {\n");

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Pet.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Pet.cs
@@ -2,42 +2,42 @@ using System;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace io.swagger.Model {
+  [DataContract]
   public class Pet {
     
-
     
+    [DataMember(Name="id", EmitDefaultValue=false)]
     public long? Id { get; set; }
 
     
-
     
+    [DataMember(Name="category", EmitDefaultValue=false)]
     public Category Category { get; set; }
 
     
-
     
+    [DataMember(Name="name", EmitDefaultValue=false)]
     public string Name { get; set; }
 
     
-
     
+    [DataMember(Name="photoUrls", EmitDefaultValue=false)]
     public List<string> PhotoUrls { get; set; }
 
     
-
     
+    [DataMember(Name="tags", EmitDefaultValue=false)]
     public List<Tag> Tags { get; set; }
 
     
-
     /* pet status in the store */
-    
+    [DataMember(Name="status", EmitDefaultValue=false)]
     public string Status { get; set; }
 
     
-
     public override string ToString()  {
       var sb = new StringBuilder();
       sb.Append("class Pet {\n");

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Pet.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Pet.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace io.swagger.Model {
+namespace IO.Swagger.Model {
   [DataContract]
   public class Pet {
     

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Tag.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Tag.cs
@@ -2,21 +2,22 @@ using System;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace io.swagger.Model {
+  [DataContract]
   public class Tag {
     
-
     
+    [DataMember(Name="id", EmitDefaultValue=false)]
     public long? Id { get; set; }
 
     
-
     
+    [DataMember(Name="name", EmitDefaultValue=false)]
     public string Name { get; set; }
 
     
-
     public override string ToString()  {
       var sb = new StringBuilder();
       sb.Append("class Tag {\n");

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Tag.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/Tag.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace io.swagger.Model {
+namespace IO.Swagger.Model {
   [DataContract]
   public class Tag {
     

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/User.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/User.cs
@@ -2,52 +2,52 @@ using System;
 using System.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace io.swagger.Model {
+  [DataContract]
   public class User {
     
-
     
+    [DataMember(Name="id", EmitDefaultValue=false)]
     public long? Id { get; set; }
 
     
-
     
+    [DataMember(Name="username", EmitDefaultValue=false)]
     public string Username { get; set; }
 
     
-
     
+    [DataMember(Name="firstName", EmitDefaultValue=false)]
     public string FirstName { get; set; }
 
     
-
     
+    [DataMember(Name="lastName", EmitDefaultValue=false)]
     public string LastName { get; set; }
 
     
-
     
+    [DataMember(Name="email", EmitDefaultValue=false)]
     public string Email { get; set; }
 
     
-
     
+    [DataMember(Name="password", EmitDefaultValue=false)]
     public string Password { get; set; }
 
     
-
     
+    [DataMember(Name="phone", EmitDefaultValue=false)]
     public string Phone { get; set; }
 
     
-
     /* User Status */
-    
+    [DataMember(Name="userStatus", EmitDefaultValue=false)]
     public int? UserStatus { get; set; }
 
     
-
     public override string ToString()  {
       var sb = new StringBuilder();
       sb.Append("class User {\n");

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/User.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/Model/User.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace io.swagger.Model {
+namespace IO.Swagger.Model {
   [DataContract]
   public class User {
     

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiException.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiException.cs
@@ -1,21 +1,17 @@
 using System;
 
 namespace IO.Swagger.Client {
+
   public class ApiException : Exception {
-    
-  	private int errorCode = 0;
+
+    public int ErrorCode { get; set; }
 
     public ApiException() {}
 
-    public int ErrorCode { 
-    	get
-    	{
-    		return errorCode;
-    	}
+    public ApiException(int errorCode, string message) : base(message) {
+      this.ErrorCode = errorCode;
     }
 
-    public ApiException(int errorCode, string message) : base(message) {
-    	this.errorCode = errorCode;
-    }
   }
+
 }

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiException.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace io.swagger.client {
+namespace IO.Swagger.Client {
   public class ApiException : Exception {
     
   	private int errorCode = 0;

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiInvoker.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiInvoker.cs
@@ -1,235 +1,81 @@
-  using System;
-  using System.Collections.Generic;
-  using System.IO;
-  using System.Linq;
-  using System.Net;
-  using System.Text;
-  using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
 
-  namespace io.swagger.client {
-    public class ApiInvoker {
-      private static readonly ApiInvoker _instance = new ApiInvoker();
-      private Dictionary<String, String> defaultHeaderMap = new Dictionary<String, String>();
+namespace io.swagger.client {
+  public class ApiInvoker {
+    private static Dictionary<String, String> defaultHeaderMap = new Dictionary<String, String>();
 
-      public static ApiInvoker GetInstance() {
-        return _instance;
-      }
+    /// <summary>
+    /// Add default header
+    /// </summary>
+    /// <param name="key">  Header field name
+    /// <param name="value"> Header field value
+    /// <returns></returns>
+    public static void AddDefaultHeader(string key, string value) {
+       defaultHeaderMap.Add(key, value);
+    }
 
-      /// <summary>
-      /// Add default header
-      /// </summary>
-      /// <param name="key">  Header field name
-      /// <param name="value"> Header field value
-      /// <returns></returns>
-      public void addDefaultHeader(string key, string value) {
-         defaultHeaderMap.Add(key, value);
-      }
+    /// <summary>
+    /// Get default header
+    /// </summary>
+    /// <returns>Dictionary of default header</returns>
+    public static Dictionary<String, String> GetDefaultHeader() {
+       return defaultHeaderMap;
+    }
 
-      /// <summary>
-      /// escape string (url-encoded)
-      /// </summary>
-      /// <param name="str"> String to be escaped
-      /// <returns>Escaped string</returns>
-      public string escapeString(string str) {
-        return str;
-      }
+    /// <summary>
+    /// escape string (url-encoded)
+    /// </summary>
+    /// <param name="str"> String to be escaped
+    /// <returns>Escaped string</returns>
+    public static string EscapeString(string str) {
+      return str;
+    }
 
-      /// <summary>
-      /// if parameter is DateTime, output in ISO8601 format, otherwise just return the string
-      /// </summary>
-      /// <param name="obj"> The parameter (header, path, query, form)
-      /// <returns>Formatted string</returns>
-      public string ParameterToString(object obj)
+    /// <summary>
+    /// if parameter is DateTime, output in ISO8601 format, otherwise just return the string
+    /// </summary>
+    /// <param name="obj"> The parameter (header, path, query, form)
+    /// <returns>Formatted string</returns>
+    public static string ParameterToString(object obj)
+    {
+      return (obj is DateTime) ? ((DateTime)obj).ToString ("u") : Convert.ToString (obj);
+    }
+
+    /// <summary>
+    /// Deserialize the JSON string into a proper object
+    /// </summary>
+    /// <param name="json"> JSON string
+    /// <param name="type"> Object type
+    /// <returns>Object representation of the JSON string</returns>
+    public static object Deserialize(string json, Type type) {
+      try
       {
-        return (obj is DateTime) ? ((DateTime)obj).ToString ("u") : Convert.ToString (obj);
+          return JsonConvert.DeserializeObject(json, type);
       }
-
-      /// <summary>
-      /// Deserialize the JSON string into a proper object
-      /// </summary>
-      /// <param name="json"> JSON string
-      /// <param name="type"> Object type
-      /// <returns>Object representation of the JSON string</returns>
-      public static object deserialize(string json, Type type) {
-        try
-        {
-            return JsonConvert.DeserializeObject(json, type);
-        }
-        catch (IOException e) {
-          throw new ApiException(500, e.Message);
-        }
-
+      catch (IOException e) {
+        throw new ApiException(500, e.Message);
       }
+    }
 
-      public static string serialize(object obj) {
-        try
-        {
-            return obj != null ? JsonConvert.SerializeObject(obj) : null;
-        }
-        catch (Exception e) {
-          throw new ApiException(500, e.Message);
-        }
-      }
-
-      public string invokeAPI(string host, string path, string method, Dictionary<String, String> queryParams, object body, Dictionary<String, String> headerParams, Dictionary<String, object> formParams)
+    /// <summary>
+    /// Serialize an object into JSON string
+    /// </summary>
+    /// <param name="obj"> Object 
+    /// <returns>JSON string</returns>
+    public static string Serialize(object obj) {
+      try
       {
-          return invokeAPIInternal(host, path, method, false, queryParams, body, headerParams, formParams) as string;
+          return obj != null ? JsonConvert.SerializeObject(obj) : null;
       }
-
-      public byte[] invokeBinaryAPI(string host, string path, string method, Dictionary<String, String> queryParams, object body, Dictionary<String, String> headerParams, Dictionary<String, object> formParams)
-      {
-          return invokeAPIInternal(host, path, method, true, queryParams, body, headerParams, formParams) as byte[];
-      }
-
-      private object invokeAPIInternal(string host, string path, string method, bool binaryResponse, Dictionary<String, String> queryParams, object body, Dictionary<String, String> headerParams, Dictionary<String, object> formParams) {
-        var b = new StringBuilder();
-
-        foreach (var queryParamItem in queryParams)
-        {
-            var value = queryParamItem.Value;
-            if (value == null) continue;
-            b.Append(b.ToString().Length == 0 ? "?" : "&");
-            b.Append(escapeString(queryParamItem.Key)).Append("=").Append(escapeString(value));
-        }
-
-        var querystring = b.ToString();
-
-          host = host.EndsWith("/") ? host.Substring(0, host.Length - 1) : host;
-
-          var client = WebRequest.Create(host + path + querystring);
-          client.Method = method;
-
-          byte[] formData = null;
-          if (formParams.Count > 0)
-          {
-              string formDataBoundary = String.Format("----------{0:N}", Guid.NewGuid());
-              client.ContentType = "multipart/form-data; boundary=" + formDataBoundary;
-              formData = GetMultipartFormData(formParams, formDataBoundary);
-              client.ContentLength = formData.Length;
-          }
-          else
-          {
-              client.ContentType = "application/json";
-          }
-
-          foreach (var headerParamsItem in headerParams)
-          {
-              client.Headers.Add(headerParamsItem.Key, headerParamsItem.Value);
-          }
-          foreach (var defaultHeaderMapItem in defaultHeaderMap.Where(defaultHeaderMapItem => !headerParams.ContainsKey(defaultHeaderMapItem.Key)))
-          {
-              client.Headers.Add(defaultHeaderMapItem.Key, defaultHeaderMapItem.Value);
-          }
-
-          switch (method)
-          {
-              case "GET":
-                  break;
-              case "POST":
-              case "PATCH":
-              case "PUT":
-              case "DELETE":
-                  using (Stream requestStream = client.GetRequestStream())
-                  {
-                      if (formData != null)
-                      {
-                          requestStream.Write(formData, 0, formData.Length);
-                      }
-
-                      var swRequestWriter = new StreamWriter(requestStream);
-                      swRequestWriter.Write(serialize(body));
-                      swRequestWriter.Close();
-                  }
-                  break;
-              default:
-                  throw new ApiException(500, "unknown method type " + method);
-          }
-
-          try
-          {
-              var webResponse = (HttpWebResponse)client.GetResponse();
-              if (webResponse.StatusCode != HttpStatusCode.OK)
-              {
-                  webResponse.Close();
-                  throw new ApiException((int)webResponse.StatusCode, webResponse.StatusDescription);
-              }
-
-              if (binaryResponse)
-              {
-                  using (var memoryStream = new MemoryStream())
-                  {
-                      webResponse.GetResponseStream().CopyTo(memoryStream);
-                      return memoryStream.ToArray();
-                  }
-              }
-              else
-              {
-                  using (var responseReader = new StreamReader(webResponse.GetResponseStream()))
-                  {
-                      var responseData = responseReader.ReadToEnd();
-                      return responseData;
-                  }
-              }
-          }
-          catch(WebException ex)
-          {
-              var response = ex.Response as HttpWebResponse;
-              int statusCode = 0;
-              if (response != null)
-              {
-                  statusCode = (int)response.StatusCode;
-                  response.Close();
-              }
-              throw new ApiException(statusCode, ex.Message);
-          }
-      }
-
-      private static byte[] GetMultipartFormData(Dictionary<string, object> postParameters, string boundary)
-      {
-          Stream formDataStream = new System.IO.MemoryStream();
-          bool needsCLRF = false;
-
-          foreach (var param in postParameters)
-          {
-              // Thanks to feedback from commenters, add a CRLF to allow multiple parameters to be added.
-              // Skip it on the first parameter, add it to subsequent parameters.
-              if (needsCLRF)
-                  formDataStream.Write(Encoding.UTF8.GetBytes("\r\n"), 0, Encoding.UTF8.GetByteCount("\r\n"));
-
-              needsCLRF = true;
-
-              if (param.Value is byte[])
-              {
-                  string postData = string.Format("--{0}\r\nContent-Disposition: form-data; name=\"{1}\"; filename=\"{1}\"\r\nContent-Type: {2}\r\n\r\n",
-                      boundary,
-                      param.Key,
-                      "application/octet-stream");
-                  formDataStream.Write(Encoding.UTF8.GetBytes(postData), 0, Encoding.UTF8.GetByteCount(postData));
-
-                  // Write the file data directly to the Stream, rather than serializing it to a string.
-                  formDataStream.Write((param.Value as byte[]), 0, (param.Value as byte[]).Length);
-              }
-              else
-              {
-                  string postData = string.Format("--{0}\r\nContent-Disposition: form-data; name=\"{1}\"\r\n\r\n{2}",
-                      boundary,
-                      param.Key,
-                      param.Value);
-                  formDataStream.Write(Encoding.UTF8.GetBytes(postData), 0, Encoding.UTF8.GetByteCount(postData));
-              }
-          }
-
-          // Add the end of the request.  Start with a newline
-          string footer = "\r\n--" + boundary + "--\r\n";
-          formDataStream.Write(Encoding.UTF8.GetBytes(footer), 0, Encoding.UTF8.GetByteCount(footer));
-
-          // Dump the Stream into a byte[]
-          formDataStream.Position = 0;
-          byte[] formData = new byte[formDataStream.Length];
-          formDataStream.Read(formData, 0, formData.Length);
-          formDataStream.Close();
-
-          return formData;
+      catch (Exception e) {
+        throw new ApiException(500, e.Message);
       }
     }
   }
+}

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiInvoker.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiInvoker.cs
@@ -6,7 +6,7 @@ using System.Net;
 using System.Text;
 using Newtonsoft.Json;
 
-namespace io.swagger.client {
+namespace IO.Swagger.Client {
   public class ApiInvoker {
     private static Dictionary<String, String> defaultHeaderMap = new Dictionary<String, String>();
 


### PR DESCRIPTION
Use RestSharp to make HTTP calls. Tested with the following:
- GetPetById
- UpdatePetWithForm (confirmed by inspecting the HTTP request using tcpdump)
- AddPet

Add `DataContract` to CSharp models (similar to @jsonproperty in Java) to properly map attributes with special characters. Deserialisation of responses from server works fine (tested with Pet, a model with sub-models)