### PR TITLE
[Ruby] bug fixes for posting with sub-models and enhancements (refactoring)

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/RubyClientCodegen.java
@@ -72,6 +72,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
     supportingFiles.add(new SupportingFile("swagger/response.mustache", "", "lib/swagger/response.rb"));
     supportingFiles.add(new SupportingFile("swagger/version.mustache", "", "lib/swagger/version.rb"));
     supportingFiles.add(new SupportingFile("swagger/configuration.mustache", "", "lib/swagger/configuration.rb"));
+    supportingFiles.add(new SupportingFile("base_object.mustache", "", "lib/model/base_object.rb"));
   }
 
   @Override

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -45,31 +45,12 @@ class {{classname}}
     form_params["{{baseName}}"] = opts[:'{{paramName}}'] if opts[:'{{paramName}}']{{/required}}{{/formParams}}
 
     # http body (model)
-    post_body = nil{{#bodyParam}}
-    _body_param = {{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}
-    if _body_param != nil
-      if _body_param.is_a?(Array)
-        _array = Array.new
-        _body_param.each do |item|
-          if item.respond_to?(:to_body)
-            _array.push item.to_body
-          else
-            _array.push item
-          end
-        end
-        post_body = _array
-      else 
-        if _body_param.respond_to?(:to_body)
-          post_body = _body_param.to_body
-        else
-          post_body = _body_param
-        end
-      end
-    end{{/bodyParam}}
+    {{^bodyParam}}post_body = nil
+    {{/bodyParam}}{{#bodyParam}}post_body = Swagger::Request.object_to_http_body({{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}})
+    {{/bodyParam}}
 
-{{#returnType}}
-    response = Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    {{#returnContainer}}response.map {|response| {{/returnContainer}}{{returnBaseType}}.new(response){{#returnContainer}} }{{/returnContainer}}{{/returnType}}{{^returnType}}    Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make{{/returnType}}
+    {{#returnType}}response = Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
+    {{#returnContainer}}response.map {|response| {{/returnContainer}}obj = {{returnBaseType}}.new() and obj.build_from_hash(response){{#returnContainer}} }{{/returnContainer}}{{/returnType}}{{^returnType}}    Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make{{/returnType}}
   end
 {{/operation}}
 end

--- a/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
@@ -1,0 +1,83 @@
+# base class containing fundamental method such as to_hash, build_from_hash and more
+class BaseObject
+
+  # return the object in the form of hash
+  def to_body
+    body = {}
+    self.class.attribute_map.each_pair do |key, value|
+      body[value] = self.send(key) unless self.send(key).nil?
+    end
+    body
+  end
+
+  # build the object from hash
+  def build_from_hash(attributes)
+    return nil unless attributes.is_a?(Hash)
+    self.class.swagger_types.each_pair do |key, type|
+      if type =~ /^array\[(.*)\]/i
+        if attributes[self.class.attribute_map[key]].is_a?(Array)
+          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+        else
+          #TODO show warning in debug mode
+        end
+      elsif !attributes[self.class.attribute_map[key]].nil?
+        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+      else
+        # data not found in attributes(hash), not an issue as the data can be optional
+      end
+    end
+
+    self
+  end
+
+  def _deserialize(type, value)
+    case type
+    when :DateTime
+      DateTime.parse(value)
+    when :string
+      value.to_s
+    when :int
+      value.to_i
+    when :double
+      value.to_f
+    when :boolean
+      if value =~ /^(true|t|yes|y|1)$/i
+        true
+      else
+        false
+      end
+    else # model
+      _model = Object.const_get(type).new
+      _model.build_from_hash(value)
+    end
+  end
+
+
+
+  # to_body is an alias to to_body (backward compatibility)
+  def to_hash
+    hash = {}
+    self.class.attribute_map.each_pair do |key, value|
+      if self.send(key).is_a?(Array)
+        next if self.send(key).empty?
+        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+      else
+        unless (_tmp_value = _to_hash self.send(key)).nil?
+          hash[value] = _tmp_value
+        end
+      end
+    end
+    hash
+  end
+
+  # Method to output non-array value in the form of hash
+  # For object, use to_hash. Otherwise, just return the value
+  def _to_hash(value)
+    if value.respond_to? :to_hash
+      value.to_hash
+    else
+      value
+    end
+  end
+
+end

--- a/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
@@ -31,7 +31,7 @@ class BaseObject
   end
 
   def _deserialize(type, value)
-    case type
+    case type.to_s
     when :DateTime
       DateTime.parse(value)
     when :string

--- a/modules/swagger-codegen/src/main/resources/ruby/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/model.mustache
@@ -1,35 +1,119 @@
-{{#models}}
+require_relative 'base_object'
 
-{{#model}}
-class {{classname}}
+{{#models}}#{{description}}
+{{#model}}class {{classname}} < BaseObject
   attr_accessor {{#vars}}:{{{name}}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{newline}}
-  # :internal => :external
+  # attribute mapping from ruby-style variable name to JSON key
   def self.attribute_map
     {
-      {{#vars}}:{{{name}}} => :'{{{baseName}}}'{{#hasMore}},{{/hasMore}}
+      {{#vars}}
+      # {{description}}
+      :'{{{name}}}' => :'{{{baseName}}}'{{#hasMore}},{{/hasMore}}
+      {{/vars}}
+    }
+  end
+
+  # attribute type
+  def self.swagger_types
+    {
+      {{#vars}}:'{{{name}}}' => :'{{{datatype}}}'{{#hasMore}},{{/hasMore}}
       {{/vars}}
     }
   end
 
   def initialize(attributes = {})
-    return if attributes.empty?
-    # Morph attribute keys into undescored rubyish style
+    return if !attributes.is_a?(Hash) || attributes.empty?
+
+    # convert string to symbol for hash key
+    attributes = attributes.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+
     {{#vars}}
-    if self.class.attribute_map[:"{{{name}}}"]
-      {{#isContainer}}if (value = attributes["{{{baseName}}}"]).is_a?(Array)
-        @{{{name}}} = value{{#complexType}}.map{ |v| {{complexType}}.new(v) }{{/complexType}}
-      end{{/isContainer}}{{^isContainer}}@{{{name}}} = attributes["{{{baseName}}}"]{{/isContainer}}
+    if attributes[:'{{{baseName}}}']
+      {{#isContainer}}if (value = attributes[:'{{{baseName}}}']).is_a?(Array)
+        @{{{name}}} = value
+      end{{/isContainer}}{{^isContainer}}@{{{name}}} = attributes[:'{{{baseName}}}']{{/isContainer}}
     end
     {{/vars}}
   end
 
-  def to_body
-    body = {}
-    self.class.attribute_map.each_pair do |key, value|
-      body[value] = self.send(key) unless self.send(key).nil?
-    end
-    body
-  end
+#  # return the object in the form of hash
+#  def to_body
+#    body = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      body[value] = self.send(key) unless self.send(key).nil?
+#    end
+#    body
+#  end
+#
+#  # build the object from hash
+#  def build_from_hash(attributes)
+#    self.class.swagger_types.each_pair do |key, type|
+#      if type =~ /^array\[(.*)\]/i
+#        if attributes[self.class.attribute_map[key]].is_a?(Array)
+#          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+#        else
+#          #TODO show warning in debug mode
+#        end
+#      elsif !attributes[self.class.attribute_map[key]].nil?
+#        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+#      else
+#        # data not found in attributes(hash), not an issue as the data can be optional
+#      end
+#    end
+#
+#    self
+#  end
+#
+#  def _deserialize(type, value)
+#    case type
+#    when :DateTime
+#      DateTime.parse(value)
+#    when :string
+#      value.to_s
+#    when :int
+#      value.to_i
+#    when :double
+#      value.to_f
+#    when :boolean
+#      if value =~ /^(true|t|yes|y|1)$/i
+#        true
+#      else
+#        false
+#      end
+#    else # model
+#      _model = Object.const_get(type).new
+#      _model.build_from_hash(value)
+#    end
+#  end
+#
+#
+#
+#  # to_body is an alias to to_body (backward compatibility)
+#  def to_hash
+#    hash = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      if self.send(key).is_a?(Array)
+#        next if self.send(key).empty?
+#        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+#      else
+#        unless (_tmp_value = _to_hash self.send(key)).nil?
+#          hash[value] = _tmp_value
+#        end
+#      end
+#    end
+#    hash
+#  end
+#
+#  # Method to output non-array value in the form of hash
+#  # For object, use to_hash. Otherwise, just return the value
+#  def _to_hash(value)
+#    if value.respond_to? :to_hash
+#      value.to_hash
+#    else
+#      value
+#    end
+#  end
+
 end
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/ruby/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger.mustache
@@ -75,31 +75,6 @@ module Swagger
       Swagger.configuration.auth_token = response_body['token']
     end
 
-    # static method to convert object (array, hash, object, etc) to JSON string
-    # @param model object to be converted into JSON string
-    # @return string JSON string representation of the object
-    def self.object_to_http_body model
-      return if model.nil?
-      _body = nil
-      if model.is_a?(Array)
-        _body = model.map{|m| object_to_hash(m) }
-      else
-        _body = object_to_hash(model)
-      end
-      _body.to_json
-    end
-
-    # static method to convert object(non-array) to hash
-    # @param obj object to be converted into JSON string
-    # @return string JSON string representation of the object
-    def self.object_to_hash obj
-      if obj.respond_to?(:to_hash)
-        obj.to_hash
-      else
-        obj
-      end
-    end
-
   end
   
 end

--- a/modules/swagger-codegen/src/main/resources/ruby/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger.mustache
@@ -4,6 +4,7 @@ require 'swagger/request'
 require 'swagger/response'
 require 'swagger/version'
 require 'logger'
+require 'json'
 
 module Swagger
     
@@ -72,6 +73,31 @@ module Swagger
       
       response_body = request.response.body
       Swagger.configuration.auth_token = response_body['token']
+    end
+
+    # static method to convert object (array, hash, object, etc) to JSON string
+    # @param model object to be converted into JSON string
+    # @return string JSON string representation of the object
+    def self.object_to_http_body model
+      return if model.nil?
+      _body = nil
+      if model.is_a?(Array)
+        _body = model.map{|m| object_to_hash(m) }
+      else
+        _body = object_to_hash(model)
+      end
+      _body.to_json
+    end
+
+    # static method to convert object(non-array) to hash
+    # @param obj object to be converted into JSON string
+    # @return string JSON string representation of the object
+    def self.object_to_hash obj
+      if obj.respond_to?(:to_hash)
+        obj.to_hash
+      else
+        obj
+      end
     end
 
   end

--- a/modules/swagger-codegen/src/main/resources/ruby/swagger/request.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger/request.mustache
@@ -234,5 +234,30 @@ module Swagger
       end
     end
 
+    # static method to convert object (array, hash, object, etc) to JSON string
+    # @param model object to be converted into JSON string
+    # @return string JSON string representation of the object
+    def self.object_to_http_body model
+      return if model.nil?
+      _body = nil
+      if model.is_a?(Array)
+        _body = model.map{|m| object_to_hash(m) }
+      else
+        _body = object_to_hash(model)
+      end
+      _body.to_json
+    end
+
+    # static method to convert object(non-array) to hash
+    # @param obj object to be converted into JSON string
+    # @return string JSON string representation of the object
+    def self.object_to_hash obj
+      if obj.respond_to?(:to_hash)
+        obj.to_hash
+      else
+        obj
+      end
+    end
+
   end
 end

--- a/modules/swagger-codegen/src/main/resources/ruby/swagger/response.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger/response.mustache
@@ -28,7 +28,7 @@ module Swagger
     # If body is JSON, parse it
     # Otherwise return raw string
     def body
-      JSON.parse raw.body
+      JSON.parse(raw.body, :symbolize_names => true)
     rescue
       raw.body
     end

--- a/samples/client/petstore/ruby/lib/model/base_object.rb
+++ b/samples/client/petstore/ruby/lib/model/base_object.rb
@@ -1,0 +1,83 @@
+# base class containing fundamental method such as to_hash, build_from_hash and more
+class BaseObject
+
+  # return the object in the form of hash
+  def to_body
+    body = {}
+    self.class.attribute_map.each_pair do |key, value|
+      body[value] = self.send(key) unless self.send(key).nil?
+    end
+    body
+  end
+
+  # build the object from hash
+  def build_from_hash(attributes)
+    return nil unless attributes.is_a?(Hash)
+    self.class.swagger_types.each_pair do |key, type|
+      if type =~ /^array\[(.*)\]/i
+        if attributes[self.class.attribute_map[key]].is_a?(Array)
+          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+        else
+          #TODO show warning in debug mode
+        end
+      elsif !attributes[self.class.attribute_map[key]].nil?
+        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+      else
+        # data not found in attributes(hash), not an issue as the data can be optional
+      end
+    end
+
+    self
+  end
+
+  def _deserialize(type, value)
+    case type
+    when :DateTime
+      DateTime.parse(value)
+    when :string
+      value.to_s
+    when :int
+      value.to_i
+    when :double
+      value.to_f
+    when :boolean
+      if value =~ /^(true|t|yes|y|1)$/i
+        true
+      else
+        false
+      end
+    else # model
+      _model = Object.const_get(type).new
+      _model.build_from_hash(value)
+    end
+  end
+
+
+
+  # to_body is an alias to to_body (backward compatibility)
+  def to_hash
+    hash = {}
+    self.class.attribute_map.each_pair do |key, value|
+      if self.send(key).is_a?(Array)
+        next if self.send(key).empty?
+        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+      else
+        unless (_tmp_value = _to_hash self.send(key)).nil?
+          hash[value] = _tmp_value
+        end
+      end
+    end
+    hash
+  end
+
+  # Method to output non-array value in the form of hash
+  # For object, use to_hash. Otherwise, just return the value
+  def _to_hash(value)
+    if value.respond_to? :to_hash
+      value.to_hash
+    else
+      value
+    end
+  end
+
+end

--- a/samples/client/petstore/ruby/lib/model/base_object.rb
+++ b/samples/client/petstore/ruby/lib/model/base_object.rb
@@ -31,7 +31,7 @@ class BaseObject
   end
 
   def _deserialize(type, value)
-    case type
+    case type.to_s
     when :DateTime
       DateTime.parse(value)
     when :string

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -37,18 +37,24 @@ class PetApi
     _body_param = opts[:'body']
     if _body_param != nil
       if _body_param.is_a?(Array)
-        _array = Array.new
-        _body_param.each do |item|
-          if item.respond_to?(:to_body)
-            _array.push item.to_body
+        #_array = Array.new
+        #_body_param.each do |item|
+        #  if item.respond_to?(:to_body)
+        #    _array.push item.to_body
+        #  else
+        #    _array.push item
+        #  end
+        #end
+        post_body = _array.map{ |v| 
+          if v.respond_to?(:to_hash)
+            v.to_hash
           else
-            _array.push item
+            v
           end
-        end
-        post_body = _array
+        }
       else 
-        if _body_param.respond_to?(:to_body)
-          post_body = _body_param.to_body
+        if _body_param.respond_to?(:to_hash)
+          post_body = _body_param.to_hash
         else
           post_body = _body_param
         end

--- a/samples/client/petstore/ruby/lib/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/pet_api.rb
@@ -33,35 +33,10 @@ class PetApi
     form_params = {}
 
     # http body (model)
-    post_body = nil
-    _body_param = opts[:'body']
-    if _body_param != nil
-      if _body_param.is_a?(Array)
-        #_array = Array.new
-        #_body_param.each do |item|
-        #  if item.respond_to?(:to_body)
-        #    _array.push item.to_body
-        #  else
-        #    _array.push item
-        #  end
-        #end
-        post_body = _array.map{ |v| 
-          if v.respond_to?(:to_hash)
-            v.to_hash
-          else
-            v
-          end
-        }
-      else 
-        if _body_param.respond_to?(:to_hash)
-          post_body = _body_param.to_hash
-        else
-          post_body = _body_param
-        end
-      end
-    end
+    post_body = Swagger::Request.object_to_http_body(opts[:'body'])
+    
 
-    Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Add a new pet to the store
@@ -93,29 +68,10 @@ class PetApi
     form_params = {}
 
     # http body (model)
-    post_body = nil
-    _body_param = opts[:'body']
-    if _body_param != nil
-      if _body_param.is_a?(Array)
-        _array = Array.new
-        _body_param.each do |item|
-          if item.respond_to?(:to_body)
-            _array.push item.to_body
-          else
-            _array.push item
-          end
-        end
-        post_body = _array
-      else 
-        if _body_param.respond_to?(:to_body)
-          post_body = _body_param.to_body
-        else
-          post_body = _body_param
-        end
-      end
-    end
+    post_body = Swagger::Request.object_to_http_body(opts[:'body'])
+    
 
-    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Finds Pets by status
@@ -149,9 +105,10 @@ class PetApi
 
     # http body (model)
     post_body = nil
+    
 
     response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    response.map {|response| Pet.new(response) }
+    response.map {|response| obj = Pet.new() and obj.build_from_hash(response) }
   end
 
   # Finds Pets by tags
@@ -185,9 +142,10 @@ class PetApi
 
     # http body (model)
     post_body = nil
+    
 
     response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    response.map {|response| Pet.new(response) }
+    response.map {|response| obj = Pet.new() and obj.build_from_hash(response) }
   end
 
   # Find pet by ID
@@ -223,9 +181,10 @@ class PetApi
 
     # http body (model)
     post_body = nil
+    
 
     response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    Pet.new(response)
+    obj = Pet.new() and obj.build_from_hash(response)
   end
 
   # Updates a pet in the store with form data
@@ -265,8 +224,9 @@ class PetApi
 
     # http body (model)
     post_body = nil
+    
 
-    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Deletes a pet
@@ -304,8 +264,9 @@ class PetApi
 
     # http body (model)
     post_body = nil
+    
 
-    Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # uploads an image
@@ -345,7 +306,8 @@ class PetApi
 
     # http body (model)
     post_body = nil
+    
 
-    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 end

--- a/samples/client/petstore/ruby/lib/store_api.rb
+++ b/samples/client/petstore/ruby/lib/store_api.rb
@@ -33,9 +33,10 @@ class StoreApi
 
     # http body (model)
     post_body = nil
+    
 
     response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    response.map {|response| map.new(response) }
+    response.map {|response| obj = map.new() and obj.build_from_hash(response) }
   end
 
   # Place an order for a pet
@@ -67,30 +68,11 @@ class StoreApi
     form_params = {}
 
     # http body (model)
-    post_body = nil
-    _body_param = opts[:'body']
-    if _body_param != nil
-      if _body_param.is_a?(Array)
-        _array = Array.new
-        _body_param.each do |item|
-          if item.respond_to?(:to_body)
-            _array.push item.to_body
-          else
-            _array.push item
-          end
-        end
-        post_body = _array
-      else 
-        if _body_param.respond_to?(:to_body)
-          post_body = _body_param.to_body
-        else
-          post_body = _body_param
-        end
-      end
-    end
+    post_body = Swagger::Request.object_to_http_body(opts[:'body'])
+    
 
     response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    Order.new(response)
+    obj = Order.new() and obj.build_from_hash(response)
   end
 
   # Find purchase order by ID
@@ -126,9 +108,10 @@ class StoreApi
 
     # http body (model)
     post_body = nil
+    
 
     response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    Order.new(response)
+    obj = Order.new() and obj.build_from_hash(response)
   end
 
   # Delete purchase order by ID
@@ -164,7 +147,8 @@ class StoreApi
 
     # http body (model)
     post_body = nil
+    
 
-    Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 end

--- a/samples/client/petstore/ruby/lib/swagger.rb
+++ b/samples/client/petstore/ruby/lib/swagger.rb
@@ -75,31 +75,6 @@ module Swagger
       Swagger.configuration.auth_token = response_body['token']
     end
 
-    # static method to convert object (array, hash, object, etc) to JSON string
-    # @param model object to be converted into JSON string
-    # @return string JSON string representation of the object
-    def self.object_to_http_body model
-      return if model.nil?
-      _body = nil
-      if model.is_a?(Array)
-        _body = model.map{|m| object_to_hash(m) }
-      else
-        _body = object_to_hash(model)
-      end
-      _body.to_json
-    end
-
-    # static method to convert object(non-array) to hash
-    # @param obj object to be converted into JSON string
-    # @return string JSON string representation of the object
-    def self.object_to_hash obj
-      if obj.respond_to?(:to_hash)
-        obj.to_hash
-      else
-        obj
-      end
-    end
-
   end
   
 end

--- a/samples/client/petstore/ruby/lib/swagger.rb
+++ b/samples/client/petstore/ruby/lib/swagger.rb
@@ -4,6 +4,7 @@ require 'swagger/request'
 require 'swagger/response'
 require 'swagger/version'
 require 'logger'
+require 'json'
 
 module Swagger
     
@@ -72,6 +73,31 @@ module Swagger
       
       response_body = request.response.body
       Swagger.configuration.auth_token = response_body['token']
+    end
+
+    # static method to convert object (array, hash, object, etc) to JSON string
+    # @param model object to be converted into JSON string
+    # @return string JSON string representation of the object
+    def self.object_to_http_body model
+      return if model.nil?
+      _body = nil
+      if model.is_a?(Array)
+        _body = model.map{|m| object_to_hash(m) }
+      else
+        _body = object_to_hash(model)
+      end
+      _body.to_json
+    end
+
+    # static method to convert object(non-array) to hash
+    # @param obj object to be converted into JSON string
+    # @return string JSON string representation of the object
+    def self.object_to_hash obj
+      if obj.respond_to?(:to_hash)
+        obj.to_hash
+      else
+        obj
+      end
     end
 
   end

--- a/samples/client/petstore/ruby/lib/swagger/request.rb
+++ b/samples/client/petstore/ruby/lib/swagger/request.rb
@@ -234,5 +234,30 @@ module Swagger
       end
     end
 
+    # static method to convert object (array, hash, object, etc) to JSON string
+    # @param model object to be converted into JSON string
+    # @return string JSON string representation of the object
+    def self.object_to_http_body model
+      return if model.nil?
+      _body = nil
+      if model.is_a?(Array)
+        _body = model.map{|m| object_to_hash(m) }
+      else
+        _body = object_to_hash(model)
+      end
+      _body.to_json
+    end
+
+    # static method to convert object(non-array) to hash
+    # @param obj object to be converted into JSON string
+    # @return string JSON string representation of the object
+    def self.object_to_hash obj
+      if obj.respond_to?(:to_hash)
+        obj.to_hash
+      else
+        obj
+      end
+    end
+
   end
 end

--- a/samples/client/petstore/ruby/lib/swagger/response.rb
+++ b/samples/client/petstore/ruby/lib/swagger/response.rb
@@ -28,7 +28,7 @@ module Swagger
     # If body is JSON, parse it
     # Otherwise return raw string
     def body
-      JSON.parse raw.body
+      JSON.parse(raw.body, :symbolize_names => true)
     rescue
       raw.body
     end

--- a/samples/client/petstore/ruby/lib/user_api.rb
+++ b/samples/client/petstore/ruby/lib/user_api.rb
@@ -33,29 +33,10 @@ class UserApi
     form_params = {}
 
     # http body (model)
-    post_body = nil
-    _body_param = opts[:'body']
-    if _body_param != nil
-      if _body_param.is_a?(Array)
-        _array = Array.new
-        _body_param.each do |item|
-          if item.respond_to?(:to_body)
-            _array.push item.to_body
-          else
-            _array.push item
-          end
-        end
-        post_body = _array
-      else 
-        if _body_param.respond_to?(:to_body)
-          post_body = _body_param.to_body
-        else
-          post_body = _body_param
-        end
-      end
-    end
+    post_body = Swagger::Request.object_to_http_body(opts[:'body'])
+    
 
-    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Creates list of users with given input array
@@ -87,29 +68,10 @@ class UserApi
     form_params = {}
 
     # http body (model)
-    post_body = nil
-    _body_param = opts[:'body']
-    if _body_param != nil
-      if _body_param.is_a?(Array)
-        _array = Array.new
-        _body_param.each do |item|
-          if item.respond_to?(:to_body)
-            _array.push item.to_body
-          else
-            _array.push item
-          end
-        end
-        post_body = _array
-      else 
-        if _body_param.respond_to?(:to_body)
-          post_body = _body_param.to_body
-        else
-          post_body = _body_param
-        end
-      end
-    end
+    post_body = Swagger::Request.object_to_http_body(opts[:'body'])
+    
 
-    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Creates list of users with given input array
@@ -141,29 +103,10 @@ class UserApi
     form_params = {}
 
     # http body (model)
-    post_body = nil
-    _body_param = opts[:'body']
-    if _body_param != nil
-      if _body_param.is_a?(Array)
-        _array = Array.new
-        _body_param.each do |item|
-          if item.respond_to?(:to_body)
-            _array.push item.to_body
-          else
-            _array.push item
-          end
-        end
-        post_body = _array
-      else 
-        if _body_param.respond_to?(:to_body)
-          post_body = _body_param.to_body
-        else
-          post_body = _body_param
-        end
-      end
-    end
+    post_body = Swagger::Request.object_to_http_body(opts[:'body'])
+    
 
-    Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Logs user into the system
@@ -199,9 +142,10 @@ class UserApi
 
     # http body (model)
     post_body = nil
+    
 
     response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    string.new(response)
+    obj = string.new() and obj.build_from_hash(response)
   end
 
   # Logs out current logged in user session
@@ -233,8 +177,9 @@ class UserApi
 
     # http body (model)
     post_body = nil
+    
 
-    Swagger::Request.new(:GET, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:GET, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Get user by user name
@@ -270,9 +215,10 @@ class UserApi
 
     # http body (model)
     post_body = nil
+    
 
     response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-    User.new(response)
+    obj = User.new() and obj.build_from_hash(response)
   end
 
   # Updated user
@@ -308,29 +254,10 @@ class UserApi
     form_params = {}
 
     # http body (model)
-    post_body = nil
-    _body_param = opts[:'body']
-    if _body_param != nil
-      if _body_param.is_a?(Array)
-        _array = Array.new
-        _body_param.each do |item|
-          if item.respond_to?(:to_body)
-            _array.push item.to_body
-          else
-            _array.push item
-          end
-        end
-        post_body = _array
-      else 
-        if _body_param.respond_to?(:to_body)
-          post_body = _body_param.to_body
-        else
-          post_body = _body_param
-        end
-      end
-    end
+    post_body = Swagger::Request.object_to_http_body(opts[:'body'])
+    
 
-    Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 
   # Delete user
@@ -366,7 +293,8 @@ class UserApi
 
     # http body (model)
     post_body = nil
+    
 
-    Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+        Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
   end
 end

--- a/samples/client/petstore/ruby/models/base_object.rb
+++ b/samples/client/petstore/ruby/models/base_object.rb
@@ -1,0 +1,86 @@
+require 'json'
+#
+class BaseObject
+  
+  # return the object in the form of hash
+  def to_body
+    body = {}
+    self.class.attribute_map.each_pair do |key, value|
+      body[value] = self.send(key) unless self.send(key).nil?
+    end
+    body
+  end
+
+  # build the object from hash
+  def build_from_hash(attributes)
+    self.class.swagger_types.each_pair do |key, type|
+      if type =~ /^array\[(.*)\]/i
+        if attributes[self.class.attribute_map[key]].is_a?(Array)
+          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+        else
+          #TODO show warning in debug mode
+        end
+      elsif !attributes[self.class.attribute_map[key]].nil?
+        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+      else
+        # data not found in attributes(hash), not an issue as the data can be optional
+      end
+    end
+
+    self
+  end
+
+  # deserialize value based on type
+  def _deserialize(type, value)
+    case type
+    when :DateTime
+      DateTime.parse(value)
+    when :string
+      value.to_s
+    when :int
+      value.to_i
+    when :double
+      value.to_f
+    when :boolean
+      if value =~ /^(true|t|yes|y|1)$/i
+        true
+      else
+        false
+      end
+    else # model
+      _model = Object.const_get(type).new
+      _model.build_from_hash(value)
+    end
+  end
+
+  #def to_json
+  #  self.to_hash.to_json
+  #end
+
+  # to_body is an alias to to_body (backward compatibility)
+  def to_hash
+    hash = {}
+    self.class.attribute_map.each_pair do |key, value|
+      if self.send(key).is_a?(Array)
+        next if self.send(key).empty?
+        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+      else
+        unless (_tmp_value = _to_hash self.send(key)).nil?
+          hash[value] = _tmp_value
+        end
+      end
+    end
+    hash
+  end
+
+  # Method to output non-array value in the form of hash
+  # For object, use to_hash. Otherwise, just return the value
+  def _to_hash(value)
+    if value.respond_to? :to_hash
+      value.to_hash
+    else
+      value
+    end
+  end
+
+end

--- a/samples/client/petstore/ruby/models/base_object.rb
+++ b/samples/client/petstore/ruby/models/base_object.rb
@@ -32,7 +32,7 @@ class BaseObject
 
   # deserialize value based on type
   def _deserialize(type, value)
-    case type
+    case type.to_sym
     when :DateTime
       DateTime.parse(value)
     when :string

--- a/samples/client/petstore/ruby/models/category.rb
+++ b/samples/client/petstore/ruby/models/category.rb
@@ -1,34 +1,123 @@
+require_relative 'base_object'
 
-class Category
+#
+class Category < BaseObject
   attr_accessor :id, :name
-  # :internal => :external
+  # attribute mapping from ruby-style variable name to JSON key
   def self.attribute_map
     {
-      :id => :'id',
-      :name => :'name'
+      
+      # 
+      :'id' => :'id',
+      
+      # 
+      :'name' => :'name'
+      
+    }
+  end
+
+  # attribute type
+  def self.swagger_types
+    {
+      :'id' => :'int',
+      :'name' => :'string'
       
     }
   end
 
   def initialize(attributes = {})
-    return if attributes.empty?
-    # Morph attribute keys into undescored rubyish style
+    return if !attributes.is_a?(Hash) || attributes.empty?
+
+    # convert string to symbol for hash key
+    attributes = attributes.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+
     
-    if self.class.attribute_map[:"id"]
-      @id = attributes["id"]
+    if attributes[:'id']
+      @id = attributes[:'id']
     end
     
-    if self.class.attribute_map[:"name"]
-      @name = attributes["name"]
+    if attributes[:'name']
+      @name = attributes[:'name']
     end
     
   end
 
-  def to_body
-    body = {}
-    self.class.attribute_map.each_pair do |key, value|
-      body[value] = self.send(key) unless self.send(key).nil?
-    end
-    body
-  end
+#  # return the object in the form of hash
+#  def to_body
+#    body = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      body[value] = self.send(key) unless self.send(key).nil?
+#    end
+#    body
+#  end
+#
+#  # build the object from hash
+#  def build_from_hash(attributes)
+#    self.class.swagger_types.each_pair do |key, type|
+#      if type =~ /^array\[(.*)\]/i
+#        if attributes[self.class.attribute_map[key]].is_a?(Array)
+#          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+#        else
+#          #TODO show warning in debug mode
+#        end
+#      elsif !attributes[self.class.attribute_map[key]].nil?
+#        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+#      else
+#        # data not found in attributes(hash), not an issue as the data can be optional
+#      end
+#    end
+#
+#    self
+#  end
+#
+#  def _deserialize(type, value)
+#    case type
+#    when :DateTime
+#      DateTime.parse(value)
+#    when :string
+#      value.to_s
+#    when :int
+#      value.to_i
+#    when :double
+#      value.to_f
+#    when :boolean
+#      if value =~ /^(true|t|yes|y|1)$/i
+#        true
+#      else
+#        false
+#      end
+#    else # model
+#      _model = Object.const_get(type).new
+#      _model.build_from_hash(value)
+#    end
+#  end
+#
+#
+#
+#  # to_body is an alias to to_body (backward compatibility)
+#  def to_hash
+#    hash = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      if self.send(key).is_a?(Array)
+#        next if self.send(key).empty?
+#        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+#      else
+#        unless (_tmp_value = _to_hash self.send(key)).nil?
+#          hash[value] = _tmp_value
+#        end
+#      end
+#    end
+#    hash
+#  end
+#
+#  # Method to output non-array value in the form of hash
+#  # For object, use to_hash. Otherwise, just return the value
+#  def _to_hash(value)
+#    if value.respond_to? :to_hash
+#      value.to_hash
+#    else
+#      value
+#    end
+#  end
+
 end

--- a/samples/client/petstore/ruby/models/order.rb
+++ b/samples/client/petstore/ruby/models/order.rb
@@ -1,54 +1,155 @@
+require_relative 'base_object'
 
-class Order
+#
+class Order < BaseObject
   attr_accessor :id, :pet_id, :quantity, :ship_date, :status, :complete
-  # :internal => :external
+  # attribute mapping from ruby-style variable name to JSON key
   def self.attribute_map
     {
-      :id => :'id',
-      :pet_id => :'petId',
-      :quantity => :'quantity',
-      :ship_date => :'shipDate',
-      :status => :'status',
-      :complete => :'complete'
+      
+      # 
+      :'id' => :'id',
+      
+      # 
+      :'pet_id' => :'petId',
+      
+      # 
+      :'quantity' => :'quantity',
+      
+      # 
+      :'ship_date' => :'shipDate',
+      
+      # Order Status
+      :'status' => :'status',
+      
+      # 
+      :'complete' => :'complete'
+      
+    }
+  end
+
+  # attribute type
+  def self.swagger_types
+    {
+      :'id' => :'int',
+      :'pet_id' => :'int',
+      :'quantity' => :'int',
+      :'ship_date' => :'DateTime',
+      :'status' => :'string',
+      :'complete' => :'boolean'
       
     }
   end
 
   def initialize(attributes = {})
-    return if attributes.empty?
-    # Morph attribute keys into undescored rubyish style
+    return if !attributes.is_a?(Hash) || attributes.empty?
+
+    # convert string to symbol for hash key
+    attributes = attributes.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+
     
-    if self.class.attribute_map[:"id"]
-      @id = attributes["id"]
+    if attributes[:'id']
+      @id = attributes[:'id']
     end
     
-    if self.class.attribute_map[:"pet_id"]
-      @pet_id = attributes["petId"]
+    if attributes[:'petId']
+      @pet_id = attributes[:'petId']
     end
     
-    if self.class.attribute_map[:"quantity"]
-      @quantity = attributes["quantity"]
+    if attributes[:'quantity']
+      @quantity = attributes[:'quantity']
     end
     
-    if self.class.attribute_map[:"ship_date"]
-      @ship_date = attributes["shipDate"]
+    if attributes[:'shipDate']
+      @ship_date = attributes[:'shipDate']
     end
     
-    if self.class.attribute_map[:"status"]
-      @status = attributes["status"]
+    if attributes[:'status']
+      @status = attributes[:'status']
     end
     
-    if self.class.attribute_map[:"complete"]
-      @complete = attributes["complete"]
+    if attributes[:'complete']
+      @complete = attributes[:'complete']
     end
     
   end
 
-  def to_body
-    body = {}
-    self.class.attribute_map.each_pair do |key, value|
-      body[value] = self.send(key) unless self.send(key).nil?
-    end
-    body
-  end
+#  # return the object in the form of hash
+#  def to_body
+#    body = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      body[value] = self.send(key) unless self.send(key).nil?
+#    end
+#    body
+#  end
+#
+#  # build the object from hash
+#  def build_from_hash(attributes)
+#    self.class.swagger_types.each_pair do |key, type|
+#      if type =~ /^array\[(.*)\]/i
+#        if attributes[self.class.attribute_map[key]].is_a?(Array)
+#          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+#        else
+#          #TODO show warning in debug mode
+#        end
+#      elsif !attributes[self.class.attribute_map[key]].nil?
+#        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+#      else
+#        # data not found in attributes(hash), not an issue as the data can be optional
+#      end
+#    end
+#
+#    self
+#  end
+#
+#  def _deserialize(type, value)
+#    case type
+#    when :DateTime
+#      DateTime.parse(value)
+#    when :string
+#      value.to_s
+#    when :int
+#      value.to_i
+#    when :double
+#      value.to_f
+#    when :boolean
+#      if value =~ /^(true|t|yes|y|1)$/i
+#        true
+#      else
+#        false
+#      end
+#    else # model
+#      _model = Object.const_get(type).new
+#      _model.build_from_hash(value)
+#    end
+#  end
+#
+#
+#
+#  # to_body is an alias to to_body (backward compatibility)
+#  def to_hash
+#    hash = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      if self.send(key).is_a?(Array)
+#        next if self.send(key).empty?
+#        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+#      else
+#        unless (_tmp_value = _to_hash self.send(key)).nil?
+#          hash[value] = _tmp_value
+#        end
+#      end
+#    end
+#    hash
+#  end
+#
+#  # Method to output non-array value in the form of hash
+#  # For object, use to_hash. Otherwise, just return the value
+#  def _to_hash(value)
+#    if value.respond_to? :to_hash
+#      value.to_hash
+#    else
+#      value
+#    end
+#  end
+
 end

--- a/samples/client/petstore/ruby/models/pet.rb
+++ b/samples/client/petstore/ruby/models/pet.rb
@@ -1,58 +1,160 @@
+require_relative 'base_object'
 
-class Pet
+#
+class Pet < BaseObject
   attr_accessor :id, :category, :name, :photo_urls, :tags, :status
-  # :internal => :external
+  # attribute mapping from ruby-style variable name to JSON key
   def self.attribute_map
     {
-      :id => :'id',
-      :category => :'category',
-      :name => :'name',
-      :photo_urls => :'photoUrls',
-      :tags => :'tags',
-      :status => :'status'
+      
+      # 
+      :'id' => :'id',
+      
+      # 
+      :'category' => :'category',
+      
+      # 
+      :'name' => :'name',
+      
+      # 
+      :'photo_urls' => :'photoUrls',
+      
+      # 
+      :'tags' => :'tags',
+      
+      # pet status in the store
+      :'status' => :'status'
+      
+    }
+  end
+
+  # attribute type
+  def self.swagger_types
+    {
+      :'id' => :'int',
+      :'category' => :'Category',
+      :'name' => :'string',
+      :'photo_urls' => :'array[string]',
+      :'tags' => :'array[Tag]',
+      :'status' => :'string'
       
     }
   end
 
   def initialize(attributes = {})
-    return if attributes.empty?
-    # Morph attribute keys into undescored rubyish style
+    return if !attributes.is_a?(Hash) || attributes.empty?
+
+    # convert string to symbol for hash key
+    attributes = attributes.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+
     
-    if self.class.attribute_map[:"id"]
-      @id = attributes["id"]
+    if attributes[:'id']
+      @id = attributes[:'id']
     end
     
-    if self.class.attribute_map[:"category"]
-      @category = attributes["category"]
+    if attributes[:'category']
+      @category = attributes[:'category']
     end
     
-    if self.class.attribute_map[:"name"]
-      @name = attributes["name"]
+    if attributes[:'name']
+      @name = attributes[:'name']
     end
     
-    if self.class.attribute_map[:"photo_urls"]
-      if (value = attributes["photoUrls"]).is_a?(Array)
+    if attributes[:'photoUrls']
+      if (value = attributes[:'photoUrls']).is_a?(Array)
         @photo_urls = value
       end
     end
     
-    if self.class.attribute_map[:"tags"]
-      if (value = attributes["tags"]).is_a?(Array)
-        @tags = value.map{ |v| Tag.new(v) }
+    if attributes[:'tags']
+      if (value = attributes[:'tags']).is_a?(Array)
+        #@tags = value.map{ |v| Tag.new(v) }
+        @tags = value
       end
     end
     
-    if self.class.attribute_map[:"status"]
-      @status = attributes["status"]
+    if attributes[:'status']
+      @status = attributes[:'status']
     end
     
   end
 
-  def to_body
-    body = {}
-    self.class.attribute_map.each_pair do |key, value|
-      body[value] = self.send(key) unless self.send(key).nil?
-    end
-    body
-  end
+#  # return the object in the form of hash
+#  def to_body
+#    body = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      body[value] = self.send(key) unless self.send(key).nil?
+#    end
+#    body
+#  end
+#
+#  # build the object from hash
+#  def build_from_hash(attributes)
+#    self.class.swagger_types.each_pair do |key, type|
+#      if type =~ /^array\[(.*)\]/i
+#        if attributes[self.class.attribute_map[key]].is_a?(Array)
+#          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+#        else
+#          #TODO show warning in debug mode
+#        end
+#      elsif !attributes[self.class.attribute_map[key]].nil?
+#        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+#      else
+#        # data not found in attributes(hash), not an issue as the data can be optional
+#      end
+#    end
+#
+#    self
+#  end
+#
+#  def _deserialize(type, value)
+#    case type
+#    when :DateTime
+#      DateTime.parse(value)
+#    when :string
+#      value.to_s
+#    when :int
+#      value.to_i
+#    when :double
+#      value.to_f
+#    when :boolean
+#      if value =~ /^(true|t|yes|y|1)$/i
+#        true
+#      else
+#        false
+#      end
+#    else # model
+#      _model = Object.const_get(type).new
+#      _model.build_from_hash(value)
+#    end
+#  end
+#
+#
+#
+#  # to_body is an alias to to_body (backward compatibility)
+#  def to_hash
+#    hash = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      if self.send(key).is_a?(Array)
+#        next if self.send(key).empty?
+#        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+#      else
+#        unless (_tmp_value = _to_hash self.send(key)).nil?
+#          hash[value] = _tmp_value
+#        end
+#      end
+#    end
+#    hash
+#  end
+#
+#  # Method to output non-array value in the form of hash
+#  # For object, use to_hash. Otherwise, just return the value
+#  def _to_hash(value)
+#    if value.respond_to? :to_hash
+#      value.to_hash
+#    else
+#      value
+#    end
+#  end
+
 end

--- a/samples/client/petstore/ruby/models/pet.rb
+++ b/samples/client/petstore/ruby/models/pet.rb
@@ -68,7 +68,6 @@ class Pet < BaseObject
     
     if attributes[:'tags']
       if (value = attributes[:'tags']).is_a?(Array)
-        #@tags = value.map{ |v| Tag.new(v) }
         @tags = value
       end
     end

--- a/samples/client/petstore/ruby/models/tag.rb
+++ b/samples/client/petstore/ruby/models/tag.rb
@@ -1,34 +1,123 @@
+require_relative 'base_object'
 
-class Tag
+#
+class Tag < BaseObject
   attr_accessor :id, :name
-  # :internal => :external
+  # attribute mapping from ruby-style variable name to JSON key
   def self.attribute_map
     {
-      :id => :'id',
-      :name => :'name'
+      
+      # 
+      :'id' => :'id',
+      
+      # 
+      :'name' => :'name'
+      
+    }
+  end
+
+  # attribute type
+  def self.swagger_types
+    {
+      :'id' => :'int',
+      :'name' => :'string'
       
     }
   end
 
   def initialize(attributes = {})
-    return if attributes.empty?
-    # Morph attribute keys into undescored rubyish style
+    return if !attributes.is_a?(Hash) || attributes.empty?
+
+    # convert string to symbol for hash key
+    attributes = attributes.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+
     
-    if self.class.attribute_map[:"id"]
-      @id = attributes["id"]
+    if attributes[:'id']
+      @id = attributes[:'id']
     end
     
-    if self.class.attribute_map[:"name"]
-      @name = attributes["name"]
+    if attributes[:'name']
+      @name = attributes[:'name']
     end
     
   end
 
-  def to_body
-    body = {}
-    self.class.attribute_map.each_pair do |key, value|
-      body[value] = self.send(key) unless self.send(key).nil?
-    end
-    body
-  end
+#  # return the object in the form of hash
+#  def to_body
+#    body = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      body[value] = self.send(key) unless self.send(key).nil?
+#    end
+#    body
+#  end
+#
+#  # build the object from hash
+#  def build_from_hash(attributes)
+#    self.class.swagger_types.each_pair do |key, type|
+#      if type =~ /^array\[(.*)\]/i
+#        if attributes[self.class.attribute_map[key]].is_a?(Array)
+#          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+#        else
+#          #TODO show warning in debug mode
+#        end
+#      elsif !attributes[self.class.attribute_map[key]].nil?
+#        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+#      else
+#        # data not found in attributes(hash), not an issue as the data can be optional
+#      end
+#    end
+#
+#    self
+#  end
+#
+#  def _deserialize(type, value)
+#    case type
+#    when :DateTime
+#      DateTime.parse(value)
+#    when :string
+#      value.to_s
+#    when :int
+#      value.to_i
+#    when :double
+#      value.to_f
+#    when :boolean
+#      if value =~ /^(true|t|yes|y|1)$/i
+#        true
+#      else
+#        false
+#      end
+#    else # model
+#      _model = Object.const_get(type).new
+#      _model.build_from_hash(value)
+#    end
+#  end
+#
+#
+#
+#  # to_body is an alias to to_body (backward compatibility)
+#  def to_hash
+#    hash = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      if self.send(key).is_a?(Array)
+#        next if self.send(key).empty?
+#        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+#      else
+#        unless (_tmp_value = _to_hash self.send(key)).nil?
+#          hash[value] = _tmp_value
+#        end
+#      end
+#    end
+#    hash
+#  end
+#
+#  # Method to output non-array value in the form of hash
+#  # For object, use to_hash. Otherwise, just return the value
+#  def _to_hash(value)
+#    if value.respond_to? :to_hash
+#      value.to_hash
+#    else
+#      value
+#    end
+#  end
+
 end

--- a/samples/client/petstore/ruby/models/user.rb
+++ b/samples/client/petstore/ruby/models/user.rb
@@ -1,64 +1,171 @@
+require_relative 'base_object'
 
-class User
+#
+class User < BaseObject
   attr_accessor :id, :username, :first_name, :last_name, :email, :password, :phone, :user_status
-  # :internal => :external
+  # attribute mapping from ruby-style variable name to JSON key
   def self.attribute_map
     {
-      :id => :'id',
-      :username => :'username',
-      :first_name => :'firstName',
-      :last_name => :'lastName',
-      :email => :'email',
-      :password => :'password',
-      :phone => :'phone',
-      :user_status => :'userStatus'
+      
+      # 
+      :'id' => :'id',
+      
+      # 
+      :'username' => :'username',
+      
+      # 
+      :'first_name' => :'firstName',
+      
+      # 
+      :'last_name' => :'lastName',
+      
+      # 
+      :'email' => :'email',
+      
+      # 
+      :'password' => :'password',
+      
+      # 
+      :'phone' => :'phone',
+      
+      # User Status
+      :'user_status' => :'userStatus'
+      
+    }
+  end
+
+  # attribute type
+  def self.swagger_types
+    {
+      :'id' => :'int',
+      :'username' => :'string',
+      :'first_name' => :'string',
+      :'last_name' => :'string',
+      :'email' => :'string',
+      :'password' => :'string',
+      :'phone' => :'string',
+      :'user_status' => :'int'
       
     }
   end
 
   def initialize(attributes = {})
-    return if attributes.empty?
-    # Morph attribute keys into undescored rubyish style
+    return if !attributes.is_a?(Hash) || attributes.empty?
+
+    # convert string to symbol for hash key
+    attributes = attributes.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+
     
-    if self.class.attribute_map[:"id"]
-      @id = attributes["id"]
+    if attributes[:'id']
+      @id = attributes[:'id']
     end
     
-    if self.class.attribute_map[:"username"]
-      @username = attributes["username"]
+    if attributes[:'username']
+      @username = attributes[:'username']
     end
     
-    if self.class.attribute_map[:"first_name"]
-      @first_name = attributes["firstName"]
+    if attributes[:'firstName']
+      @first_name = attributes[:'firstName']
     end
     
-    if self.class.attribute_map[:"last_name"]
-      @last_name = attributes["lastName"]
+    if attributes[:'lastName']
+      @last_name = attributes[:'lastName']
     end
     
-    if self.class.attribute_map[:"email"]
-      @email = attributes["email"]
+    if attributes[:'email']
+      @email = attributes[:'email']
     end
     
-    if self.class.attribute_map[:"password"]
-      @password = attributes["password"]
+    if attributes[:'password']
+      @password = attributes[:'password']
     end
     
-    if self.class.attribute_map[:"phone"]
-      @phone = attributes["phone"]
+    if attributes[:'phone']
+      @phone = attributes[:'phone']
     end
     
-    if self.class.attribute_map[:"user_status"]
-      @user_status = attributes["userStatus"]
+    if attributes[:'userStatus']
+      @user_status = attributes[:'userStatus']
     end
     
   end
 
-  def to_body
-    body = {}
-    self.class.attribute_map.each_pair do |key, value|
-      body[value] = self.send(key) unless self.send(key).nil?
-    end
-    body
-  end
+#  # return the object in the form of hash
+#  def to_body
+#    body = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      body[value] = self.send(key) unless self.send(key).nil?
+#    end
+#    body
+#  end
+#
+#  # build the object from hash
+#  def build_from_hash(attributes)
+#    self.class.swagger_types.each_pair do |key, type|
+#      if type =~ /^array\[(.*)\]/i
+#        if attributes[self.class.attribute_map[key]].is_a?(Array)
+#          self.send("#{key}=", attributes[self.class.attribute_map[key]].map{ |v| _deserialize($1, v) } )
+#        else
+#          #TODO show warning in debug mode
+#        end
+#      elsif !attributes[self.class.attribute_map[key]].nil?
+#        self.send("#{key}=", _deserialize(type, attributes[self.class.attribute_map[key]]))
+#      else
+#        # data not found in attributes(hash), not an issue as the data can be optional
+#      end
+#    end
+#
+#    self
+#  end
+#
+#  def _deserialize(type, value)
+#    case type
+#    when :DateTime
+#      DateTime.parse(value)
+#    when :string
+#      value.to_s
+#    when :int
+#      value.to_i
+#    when :double
+#      value.to_f
+#    when :boolean
+#      if value =~ /^(true|t|yes|y|1)$/i
+#        true
+#      else
+#        false
+#      end
+#    else # model
+#      _model = Object.const_get(type).new
+#      _model.build_from_hash(value)
+#    end
+#  end
+#
+#
+#
+#  # to_body is an alias to to_body (backward compatibility)
+#  def to_hash
+#    hash = {}
+#    self.class.attribute_map.each_pair do |key, value|
+#      if self.send(key).is_a?(Array)
+#        next if self.send(key).empty?
+#        hash[value] = self.send(key).select{|v| !v.nil?}.map{ |v| _to_hash v} unless self.send(key).nil?
+#      else
+#        unless (_tmp_value = _to_hash self.send(key)).nil?
+#          hash[value] = _tmp_value
+#        end
+#      end
+#    end
+#    hash
+#  end
+#
+#  # Method to output non-array value in the form of hash
+#  # For object, use to_hash. Otherwise, just return the value
+#  def _to_hash(value)
+#    if value.respond_to? :to_hash
+#      value.to_hash
+#    else
+#      value
+#    end
+#  end
+
 end

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -34,27 +34,15 @@ describe "Pet" do
       pet.tags[0].object_id.should_not == pet2.tags[0].object_id
       pet.tags[1].object_id.should_not == pet2.tags[1].object_id
       pet.category.object_id.should_not == pet2.category.object_id
-
-      puts pet.to_json
-      pet_array = [pet, pet2]
-      puts pet_array.map{ |v| 
-        if v.respond_to?(:to_hash)
-          v.to_hash
-        else
-          v
-        end
-      }.to_json
-
     end
 
     it "should fetch a pet object" do
       pet = PetApi.get_pet_by_id(10002)
-      print pet.inspect
       pet.should be_a(Pet)
       pet.id.should == 10002
       pet.name.should == "RUBY UNIT TESTING"
-      pet.tags[0].name.should == "RUBY UNIT TESTING"
-      pet.category.name.should == "RUBY UNIT TESTING"
+      pet.tags[0].name.should == "tag test"
+      pet.category.name.should == "category test"
     end
 
     it "should find pets by status" do

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 
 describe "Pet" do
   before do
@@ -7,11 +8,53 @@ describe "Pet" do
   end
   
   describe "pet methods" do
+    it "should construct a new pet object" do
+      tag1 = Tag.new({'id' => 1, 'name'=> 'tag1'})
+      tag2 = Tag.new({'id' => 2, 'name'=> 'tag2'})
+      category1 = Category.new({:id => 1, :name => 'category unknown'})
+      # initalize using both string and symbol key
+      pet_hash = {:'id' => 10002, :'name' => "RUBY UNIT TESTING", :'status' => "pending",
+              :'photo_urls' => ["url1", "url2"], :'category' => category1,
+              :'tags' => [tag1, tag2]}
+      pet = Pet.new(pet_hash)
+      # test new
+      pet.name.should == "RUBY UNIT TESTING"
+      pet.status.should == "pending"
+      pet.id.should == 10002
+      pet.tags[0].id.should == 1
+      pet.tags[1].name.should == 'tag2'
+      pet.category.name.should == 'category unknown'
+
+      # test build_from_hash
+      pet2 = Pet.new
+      pet2.build_from_hash(pet.to_hash)
+      pet.to_hash.should == pet2.to_hash
+
+      # make sure sub-object has different object id
+      pet.tags[0].object_id.should_not == pet2.tags[0].object_id
+      pet.tags[1].object_id.should_not == pet2.tags[1].object_id
+      pet.category.object_id.should_not == pet2.category.object_id
+
+      puts pet.to_json
+      pet_array = [pet, pet2]
+      puts pet_array.map{ |v| 
+        if v.respond_to?(:to_hash)
+          v.to_hash
+        else
+          v
+        end
+      }.to_json
+
+    end
+
     it "should fetch a pet object" do
       pet = PetApi.get_pet_by_id(10002)
+      print pet.inspect
       pet.should be_a(Pet)
       pet.id.should == 10002
       pet.name.should == "RUBY UNIT TESTING"
+      pet.tags[0].name.should == "RUBY UNIT TESTING"
+      pet.category.name.should == "RUBY UNIT TESTING"
     end
 
     it "should find pets by status" do

--- a/samples/client/petstore/ruby/spec/response_spec.rb
+++ b/samples/client/petstore/ruby/spec/response_spec.rb
@@ -19,7 +19,7 @@ describe Swagger::Response do
   describe "initialization" do
     it "sets body" do
       @response.body.class.should == Hash
-      @response.body.has_key?('name').should == true
+      @response.body.has_key?(:'name').should == true
     end
 
     it "sets code" do

--- a/samples/client/petstore/ruby/spec/spec_helper.rb
+++ b/samples/client/petstore/ruby/spec/spec_helper.rb
@@ -49,7 +49,10 @@ def prepare_pet
   # remove the pet
   PetApi.delete_pet(10002)
   # recreate the pet
-  pet = Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING")
+  category = Category.new('id' => 20002, 'name' => 'category test')
+  tag = Tag.new('id' => 30002, 'name' => 'tag test')
+  pet = Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING", 'photo_urls' => 'photo url',
+                'category' => category, 'tags' => [tag], 'status' => 'pending')
   PetApi.add_pet(:body => pet)
 end
 

--- a/samples/client/petstore/ruby/spec/spec_helper.rb
+++ b/samples/client/petstore/ruby/spec/spec_helper.rb
@@ -53,7 +53,8 @@ def prepare_pet
   tag = Tag.new('id' => 30002, 'name' => 'tag test')
   pet = Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING", 'photo_urls' => 'photo url',
                 'category' => category, 'tags' => [tag], 'status' => 'pending')
-  PetApi.add_pet(:body => pet)
+
+  PetApi.add_pet(:'body'=> pet)
 end
 
 # always delete and then re-create the store order 


### PR DESCRIPTION
- all models now inherit base_model.rb, which provides common methods like `to_hash`, `build_from_hash`
- fixed bug with posting objects with sub-models #752 
- added rspec test cases for posting objects with sub-models
- refactored post model into a function `object_to_http_body` in Swagger::Request

Ruby integration test result:
```
[INFO] --- exec-maven-plugin:1.2.1:exec (bundle-test) @ RubyPetstoreClientTests ---
..............................................

Finished in 28.08 seconds (files took 0.52256 seconds to load)
46 examples, 0 failures

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 35.214s
[INFO] Finished at: Mon May 18 00:09:43 HKT 2015
[INFO] Final Memory: 8M/30M
[INFO] ------------------------------------------------------------------------
```