### PR TITLE
[C#] Fix "object' type for response

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/CSharpClientCodegen.java
@@ -83,6 +83,7 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
     typeMapping.put("file", "string"); // path to file
     typeMapping.put("array", "List");
     typeMapping.put("map", "Dictionary");
+    typeMapping.put("object", "Object");
 
   }
 

--- a/modules/swagger-codegen/src/main/resources/csharp/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/apiInvoker.mustache
@@ -53,10 +53,13 @@ namespace {{invokerPackage}} {
     /// <param name="json"> JSON string
     /// <param name="type"> Object type
     /// <returns>Object representation of the JSON string</returns>
-    public static object Deserialize(string json, Type type) {
+    public static object Deserialize(string content, Type type) {
+      if (type.GetType() == typeof(Object))
+        return (Object)content;
+
       try
       {
-          return JsonConvert.DeserializeObject(json, type);
+          return JsonConvert.DeserializeObject(content, type);
       }
       catch (IOException e) {
         throw new ApiException(500, e.Message);

--- a/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiInvoker.cs
+++ b/samples/client/petstore/csharp/src/main/csharp/io/swagger/client/ApiInvoker.cs
@@ -53,10 +53,13 @@ namespace IO.Swagger.Client {
     /// <param name="json"> JSON string
     /// <param name="type"> Object type
     /// <returns>Object representation of the JSON string</returns>
-    public static object Deserialize(string json, Type type) {
+    public static object Deserialize(string content, Type type) {
+      if (type.GetType() == typeof(Object))
+        return (Object)content;
+
       try
       {
-          return JsonConvert.DeserializeObject(json, type);
+          return JsonConvert.DeserializeObject(content, type);
       }
       catch (IOException e) {
         throw new ApiException(500, e.Message);


### PR DESCRIPTION
To address #730 

Tested with type set to `object` with and without $ref