### PR TITLE
[Perl] better logic for accept and content-type, added test cases

### DIFF
--- a/modules/swagger-codegen/src/main/resources/perl/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/APIClient.mustache
@@ -253,4 +253,39 @@ sub deserialize
 
 }
 
+# return 'Accept' based on an array of accept provided
+# @param [Array] header_accept_array Array fo 'Accept'
+# @return String Accept (e.g. application/json)
+sub select_header_accept
+{
+  my ($self, @header) = @_;
+
+  if (@header == 0 || (@header == 1 && $header[0] eq '')) {
+    return undef;
+  } elsif (grep(/^application\/json$/i, @header)) {
+    return 'application/json';
+  } else {
+    return join(',', @header);
+  }
+
+}
+
+# return the content type based on an array of content-type provided
+# @param [Array] content_type_array Array fo content-type
+# @return String Content-Type (e.g. application/json)
+sub select_header_content_type
+{
+  my ($self, @header) = @_;
+
+  if (@header == 0 || (@header == 1 && $header[0] eq '')) {
+    return 'application/json'; # default to application/json
+  } elsif (grep(/^application\/json$/i, @header)) {
+    return 'application/json';
+  } else {
+    return join(',', @header);
+  }
+
+}
+
+
 1;

--- a/modules/swagger-codegen/src/main/resources/perl/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/api.mustache
@@ -90,8 +90,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ({{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}});
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type({{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}});
 
       {{#queryParams}} # query params

--- a/modules/swagger-codegen/src/main/resources/perl/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/api.mustache
@@ -85,12 +85,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = '{{#produces}}{{mediaType}}{{#hasMore}}, {{/hasMore}}{{/produces}}';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept({{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}});
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ({{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}});
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ({{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}});
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type({{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}});
 
       {{#queryParams}} # query params
       if ( exists $args{'{{paramName}}'}) {

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/APIClient.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/APIClient.pm
@@ -253,4 +253,39 @@ sub deserialize
 
 }
 
+# return 'Accept' based on an array of accept provided
+# @param [Array] header_accept_array Array fo 'Accept'
+# @return String Accept (e.g. application/json)
+sub select_header_accept
+{
+  my ($self, @header) = @_;
+
+  if (@header == 0 || (@header == 1 && $header[0] eq '')) {
+    return undef;
+  } elsif (grep(/^application\/json$/i, @header)) {
+    return 'application/json';
+  } else {
+    return join(',', @header);
+  }
+
+}
+
+# return the content type based on an array of content-type provided
+# @param [Array] content_type_array Array fo content-type
+# @return String Content-Type (e.g. application/json)
+sub select_header_content_type
+{
+  my ($self, @header) = @_;
+
+  if (@header == 0 || (@header == 1 && $header[0] eq '')) {
+    return 'application/json'; # default to application/json
+  } elsif (grep(/^application\/json$/i, @header)) {
+    return 'application/json';
+  } else {
+    return join(',', @header);
+  }
+
+}
+
+
 1;

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/PetApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/PetApi.pm
@@ -86,12 +86,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ('application/json','application/xml',);
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ('application/json','application/xml',);
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json', 'application/xml', );
 
       
       
@@ -137,12 +139,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ('application/json','application/xml',);
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ('application/json','application/xml',);
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json', 'application/xml', );
 
       
       
@@ -188,12 +192,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
        # query params
       if ( exists $args{'status'}) {
@@ -242,12 +248,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
        # query params
       if ( exists $args{'tags'}) {
@@ -301,12 +309,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -364,12 +374,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ('application/x-www-form-urlencoded',);
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ('application/x-www-form-urlencoded',);
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/x-www-form-urlencoded', );
 
       
       
@@ -433,12 +445,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
        # header params
@@ -496,12 +510,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ('multipart/form-data',);
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ('multipart/form-data',);
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('multipart/form-data', );
 
       
       

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/PetApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/PetApi.pm
@@ -91,8 +91,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ('application/json','application/xml',);
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json', 'application/xml', );
 
       
@@ -144,8 +142,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ('application/json','application/xml',);
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json', 'application/xml', );
 
       
@@ -197,8 +193,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
        # query params
@@ -253,8 +247,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
        # query params
@@ -314,8 +306,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -379,8 +369,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ('application/x-www-form-urlencoded',);
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/x-www-form-urlencoded', );
 
       
@@ -450,8 +438,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -515,8 +501,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ('multipart/form-data',);
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('multipart/form-data', );
 
       

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/StoreApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/StoreApi.pm
@@ -81,12 +81,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -132,12 +134,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -191,12 +195,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -252,12 +258,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/StoreApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/StoreApi.pm
@@ -86,8 +86,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -139,8 +137,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -200,8 +196,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -263,8 +257,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/UserApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/UserApi.pm
@@ -86,12 +86,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -137,12 +139,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -188,12 +192,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -240,12 +246,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
        # query params
       if ( exists $args{'username'}) {
@@ -296,12 +304,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -349,12 +359,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -411,12 +423,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       
@@ -472,12 +486,14 @@ sub new {
       my $header_params = {};
       my $form_params = {};
 
-      my $_header_accept = 'application/json, application/xml';
-      if ($_header_accept ne '') {
+      # 'Accept' and 'Content-Type' header
+      my $_header_accept = $self->{api_client}->select_header_accept('application/json', 'application/xml');
+      if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      my @_header_content_type = ();
-      $header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      #my @_header_content_type = ();
+      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
       

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/UserApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/UserApi.pm
@@ -91,8 +91,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -144,8 +142,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -197,8 +193,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -251,8 +245,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
        # query params
@@ -309,8 +301,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -364,8 +354,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -428,8 +416,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       
@@ -491,8 +477,6 @@ sub new {
       if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
       }
-      #my @_header_content_type = ();
-      #$header_params->{'Content-Type'} = scalar(@_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
       $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
       

--- a/samples/client/petstore/perl/t/01_pet_api.t
+++ b/samples/client/petstore/perl/t/01_pet_api.t
@@ -1,4 +1,4 @@
-use Test::More tests => 25;
+use Test::More tests => 31;
 use Test::Exception;
 
 use lib 'lib';
@@ -11,6 +11,16 @@ use_ok('WWW::SwaggerClient::Object::Pet');
 use_ok('WWW::SwaggerClient::Object::Tag');
 use_ok('WWW::SwaggerClient::Object::Category');
 my $api = WWW::SwaggerClient::PetApi->new();
+
+# test select_header_content_type
+is $api->{api_client}->select_header_content_type('application/xml', 'Application/JSON'), 'application/json', 'get the proper content type application/json but not application/xml';
+is $api->{api_client}->select_header_content_type('application/xml'), 'application/xml', 'get the proper content type application/json'; 
+is $api->{api_client}->select_header_content_type(''), 'application/json', 'get the proper content type application/json (default)'; 
+
+# test select_header_accept
+is $api->{api_client}->select_header_accept('application/xml', 'Application/JSON'), 'application/json', 'get the proper accept application/json but not application/xml';
+is $api->{api_client}->select_header_content_type('application/xml'), 'application/xml', 'get the proper accept application/json'; 
+is $api->{api_client}->select_header_accept(''), undef, 'get the proper accept "undef" (default)';
 
 my $pet_id = 10008;
 


### PR DESCRIPTION
For accept and content-type, use `application/json` if it's in the consumes/produces list. This is to avoid `application/xml` being used as the API client cannot handle XML response at the moment

Added test case for new functions for performing the above.