### PR TITLE
[PHP] Add authentication support (API key, HTTP basic)

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultGenerator.java
@@ -218,6 +218,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
       bundle.put("models", allModels);
       bundle.put("apiFolder", config.apiPackage().replace('.', File.separatorChar));
       bundle.put("modelPackage", config.modelPackage());
+      bundle.put("authMethods", config.fromSecurity(swagger.getSecurityDefinitions()));
       if (swagger.getExternalDocs() != null) {
         bundle.put("externalDocs", swagger.getExternalDocs());
       }

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -84,6 +84,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
     typeMapping.put("list", "array");
 
     supportingFiles.add(new SupportingFile("composer.mustache", packagePath, "composer.json"));
+    supportingFiles.add(new SupportingFile("configuration.mustache", packagePath + "/lib", "Configuration.php"));
     supportingFiles.add(new SupportingFile("APIClient.mustache", packagePath + "/lib", "APIClient.php"));
     supportingFiles.add(new SupportingFile("APIClientException.mustache", packagePath + "/lib", "APIClientException.php"));
     supportingFiles.add(new SupportingFile("require.mustache", packagePath, invokerPackage + ".php"));

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -68,6 +68,8 @@ class APIClient {
   }
 
   /**
+   * update hearder and query param based on authentication setting
+   * 
    * @param array $headerParams
    * @param array $queryParams
    * @param array $authSettings
@@ -83,7 +85,8 @@ class APIClient {
       switch($auth) {
         {{#authMethods}}
         case '{{name}}':
-           {{#isApiKey}}{{#isKeyInHeader}}$headerParams['{{keyParamName}}'] = Configuration::$api_key;{{/isKeyInHeader}}{{#isKeyInQuery}}$queryParams['{{keyParamName}}'] = Configuration::$api_key;{{/isKeyInQuery}}{{#isBasic}}$headerParams['Authorization'] = base64_encode(Configuraiton::$username.":"Configuration::$password){{/isBasic}}{{/isApiKey}}
+           {{#isApiKey}}{{#isKeyInHeader}}$headerParams['{{keyParamName}}'] = Configuration::$apiKey['{{keyParamName}}'];{{/isKeyInHeader}}{{#isKeyInQuery}}$queryParams['{{keyParamName}}'] = Configuration::$apiKey['{{keyParamName}}'];{{/isKeyInQuery}}{{#isBasic}}$headerParams['Authorization'] = base64_encode(Configuraiton::$username.":"Configuration::$password){{/isBasic}}{{/isApiKey}}
+           {{#isOAuth}}#TODO support oauth{{/isOAuth}}
            break;
         {{/authMethods}}
       }

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -36,13 +36,14 @@ class APIClient {
   protected $user_agent = "PHP-Swagger";
 
   /**
-   * @param string $host the address of the API server
-   * @param string $headerName a header to pass on requests 
+   * @param string $host Base url of the API server (optional)
    */
