### PR TITLE
Fixes a bug with Node.js example generating invalid package.json and swa...

### DIFF
--- a/modules/swagger-codegen/src/main/resources/nodejs/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/nodejs/package.mustache
@@ -1,7 +1,7 @@
 {
   "name": "{{projectName}}",
   "version": "{{appVersion}}",
-  "description": "{{appDescription}}",
+  "description": "{{{appDescription}}}",
   "main": "index.js",
   "keywords": [
     "swagger"

--- a/modules/swagger-codegen/src/main/resources/nodejs/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/nodejs/swagger.mustache
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "{{appName}}",
-    "description": "{{appDescription}}",
+    "description": "{{{appDescription}}}",
     "version": "{{apiVersion}}"
   },
 {{#apiInfo}}


### PR DESCRIPTION
...gger.json

Currently string "... You can find out more about Swagger at <a href=\"http://swagger.io\">http://swagger.io</a> or ... " gets URL encoded, resuling in Node js throwing "Unable to parse" error.

Use of {{{ }}} forces mustache to skip URL encoding
http://mustache.github.io/mustache.5.html#Partials