### PR TITLE
Adds default settings for the generated Swagger ruby client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/swagger.mustache
@@ -28,6 +28,8 @@ module Swagger
     #
     def configure
       self.configuration ||= Configuration.new
+      self.configuration.host = '{{host}}'
+      self.configuration.base_path = '{{basePath}}'
       yield(configuration) if block_given?
 
       # Configure logger.  Default to use Rails


### PR DESCRIPTION
I was having a bit of pain when first using the generated client, though
I'm not entirely sure if this is the correct approach. I just noticed that
when trying to make API requests I needed to call `Swagger.configure` before
things would work, but then it would attempt to call the pets API instead of
my API that I had just conusmed to generate the client.

--------------

This is just something that I observed while using the generated Ruby client. I see that you can pass in a block to `Swagger.configure` though much of the work there seems counter to the reason behind generating an API client.

A concern I have with this approach is that it could result in some clobbering if an application is using multiple swagger clients. Perhaps the generated swagger clients should be name spaced to the API they are wrapping to protect against that?

I'd love to hear your thoughts.