-  function __construct($host, $headerName = null, $headerValue = null) {
-    $this->host = $host;
-    $this->headerName = $headerName;
-    $this->headerValue = $headerValue;
+  function __construct($host = null) {
+    if ($host == null) {
+      $this->host = '{{basePath}}';
+    } else {
+      $this->host = $host;
+    }
   }
 
   /**
@@ -124,18 +125,11 @@ class APIClient {
     # determine authentication setting
     $this->updateParamsForAuth($headerParams, $queryParams, $authSettings);
 
-    # Allow API key from $headerParams to override default
-    $added_api_key = False;
+    # construct the http header
     if ($headerParams != null) {
       foreach ($headerParams as $key => $val) {
         $headers[] = "$key: $val";
-        if ($key == $this->headerName) {
-          $added_api_key = True;
-        }
       }
-    }
-    if (! $added_api_key && $this->headerName != null) {
-      $headers[] = $this->headerName . ": " . $this->headerValue;
     }
 
     // form data

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -68,6 +68,30 @@ class APIClient {
   }
 
   /**
+   * @param array $headerParams
+   * @param array $queryParams
+   * @param array $authSettings
+   */
+  public function updateParamsForAuth(&$headerParams, &$queryParams, $authSettings)
+  {
+    if (count($authSettings) == 0)
+      return;
+
+    // one endpoint can have more than 1 auth settings
+    foreach($authSettings as $auth) {
+      // determine which one to use
+      switch($auth) {
+        {{#authMethods}}
+        case '{{name}}':
+           {{#isApiKey}}{{#isKeyInHeader}}$headerParams['{{keyParamName}}'] = Configuration::$api_key;{{/isKeyInHeader}}{{#isKeyInQuery}}$queryParams['{{keyParamName}}'] = Configuration::$api_key;{{/isKeyInQuery}}{{#isBasic}}$headerParams['Authorization'] = base64_encode(Configuraiton::$username.":"Configuration::$password){{/isBasic}}{{/isApiKey}}
+           break;
+        {{/authMethods}}
+      }
+    }
+  }
+  
+
+  /**
    * @param string $resourcePath path to method endpoint
    * @param string $method method to call
    * @param array $queryParams parameters to be place in query URL
@@ -76,7 +100,7 @@ class APIClient {
    * @return mixed
    */
   public function callAPI($resourcePath, $method, $queryParams, $postData,
-    $headerParams) {
+    $headerParams, $authSettings) {
 
     $headers = array();
 

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -68,6 +68,19 @@ class APIClient {
   }
 
   /**
+   * Get API key (with prefix if set)
+   * @param string key name
+   * @return string
+   */
+  public function getApiKeyWithPrefix($apiKey) {
+    if (Configuration::$apiKeyPrefix[$apiKey]) {
+      return Configuration::$apiKeyPrefix[$apiKey]." ".Configuration::$apiKey[$apiKey];
+    } else {
+      return Configuration::$apiKey[$apiKey];
+    }
+  }
+
+  /**
    * update hearder and query param based on authentication setting
    * 
    * @param array $headerParams
@@ -85,15 +98,16 @@ class APIClient {
       switch($auth) {
         {{#authMethods}}
         case '{{name}}':
-           {{#isApiKey}}{{#isKeyInHeader}}$headerParams['{{keyParamName}}'] = Configuration::$apiKey['{{keyParamName}}'];{{/isKeyInHeader}}{{#isKeyInQuery}}$queryParams['{{keyParamName}}'] = Configuration::$apiKey['{{keyParamName}}'];{{/isKeyInQuery}}{{#isBasic}}$headerParams['Authorization'] = base64_encode(Configuraiton::$username.":"Configuration::$password){{/isBasic}}{{/isApiKey}}
-           {{#isOAuth}}#TODO support oauth{{/isOAuth}}
-           break;
+          {{#isApiKey}}{{#isKeyInHeader}}$headerParams['{{keyParamName}}'] = $this->getApiKeyWithPrefix('{{keyParamName}}');{{/isKeyInHeader}}{{#isKeyInQuery}}$queryParams['{{keyParamName}}'] = $this->getApiKeyWithPrefix('{{keyParamName}}');{{/isKeyInQuery}}{{#isBasic}}$headerParams['Authorization'] = base64_encode(Configuraiton::$username.":"Configuration::$password){{/isBasic}}{{/isApiKey}}
+          {{#isOAuth}}//TODO support oauth{{/isOAuth}}
+          break;
         {{/authMethods}}
+        default:
+          //TODO show warning about security definition not found
       }
     }
   }
   
-
   /**
    * @param string $resourcePath path to method endpoint
    * @param string $method method to call
@@ -106,6 +120,9 @@ class APIClient {
     $headerParams, $authSettings) {
 
     $headers = array();
+
+    # determine authentication setting
+    $this->updateParamsForAuth($headerParams, $queryParams, $authSettings);
 
     # Allow API key from $headerParams to override default
     $added_api_key = False;

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -71,7 +71,7 @@ class APIClient {
   /**
    * Get API key (with prefix if set)
    * @param string key name
-   * @return string
+   * @return string API key with the prefix
    */
   public function getApiKeyWithPrefix($apiKey) {
     if (Configuration::$apiKeyPrefix[$apiKey]) {
@@ -84,9 +84,9 @@ class APIClient {
   /**
    * update hearder and query param based on authentication setting
    * 
-   * @param array $headerParams
-   * @param array $queryParams
-   * @param array $authSettings
+   * @param array $headerParams header parameters (by ref)
+   * @param array $queryParams query parameters (by ref)
+   * @param array $authSettings array of authentication scheme (e.g ['api_key'])
    */
   public function updateParamsForAuth(&$headerParams, &$queryParams, $authSettings)
   {

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -99,7 +99,7 @@ class APIClient {
       switch($auth) {
         {{#authMethods}}
         case '{{name}}':
-          {{#isApiKey}}{{#isKeyInHeader}}$headerParams['{{keyParamName}}'] = $this->getApiKeyWithPrefix('{{keyParamName}}');{{/isKeyInHeader}}{{#isKeyInQuery}}$queryParams['{{keyParamName}}'] = $this->getApiKeyWithPrefix('{{keyParamName}}');{{/isKeyInQuery}}{{#isBasic}}$headerParams['Authorization'] = base64_encode(Configuraiton::$username.":"Configuration::$password){{/isBasic}}{{/isApiKey}}
+          {{#isApiKey}}{{#isKeyInHeader}}$headerParams['{{keyParamName}}'] = $this->getApiKeyWithPrefix('{{keyParamName}}');{{/isKeyInHeader}}{{#isKeyInQuery}}$queryParams['{{keyParamName}}'] = $this->getApiKeyWithPrefix('{{keyParamName}}');{{/isKeyInQuery}}{{/isApiKey}}{{#isBasic}}$headerParams['Authorization'] = 'Basic '.base64_encode(Configuration::$username.":".Configuration::$password);{{/isBasic}}
           {{#isOAuth}}//TODO support oauth{{/isOAuth}}
           break;
         {{/authMethods}}

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -92,18 +92,20 @@ class {{classname}} {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array({{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}});
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       {{#returnType}}if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                '{{returnType}}');
-  		return $responseObject;{{/returnType}}
+      $responseObject = $this->apiClient->deserialize($response,'{{returnType}}');
+      return $responseObject;{{/returnType}}
   }
   {{/operation}}
 {{newline}}

--- a/modules/swagger-codegen/src/main/resources/php/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/configuration.mustache
@@ -1,0 +1,36 @@
+<?php
+/**
+ *  Copyright 2015 Reverb Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace {{invokerPackage}};
+
+class Configuration {
+
+  public static $PATCH = "PATCH";
+  public static $POST = "POST";
+  public static $GET = "GET";
+  public static $PUT = "PUT";
+  public static $DELETE = "DELETE";
+
+  // authentication setting
+  public static $apiKey = array();
+  public static $apiKeyPrefix = array();
+  public static $username = '';
+  public static $password = '';
+
+
+}
+

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -429,6 +429,9 @@
         "security": [
           {
             "api_key": []
+          },
+          {
+            "api_secret": []
           }
         ]
       }
@@ -801,6 +804,11 @@
       "type": "apiKey",
       "name": "api_key",
       "in": "header"
+    },
+    "api_secret": {
+      "type": "apiKey",
+      "name": "api_secret",
+      "in": "query"
     },
     "petstore_auth": {
       "type": "oauth2",

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -429,9 +429,6 @@
         "security": [
           {
             "api_key": []
-          },
-          {
-            "api_secret": []
           }
         ]
       }
@@ -804,11 +801,6 @@
       "type": "apiKey",
       "name": "api_key",
       "in": "header"
-    },
-    "api_secret": {
-      "type": "apiKey",
-      "name": "api_secret",
-      "in": "query"
     },
     "petstore_auth": {
       "type": "oauth2",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -68,6 +68,8 @@ class APIClient {
   }
 
   /**
+   * update hearder and query param based on authentication setting
+   * 
    * @param array $headerParams
    * @param array $queryParams
    * @param array $authSettings
@@ -79,16 +81,22 @@ class APIClient {
 
     // one endpoint can have more than 1 auth settings
     foreach($authSettings as $auth) {
-      // determine which auth scheme  to use
+      // determine which one to use
       switch($auth) {
         
         case 'api_key':
-           $headerParams['api_key'] = Configuration::$api_key;
+           $headerParams['api_key'] = Configuration::$apiKey['api_key'];
+           
+           break;
+        
+        case 'api_secret':
+           $queryParams['api_secret'] = Configuration::$apiKey['api_secret'];
            
            break;
         
         case 'petstore_auth':
            
+           #TODO support oauth
            break;
         
       }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -36,13 +36,14 @@ class APIClient {
   protected $user_agent = "PHP-Swagger";
 
   /**
-   * @param string $host the address of the API server
-   * @param string $headerName a header to pass on requests 
+   * @param string $host Base url of the API server (optional)
    */
-  function __construct($host, $headerName = null, $headerValue = null) {
-    $this->host = $host;
-    $this->headerName = $headerName;
-    $this->headerValue = $headerValue;
+  function __construct($host = null) {
+    if ($host == null) {
+      $this->host = 'http://petstore.swagger.io/v2';
+    } else {
+      $this->host = $host;
+    }
   }
 
   /**
@@ -134,18 +135,11 @@ class APIClient {
     # determine authentication setting
     $this->updateParamsForAuth($headerParams, $queryParams, $authSettings);
 
-    # Allow API key from $headerParams to override default
-    $added_api_key = False;
+    # construct the http header
     if ($headerParams != null) {
       foreach ($headerParams as $key => $val) {
         $headers[] = "$key: $val";
-        if ($key == $this->headerName) {
-          $added_api_key = True;
-        }
       }
-    }
-    if (! $added_api_key && $this->headerName != null) {
-      $headers[] = $this->headerName . ": " . $this->headerValue;
     }
 
     // form data

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -103,11 +103,6 @@ class APIClient {
           
           break;
         
-        case 'api_secret':
-          $queryParams['api_secret'] = $this->getApiKeyWithPrefix('api_secret');
-          
-          break;
-        
         case 'petstore_auth':
           
           //TODO support oauth

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -68,6 +68,35 @@ class APIClient {
   }
 
   /**
+   * @param array $headerParams
+   * @param array $queryParams
+   * @param array $authSettings
+   */
+  public function updateParamsForAuth(&$headerParams, &$queryParams, $authSettings)
+  {
+    if (count($authSettings) == 0)
+      return;
+
+    // one endpoint can have more than 1 auth settings
+    foreach($authSettings as $auth) {
+      // determine which auth scheme  to use
+      switch($auth) {
+        
+        case 'api_key':
+           $headerParams['api_key'] = Configuration::$api_key;
+           
+           break;
+        
+        case 'petstore_auth':
+           
+           break;
+        
+      }
+    }
+  }
+  
+
+  /**
    * @param string $resourcePath path to method endpoint
    * @param string $method method to call
    * @param array $queryParams parameters to be place in query URL
@@ -76,7 +105,7 @@ class APIClient {
    * @return mixed
    */
   public function callAPI($resourcePath, $method, $queryParams, $postData,
-    $headerParams) {
+    $headerParams, $authSettings) {
 
     $headers = array();
 
@@ -142,20 +171,21 @@ class APIClient {
     $response_info = curl_getinfo($curl);
 
     // Handle the response
-    if ($response === false) { // error, likely in the client side
-      throw new APIClientException("API Error ($url): ".curl_error($curl), 0, $response_info, $response);
+    if ($response_info['http_code'] == 0) {
+      throw new APIClientException("TIMEOUT: api call to " . $url .
+        " took more than 5s to return", 0, $response_info, $response);
     } else if ($response_info['http_code'] >= 200 && $response_info['http_code'] <= 299 ) {
       $data = json_decode($response);
       if (json_last_error() > 0) { // if response is a string
         $data = $response;
       }
-    } else if ($response_info['http_code'] == 401) { // server returns 401
+    } else if ($response_info['http_code'] == 401) {
       throw new APIClientException("Unauthorized API request to " . $url .
           ": " . serialize($response), 0, $response_info, $response);
-    } else if ($response_info['http_code'] == 404) { // server returns 404
+    } else if ($response_info['http_code'] == 404) {
       $data = null;
     } else {
-      throw new APIClientException("Can't connect to the API: " . $url .
+      throw new APIClientException("Can't connect to the api: " . $url .
         " response code: " .
         $response_info['http_code'], 0, $response_info, $response);
     }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -71,7 +71,7 @@ class APIClient {
   /**
    * Get API key (with prefix if set)
    * @param string key name
-   * @return string
+   * @return string API key with the prefix
    */
   public function getApiKeyWithPrefix($apiKey) {
     if (Configuration::$apiKeyPrefix[$apiKey]) {
@@ -84,9 +84,9 @@ class APIClient {
   /**
    * update hearder and query param based on authentication setting
    * 
-   * @param array $headerParams
-   * @param array $queryParams
-   * @param array $authSettings
+   * @param array $headerParams header parameters (by ref)
+   * @param array $queryParams query parameters (by ref)
+   * @param array $authSettings array of authentication scheme (e.g ['api_key'])
    */
   public function updateParamsForAuth(&$headerParams, &$queryParams, $authSettings)
   {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -68,6 +68,19 @@ class APIClient {
   }
 
   /**
+   * Get API key (with prefix if set)
+   * @param string key name
+   * @return string
+   */
+  public function getApiKeyWithPrefix($apiKey) {
+    if (Configuration::$apiKeyPrefix[$apiKey]) {
+      return Configuration::$apiKeyPrefix[$apiKey]." ".Configuration::$apiKey[$apiKey];
+    } else {
+      return Configuration::$apiKey[$apiKey];
+    }
+  }
+
+  /**
    * update hearder and query param based on authentication setting
    * 
    * @param array $headerParams
@@ -85,25 +98,26 @@ class APIClient {
       switch($auth) {
         
         case 'api_key':
-           $headerParams['api_key'] = Configuration::$apiKey['api_key'];
-           
-           break;
+          $headerParams['api_key'] = $this->getApiKeyWithPrefix('api_key');
+          
+          break;
         
         case 'api_secret':
-           $queryParams['api_secret'] = Configuration::$apiKey['api_secret'];
-           
-           break;
+          $queryParams['api_secret'] = $this->getApiKeyWithPrefix('api_secret');
+          
+          break;
         
         case 'petstore_auth':
-           
-           #TODO support oauth
-           break;
+          
+          //TODO support oauth
+          break;
         
+        default:
+          //TODO show warning about security definition not found
       }
     }
   }
   
-
   /**
    * @param string $resourcePath path to method endpoint
    * @param string $method method to call
@@ -116,6 +130,9 @@ class APIClient {
     $headerParams, $authSettings) {
 
     $headers = array();
+
+    # determine authentication setting
+    $this->updateParamsForAuth($headerParams, $queryParams, $authSettings);
 
     # Allow API key from $headerParams to override default
     $added_api_key = False;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ *  Copyright 2015 Reverb Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+namespace SwaggerClient;
+
+class Configuration {
+
+  public static $PATCH = "PATCH";
+  public static $POST = "POST";
+  public static $GET = "GET";
+  public static $PUT = "PUT";
+  public static $DELETE = "DELETE";
+
+  // authentication setting
+  public static $apiKey = array();
+  public static $apiKeyPrefix = array();
+  public static $username = '';
+  public static $password = '';
+
+
+}
+

--- a/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
@@ -73,10 +73,13 @@ class PetApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('petstore_auth');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -125,10 +128,13 @@ class PetApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('petstore_auth');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -176,18 +182,20 @@ class PetApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('petstore_auth');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                'array[Pet]');
-  		return $responseObject;
+      $responseObject = $this->apiClient->deserialize($response,'array[Pet]');
+      return $responseObject;
   }
   
   /**
@@ -233,18 +241,20 @@ class PetApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('petstore_auth');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                'array[Pet]');
-  		return $responseObject;
+      $responseObject = $this->apiClient->deserialize($response,'array[Pet]');
+      return $responseObject;
   }
   
   /**
@@ -296,18 +306,20 @@ class PetApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('api_key', 'petstore_auth');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                'Pet');
-  		return $responseObject;
+      $responseObject = $this->apiClient->deserialize($response,'Pet');
+      return $responseObject;
   }
   
   /**
@@ -367,10 +379,13 @@ class PetApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('petstore_auth');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -428,10 +443,13 @@ class PetApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('petstore_auth');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -493,10 +511,13 @@ class PetApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('petstore_auth');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
@@ -69,7 +69,7 @@ class StoreApi {
       }
 
       // authentication setting, if any
-      $authSettings = array('api_key');
+      $authSettings = array('api_key', 'api_secret');
 
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,

--- a/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
@@ -68,18 +68,20 @@ class StoreApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array('api_key');
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                'map[string,int]');
-  		return $responseObject;
+      $responseObject = $this->apiClient->deserialize($response,'map[string,int]');
+      return $responseObject;
   }
   
   /**
@@ -126,18 +128,20 @@ class StoreApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                'Order');
-  		return $responseObject;
+      $responseObject = $this->apiClient->deserialize($response,'Order');
+      return $responseObject;
   }
   
   /**
@@ -189,18 +193,20 @@ class StoreApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                'Order');
-  		return $responseObject;
+      $responseObject = $this->apiClient->deserialize($response,'Order');
+      return $responseObject;
   }
   
   /**
@@ -252,10 +258,13 @@ class StoreApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
@@ -69,7 +69,7 @@ class StoreApi {
       }
 
       // authentication setting, if any
-      $authSettings = array('api_key', 'api_secret');
+      $authSettings = array('api_key');
 
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,

--- a/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
@@ -73,10 +73,13 @@ class UserApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -125,10 +128,13 @@ class UserApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -177,10 +183,13 @@ class UserApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -232,18 +241,20 @@ class UserApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                'string');
-  		return $responseObject;
+      $responseObject = $this->apiClient->deserialize($response,'string');
+      return $responseObject;
   }
   
   /**
@@ -285,10 +296,13 @@ class UserApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -342,18 +356,20 @@ class UserApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       if(! $response) {
         return null;
       }
 
-  		$responseObject = $this->apiClient->deserialize($response,
-  		                                                'User');
-  		return $responseObject;
+      $responseObject = $this->apiClient->deserialize($response,'User');
+      return $responseObject;
   }
   
   /**
@@ -410,10 +426,13 @@ class UserApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }
@@ -467,10 +486,13 @@ class UserApi {
         $httpBody = $formParams;
       }
 
+      // authentication setting, if any
+      $authSettings = array();
+
       // make the API Call
       $response = $this->apiClient->callAPI($resourcePath, $method,
                                             $queryParams, $httpBody,
-                                            $headerParams);
+                                            $headerParams, $authSettings);
 
       
   }

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -31,6 +31,36 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $add_response = $pet_api->addPet($new_pet);
   }
 
+  public function testConfiguration() 
+  {
+    $api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
+    SwaggerClient\Configuration::$apiKey['api_key'] = '123456';
+    $headerParams = array('test1' => 'value1');
+    $queryParams = array('test2' => 'value2');
+    $authSettings = array('api_key', 'unknown');
+    
+    # test prefix
+    SwaggerClient\Configuration::$apiKeyPrefix['api_key'] = 'PREFIX';
+    $this->assertSame('PREFIX', SwaggerClient\Configuration::$apiKeyPrefix['api_key']);
+
+    # update parameters based on auth setting
+    $api_client->updateParamsForAuth($headerParams, $queryParams, $authSettings);
+
+    # test api key 
+    $this->assertSame($headerParams['test1'], 'value1');
+    $this->assertSame($headerParams['api_key'], 'PREFIX 123456');
+    $this->assertSame($queryParams['test2'], 'value2');
+
+    # test http basic auth
+    SwaggerClient\Configuration::$username = 'test_username';
+    SwaggerClient\Configuration::$password = 'test_password';
+    $this->assertSame('test_username', SwaggerClient\Configuration::$username);
+    $this->assertSame('test_password', SwaggerClient\Configuration::$password);
+
+
+
+  }
+
   // test getPetById with a Pet object (id 10005)
   public function testGetPetById()
   {

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -35,6 +35,7 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
   {
     $api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
     SwaggerClient\Configuration::$apiKey['api_key'] = '123456';
+
     $headerParams = array('test1' => 'value1');
     $queryParams = array('test2' => 'value2');
     $authSettings = array('api_key', 'unknown');
@@ -62,8 +63,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
   // test getPetById with a Pet object (id 10005)
   public function testGetPetById()
   {
-    // initialize the API client
-    $api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
+    // initialize the API client without host
+    $api_client = new SwaggerClient\APIClient();
     SwaggerClient\Configuration::$apiKey['api_key'] = '111222333444555';
     $pet_id = 10005;  // ID of pet that needs to be fetched
     $pet_api = new SwaggerClient\PetAPI($api_client);

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -57,8 +57,6 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $this->assertSame('test_username', SwaggerClient\Configuration::$username);
     $this->assertSame('test_password', SwaggerClient\Configuration::$password);
 
-
-
   }
 
   // test getPetById with a Pet object (id 10005)
@@ -66,6 +64,7 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
   {
     // initialize the API client
     $api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
+    SwaggerClient\Configuration::$apiKey['api_key'] = '111222333444555';
     $pet_id = 10005;  // ID of pet that needs to be fetched
     $pet_api = new SwaggerClient\PetAPI($api_client);
     // return Pet (model)


### PR DESCRIPTION
- Support API key, HTTP basic
- Add a Configuration class for authentication-related setting
- Tested with 2 API key and HTTP basic auth
- Added test case for API key authentication using getPetById
```
./vendor/bin/phpunit tests                        

PHPUnit 4.6.6 by Sebastian Bergmann and contributors.

.......

Time: 5.67 seconds, Memory: 4.50Mb

OK (7 tests, 157 assertions)
```