### PR TITLE
Found the 2.0.17 tag under 2.0.17 instead of v2.0.17.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Swagger Specification has undergone 3 revisions since initial creation in 20
 Swagger Codegen Version | Release Date | Swagger Spec compatibility | Notes
 ----------------------- | ------------ | -------------------------- | -----
 2.1.0-M2                | 2015-04-06   | 1.0, 1.1, 1.2, 2.0   | [master](https://github.com/swagger-api/swagger-codegen)
-2.0.18                  | 2015-02-09   | 1.1, 1.2      | [tag v2.0.18](https://github.com/swagger-api/swagger-codegen/tree/v2.0.18)
+2.0.17                  | 2014-08-22   | 1.1, 1.2      | [tag v2.0.17](https://github.com/swagger-api/swagger-codegen/tree/2.0.17)
 1.0.4                   | 2012-04-12   | 1.0, 1.1      | [tag v1.0.4](https://github.com/swagger-api/swagger-codegen/tree/swagger-codegen_2.9.1-1.1)
 
 


### PR DESCRIPTION
My last pull request changed to use 2.0.18 but after further research I found that the 2.0.17 tag still exists but the URL is not correct. This reverts my change and links to the 2.0.17 tag.

Sorry about the confusion.