### PR TITLE
Fix required parameter validation for Objc

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -69,6 +69,11 @@ static NSString * basePath = @"{{basePath}}";
         {{#returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)({{{returnType}}} output, NSError* error))completionBlock{{/returnBaseType}}
         {{^returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock{{/returnBaseType}} {
 
+    {{#allParams}}{{#required}}
+    // verify the required parameter '{{paramName}}' is set
+    NSAssert({{paramName}} != nil, @"Missing the required parameter `{{paramName}}` when calling {{nickname}}");
+    {{/required}}{{/allParams}}
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@{{path}}", basePath];
 
     // remove format in URL if needed

--- a/samples/client/petstore/objc/client/SWGPetApi.m
+++ b/samples/client/petstore/objc/client/SWGPetApi.m
@@ -67,6 +67,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         completionHandler: (void (^)(NSError* error))completionBlock {
 
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/pet", basePath];
 
     // remove format in URL if needed
@@ -157,6 +159,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         
         completionHandler: (void (^)(NSError* error))completionBlock {
+
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/pet", basePath];
 
@@ -249,6 +253,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock
          {
 
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/pet/findByStatus", basePath];
 
     // remove format in URL if needed
@@ -335,6 +341,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock
          {
+
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/pet/findByTags", basePath];
 
@@ -423,6 +431,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         completionHandler: (void (^)(SWGPet* output, NSError* error))completionBlock
          {
 
+    
+    // verify the required parameter 'petId' is set
+    NSAssert(petId != nil, @"Missing the required parameter `petId` when calling getPetById");
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/pet/{petId}", basePath];
 
     // remove format in URL if needed
@@ -509,6 +522,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         
         completionHandler: (void (^)(NSError* error))completionBlock {
+
+    
+    // verify the required parameter 'petId' is set
+    NSAssert(petId != nil, @"Missing the required parameter `petId` when calling updatePetWithForm");
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/pet/{petId}", basePath];
 
@@ -597,6 +615,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         completionHandler: (void (^)(NSError* error))completionBlock {
 
+    
+    // verify the required parameter 'petId' is set
+    NSAssert(petId != nil, @"Missing the required parameter `petId` when calling deletePet");
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/pet/{petId}", basePath];
 
     // remove format in URL if needed
@@ -671,6 +694,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         
         completionHandler: (void (^)(NSError* error))completionBlock {
+
+    
+    // verify the required parameter 'petId' is set
+    NSAssert(petId != nil, @"Missing the required parameter `petId` when calling uploadFile");
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/pet/{petId}/uploadImage", basePath];
 

--- a/samples/client/petstore/objc/client/SWGStoreApi.m
+++ b/samples/client/petstore/objc/client/SWGStoreApi.m
@@ -64,6 +64,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         (void (^)(NSDictionary* output, NSError* error))completionBlock
          {
 
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/store/inventory", basePath];
 
     // remove format in URL if needed
@@ -137,6 +139,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         completionHandler: (void (^)(SWGOrder* output, NSError* error))completionBlock
          {
+
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/store/order", basePath];
 
@@ -243,6 +247,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         completionHandler: (void (^)(SWGOrder* output, NSError* error))completionBlock
          {
 
+    
+    // verify the required parameter 'orderId' is set
+    NSAssert(orderId != nil, @"Missing the required parameter `orderId` when calling getOrderById");
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/store/order/{orderId}", basePath];
 
     // remove format in URL if needed
@@ -325,6 +334,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         
         completionHandler: (void (^)(NSError* error))completionBlock {
+
+    
+    // verify the required parameter 'orderId' is set
+    NSAssert(orderId != nil, @"Missing the required parameter `orderId` when calling deleteOrder");
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/store/order/{orderId}", basePath];
 

--- a/samples/client/petstore/objc/client/SWGUserApi.m
+++ b/samples/client/petstore/objc/client/SWGUserApi.m
@@ -66,6 +66,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         completionHandler: (void (^)(NSError* error))completionBlock {
 
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/user", basePath];
 
     // remove format in URL if needed
@@ -157,6 +159,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         completionHandler: (void (^)(NSError* error))completionBlock {
 
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/user/createWithArray", basePath];
 
     // remove format in URL if needed
@@ -247,6 +251,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         
         completionHandler: (void (^)(NSError* error))completionBlock {
+
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/user/createWithList", basePath];
 
@@ -341,6 +347,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         completionHandler: (void (^)(NSString* output, NSError* error))completionBlock
          {
 
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/user/login", basePath];
 
     // remove format in URL if needed
@@ -427,6 +435,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         (void (^)(NSError* error))completionBlock {
 
+    
+
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/user/logout", basePath];
 
     // remove format in URL if needed
@@ -494,6 +504,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         completionHandler: (void (^)(SWGUser* output, NSError* error))completionBlock
          {
+
+    
+    // verify the required parameter 'username' is set
+    NSAssert(username != nil, @"Missing the required parameter `username` when calling getUserByName");
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/user/{username}", basePath];
 
@@ -579,6 +594,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         
         completionHandler: (void (^)(NSError* error))completionBlock {
+
+    
+    // verify the required parameter 'username' is set
+    NSAssert(username != nil, @"Missing the required parameter `username` when calling updateUser");
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/user/{username}", basePath];
 
@@ -671,6 +691,11 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
         
         
         completionHandler: (void (^)(NSError* error))completionBlock {
+
+    
+    // verify the required parameter 'username' is set
+    NSAssert(username != nil, @"Missing the required parameter `username` when calling deleteUser");
+    
 
     NSMutableString* requestUrl = [NSMutableString stringWithFormat:@"%@/user/{username}", basePath];
 


### PR DESCRIPTION
* Added required parameter check for objc client.

  Currently, required parameter validation is missing/broken. 
  This PR aims to improve the method/function by ensuring that the required parameter is set. 
  Otherwise, an exception will be thrown.

* Tested without issue.
  
   ```sh
  Test Case '-[PetApiTest testUploadFile]' passed (0.411 seconds).
Test Suite 'PetApiTest' passed at 2015-05-19 09:04:38 +0000.
	 Executed 6 tests, with 0 failures (0 unexpected) in 6.423 (6.426) seconds
Test Suite 'PetstoreClientTests.xctest' passed at 2015-05-19 09:04:38 +0000.
	 Executed 6 tests, with 0 failures (0 unexpected) in 6.423 (6.427) seconds
Test Suite 'All tests' passed at 2015-05-19 09:04:38 +0000.
	 Executed 6 tests, with 0 failures (0 unexpected) in 6.423 (6.429) seconds
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 31.758 s
[INFO] Finished at: 2015-05-19T17:04:38+08:00
[INFO] Final Memory: 11M/156M
[INFO] ------------------------------------------------------------------------
   ```
