### PR TITLE
Minor improvement to Ruby API Client 'accept' and 'content-type' header

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -29,11 +29,13 @@ class {{classname}}
     # header parameters
     header_params = {}
 
-    _header_accept = '{{#produces}}{{mediaType}}{{#hasMore}}, {{/hasMore}}{{/produces}}'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = [{{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}]
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = [{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}]
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'{{#headerParams}}{{#required}}
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type){{#headerParams}}{{#required}}
     header_params[:'{{{baseName}}}'] = {{{paramName}}}{{/required}}{{/headerParams}}{{#headerParams}}{{^required}}
     header_params[:'{{{baseName}}}'] = opts[:'{{{paramName}}}'] if opts[:'{{{paramName}}}']{{/required}}{{/headerParams}}
 

--- a/modules/swagger-codegen/src/main/resources/ruby/swagger/request.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger/request.mustache
@@ -208,5 +208,31 @@ module Swagger
       @response.headers.gsub(/\n/, '<br/>') # <- This is for Typhoeus
     end
 
+    # return 'Accept' based on an array of accept provided
+    # @param [Array] header_accept_array Array fo 'Accept'
+    # @return String Accept (e.g. application/json)
+    def self.select_header_accept header_accept_array
+      if header_accept_array.empty?
+        return
+      elsif header_accept_array.any?{ |s| s.casecmp('application/json')==0 }
+        'application/json' # look for json data by default
+      else
+        header_accept_array.join(',')
+      end
+    end
+
+    # return the content type based on an array of content-type provided
+    # @param [Array] content_type_array Array fo content-type
+    # @return String Content-Type (e.g. application/json)
+    def self.select_header_content_type content_type_array
+      if content_type_array.empty?
+        'application/json' # use application/json by default
+      elsif content_type_array.any?{ |s| s.casecmp('application/json')==0 }
+        'application/json' # use application/json if it's included
+      else
+        content_type_array[0]; # otherwise, use the first one
+      end
+    end
+
   end
 end

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -21,11 +21,13 @@ class PetApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = ['application/json', 'application/xml', ]
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -73,11 +75,13 @@ class PetApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = ['application/json', 'application/xml', ]
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -126,11 +130,13 @@ class PetApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -160,11 +166,13 @@ class PetApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -196,11 +204,13 @@ class PetApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -234,11 +244,13 @@ class PetApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = ['application/x-www-form-urlencoded', ]
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -272,11 +284,13 @@ class PetApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
     header_params[:'api_key'] = opts[:'api_key'] if opts[:'api_key']
 
     # form parameters
@@ -310,11 +324,13 @@ class PetApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = ['multipart/form-data', ]
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}

--- a/samples/client/petstore/ruby/lib/store_api.rb
+++ b/samples/client/petstore/ruby/lib/store_api.rb
@@ -20,11 +20,13 @@ class StoreApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -53,11 +55,13 @@ class StoreApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -109,11 +113,13 @@ class StoreApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -145,11 +151,13 @@ class StoreApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}

--- a/samples/client/petstore/ruby/lib/swagger/request.rb
+++ b/samples/client/petstore/ruby/lib/swagger/request.rb
@@ -208,5 +208,31 @@ module Swagger
       @response.headers.gsub(/\n/, '<br/>') # <- This is for Typhoeus
     end
 
+    # return 'Accept' based on an array of accept provided
+    # @param [Array] header_accept_array Array fo 'Accept'
+    # @return String Accept (e.g. application/json)
+    def self.select_header_accept header_accept_array
+      if header_accept_array.empty?
+        return
+      elsif header_accept_array.any?{ |s| s.casecmp('application/json')==0 }
+        'application/json' # look for json data by default
+      else
+        header_accept_array.join(',')
+      end
+    end
+
+    # return the content type based on an array of content-type provided
+    # @param [Array] content_type_array Array fo content-type
+    # @return String Content-Type (e.g. application/json)
+    def self.select_header_content_type content_type_array
+      if content_type_array.empty?
+        'application/json' # use application/json by default
+      elsif content_type_array.any?{ |s| s.casecmp('application/json')==0 }
+        'application/json' # use application/json if it's included
+      else
+        content_type_array[0]; # otherwise, use the first one
+      end
+    end
+
   end
 end

--- a/samples/client/petstore/ruby/lib/user_api.rb
+++ b/samples/client/petstore/ruby/lib/user_api.rb
@@ -21,11 +21,13 @@ class UserApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -73,11 +75,13 @@ class UserApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -125,11 +129,13 @@ class UserApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -180,11 +186,13 @@ class UserApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -212,11 +220,13 @@ class UserApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -247,11 +257,13 @@ class UserApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -284,11 +296,13 @@ class UserApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}
@@ -339,11 +353,13 @@ class UserApi
     # header parameters
     header_params = {}
 
-    _header_accept = 'application/json, application/xml'
-    header_params['Accept'] = _header_accept if _header_accept != ''
+    # HTTP header 'Accept' (if needed)
+    _header_accept = ['application/json', 'application/xml']
+    _header_accept_result = Swagger::Request.select_header_accept(_header_accept) and header_params['Accept'] = _header_accept_result
 
+    # HTTP header 'Content-Type'
     _header_content_type = []
-    header_params['Content-Type'] = _header_content_type.length > 0 ? _header_content_type[0] : 'application/json'
+    header_params['Content-Type'] = Swagger::Request.select_header_content_type(_header_content_type)
 
     # form parameters
     form_params = {}


### PR DESCRIPTION
For #745, this PR will update Ruby API client so that Accept and Content-Type header will use "application/json" if it's provided in the Swagger spec.

Integration test result:
```
[INFO] --- exec-maven-plugin:1.2.1:exec (bundle-test) @ RubyPetstoreClientTests ---
.............................................

Finished in 28.56 seconds (files took 0.30172 seconds to load)
45 examples, 0 failures

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 32.382 s
[INFO] Finished at: 2015-05-15T20:53:29+08:00
[INFO] Final Memory: 11M/245M
[INFO] ------------------------------------------------------------------------
```

Also performed testing by flipping the order of application/xml, application/json in petstore.json and tests are fine.