### PR TITLE
Return nil in Ruby clients for operations that have no response type defined

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -12,7 +12,7 @@ module {{moduleName}}
 {{#allParams}}{{#required}}    # @param {{paramName}} {{description}}
 {{/required}}{{/allParams}}    # @param [Hash] opts the optional parameters
 {{#allParams}}{{^required}}    # @option opts [{{dataType}}] :{{paramName}} {{description}}
-{{/required}}{{/allParams}}    # @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
+{{/required}}{{/allParams}}    # @return [{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}]
     def self.{{nickname}}({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
       {{#allParams}}{{#required}}
       # verify the required parameter '{{paramName}}' is set

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -51,7 +51,8 @@ module {{moduleName}}
       {{/bodyParam}}
 
       {{#returnType}}response = Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-      {{#returnContainer}}response.map {|response| {{/returnContainer}}obj = {{returnBaseType}}.new() and obj.build_from_hash(response){{#returnContainer}} }{{/returnContainer}}{{/returnType}}{{^returnType}}      Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make{{/returnType}}
+      {{#returnContainer}}response.map {|response| {{/returnContainer}}obj = {{returnBaseType}}.new() and obj.build_from_hash(response){{#returnContainer}} }{{/returnContainer}}{{/returnType}}{{^returnType}}      Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil{{/returnType}}
   end
 {{/operation}}
   end

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -51,9 +51,9 @@ module {{moduleName}}
       {{/bodyParam}}
 
       {{#returnType}}response = Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
-      {{#returnContainer}}response.map {|response| {{/returnContainer}}obj = {{returnBaseType}}.new() and obj.build_from_hash(response){{#returnContainer}} }{{/returnContainer}}{{/returnType}}{{^returnType}}      Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      {{#returnContainer}}response.map {|response| {{/returnContainer}}obj = {{returnBaseType}}.new() and obj.build_from_hash(response){{#returnContainer}} }{{/returnContainer}}{{/returnType}}{{^returnType}}Swagger::Request.new(:{{httpMethod}}, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
       nil{{/returnType}}
-  end
+    end
 {{/operation}}
   end
 {{/operations}}

--- a/samples/client/petstore/ruby/lib/swagger_client/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/swagger_client/api/pet_api.rb
@@ -9,7 +9,7 @@ module SwaggerClient
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [Pet] :body Pet object that needs to be added to the store
-    # @return void
+    # @return [nil]
     def self.update_pet(opts = {})
       
 
@@ -45,7 +45,7 @@ module SwaggerClient
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [Pet] :body Pet object that needs to be added to the store
-    # @return void
+    # @return [nil]
     def self.add_pet(opts = {})
       
 
@@ -81,7 +81,7 @@ module SwaggerClient
     # Multiple status values can be provided with comma seperated strings
     # @param [Hash] opts the optional parameters
     # @option opts [array[string]] :status Status values that need to be considered for filter
-    # @return array[Pet]
+    # @return [array[Pet]]
     def self.find_pets_by_status(opts = {})
       
 
@@ -118,7 +118,7 @@ module SwaggerClient
     # Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
     # @param [Hash] opts the optional parameters
     # @option opts [array[string]] :tags Tags to filter by
-    # @return array[Pet]
+    # @return [array[Pet]]
     def self.find_pets_by_tags(opts = {})
       
 
@@ -155,7 +155,7 @@ module SwaggerClient
     # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
     # @param pet_id ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
-    # @return Pet
+    # @return [Pet]
     def self.get_pet_by_id(pet_id, opts = {})
       
       # verify the required parameter 'pet_id' is set
@@ -196,7 +196,7 @@ module SwaggerClient
     # @param [Hash] opts the optional parameters
     # @option opts [string] :name Updated name of the pet
     # @option opts [string] :status Updated status of the pet
-    # @return void
+    # @return [nil]
     def self.update_pet_with_form(pet_id, opts = {})
       
       # verify the required parameter 'pet_id' is set
@@ -238,7 +238,7 @@ module SwaggerClient
     # @param pet_id Pet id to delete
     # @param [Hash] opts the optional parameters
     # @option opts [string] :api_key 
-    # @return void
+    # @return [nil]
     def self.delete_pet(pet_id, opts = {})
       
       # verify the required parameter 'pet_id' is set
@@ -280,7 +280,7 @@ module SwaggerClient
     # @param [Hash] opts the optional parameters
     # @option opts [string] :additional_metadata Additional data to pass to server
     # @option opts [file] :file file to upload
-    # @return void
+    # @return [nil]
     def self.upload_file(pet_id, opts = {})
       
       # verify the required parameter 'pet_id' is set

--- a/samples/client/petstore/ruby/lib/swagger_client/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/swagger_client/api/pet_api.rb
@@ -37,8 +37,9 @@ module SwaggerClient
       post_body = Swagger::Request.object_to_http_body(opts[:'body'])
       
 
-            Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # Add a new pet to the store
     # 
@@ -72,8 +73,9 @@ module SwaggerClient
       post_body = Swagger::Request.object_to_http_body(opts[:'body'])
       
 
-            Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # Finds Pets by status
     # Multiple status values can be provided with comma seperated strings
@@ -110,7 +112,7 @@ module SwaggerClient
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
       response.map {|response| obj = Pet.new() and obj.build_from_hash(response) }
-  end
+    end
 
     # Finds Pets by tags
     # Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
@@ -147,7 +149,7 @@ module SwaggerClient
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
       response.map {|response| obj = Pet.new() and obj.build_from_hash(response) }
-  end
+    end
 
     # Find pet by ID
     # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
@@ -186,7 +188,7 @@ module SwaggerClient
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
       obj = Pet.new() and obj.build_from_hash(response)
-  end
+    end
 
     # Updates a pet in the store with form data
     # 
@@ -227,8 +229,9 @@ module SwaggerClient
       post_body = nil
       
 
-            Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # Deletes a pet
     # 
@@ -267,8 +270,9 @@ module SwaggerClient
       post_body = nil
       
 
-            Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # uploads an image
     # 
@@ -309,7 +313,8 @@ module SwaggerClient
       post_body = nil
       
 
-            Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
   end
 end

--- a/samples/client/petstore/ruby/lib/swagger_client/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/swagger_client/api/store_api.rb
@@ -38,7 +38,7 @@ module SwaggerClient
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
       response.map {|response| obj = map.new() and obj.build_from_hash(response) }
-  end
+    end
 
     # Place an order for a pet
     # 
@@ -74,7 +74,7 @@ module SwaggerClient
 
       response = Swagger::Request.new(:POST, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
       obj = Order.new() and obj.build_from_hash(response)
-  end
+    end
 
     # Find purchase order by ID
     # For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
@@ -113,7 +113,7 @@ module SwaggerClient
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
       obj = Order.new() and obj.build_from_hash(response)
-  end
+    end
 
     # Delete purchase order by ID
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
@@ -150,7 +150,8 @@ module SwaggerClient
       post_body = nil
       
 
-            Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
   end
 end

--- a/samples/client/petstore/ruby/lib/swagger_client/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/swagger_client/api/store_api.rb
@@ -8,7 +8,7 @@ module SwaggerClient
     # Returns pet inventories by status
     # Returns a map of status codes to quantities
     # @param [Hash] opts the optional parameters
-    # @return map[string,int]
+    # @return [map[string,int]]
     def self.get_inventory(opts = {})
       
 
@@ -44,7 +44,7 @@ module SwaggerClient
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [Order] :body order placed for purchasing the pet
-    # @return Order
+    # @return [Order]
     def self.place_order(opts = {})
       
 
@@ -80,7 +80,7 @@ module SwaggerClient
     # For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
     # @param order_id ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
-    # @return Order
+    # @return [Order]
     def self.get_order_by_id(order_id, opts = {})
       
       # verify the required parameter 'order_id' is set
@@ -119,7 +119,7 @@ module SwaggerClient
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     # @param order_id ID of the order that needs to be deleted
     # @param [Hash] opts the optional parameters
-    # @return void
+    # @return [nil]
     def self.delete_order(order_id, opts = {})
       
       # verify the required parameter 'order_id' is set

--- a/samples/client/petstore/ruby/lib/swagger_client/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/swagger_client/api/user_api.rb
@@ -9,7 +9,7 @@ module SwaggerClient
     # This can only be done by the logged in user.
     # @param [Hash] opts the optional parameters
     # @option opts [User] :body Created user object
-    # @return void
+    # @return [nil]
     def self.create_user(opts = {})
       
 
@@ -45,7 +45,7 @@ module SwaggerClient
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [array[User]] :body List of user object
-    # @return void
+    # @return [nil]
     def self.create_users_with_array_input(opts = {})
       
 
@@ -81,7 +81,7 @@ module SwaggerClient
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [array[User]] :body List of user object
-    # @return void
+    # @return [nil]
     def self.create_users_with_list_input(opts = {})
       
 
@@ -118,7 +118,7 @@ module SwaggerClient
     # @param [Hash] opts the optional parameters
     # @option opts [string] :username The user name for login
     # @option opts [string] :password The password for login in clear text
-    # @return string
+    # @return [string]
     def self.login_user(opts = {})
       
 
@@ -155,7 +155,7 @@ module SwaggerClient
     # Logs out current logged in user session
     # 
     # @param [Hash] opts the optional parameters
-    # @return void
+    # @return [nil]
     def self.logout_user(opts = {})
       
 
@@ -191,7 +191,7 @@ module SwaggerClient
     # 
     # @param username The name that needs to be fetched. Use user1 for testing. 
     # @param [Hash] opts the optional parameters
-    # @return User
+    # @return [User]
     def self.get_user_by_name(username, opts = {})
       
       # verify the required parameter 'username' is set
@@ -231,7 +231,7 @@ module SwaggerClient
     # @param username name that need to be deleted
     # @param [Hash] opts the optional parameters
     # @option opts [User] :body Updated user object
-    # @return void
+    # @return [nil]
     def self.update_user(username, opts = {})
       
       # verify the required parameter 'username' is set
@@ -270,7 +270,7 @@ module SwaggerClient
     # This can only be done by the logged in user.
     # @param username The name that needs to be deleted
     # @param [Hash] opts the optional parameters
-    # @return void
+    # @return [nil]
     def self.delete_user(username, opts = {})
       
       # verify the required parameter 'username' is set

--- a/samples/client/petstore/ruby/lib/swagger_client/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/swagger_client/api/user_api.rb
@@ -37,8 +37,9 @@ module SwaggerClient
       post_body = Swagger::Request.object_to_http_body(opts[:'body'])
       
 
-            Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # Creates list of users with given input array
     # 
@@ -72,8 +73,9 @@ module SwaggerClient
       post_body = Swagger::Request.object_to_http_body(opts[:'body'])
       
 
-            Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # Creates list of users with given input array
     # 
@@ -107,8 +109,9 @@ module SwaggerClient
       post_body = Swagger::Request.object_to_http_body(opts[:'body'])
       
 
-            Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:POST, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # Logs user into the system
     # 
@@ -147,7 +150,7 @@ module SwaggerClient
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
       obj = string.new() and obj.build_from_hash(response)
-  end
+    end
 
     # Logs out current logged in user session
     # 
@@ -180,8 +183,9 @@ module SwaggerClient
       post_body = nil
       
 
-            Swagger::Request.new(:GET, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:GET, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # Get user by user name
     # 
@@ -220,7 +224,7 @@ module SwaggerClient
 
       response = Swagger::Request.new(:GET, path, {:params => query_params, :headers => header_params, :form_params => form_params, :body => post_body}).make.body
       obj = User.new() and obj.build_from_hash(response)
-  end
+    end
 
     # Updated user
     # This can only be done by the logged in user.
@@ -258,8 +262,9 @@ module SwaggerClient
       post_body = Swagger::Request.object_to_http_body(opts[:'body'])
       
 
-            Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:PUT, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
 
     # Delete user
     # This can only be done by the logged in user.
@@ -296,7 +301,8 @@ module SwaggerClient
       post_body = nil
       
 
-            Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
-  end
+      Swagger::Request.new(:DELETE, path, {:params => query_params,:headers => header_params, :form_params => form_params, :body => post_body}).make
+      nil
+    end
   end
 end

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -75,7 +75,9 @@ describe "Pet" do
 
     it "should create a pet" do
       pet = SwaggerClient::Pet.new('id' => 10002, 'name' => "RUBY UNIT TESTING")
-      SwaggerClient::PetApi.add_pet(:body => pet)
+      result = SwaggerClient::PetApi.add_pet(:body => pet)
+      # nothing is returned
+      result.should be_nil
 
       pet = SwaggerClient::PetApi.get_pet_by_id(10002)
       pet.id.should == 10002


### PR DESCRIPTION
Currently a `Swagger::Response` object is returned for operations that have no response type defined (since the `Swagger::Request.new(...).make` is the last statement), which might be confusing.
This PR changes it to return `nil` explicitly.