### PR TITLE
[PHP] update API client to support default header, better accept and content-type

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -24,6 +24,8 @@ class APIClient {
   public static $GET = "GET";
   public static $PUT = "PUT";
   public static $DELETE = "DELETE";
+  
+  private static $default_header = array();
 
   /*
    * @var string timeout (second) of the HTTP request, by default set to 0, no timeout
@@ -46,24 +48,55 @@ class APIClient {
   }
 
   /**
-   * Set the user agent of the API client
+   * add default header 
    *
-   *  @param string $user_agent The user agent of the API client
+   * @param string $header_name header name (e.g. Token)
+   * @param string $header_value header value (e.g. 1z8wp3)
+   */
+  public function addDefaultHeader($header_name, $header_value) {
+    if (!is_string($header_name)) 
+      throw new exception('heaer name must be a string.');
+
+    self::$default_header[$header_name] =  $header_value;
+  }
+
+  /**
+   * get the default header 
+   *
+   * @return array default header
+   */
+  public function getDefaultHeader() {
+    return self::$default_header;
+  }
+
+  /**
+   * delete the default header based on header name
+   *
+   * @param string $header_name header name (e.g. Token)
+   */
+  public function deleteDefaultHeader($header_name) {
+    unset(self::$default_header[$header_name]);
+  }
+
+  /**
+   * set the user agent of the api client
+   *
+   *  @param string $user_agent the user agent of the api client
    */
   public function setUserAgent($user_agent) {
-    if (!is_string($user_agent)) {
-      throw new Exception('User-agent must be a string.');
-    }
+    if (!is_string($user_agent))
+      throw new exception('user-agent must be a string.');
+
     $this->user_agent= $user_agent;
   }
 
   /**
    *  @param integer $seconds Number of seconds before timing out [set to 0 for no timeout]
-  */
+   */
   public function setTimeout($seconds) {
-    if (!is_numeric($seconds)) {
+    if (!is_numeric($seconds))
       throw new Exception('Timeout variable must be numeric.');
-    }
+
     $this->curl_timeout = $seconds;
   }
 
@@ -83,6 +116,9 @@ class APIClient {
     # Allow API key from $headerParams to override default
     $added_api_key = False;
     if ($headerParams != null) {
+      # add default header
+      $headerParams = array_merge((array)self::$default_header, $headerParams);
+
       foreach ($headerParams as $key => $val) {
         $headers[] = "$key: $val";
         if ($key == $this->headerName) {
@@ -111,6 +147,7 @@ class APIClient {
     }
     // return the result on success, rather than just TRUE
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
     curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 
     if (! empty($queryParams)) {

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -261,7 +261,6 @@ class APIClient {
    * @param string $class class name is passed as a string
    * @return object an instance of $class
    */
-
   public static function deserialize($data, $class)
   {
     if (null === $data) {
@@ -302,6 +301,38 @@ class APIClient {
     }
 
     return $deserialized;
+  }
+
+  /*
+   * return the header 'Accept' based on an array of Accept provided
+   *
+   * @param array[string] $accept Array of header
+   * @return string Accept (e.g. application/json)
+   */
+  public static function selectHeaderAccept($accept) {
+    if (count($accept) === 0 or (count($accept) === 1 and $accept[0] === '')) {
+      return NULL;
+    } elseif (preg_grep("/application\/json/i", $accept)) {
+      return 'application/json';
+    } else {
+      return implode(',', $accept);
+    }
+  }
+
+  /*
+   * return the content type based on an array of content-type provided
+   *
+   * @param array[string] content_type_array Array fo content-type
+   * @return string Content-Type (e.g. application/json)
+   */
+  public static function selectHeaderContentType($content_type) {
+    if (count($content_type) === 0 or (count($content_type) === 1 and $content_type[0] === '')) {
+      return 'application/json';
+    } elseif (preg_grep("/application\/json/i", $content_type)) {
+      return 'application/json';
+    } else {
+      return implode(',', $content_type);
+    }
   }
 
 }

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -55,7 +55,7 @@ class APIClient {
    */
   public function addDefaultHeader($header_name, $header_value) {
     if (!is_string($header_name)) 
-      throw new exception('heaer name must be a string.');
+      throw new \InvalidArgumentException('Header name must be a string.');
 
     self::$default_header[$header_name] =  $header_value;
   }
@@ -85,7 +85,7 @@ class APIClient {
    */
   public function setUserAgent($user_agent) {
     if (!is_string($user_agent))
-      throw new exception('user-agent must be a string.');
+      throw new \InvalidArgumentException('User-agent must be a string.');
 
     $this->user_agent= $user_agent;
   }
@@ -95,7 +95,7 @@ class APIClient {
    */
   public function setTimeout($seconds) {
     if (!is_numeric($seconds))
-      throw new Exception('Timeout variable must be numeric.');
+      throw new \InvalidArgumentException('Timeout variable must be numeric.');
 
     $this->curl_timeout = $seconds;
   }
@@ -167,7 +167,7 @@ class APIClient {
       curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
       curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
     } else if ($method != self::$GET) {
-      throw new Exception('Method ' . $method . ' is not recognized.');
+      throw new APIClientException('Method ' . $method . ' is not recognized.');
     }
     curl_setopt($curl, CURLOPT_URL, $url);
 

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -42,7 +42,7 @@ class {{classname}} {
       {{#allParams}}{{#required}}
       // verify the required parameter '{{paramName}}' is set
       if (${{paramName}} === null) {
-        throw new \Exception("Missing the required parameter ${{paramName}} when calling {{nickname}}");
+        throw new \InvalidArgumentException('Missing the required parameter ${{paramName}} when calling {{nickname}}');
       }
       {{/required}}{{/allParams}}
 

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -54,12 +54,11 @@ class {{classname}} {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = '{{#produces}}{{mediaType}}{{#hasMore}}, {{/hasMore}}{{/produces}}';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array({{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array({{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}});
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array({{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}}));
 
       {{#queryParams}}// query params
       if(${{paramName}} !== null) {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -24,6 +24,8 @@ class APIClient {
   public static $GET = "GET";
   public static $PUT = "PUT";
   public static $DELETE = "DELETE";
+  
+  private static $default_header = array();
 
   /*
    * @var string timeout (second) of the HTTP request, by default set to 0, no timeout
@@ -46,24 +48,55 @@ class APIClient {
   }
 
   /**
-   * Set the user agent of the API client
+   * add default header 
    *
-   *  @param string $user_agent The user agent of the API client
+   * @param string $header_name header name (e.g. Token)
+   * @param string $header_value header value (e.g. 1z8wp3)
+   */
+  public function addDefaultHeader($header_name, $header_value) {
+    if (!is_string($header_name)) 
+      throw new exception('heaer name must be a string.');
+
+    self::$default_header[$header_name] =  $header_value;
+  }
+
+  /**
+   * get the default header 
+   *
+   * @return array default header
+   */
+  public function getDefaultHeader() {
+    return self::$default_header;
+  }
+
+  /**
+   * delete the default header based on header name
+   *
+   * @param string $header_name header name (e.g. Token)
+   */
+  public function deleteDefaultHeader($header_name) {
+    unset(self::$default_header[$header_name]);
+  }
+
+  /**
+   * set the user agent of the api client
+   *
+   *  @param string $user_agent the user agent of the api client
    */
   public function setUserAgent($user_agent) {
-    if (!is_string($user_agent)) {
-      throw new Exception('User-agent must be a string.');
-    }
+    if (!is_string($user_agent))
+      throw new exception('user-agent must be a string.');
+
     $this->user_agent= $user_agent;
   }
 
   /**
    *  @param integer $seconds Number of seconds before timing out [set to 0 for no timeout]
-  */
+   */
   public function setTimeout($seconds) {
-    if (!is_numeric($seconds)) {
+    if (!is_numeric($seconds))
       throw new Exception('Timeout variable must be numeric.');
-    }
+
     $this->curl_timeout = $seconds;
   }
 
@@ -83,6 +116,9 @@ class APIClient {
     # Allow API key from $headerParams to override default
     $added_api_key = False;
     if ($headerParams != null) {
+      # add default header
+      $headerParams = array_merge((array)self::$default_header, $headerParams);
+
       foreach ($headerParams as $key => $val) {
         $headers[] = "$key: $val";
         if ($key == $this->headerName) {
@@ -111,6 +147,7 @@ class APIClient {
     }
     // return the result on success, rather than just TRUE
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
     curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 
     if (! empty($queryParams)) {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -55,7 +55,7 @@ class APIClient {
    */
   public function addDefaultHeader($header_name, $header_value) {
     if (!is_string($header_name)) 
-      throw new exception('heaer name must be a string.');
+      throw new \InvalidArgumentException('Header name must be a string.');
 
     self::$default_header[$header_name] =  $header_value;
   }
@@ -85,7 +85,7 @@ class APIClient {
    */
   public function setUserAgent($user_agent) {
     if (!is_string($user_agent))
-      throw new exception('user-agent must be a string.');
+      throw new \InvalidArgumentException('User-agent must be a string.');
 
     $this->user_agent= $user_agent;
   }
@@ -95,7 +95,7 @@ class APIClient {
    */
   public function setTimeout($seconds) {
     if (!is_numeric($seconds))
-      throw new Exception('Timeout variable must be numeric.');
+      throw new \InvalidArgumentException('Timeout variable must be numeric.');
 
     $this->curl_timeout = $seconds;
   }
@@ -167,7 +167,7 @@ class APIClient {
       curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
       curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
     } else if ($method != self::$GET) {
-      throw new Exception('Method ' . $method . ' is not recognized.');
+      throw new APIClientException('Method ' . $method . ' is not recognized.');
     }
     curl_setopt($curl, CURLOPT_URL, $url);
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
@@ -255,7 +255,7 @@ class PetApi {
       
       // verify the required parameter 'pet_id' is set
       if ($pet_id === null) {
-        throw new \Exception("Missing the required parameter $pet_id when calling getPetById");
+        throw new \InvalidArgumentException('Missing the required parameter $pet_id when calling getPetById');
       }
       
 
@@ -319,7 +319,7 @@ class PetApi {
       
       // verify the required parameter 'pet_id' is set
       if ($pet_id === null) {
-        throw new \Exception("Missing the required parameter $pet_id when calling updatePetWithForm");
+        throw new \InvalidArgumentException('Missing the required parameter $pet_id when calling updatePetWithForm');
       }
       
 
@@ -382,7 +382,7 @@ class PetApi {
       
       // verify the required parameter 'pet_id' is set
       if ($pet_id === null) {
-        throw new \Exception("Missing the required parameter $pet_id when calling deletePet");
+        throw new \InvalidArgumentException('Missing the required parameter $pet_id when calling deletePet');
       }
       
 
@@ -443,7 +443,7 @@ class PetApi {
       
       // verify the required parameter 'pet_id' is set
       if ($pet_id === null) {
-        throw new \Exception("Missing the required parameter $pet_id when calling uploadFile");
+        throw new \InvalidArgumentException('Missing the required parameter $pet_id when calling uploadFile');
       }
       
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
@@ -48,12 +48,11 @@ class PetApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array('application/json','application/xml',);
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array('application/json','application/xml',));
 
       
       
@@ -100,12 +99,11 @@ class PetApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array('application/json','application/xml',);
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array('application/json','application/xml',));
 
       
       
@@ -152,12 +150,11 @@ class PetApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       // query params
       if($status !== null) {
@@ -209,12 +206,11 @@ class PetApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       // query params
       if($tags !== null) {
@@ -271,12 +267,11 @@ class PetApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -336,12 +331,11 @@ class PetApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array('application/x-www-form-urlencoded',);
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array('application/x-www-form-urlencoded',));
 
       
       
@@ -400,12 +394,11 @@ class PetApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       // header params
@@ -462,12 +455,11 @@ class PetApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array('multipart/form-data',);
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array('multipart/form-data',));
 
       
       

--- a/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
@@ -47,12 +47,11 @@ class StoreApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -101,12 +100,11 @@ class StoreApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -164,12 +162,11 @@ class StoreApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -227,12 +224,11 @@ class StoreApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       

--- a/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
@@ -150,7 +150,7 @@ class StoreApi {
       
       // verify the required parameter 'order_id' is set
       if ($order_id === null) {
-        throw new \Exception("Missing the required parameter $order_id when calling getOrderById");
+        throw new \InvalidArgumentException('Missing the required parameter $order_id when calling getOrderById');
       }
       
 
@@ -212,7 +212,7 @@ class StoreApi {
       
       // verify the required parameter 'order_id' is set
       if ($order_id === null) {
-        throw new \Exception("Missing the required parameter $order_id when calling deleteOrder");
+        throw new \InvalidArgumentException('Missing the required parameter $order_id when calling deleteOrder');
       }
       
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
@@ -48,12 +48,11 @@ class UserApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -100,12 +99,11 @@ class UserApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -152,12 +150,11 @@ class UserApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -205,12 +202,11 @@ class UserApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       // query params
       if($username !== null) {
@@ -264,12 +260,11 @@ class UserApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -317,12 +312,11 @@ class UserApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -381,12 +375,11 @@ class UserApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       
@@ -442,12 +435,11 @@ class UserApi {
       $queryParams = array();
       $headerParams = array();
       $formParams = array();
-      $_header_accept = 'application/json, application/xml';
-      if ($_header_accept !== '') {
+      $_header_accept = $this->apiClient->selectHeaderAccept(array('application/json', 'application/xml'));
+      if (!is_null($_header_accept)) {
         $headerParams['Accept'] = $_header_accept;
       }
-      $_header_content_type = array();
-      $headerParams['Content-Type'] = count($_header_content_type) > 0 ? $_header_content_type[0] : 'application/json';
+      $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(array());
 
       
       

--- a/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
@@ -300,7 +300,7 @@ class UserApi {
       
       // verify the required parameter 'username' is set
       if ($username === null) {
-        throw new \Exception("Missing the required parameter $username when calling getUserByName");
+        throw new \InvalidArgumentException('Missing the required parameter $username when calling getUserByName');
       }
       
 
@@ -363,7 +363,7 @@ class UserApi {
       
       // verify the required parameter 'username' is set
       if ($username === null) {
-        throw new \Exception("Missing the required parameter $username when calling updateUser");
+        throw new \InvalidArgumentException('Missing the required parameter $username when calling updateUser');
       }
       
 
@@ -423,7 +423,7 @@ class UserApi {
       
       // verify the required parameter 'username' is set
       if ($username === null) {
-        throw new \Exception("Missing the required parameter $username when calling deleteUser");
+        throw new \InvalidArgumentException('Missing the required parameter $username when calling deleteUser');
       }
       
 

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -43,8 +43,16 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $this->assertSame('application/json', SwaggerClient\APIClient::selectHeaderContentType(array('application/xml','application/json')));
     $this->assertSame('application/json', SwaggerClient\APIClient::selectHeaderContentType(array()));
     $this->assertSame('application/yaml,application/xml', SwaggerClient\APIClient::selectHeaderContentType(array('application/yaml','application/xml')));
-   
 
+    # test addDefaultHeader and getDefaultHeader
+    SwaggerClient\APIClient::addDefaultHeader('test1', 'value1');
+    SwaggerClient\APIClient::addDefaultHeader('test2', 200);
+    $this->assertSame('value1', SwaggerClient\APIClient::getDefaultHeader()['test1']);
+    $this->assertSame(200, SwaggerClient\APIClient::getDefaultHeader()['test2']);
+
+    # test deleteDefaultHeader
+    SwaggerClient\APIClient::deleteDefaultHeader('test2');
+    $this->assertFalse(isset(SwaggerClient\APIClient::getDefaultHeader()['test2']));
   }
 
   // test getPetById with a Pet object (id 10005)

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -31,6 +31,22 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $add_response = $pet_api->addPet($new_pet);
   }
 
+  // test static functions defined in APIClient
+  public function testAPIClient()
+  { 
+    # test selectHeaderAccept
+    $this->assertSame('application/json', SwaggerClient\APIClient::selectHeaderAccept(array('application/xml','application/json')));
+    $this->assertSame(NULL, SwaggerClient\APIClient::selectHeaderAccept(array()));
+    $this->assertSame('application/yaml,application/xml', SwaggerClient\APIClient::selectHeaderAccept(array('application/yaml','application/xml')));
+   
+    # test selectHeaderContentType
+    $this->assertSame('application/json', SwaggerClient\APIClient::selectHeaderContentType(array('application/xml','application/json')));
+    $this->assertSame('application/json', SwaggerClient\APIClient::selectHeaderContentType(array()));
+    $this->assertSame('application/yaml,application/xml', SwaggerClient\APIClient::selectHeaderContentType(array('application/yaml','application/xml')));
+   
+
+  }
+
   // test getPetById with a Pet object (id 10005)
   public function testGetPetById()
   {

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -93,7 +93,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     // create updated pet object
     $updated_pet = new SwaggerClient\models\Pet;
     $updated_pet->id = $pet_id;
-    $updated_pet->status = "pending"; // new status
+    $updated_pet->name = 'updatePet'; // new name
+    $updated_pet->status = 'pending'; // new status
     // update Pet (model/json)
     $update_response = $pet_api->updatePet($updated_pet);
     // return nothing (void)
@@ -102,6 +103,7 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $response = $pet_api->getPetById($pet_id);
     $this->assertSame($response->id, $pet_id);
     $this->assertSame($response->status, 'pending');
+    $this->assertSame($response->name, 'updatePet');
   }
 
   // test updatePet and verify by the "id" of the response
@@ -112,15 +114,13 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $pet_id = 10001;  // ID of pet that needs to be fetched
     $pet_api = new SwaggerClient\PetAPI($api_client);
     // update Pet (form)
-    $update_response = $pet_api->updatePetWithForm($pet_id, null, 'sold');
+    $update_response = $pet_api->updatePetWithForm($pet_id, 'update pet with form', 'sold');
     // return nothing (void)
     $this->assertSame($update_response, NULL);
-    // TODO commented out for the time being since it's broken
-    // https://github.com/swagger-api/swagger-codegen/issues/656
-    // verify updated Pet
-    //$response = $pet_api->getPetById($pet_id);
-    //$this->assertSame($response->id, $pet_id);
-    //$this->assertSame($response->status, 'sold');
+    $response = $pet_api->getPetById($pet_id);
+    $this->assertSame($response->id, $pet_id);
+    $this->assertSame($response->name, 'update pet with form');
+    $this->assertSame($response->status, 'sold');
   }
 
   // test addPet and verify by the "id" and "name" of the response

--- a/samples/client/petstore/php/test.php
+++ b/samples/client/petstore/php/test.php
@@ -4,6 +4,8 @@ require_once('SwaggerClient-php/SwaggerClient.php');
 
 // initialize the API client
 $api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
+$api_client->addDefaultHeader("test1", "value1");
+
 $petId = 10005; // ID of pet that needs to be fetched
 try {
     $pet_api = new SwaggerClient\PetAPI($api_client);


### PR DESCRIPTION
- updated API client to support default header with test cases
- better accept and content-type (use application/json if available)
- added back test cases for updatePetWithForm
- better exception using InvalidArgumentException

```
$ ./vendor/bin/phpunit tests

PHPUnit 4.6.6 by Sebastian Bergmann and contributors.

.......

Time: 5.73 seconds, Memory: 5.50Mb

OK (7 tests, 345 assertions)
```