### PR TITLE
Adds isPrimitiveType flag to CodegenParameter.

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/CodegenParameter.java
@@ -2,7 +2,8 @@ package com.wordnik.swagger.codegen;
 
 public class CodegenParameter {
   public Boolean isFormParam, isQueryParam, isPathParam, isHeaderParam,
-    isCookieParam, isBodyParam, isFile, notFile, hasMore, isContainer, secondaryParam;
+    isCookieParam, isBodyParam, isFile, notFile, hasMore, isContainer, secondaryParam,
+    isPrimitiveType, notPrimitiveType;
   public String baseName, paramName, dataType, collectionFormat, description, baseType;
   public String jsonSchema;
 
@@ -34,6 +35,8 @@ public class CodegenParameter {
     output.isBodyParam = this.isBodyParam;
     output.required = this.required;
     output.jsonSchema = this.jsonSchema;
+    output.isPrimitiveType = this.isPrimitiveType;
+    output.notPrimitiveType = this.notPrimitiveType;
 
     return output;
   }

--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -928,6 +928,8 @@ public class DefaultCodegen {
       CodegenProperty model = fromProperty(qp.getName(), property);
       p.collectionFormat = collectionFormat;
       p.dataType = model.datatype;
+      p.isPrimitiveType = languageSpecificPrimitives.contains(p.dataType);
+      p.notPrimitiveType = !p.isPrimitiveType;
       p.paramName = toParamName(qp.getName());
 
       if(model.complexType != null) {


### PR DESCRIPTION
This is required in some languages like Obj-C where there is no automatic value boxing and
handling of primitive types require extra work compared to non-primitive types.

Case in point: `BOOL` type. To assign `BOOL` into a dictionary, one needs to box it into an
`NSValue *` instance, so to build a dictionary for sending form data, for example, you
cannot do this in the template:

    dict["{{paramName}}"] = {{paramName}};

Because if the parameter ends up being of type `BOOL`, an error about boxing values will be
generated:

    BOOL boolValue = NO;
    dict["boolValue"] = boolValue;
                        ^---------------- Cannot do the assignment here.

The fix is to wrap it in `@()` like so:

    BOOL boolValue = NO;
    dict["boolValue"] = @(boolValue);

So a flag is needed in `CodegenParameter` so we can selectively emit the right boxing or
non-boxing assignment in the templates where needed.