### PR TITLE
[PHP] Make API client more pluggable

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -92,14 +92,35 @@ class APIClient {
   }
 
   /**
-   *  @param integer $seconds Number of seconds before timing out [set to 0 for no timeout]
+   * get the user agent of the api client
+   * 
+   * @return string user agent
+   */
+  public function getUserAgent($user_agent) {
+    return $this->user_agent;
+  }
+
+  /**
+   * set the HTTP timeout value
+   *
+   * @param integer $seconds Number of seconds before timing out [set to 0 for no timeout]
    */
   public function setTimeout($seconds) {
-    if (!is_numeric($seconds))
-      throw new \InvalidArgumentException('Timeout variable must be numeric.');
+    if (!is_numeric($seconds) || $seconds < 0)
+      throw new \InvalidArgumentException('Timeout value must be numeric and a non-negative number.');
 
     $this->curl_timeout = $seconds;
   }
+
+  /**
+   * get the HTTP timeout value
+   *
+   * @return string HTTP timeout value
+   */
+  public function getTimeout() {
+    return $this->curl_timeout;
+  }
+
 
   /**
    * Get API key (with prefix if set)

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -25,8 +25,17 @@ namespace {{invokerPackage}};
 {{#operations}}
 class {{classname}} {
 
-  function __construct($apiClient) {
-    $this->apiClient = $apiClient;
+  function __construct($apiClient = null) {
+    if (null === $apiClient) {
+      if (Configuration::$apiClient === null) {
+        Configuration::$apiClient = new APIClient(); // create a new API client if not present
+        $this->apiClient = Configuration::$apiClient;
+      }
+      else
+        $this->apiClient = Configuration::$apiClient; // use the default one
+    } else {
+      $this->apiClient = $apiClient; // use the one provided by the user
+    }
   }
 
   {{#operation}}

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -38,6 +38,22 @@ class {{classname}} {
     }
   }
 
+  private $apiClient; // instance of the APIClient
+
+  /**
+   * get the API client
+   */
+  public function getApiClient() {
+    return $this->apiClient;
+  }
+
+  /**
+   * set the API client
+   */
+  public function setApiClient($apiClient) {
+    $this->apiClient = $apiClient;
+  }
+
   {{#operation}}
   /**
    * {{{nickname}}}

--- a/modules/swagger-codegen/src/main/resources/php/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/configuration.mustache
@@ -31,6 +31,16 @@ class Configuration {
   public static $username = '';
   public static $password = '';
 
+  // an instance of APIClient
+  public static $apiClient;
+
+ /*
+  *  manually initalize  API client
+  */
+  public static function init() {
+    if (self::$apiClient === null)
+      self::$apiClient = new APIClient();
+  }
 
 }
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -92,14 +92,35 @@ class APIClient {
   }
 
   /**
-   *  @param integer $seconds Number of seconds before timing out [set to 0 for no timeout]
+   * get the user agent of the api client
+   * 
+   * @return string user agent
+   */
+  public function getUserAgent($user_agent) {
+    return $this->user_agent;
+  }
+
+  /**
+   * set the HTTP timeout value
+   *
+   * @param integer $seconds Number of seconds before timing out [set to 0 for no timeout]
    */
   public function setTimeout($seconds) {
-    if (!is_numeric($seconds))
-      throw new \InvalidArgumentException('Timeout variable must be numeric.');
+    if (!is_numeric($seconds) || $seconds < 0)
+      throw new \InvalidArgumentException('Timeout value must be numeric and a non-negative number.');
 
     $this->curl_timeout = $seconds;
   }
+
+  /**
+   * get the HTTP timeout value
+   *
+   * @return string HTTP timeout value
+   */
+  public function getTimeout() {
+    return $this->curl_timeout;
+  }
+
 
   /**
    * Get API key (with prefix if set)

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
@@ -31,6 +31,16 @@ class Configuration {
   public static $username = '';
   public static $password = '';
 
+  // an instance of APIClient
+  public static $apiClient;
+
+ /*
+  *  manually initalize  API client
+  */
+  public static function init() {
+    if (self::$apiClient === null)
+      self::$apiClient = new APIClient();
+  }
 
 }
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
@@ -24,11 +24,37 @@ namespace SwaggerClient;
 
 class PetApi {
 
-  function __construct($apiClient) {
-    $this->apiClient = $apiClient;
+
+  function __construct($apiClient = null) {
+    if (null === $apiClient) {
+      if (Configuration::$apiClient === null) {
+        Configuration::$apiClient = new APIClient(); // create a new API client if not present
+        $this->apiClient = Configuration::$apiClient;
+      }
+      else
+        $this->apiClient = Configuration::$apiClient; // use the default one
+    } else {
+      $this->apiClient = $apiClient; // use the one provided by the user
+    }
   }
 
   
+  private $apiClient;
+
+  /**
+   * get the API client
+   */
+  public function getApiClient() {
+    return $this->apiClient;
+  }
+
+  /**
+   * set the API client
+   */
+  public function getApiClient($apiClient) {
+    $this->apiClient = $apiClient;
+  }
+
   /**
    * updatePet
    *

--- a/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/PetApi.php
@@ -24,7 +24,6 @@ namespace SwaggerClient;
 
 class PetApi {
 
-
   function __construct($apiClient = null) {
     if (null === $apiClient) {
       if (Configuration::$apiClient === null) {
@@ -38,8 +37,7 @@ class PetApi {
     }
   }
 
-  
-  private $apiClient;
+  private $apiClient; // instance of the APIClient
 
   /**
    * get the API client
@@ -51,10 +49,11 @@ class PetApi {
   /**
    * set the API client
    */
-  public function getApiClient($apiClient) {
+  public function setApiClient($apiClient) {
     $this->apiClient = $apiClient;
   }
 
+  
   /**
    * updatePet
    *

--- a/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
@@ -37,6 +37,22 @@ class StoreApi {
     }
   }
 
+  private $apiClient; // instance of the APIClient
+
+  /**
+   * get the API client
+   */
+  public function getApiClient() {
+    return $this->apiClient;
+  }
+
+  /**
+   * set the API client
+   */
+  public function setApiClient($apiClient) {
+    $this->apiClient = $apiClient;
+  }
+
   
   /**
    * getInventory

--- a/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/StoreApi.php
@@ -24,8 +24,17 @@ namespace SwaggerClient;
 
 class StoreApi {
 
-  function __construct($apiClient) {
-    $this->apiClient = $apiClient;
+  function __construct($apiClient = null) {
+    if (null === $apiClient) {
+      if (Configuration::$apiClient === null) {
+        Configuration::$apiClient = new APIClient(); // create a new API client if not present
+        $this->apiClient = Configuration::$apiClient;
+      }
+      else
+        $this->apiClient = Configuration::$apiClient; // use the default one
+    } else {
+      $this->apiClient = $apiClient; // use the one provided by the user
+    }
   }
 
   

--- a/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
@@ -37,6 +37,22 @@ class UserApi {
     }
   }
 
+  private $apiClient; // instance of the APIClient
+
+  /**
+   * get the API client
+   */
+  public function getApiClient() {
+    return $this->apiClient;
+  }
+
+  /**
+   * set the API client
+   */
+  public function setApiClient($apiClient) {
+    $this->apiClient = $apiClient;
+  }
+
   
   /**
    * createUser

--- a/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/UserApi.php
@@ -24,8 +24,17 @@ namespace SwaggerClient;
 
 class UserApi {
 
-  function __construct($apiClient) {
-    $this->apiClient = $apiClient;
+  function __construct($apiClient = null) {
+    if (null === $apiClient) {
+      if (Configuration::$apiClient === null) {
+        Configuration::$apiClient = new APIClient(); // create a new API client if not present
+        $this->apiClient = Configuration::$apiClient;
+      }
+      else
+        $this->apiClient = Configuration::$apiClient; // use the default one
+    } else {
+      $this->apiClient = $apiClient; // use the one provided by the user
+    }
   }
 
   

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -7,8 +7,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
 
   // add a new pet (id 10005) to ensure the pet object is available for all the tests
   public static function setUpBeforeClass() {
-    // initialize the API client
-    $api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
+    // skip initializing the API client as it should be automatic
+    //$api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
     // new pet
     $new_pet_id = 10005;
     $new_pet = new SwaggerClient\models\Pet;
@@ -26,7 +26,7 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $new_pet->tags = [$tag];
     $new_pet->category = $category;
 
-    $pet_api = new SwaggerClient\PetAPI($api_client);
+    $pet_api = new SwaggerClient\PetAPI();
     // add a new pet (model)
     $add_response = $pet_api->addPet($new_pet);
   }
@@ -34,25 +34,48 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
   // test static functions defined in APIClient
   public function testAPIClient()
   { 
-    # test selectHeaderAccept
+    // test selectHeaderAccept
     $this->assertSame('application/json', SwaggerClient\APIClient::selectHeaderAccept(array('application/xml','application/json')));
     $this->assertSame(NULL, SwaggerClient\APIClient::selectHeaderAccept(array()));
     $this->assertSame('application/yaml,application/xml', SwaggerClient\APIClient::selectHeaderAccept(array('application/yaml','application/xml')));
    
-    # test selectHeaderContentType
+    // test selectHeaderContentType
     $this->assertSame('application/json', SwaggerClient\APIClient::selectHeaderContentType(array('application/xml','application/json')));
     $this->assertSame('application/json', SwaggerClient\APIClient::selectHeaderContentType(array()));
     $this->assertSame('application/yaml,application/xml', SwaggerClient\APIClient::selectHeaderContentType(array('application/yaml','application/xml')));
 
-    # test addDefaultHeader and getDefaultHeader
+    // test addDefaultHeader and getDefaultHeader
     SwaggerClient\APIClient::addDefaultHeader('test1', 'value1');
     SwaggerClient\APIClient::addDefaultHeader('test2', 200);
     $this->assertSame('value1', SwaggerClient\APIClient::getDefaultHeader()['test1']);
     $this->assertSame(200, SwaggerClient\APIClient::getDefaultHeader()['test2']);
 
-    # test deleteDefaultHeader
+    // test deleteDefaultHeader
     SwaggerClient\APIClient::deleteDefaultHeader('test2');
     $this->assertFalse(isset(SwaggerClient\APIClient::getDefaultHeader()['test2']));
+
+    $pet_api = new SwaggerClient\PetAPI();
+    $pet_api2 = new SwaggerClient\PetAPI();
+    $apiClient3 = new SwaggerClient\APIClient();
+    $apiClient3->setUserAgent = 'api client 3';
+    $apiClient4 = new SwaggerClient\APIClient();
+    $apiClient4->setUserAgent = 'api client 4';
+    $pet_api3 = new SwaggerClient\PetAPI($apiClient3);
+
+    // same default api client
+    $this->assertSame($pet_api->getApiClient(), $pet_api2->getApiClient());
+    // confirm using the default api client in the Configuration
+    $this->assertSame($pet_api->getApiClient(), SwaggerClient\Configuration::$apiClient);
+    // 2 different api clients are not the same 
+    $this->assertNotEquals($apiClient3, $apiClient4);
+    // customized pet api not using the default (configuration) api client
+    $this->assertNotEquals($pet_api3->getApiClient(), SwaggerClient\Configuration::$apiClient);
+    // customied pet api not using the old pet api's api client
+    $this->assertNotEquals($pet_api2->getApiClient(), $pet_api3->getApiClient());
+
+    // both pet api and pet api2 share the same api client and confirm using timeout value
+    $pet_api->getApiClient()->setTimeout(999);
+    $this->assertSame(999, $pet_api2->getApiClient()->getTimeout());
 
   }
 

--- a/samples/client/petstore/php/test.php
+++ b/samples/client/petstore/php/test.php
@@ -3,12 +3,13 @@
 require_once('SwaggerClient-php/SwaggerClient.php');
 
 // initialize the API client
-$api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
-$api_client->addDefaultHeader("test1", "value1");
+//$api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
+//$api_client->addDefaultHeader("test1", "value1");
 
 $petId = 10005; // ID of pet that needs to be fetched
 try {
-    $pet_api = new SwaggerClient\PetAPI($api_client);
+    //$pet_api = new SwaggerClient\PetAPI($api_client);
+    $pet_api = new SwaggerClient\PetAPI();
     // return Pet (model)
     $response = $pet_api->getPetById($petId);
     var_dump($response);


### PR DESCRIPTION
This PR will allow developers to easily customize APIClient and use it to initialize the API class (e.g. PetApi)

It also allows developers to skip the initialization of a new APIClient as the API class (e.g. PetApi) will automatically construct a new default API client if no client has been initialized). For example, the following line becomes optional:
```
$api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
```