### PR TITLE
csharp: Fixed handling of 2xx result codes != 200.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/apiInvoker.mustache
@@ -120,7 +120,8 @@
           try
           {
               var webResponse = (HttpWebResponse)client.GetResponse();
-              if (webResponse.StatusCode != HttpStatusCode.OK)
+              int statusCode = (int)webResponse.StatusCode;
+              if (statusCode / 100 != 2) // non-success status
               {
                   webResponse.Close();
                   throw new ApiException((int)webResponse.StatusCode, webResponse.StatusDescription);

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiInvoker.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiInvoker.cs
@@ -120,7 +120,8 @@
           try
           {
               var webResponse = (HttpWebResponse)client.GetResponse();
-              if (webResponse.StatusCode != HttpStatusCode.OK)
+              int statusCode = (int)webResponse.StatusCode;
+              if (statusCode / 100 != 2) // non-success status
               {
                   webResponse.Close();
                   throw new ApiException((int)webResponse.StatusCode, webResponse.StatusDescription);


### PR DESCRIPTION
Before this change, API calls returning successful result codes other than 200 were treated as failures. For example, one possible successful result code for a POST or PUT operation is 201 Created; this previously resulted in an exception but is now treated as a success.

A code is classified as a success in a similar way to how javax.ws.rs.core.Response (as of jersey-core 1.8.3) determines a result code's "Family".