### PR TITLE
PHP Client Fixes

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenConfig.java
@@ -26,7 +26,7 @@ public interface CodegenConfig {
   String escapeReservedWord(String name);
   String getTypeDeclaration(Property p);
   String getTypeDeclaration(String name);
-  void processOpts();
+  void preGenerate(Swagger swagger);
   String generateExamplePath(String path, Operation operation);
 
   Set<String> reservedWords();
@@ -46,7 +46,7 @@ public interface CodegenConfig {
   Map<String, String> importMapping();
   Map<String, String> apiTemplateFiles();
   Map<String, String> modelTemplateFiles();
-  void processSwagger(Swagger swagger);
+  void postGenerate(Swagger swagger);
 
   String toApiFilename(String name);
   String toModelFilename(String name);

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -38,7 +38,7 @@ public class DefaultCodegen {
   protected Map<String, Object> additionalProperties = new HashMap<String, Object>();
   protected List<SupportingFile> supportingFiles = new ArrayList<SupportingFile>();
 
-  public void processOpts(){
+  public void preGenerate(Swagger swagger){
     if(additionalProperties.containsKey("templateDir")) {
       this.setTemplateDir((String)additionalProperties.get("templateDir"));
     }
@@ -60,7 +60,7 @@ public class DefaultCodegen {
   }
 
   // override with any special handling of the entire swagger spec
-  public void processSwagger(Swagger swagger) {}
+  public void postGenerate(Swagger swagger) {}
   
   // override with any special text escaping logic
   public String escapeText(String input) {

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultGenerator.java
@@ -281,23 +281,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     return files;
   }
 
-  protected Model recompose(ComposedModel composed, Map<String, Model> allModels) {
-    ModelImpl impl = new ModelImpl();
-
-    for (Model referred : composed.getAllOf()) {
-      Model instance = allModels.get(((RefModel) referred).getSimpleRef());
-
-      // avoid null pointers here.  Yeesh.
-      if (instance.getProperties() != null) {
-        for (Map.Entry<String, Property> entry : instance.getProperties().entrySet()) {
-          impl.addProperty(entry.getKey(), entry.getValue());
-        }
-      }
-    }
-    return impl;
-  }
-
-
   public Map<String, List<CodegenOperation>> processPaths(Map<String, Path> paths) {
     Map<String, List<CodegenOperation>> ops = new HashMap<String, List<CodegenOperation>>();
 

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -91,7 +91,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
     sfm.add(new SupportingFile("composer.mustache", packagePath, "composer.json"));
     sfm.add(new SupportingFile("APIClient.mustache", packagePath + "/lib", "APIClient.php"));
     sfm.add(new SupportingFile("APIClientException.mustache", packagePath + "/lib", "APIClientException.php"));
-    sfm.add(new SupportingFile("require.mustache", packagePath, slashReplace(invokerPackage, ".") + ".php"));
+    sfm.add(new SupportingFile("require.mustache", packagePath, "loader.php"));
 
     // let's delete anything from supportingFiles which matches.
     // this is in case supportingFiles has been modified outside of

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -91,7 +91,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
     sfm.add(new SupportingFile("composer.mustache", packagePath, "composer.json"));
     sfm.add(new SupportingFile("APIClient.mustache", packagePath + "/lib", "APIClient.php"));
     sfm.add(new SupportingFile("APIClientException.mustache", packagePath + "/lib", "APIClientException.php"));
-    //sfm.add(new SupportingFile("require.mustache", packagePath, getInvokerPackage() + ".php"));
+    sfm.add(new SupportingFile("require.mustache", packagePath, slashReplace(invokerPackage, ".") + ".php"));
 
     // let's delete anything from supportingFiles which matches.
     // this is in case supportingFiles has been modified outside of
@@ -102,7 +102,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
           it.remove();
         }
     }
-    // now add yournew ones back in
+    // now add your new ones back in
     supportingFiles.addAll(sfm.values());
   }
 

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -41,7 +41,8 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
       }
   }
 
-  protected String hostToNamespace(String hostname) {
+  // public for unit testing purposes
+  public String hostToNamespace(String hostname) {
     // fix the name space to be reverse, minus io, swap dots for backslash:
     //  db.yoyodyne.com -> yoyodyne/db
     String namespace = "SwaggerPetstore";

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -153,17 +153,17 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
     return "_" + name;
   }
 
-  private String moreDots(String inVar) {
+  private String dotToSlash(String inVar) {
       return inVar.replace('.', File.separatorChar);
   }
 
   @Override
   public String apiFileFolder() {
-    return outputFolder + "/" + moreDots(apiPackage());
+    return outputFolder + "/" + dotToSlash(apiPackage());
   }
 
   public String modelFileFolder() {
-    return outputFolder + "/" + moreDots(modelPackage());
+    return outputFolder + "/" + dotToSlash(modelPackage());
   }
 
   @Override

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/SwaggerGenerator.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/SwaggerGenerator.java
@@ -30,7 +30,7 @@ public class SwaggerGenerator extends DefaultCodegen implements CodegenConfig {
   }
 
   @Override
-  public void processSwagger(Swagger swagger) {
+  public void postGenerate(Swagger swagger) {
     String swaggerString = Json.pretty(swagger);
 
     try{

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/SwaggerYamlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/SwaggerYamlGenerator.java
@@ -30,7 +30,7 @@ public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfi
   }
 
   @Override
-  public void processSwagger(Swagger swagger) {
+  public void postGenerate(Swagger swagger) {
     try{
       String swaggerString = Yaml.mapper().writeValueAsString(swagger);
       String outputFile = outputFolder + File.separator + "swagger.yaml";

--- a/modules/swagger-codegen/src/main/resources/Java/JsonUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/JsonUtil.mustache
@@ -11,13 +11,13 @@ public class JsonUtil {
   public static ObjectMapper mapper;
 
   static {
-  	mapper = new ObjectMapper();
-	  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-	  mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-	  mapper.registerModule(new JodaModule());
-	}
+    mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    mapper.registerModule(new JodaModule());
+  }
 
-	public static ObjectMapper getJsonMapper() {
-		return mapper;
-	}
+  public static ObjectMapper getJsonMapper() {
+    return mapper;
+  }
 }

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -33,6 +33,9 @@ class APIClient {
     $this->host = $host;
     $this->headerName = $headerName;
     $this->headerValue = $headerValue;
+    // set to null to avoid E_STRICT warnings
+    $this->curl_timeout = null;
+    $this->user_agent = null;
   }
 
   /**
@@ -54,7 +57,7 @@ class APIClient {
     if (!is_numeric($seconds)) {
       throw new Exception('Timeout variable must be numeric.');
     }
-    $this->curl_timout = $seconds;
+    $this->curl_timeout = $seconds;
   }
 
   /**
@@ -84,15 +87,19 @@ class APIClient {
       $headers[] = $this->headerName . ": " . $this->headerValue;
     }
 
-    if (strpos($headers['Content-Type'], "multipart/form-data") < 0 and (is_object($postData) or is_array($postData))) {
-      $postData = json_encode($this->sanitizeForSerialization($postData));
+    if (isset($headers['Content-Type'])) {
+      if (strpos($headers['Content-Type'], "multipart/form-data") !== false) {
+        if (is_object($postData) or is_array($postData)) {
+          $postData = json_encode($this->sanitizeForSerialization($postData));
+        }
+      }
     }
 
     $url = $this->host . $resourcePath;
 
     $curl = curl_init();
-    if ($this->curl_timout) {
-      curl_setopt($curl, CURLOPT_TIMEOUT, $this->curl_timout);
+    if ($this->curl_timeout) {
+      curl_setopt($curl, CURLOPT_TIMEOUT, $this->curl_timeout);
     }
     // return the result on success, rather than just TRUE
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
@@ -253,6 +260,7 @@ class APIClient {
 
   public static function deserialize($data, $class)
   {
+    // translate json schema types to valid php types
     $translateTypes = array(
       "boolean" => "bool",
       "integer" => "int",

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -289,7 +289,7 @@ class APIClient {
       $deserialized = $values;
     } elseif ($class == 'DateTime') {
       $deserialized = new \DateTime($data);
-    } elseif (in_array($class, array('string', 'int', 'float', 'bool'))) {
+    } elseif (in_array($class, array('string', 'int', 'float', 'bool', 'object'))) {
       settype($data, $class);
       $deserialized = $data;
     } elseif (isset($translateTypes[$class])) {

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -253,6 +253,12 @@ class APIClient {
 
   public static function deserialize($data, $class)
   {
+    $translateTypes = array(
+      "boolean" => "bool",
+      "integer" => "int",
+      "number"  => "float",
+    );
+
     if (null === $data) {
       $deserialized = null;
     } elseif (substr($class, 0, 4) == 'map[') {
@@ -277,6 +283,9 @@ class APIClient {
       $deserialized = new \DateTime($data);
     } elseif (in_array($class, array('string', 'int', 'float', 'bool'))) {
       settype($data, $class);
+      $deserialized = $data;
+    } elseif (isset($translateTypes[$class])) {
+      settype($data, $translateTypes[$class]);
       $deserialized = $data;
     } else {
       $class = "{{invokerPackage}}\\models\\".$class;

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -73,7 +73,6 @@ class {{classname}} {
         $formParams['{{baseName}}'] = {{#isFile}}'@' . {{/isFile}}$this->apiClient->toFormValue(${{paramName}});
       }{{/formParams}}
       {{#bodyParams}}// body params
-      $body = null;
       if (isset(${{paramName}})) {
         $body = ${{paramName}};
       }{{/bodyParams}}
@@ -89,14 +88,14 @@ class {{classname}} {
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $body,
                                             $headerParams);
-
-      {{#returnType}}if(! $response) {
+      {{#returnType}}
+      if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                '{{returnType}}');
-  		return $responseObject;{{/returnType}}
+      $responseObject = $this->apiClient->deserialize($response,
+                                                       '{{returnType}}');
+      return $responseObject;{{/returnType}}
   }
   {{/operation}}
 {{newline}}

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -40,6 +40,7 @@ class {{classname}} {
    */
    public function {{nickname}}({{#allParams}}${{paramName}}{{#optional}}=null{{/optional}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
 
+      $body = null;
       // parse inputs
       $resourcePath = "{{path}}";
       $resourcePath = str_replace("{format}", "json", $resourcePath);

--- a/modules/swagger-codegen/src/main/resources/php/composer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/composer.mustache
@@ -1,5 +1,5 @@
 {
-  "name": "{{invokerPackage}}/{{invokerPackage}}-php",
+  "name": "{{forwardInvokerPackage}}",
   "description": "{{description}}",
   "keywords": [
     "swagger",
@@ -27,6 +27,6 @@
     "squizlabs/php_codesniffer": "~2.0"
   },
   "autoload": {
-    "psr-4": { "{{invokerPackage}}\\" : "lib/" }
+    "psr-4": { "{{escapedInvokerPackage}}\\" : "lib/" }
   }
 }

--- a/modules/swagger-codegen/src/main/resources/php/require.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/require.mustache
@@ -13,4 +13,3 @@ foreach (glob(dirname(__FILE__)."/lib/*.php") as $filename)
 {
       require_once $filename;
 }
-?>

--- a/modules/swagger-codegen/src/main/resources/swagger-static/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/swagger-static/index.mustache
@@ -30,14 +30,14 @@
           </ul>
         </div>
         {{#apiInfo}}
-    		{{#apis}}
+        {{#apis}}
         <div class="section-box">
           <div class="section-header">
             <a href="#!/{{classname}}">{{classname}}</a>
           </div>
           <ul>
-			      {{#operations}}
-			      {{#operation}}
+            {{#operations}}
+            {{#operation}}
             <li><a href="#!/{{classname}}#{{nickname}}">{{nickname}}</a></li>
             {{/operation}}
             {{/operations}}

--- a/modules/swagger-codegen/src/test/scala/php/PhpGeneratorTest.scala
+++ b/modules/swagger-codegen/src/test/scala/php/PhpGeneratorTest.scala
@@ -1,0 +1,20 @@
+package php
+
+import com.wordnik.swagger.codegen.languages.PhpClientCodegen
+import org.junit.runner.RunWith
+import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class PhpGeneratorTest extends FlatSpec with Matchers {
+
+    it should "change host names to slashes" in {
+      val generator = new PhpClientCodegen()
+
+      val hostName = "dynamic.yoyodyne.com"
+      val expected = "yoyodyne\\dynamic"
+
+      generator.hostToNamespace(hostName) should be (expected)
+    }
+}


### PR DESCRIPTION
Dear Swagger,

I have updated the php client generator.  I'm not personally a php guy, but have worked with our php guys to produce something that they are happy with.  I humbly submit this PR for your consideration.

Notable Functionality
================
- Modified Java code
  - The package is based on the hostname rather than being hard coded to `SwaggerPetstore`
  - Renamed `processOpts` to `preGenerate`
  - Renamed `processSwagger` to `postGenerate`
  - Passing the `swagger` object to both `pre-` and `postGenerate`
  - Added a setter method for `invokerPackage`
  - Numerous additional values depend on `invokerPackage`, so these were moved inside of the setter
- Modified mustache templates
  - Added code to avoid warnings when running php with `E_STRICT`
  - Added additional deserialization code to handle translating the JSON schema types into valid php types (e.g. "number" to "float")
  - Changes some tabs to spaces
- Modified php client layout
  - Renamed the autoloader file to just be `loader.php`.  This avoided the problem of having files with weird names like `yoyodyne\\db.php`
- Modified scala
  - Added a unit test for the hostname to package name method. This is literally the first piece of Scala I have written so YMMV.
