### PR TITLE
Jar and aar support for Android

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/AndroidClientCodegen.java
@@ -11,7 +11,8 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
   protected String groupId = "io.swagger";
   protected String artifactId = "swagger-android-client";
   protected String artifactVersion = "1.0.0";
-  protected String sourceFolder = "src/main/java";
+  protected String projectFolder = "src/main";
+  protected String sourceFolder = projectFolder + "/java";
 
   public CodegenType getTag() {
     return CodegenType.CLIENT;
@@ -51,6 +52,7 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
     additionalProperties.put("artifactVersion", artifactVersion);
 
     supportingFiles.add(new SupportingFile("build.mustache", "", "build.gradle"));
+    supportingFiles.add(new SupportingFile("manifest.mustache", projectFolder, "AndroidManifest.xml"));
     supportingFiles.add(new SupportingFile("apiInvoker.mustache", 
       (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "ApiInvoker.java"));
     supportingFiles.add(new SupportingFile("httpPatch.mustache", 

--- a/modules/swagger-codegen/src/main/resources/android-java/build.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/build.mustache
@@ -1,48 +1,43 @@
-apply plugin: 'com.android.application'
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.2.2'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
+apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "22.0.0"
-
+    buildToolsVersion '22.0.0'
     defaultConfig {
-        applicationId "{{invokerPackage}}"
         minSdkVersion 14
         targetSdkVersion 22
-        versionCode 1
-        versionName "{{artifactVersion}}"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-
-    packagingOptions {
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/notice.txt'
-        exclude 'META-INF/license.txt'
-        exclude 'META-INF/ASL2.0'
-        exclude 'META-INF/services/com.fasterxml.jackson.core.JsonFactory'
-        exclude 'META-INF/services/com.fasterxml.jackson.core.ObjectCodec'
     }
 }
 
 ext {
-    swagger_annotations_version = '1.5.3-M1'
-    jackson_version = '2.5.2'
-    apache_httpclient_version = '4.3.5.1'
-    apache_httpmime_version = '4.4.1'
+    swagger_annotations_version = "1.5.3-M1"
+    jackson_version = "2.5.2"
+    httpclient_version = "4.3.3"
+    junit_version = "4.8.1"
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.0.0'
     compile "com.wordnik:swagger-annotations:$swagger_annotations_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    compile "org.apache.httpcomponents:httpclient-android:$apache_httpclient_version"
-    compile "org.apache.httpcomponents:httpmime:$apache_httpmime_version"
+    compile "org.apache.httpcomponents:httpcore:$httpclient_version"
+    compile "org.apache.httpcomponents:httpclient:$httpclient_version"
+    compile "org.apache.httpcomponents:httpmime:$httpclient_version"
+    testCompile "junit:junit:$junit_version"
 }

--- a/modules/swagger-codegen/src/main/resources/android-java/build.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/build.mustache
@@ -41,3 +41,15 @@ dependencies {
     compile "org.apache.httpcomponents:httpmime:$httpclient_version"
     testCompile "junit:junit:$junit_version"
 }
+
+afterEvaluate {
+    android.libraryVariants.all { variant ->
+        def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
+        task.description = "Create jar artifact for ${variant.name}"
+        task.dependsOn variant.javaCompile
+        task.from variant.javaCompile.destinationDir
+        task.destinationDir = project.file("${project.buildDir}/outputs/jar")
+        task.archiveName = "${project.name}-${variant.baseName}.jar"
+        artifacts.add('archives', task);
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/android-java/manifest.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/manifest.mustache
@@ -1,0 +1,3 @@
+<manifest package="{{invokerPackage}}">
+    <application />
+</manifest>

--- a/samples/client/petstore/android-java/build.gradle
+++ b/samples/client/petstore/android-java/build.gradle
@@ -41,3 +41,15 @@ dependencies {
     compile "org.apache.httpcomponents:httpmime:$httpclient_version"
     testCompile "junit:junit:$junit_version"
 }
+
+afterEvaluate {
+    android.libraryVariants.all { variant ->
+        def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
+        task.description = "Create jar artifact for ${variant.name}"
+        task.dependsOn variant.javaCompile
+        task.from variant.javaCompile.destinationDir
+        task.destinationDir = project.file("${project.buildDir}/outputs/jar")
+        task.archiveName = "${project.name}-${variant.baseName}.jar"
+        artifacts.add('archives', task);
+    }
+}

--- a/samples/client/petstore/android-java/build.gradle
+++ b/samples/client/petstore/android-java/build.gradle
@@ -1,48 +1,43 @@
-apply plugin: 'com.android.application'
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.2.2'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
+apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "22.0.0"
-
+    buildToolsVersion '22.0.0'
     defaultConfig {
-        applicationId "io.swagger.client"
         minSdkVersion 14
         targetSdkVersion 22
-        versionCode 1
-        versionName "1.0.0"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-
-    packagingOptions {
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/notice.txt'
-        exclude 'META-INF/license.txt'
-        exclude 'META-INF/ASL2.0'
-        exclude 'META-INF/services/com.fasterxml.jackson.core.JsonFactory'
-        exclude 'META-INF/services/com.fasterxml.jackson.core.ObjectCodec'
     }
 }
 
 ext {
-    swagger_annotations_version = '1.5.3-M1'
-    jackson_version = '2.5.2'
-    apache_httpclient_version = '4.3.5.1'
-    apache_httpmime_version = '4.4.1'
+    swagger_annotations_version = "1.5.3-M1"
+    jackson_version = "2.5.2"
+    httpclient_version = "4.3.3"
+    junit_version = "4.8.1"
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.0.0'
     compile "com.wordnik:swagger-annotations:$swagger_annotations_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    compile "org.apache.httpcomponents:httpclient-android:$apache_httpclient_version"
-    compile "org.apache.httpcomponents:httpmime:$apache_httpmime_version"
+    compile "org.apache.httpcomponents:httpcore:$httpclient_version"
+    compile "org.apache.httpcomponents:httpclient:$httpclient_version"
+    compile "org.apache.httpcomponents:httpmime:$httpclient_version"
+    testCompile "junit:junit:$junit_version"
 }

--- a/samples/client/petstore/android-java/src/main/AndroidManifest.xml
+++ b/samples/client/petstore/android-java/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest package="io.swagger.client">
+    <application />
+</manifest>


### PR DESCRIPTION
https://github.com/swagger-api/swagger-codegen/pull/699 breaks the automated build for android client jar version, this pull request fixes it. In addition, it set ups build.gradle to be used as library module in android project structure.