### PR TITLE
Pretty print for models of python client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -48,5 +48,13 @@ class {{classname}}(object):
         {{/description}}
         self.{{name}} = None # {{{datatype}}}
         {{/vars}}
+
+    def __repr__(self):
+        properties = []
+        for p in self.__dict__:
+            if p != 'swaggerTypes' and p != 'attributeMap':
+                properties.append('{prop}={val!r}'.format(prop=p, val=self.__dict__[p]))
+
+        return '<{name} {props}>'.format(name=__name__, props=' '.join(properties))
 {{/model}}
 {{/models}}

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/category.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/category.py
@@ -52,3 +52,11 @@ class Category(object):
         
         self.name = None # str
         
+
+    def __repr__(self):
+        properties = []
+        for p in self.__dict__:
+            if p != 'swaggerTypes' and p != 'attributeMap':
+                properties.append('{prop}={val!r}'.format(prop=p, val=self.__dict__[p]))
+
+        return '<{name} {props}>'.format(name=__name__, props=' '.join(properties))

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/order.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/order.py
@@ -85,3 +85,11 @@ class Order(object):
         
         self.complete = None # bool
         
+
+    def __repr__(self):
+        properties = []
+        for p in self.__dict__:
+            if p != 'swaggerTypes' and p != 'attributeMap':
+                properties.append('{prop}={val!r}'.format(prop=p, val=self.__dict__[p]))
+
+        return '<{name} {props}>'.format(name=__name__, props=' '.join(properties))

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/pet.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/pet.py
@@ -85,3 +85,11 @@ class Pet(object):
         
         self.status = None # str
         
+
+    def __repr__(self):
+        properties = []
+        for p in self.__dict__:
+            if p != 'swaggerTypes' and p != 'attributeMap':
+                properties.append('{prop}={val!r}'.format(prop=p, val=self.__dict__[p]))
+
+        return '<{name} {props}>'.format(name=__name__, props=' '.join(properties))

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/tag.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/tag.py
@@ -52,3 +52,11 @@ class Tag(object):
         
         self.name = None # str
         
+
+    def __repr__(self):
+        properties = []
+        for p in self.__dict__:
+            if p != 'swaggerTypes' and p != 'attributeMap':
+                properties.append('{prop}={val!r}'.format(prop=p, val=self.__dict__[p]))
+
+        return '<{name} {props}>'.format(name=__name__, props=' '.join(properties))

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/user.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/models/user.py
@@ -101,3 +101,11 @@ class User(object):
         
         self.user_status = None # int
         
+
+    def __repr__(self):
+        properties = []
+        for p in self.__dict__:
+            if p != 'swaggerTypes' and p != 'attributeMap':
+                properties.append('{prop}={val!r}'.format(prop=p, val=self.__dict__[p]))
+
+        return '<{name} {props}>'.format(name=__name__, props=' '.join(properties))


### PR DESCRIPTION
Normally, python will output the memory address when print object.
```sh
<__console__.A instance at 0x1047ba998>
```
Overwrite the instance method `__repr__`,  the `pprint` method will output the properties infos of the models.
```sh
>>> pprint(pet)
<SwaggerPetstore.models.pet category=<SwaggerPetstore.models.category id=1 name='dog'> status='sold' nam
e='hello kity' tags=[<SwaggerPetstore.models.tag id=1 name='green'>] photo_urls=['foobar'] id=1>
```