### PR TITLE
[PHP] Fix warning/error related to PHP5.3

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -41,7 +41,7 @@ class APIClient {
    * @param string $host Base url of the API server (optional)
    */
   function __construct($host = null) {
-    if ($host == null) {
+    if ($host === null) {
       $this->host = '{{basePath}}';
     } else {
       $this->host = $host;
@@ -107,10 +107,12 @@ class APIClient {
    * @return string API key with the prefix
    */
   public function getApiKeyWithPrefix($apiKey) {
-    if (Configuration::$apiKeyPrefix[$apiKey]) {
+    if (isset(Configuration::$apiKeyPrefix[$apiKey])) {
       return Configuration::$apiKeyPrefix[$apiKey]." ".Configuration::$apiKey[$apiKey];
-    } else {
+    } else if (isset(Configuration::$apiKey[$apiKey])) {
       return Configuration::$apiKey[$apiKey];
+    } else {
+      return;
     }
   }
 
@@ -368,7 +370,7 @@ class APIClient {
       $instance = new $class();
       foreach ($instance::$swaggerTypes as $property => $type) {
         $original_property_name = $instance::$attributeMap[$property];
-        if (isset($original_property_name)) {
+        if (isset($original_property_name) && isset($data->$original_property_name)) {
           $instance->$property = self::deserialize($data->$original_property_name, $type);
         }
       }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -41,7 +41,7 @@ class APIClient {
    * @param string $host Base url of the API server (optional)
    */
   function __construct($host = null) {
-    if ($host == null) {
+    if ($host === null) {
       $this->host = 'http://petstore.swagger.io/v2';
     } else {
       $this->host = $host;
@@ -107,10 +107,12 @@ class APIClient {
    * @return string API key with the prefix
    */
   public function getApiKeyWithPrefix($apiKey) {
-    if (Configuration::$apiKeyPrefix[$apiKey]) {
+    if (isset(Configuration::$apiKeyPrefix[$apiKey])) {
       return Configuration::$apiKeyPrefix[$apiKey]." ".Configuration::$apiKey[$apiKey];
-    } else {
+    } else if (isset(Configuration::$apiKey[$apiKey])) {
       return Configuration::$apiKey[$apiKey];
+    } else {
+      return;
     }
   }
 
@@ -373,7 +375,7 @@ class APIClient {
       $instance = new $class();
       foreach ($instance::$swaggerTypes as $property => $type) {
         $original_property_name = $instance::$attributeMap[$property];
-        if (isset($original_property_name)) {
+        if (isset($original_property_name) && isset($data->$original_property_name)) {
           $instance->$property = self::deserialize($data->$original_property_name, $type);
         }
       }

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -23,7 +23,7 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $category->id = $new_pet_id; // use the same id as pet
     $category->name = "test php category";
 
-    $new_pet->tags = [$tag];
+    $new_pet->tags = array($tag);
     $new_pet->category = $category;
 
     $pet_api = new SwaggerClient\PetAPI($api_client);
@@ -47,12 +47,14 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     # test addDefaultHeader and getDefaultHeader
     SwaggerClient\APIClient::addDefaultHeader('test1', 'value1');
     SwaggerClient\APIClient::addDefaultHeader('test2', 200);
-    $this->assertSame('value1', SwaggerClient\APIClient::getDefaultHeader()['test1']);
-    $this->assertSame(200, SwaggerClient\APIClient::getDefaultHeader()['test2']);
+    $defaultHeader = SwaggerClient\APIClient::getDefaultHeader();
+    $this->assertSame('value1', $defaultHeader['test1']);
+    $this->assertSame(200, $defaultHeader['test2']);
 
     # test deleteDefaultHeader
     SwaggerClient\APIClient::deleteDefaultHeader('test2');
-    $this->assertFalse(isset(SwaggerClient\APIClient::getDefaultHeader()['test2']));
+    $defaultHeader = SwaggerClient\APIClient::getDefaultHeader();
+    $this->assertFalse(isset($defaultHeader['test2']));
 
   }
 


### PR DESCRIPTION
Currently, test cases failed with PHP5.3 but not PHP5.5 

This PR will address the issue to allow test cases run without issue using PHP5.3

The change has been tested with both PHP5.3 and PHP5.5:
```
SwaggerClient-php|php53_fix_warning ⇒ php -v                                             
PHP 5.5.20 (cli) (built: Feb 25 2015 23:30:53) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
SwaggerClient-php|php53_fix_warning ⇒  ./vendor/bin/phpunit tests                        

PHPUnit 4.6.6 by Sebastian Bergmann and contributors.

.......

Time: 6.65 seconds, Memory: 4.50Mb

OK (7 tests, 157 assertions)
```

```
➜  SwaggerClient-php git:(php53_fix_warning) ✗ php -v
PHP 5.3.10-1ubuntu3.14 with Suhosin-Patch (cli) (built: Sep  4 2014 07:08:49) 
Copyright (c) 1997-2012 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2012 Zend Technologies
➜  SwaggerClient-php git:(php53_fix_warning) ./vendor/bin/phpunit tests       

PHPUnit 4.6.6 by Sebastian Bergmann and contributors.

.......

Time: 7.31 seconds, Memory: 8.50Mb

OK (7 tests, 157 assertions)
```

