### PR TITLE
html: build and remove dead css include

### DIFF
--- a/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
@@ -2,7 +2,6 @@
   <head>
     <meta charset="utf-8" />
     <title>API Reference</title>
-    <link rel="stylesheet" type="text/css" href="site.css" media="screen" />
   </head>
   <body>
   <h1>{{{appName}}}</h1>

--- a/samples/html/index.html
+++ b/samples/html/index.html
@@ -2,7 +2,6 @@
   <head>
     <meta charset="utf-8" />
     <title>API Reference</title>
-    <link rel="stylesheet" type="text/css" href="site.css" media="screen" />
   </head>
   <body>
   <h1>Swagger Petstore</h1>


### PR DESCRIPTION
Remove dead include of site.css
Includes latest build, not sure if I should have left the build alone ?
fixes #666 