### PR TITLE
Reverted JsonUtil.mustache for JavaClientCodegen after PR #726.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/JsonUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/JsonUtil.mustache
@@ -1,17 +1,23 @@
 package {{invokerPackage}};
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.core.JsonGenerator.Feature;
+
+import com.fasterxml.jackson.datatype.joda.*;
 
 public class JsonUtil {
-  public static GsonBuilder gsonBuilder;
+  public static ObjectMapper mapper;
 
   static {
-    gsonBuilder = new GsonBuilder();
-    gsonBuilder.serializeNulls();
-  }
+  	mapper = new ObjectMapper();
+	  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+	  mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+	  mapper.registerModule(new JodaModule());
+	}
 
-  public static Gson getGson() {
-    return gsonBuilder.create();
-  }
-};
+	public static ObjectMapper getJsonMapper() {
+		return mapper;
+	}
+}


### PR DESCRIPTION
Generated Java sample for the Pet Store is broken after the PR #726:
```
$ ./bin/java-petstore.sh ; cd samples/client/petstore/java; mvn clean package
...
[INFO] 9 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.936s
[INFO] Finished at: Fri May 08 12:32:56 UTC 2015
[INFO] Final Memory: 13M/303M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project swagger-java-client: Compilation failure: Compilation failure:
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/JsonUtil.java:[3,22] error: package com.google.gson does not exist
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/JsonUtil.java:[4,22] error: package com.google.gson does not exist
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/JsonUtil.java:[7,16] error: cannot find symbol
[ERROR] class JsonUtil
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/JsonUtil.java:[14,16] error: cannot find symbol
[ERROR] class JsonUtil
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java:[134,36] error: cannot find symbol
[ERROR] class JsonUtil
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java:[135,42] error: cannot find symbol
[ERROR] class JsonUtil
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java:[145,23] error: cannot find symbol
[ERROR] class JsonUtil
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/ApiInvoker.java:[156,23] error: cannot find symbol
[ERROR] class JsonUtil
[ERROR] /home/swagger.io/swagger-codegen/samples/client/petstore/java/src/main/java/io/swagger/client/JsonUtil.java:[10,22] error: cannot find symbol
```
