### PR TITLE
[Python] Make API client more pluggable

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PythonClientCodegen.java
@@ -71,6 +71,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
     supportingFiles.add(new SupportingFile("swagger.mustache", invokerPackage, "swagger.py"));
     supportingFiles.add(new SupportingFile("rest.mustache", invokerPackage, "rest.py"));
     supportingFiles.add(new SupportingFile("util.mustache", invokerPackage, "util.py"));
+    supportingFiles.add(new SupportingFile("config.mustache", invokerPackage, "config.py"));
     supportingFiles.add(new SupportingFile("__init__package.mustache", invokerPackage, "__init__.py"));
     supportingFiles.add(new SupportingFile("__init__model.mustache", modelPackage.replace('.', File.separatorChar), "__init__.py"));
     supportingFiles.add(new SupportingFile("__init__api.mustache", apiPackage.replace('.', File.separatorChar), "__init__.py"));

--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -29,8 +29,6 @@ from six import iteritems
 
 from ..util import remove_none
 
-from ..swagger import ApiClient
-
 from .. import config
 
 {{#operations}}
@@ -76,12 +74,12 @@ class {{classname}}(object):
         body_params = {{#bodyParam}}params.get('{{paramName}}'){{/bodyParam}}{{^bodyParam}}None{{/bodyParam}}
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept([{{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}])
+        header_params['Accept'] = self.api_client.select_header_accept([{{#produces}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([{{#consumes}}'{{mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,

--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -31,11 +31,16 @@ from ..util import remove_none
 
 from ..swagger import ApiClient
 
+from .. import config
+
 {{#operations}}
 class {{classname}}(object):
 
-    def __init__(self, api_client):
-        self.api_client = api_client
+    def __init__(self, api_client=None):
+        if api_client:
+            self.api_client = api_client
+        else:
+            self.api_client = config.api_client
     {{#operation}}
     def {{nickname}}(self, {{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}**kwargs):
         """

--- a/modules/swagger-codegen/src/main/resources/python/config.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/config.mustache
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+from .swagger import ApiClient
+
+# Configuration variables
+
+api_client = ApiClient("{{basePath}}")
+

--- a/modules/swagger-codegen/src/main/resources/python/swagger.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/swagger.mustache
@@ -66,28 +66,28 @@ class ApiClient(object):
     if self.cookie:
       headers['Cookie'] = self.cookie
     if headers:
-      headers = ApiClient.sanitize_for_serialization(headers)
+      headers = self.sanitize_for_serialization(headers)
 
     # path parameters
     if path_params:
-      path_params = ApiClient.sanitize_for_serialization(path_params)
+      path_params = self.sanitize_for_serialization(path_params)
       for k, v in iteritems(path_params):
         replacement = quote(str(self.to_path_value(v)))
         resource_path = resource_path.replace('{' + k + '}', replacement)
 
     # query parameters
     if query_params:
-      query_params = ApiClient.sanitize_for_serialization(query_params)
+      query_params = self.sanitize_for_serialization(query_params)
       query_params = {k: self.to_path_value(v) for k, v in iteritems(query_params)}
 
     # post parameters
     if post_params:
       post_params = self.prepare_post_parameters(post_params, files)
-      post_params = ApiClient.sanitize_for_serialization(post_params)
+      post_params = self.sanitize_for_serialization(post_params)
 
     # body
     if body:
-      body = ApiClient.sanitize_for_serialization(body)
+      body = self.sanitize_for_serialization(body)
 
     # request url
     url = self.host + resource_path
@@ -115,8 +115,7 @@ class ApiClient(object):
     else:
       return str(obj)
 
-  @staticmethod
-  def sanitize_for_serialization(obj):
+  def sanitize_for_serialization(self, obj):
     """
     Sanitize an object for Request.
 
@@ -132,7 +131,7 @@ class ApiClient(object):
     elif isinstance(obj, (str, int, float, bool, tuple)):
       return obj
     elif isinstance(obj, list):
-      return [ApiClient.sanitize_for_serialization(sub_obj) for sub_obj in obj]
+      return [self.sanitize_for_serialization(sub_obj) for sub_obj in obj]
     elif isinstance(obj, (datetime.datetime, datetime.date)):
       return obj.isoformat()
     else:
@@ -145,7 +144,7 @@ class ApiClient(object):
         obj_dict = {obj.attribute_map[key]: val
                     for key, val in iteritems(obj.__dict__)
                     if key != 'swagger_types' and key != 'attribute_map' and val is not None}
-      return {key: ApiClient.sanitize_for_serialization(val)
+      return {key: self.sanitize_for_serialization(val)
               for key, val in iteritems(obj_dict)}
 
   def deserialize(self, obj, obj_class):
@@ -253,8 +252,7 @@ class ApiClient(object):
 
     return params
 
-  @staticmethod
-  def select_header_accept(accepts):
+  def select_header_accept(self, accepts):
     """
     Return `Accept` based on an array of accepts provided
     """
@@ -268,8 +266,7 @@ class ApiClient(object):
     else:
       return ', '.join(accepts)
 
-  @staticmethod
-  def select_header_content_type(content_types):
+  def select_header_content_type(self, content_types):
     """
     Return `Content-Type` baseed on an array of content_types provided
     """

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/pet_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/pet_api.py
@@ -31,10 +31,15 @@ from ..util import remove_none
 
 from ..swagger import ApiClient
 
+from .. import config
+
 class PetApi(object):
 
-    def __init__(self, api_client):
-        self.api_client = api_client
+    def __init__(self, api_client=None):
+        if api_client:
+            self.api_client = api_client
+        else:
+            self.api_client = config.api_client
     
     def update_pet(self, **kwargs):
         """

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/pet_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/pet_api.py
@@ -29,8 +29,6 @@ from six import iteritems
 
 from ..util import remove_none
 
-from ..swagger import ApiClient
-
 from .. import config
 
 class PetApi(object):
@@ -71,12 +69,12 @@ class PetApi(object):
         body_params = params.get('body')
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type(['application/json', 'application/xml'])
+        header_params['Content-Type'] = self.api_client.select_header_content_type(['application/json', 'application/xml'])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -112,12 +110,12 @@ class PetApi(object):
         body_params = params.get('body')
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type(['application/json', 'application/xml'])
+        header_params['Content-Type'] = self.api_client.select_header_content_type(['application/json', 'application/xml'])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -153,12 +151,12 @@ class PetApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -196,12 +194,12 @@ class PetApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -243,12 +241,12 @@ class PetApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -292,12 +290,12 @@ class PetApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type(['application/x-www-form-urlencoded'])
+        header_params['Content-Type'] = self.api_client.select_header_content_type(['application/x-www-form-urlencoded'])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -338,12 +336,12 @@ class PetApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -385,12 +383,12 @@ class PetApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type(['multipart/form-data'])
+        header_params['Content-Type'] = self.api_client.select_header_content_type(['multipart/form-data'])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/store_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/store_api.py
@@ -31,10 +31,15 @@ from ..util import remove_none
 
 from ..swagger import ApiClient
 
+from .. import config
+
 class StoreApi(object):
 
-    def __init__(self, api_client):
-        self.api_client = api_client
+    def __init__(self, api_client=None):
+        if api_client:
+            self.api_client = api_client
+        else:
+            self.api_client = config.api_client
     
     def get_inventory(self, **kwargs):
         """

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/store_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/store_api.py
@@ -29,8 +29,6 @@ from six import iteritems
 
 from ..util import remove_none
 
-from ..swagger import ApiClient
-
 from .. import config
 
 class StoreApi(object):
@@ -70,12 +68,12 @@ class StoreApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -113,12 +111,12 @@ class StoreApi(object):
         body_params = params.get('body')
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -160,12 +158,12 @@ class StoreApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -207,12 +205,12 @@ class StoreApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/user_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/user_api.py
@@ -29,8 +29,6 @@ from six import iteritems
 
 from ..util import remove_none
 
-from ..swagger import ApiClient
-
 from .. import config
 
 class UserApi(object):
@@ -71,12 +69,12 @@ class UserApi(object):
         body_params = params.get('body')
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -112,12 +110,12 @@ class UserApi(object):
         body_params = params.get('body')
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -153,12 +151,12 @@ class UserApi(object):
         body_params = params.get('body')
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -195,12 +193,12 @@ class UserApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -237,12 +235,12 @@ class UserApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -282,12 +280,12 @@ class UserApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -330,12 +328,12 @@ class UserApi(object):
         body_params = params.get('body')
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,
@@ -375,12 +373,12 @@ class UserApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = ApiClient.select_header_accept(['application/json', 'application/xml'])
+        header_params['Accept'] = self.api_client.select_header_accept(['application/json', 'application/xml'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = ApiClient.select_header_content_type([])
+        header_params['Content-Type'] = self.api_client.select_header_content_type([])
 
         response = self.api_client.call_api(resource_path, method, path_params, query_params, header_params,
                                             body=body_params, post_params=form_params, files=files,

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/user_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/apis/user_api.py
@@ -31,10 +31,15 @@ from ..util import remove_none
 
 from ..swagger import ApiClient
 
+from .. import config
+
 class UserApi(object):
 
-    def __init__(self, api_client):
-        self.api_client = api_client
+    def __init__(self, api_client=None):
+        if api_client:
+            self.api_client = api_client
+        else:
+            self.api_client = config.api_client
     
     def create_user(self, **kwargs):
         """

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/config.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/config.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+from .swagger import ApiClient
+
+# Configuration variables
+
+api_client = ApiClient("http://petstore.swagger.io/v2")
+

--- a/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/swagger.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/SwaggerPetstore/swagger.py
@@ -66,28 +66,28 @@ class ApiClient(object):
     if self.cookie:
       headers['Cookie'] = self.cookie
     if headers:
-      headers = ApiClient.sanitize_for_serialization(headers)
+      headers = self.sanitize_for_serialization(headers)
 
     # path parameters
     if path_params:
-      path_params = ApiClient.sanitize_for_serialization(path_params)
+      path_params = self.sanitize_for_serialization(path_params)
       for k, v in iteritems(path_params):
         replacement = quote(str(self.to_path_value(v)))
         resource_path = resource_path.replace('{' + k + '}', replacement)
 
     # query parameters
     if query_params:
-      query_params = ApiClient.sanitize_for_serialization(query_params)
+      query_params = self.sanitize_for_serialization(query_params)
       query_params = {k: self.to_path_value(v) for k, v in iteritems(query_params)}
 
     # post parameters
     if post_params:
       post_params = self.prepare_post_parameters(post_params, files)
-      post_params = ApiClient.sanitize_for_serialization(post_params)
+      post_params = self.sanitize_for_serialization(post_params)
 
     # body
     if body:
-      body = ApiClient.sanitize_for_serialization(body)
+      body = self.sanitize_for_serialization(body)
 
     # request url
     url = self.host + resource_path
@@ -115,8 +115,7 @@ class ApiClient(object):
     else:
       return str(obj)
 
-  @staticmethod
-  def sanitize_for_serialization(obj):
+  def sanitize_for_serialization(self, obj):
     """
     Sanitize an object for Request.
 
@@ -132,7 +131,7 @@ class ApiClient(object):
     elif isinstance(obj, (str, int, float, bool, tuple)):
       return obj
     elif isinstance(obj, list):
-      return [ApiClient.sanitize_for_serialization(sub_obj) for sub_obj in obj]
+      return [self.sanitize_for_serialization(sub_obj) for sub_obj in obj]
     elif isinstance(obj, (datetime.datetime, datetime.date)):
       return obj.isoformat()
     else:
@@ -145,7 +144,7 @@ class ApiClient(object):
         obj_dict = {obj.attribute_map[key]: val
                     for key, val in iteritems(obj.__dict__)
                     if key != 'swagger_types' and key != 'attribute_map' and val is not None}
-      return {key: ApiClient.sanitize_for_serialization(val)
+      return {key: self.sanitize_for_serialization(val)
               for key, val in iteritems(obj_dict)}
 
   def deserialize(self, obj, obj_class):
@@ -253,8 +252,7 @@ class ApiClient(object):
 
     return params
 
-  @staticmethod
-  def select_header_accept(accepts):
+  def select_header_accept(self, accepts):
     """
     Return `Accept` based on an array of accepts provided
     """
@@ -268,8 +266,7 @@ class ApiClient(object):
     else:
       return ', '.join(accepts)
 
-  @staticmethod
-  def select_header_content_type(content_types):
+  def select_header_content_type(self, content_types):
     """
     Return `Content-Type` baseed on an array of content_types provided
     """

--- a/samples/client/petstore/python/SwaggerPetstore-python/tests/test_api_client.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/tests/test_api_client.py
@@ -23,44 +23,42 @@ class ApiClientTests(unittest.TestCase):
 
     def test_select_header_accept(self):
         accepts = ['APPLICATION/JSON', 'APPLICATION/XML']
-        accept = SwaggerPetstore.ApiClient.select_header_accept(accepts)
+        accept = self.api_client.select_header_accept(accepts)
         self.assertEqual(accept, 'application/json')
         
         accepts = ['application/json', 'application/xml']
-        accept = SwaggerPetstore.ApiClient.select_header_accept(accepts)
+        accept = self.api_client.select_header_accept(accepts)
         self.assertEqual(accept, 'application/json')
 
         accepts = ['application/xml', 'application/json']
-        accept = SwaggerPetstore.ApiClient.select_header_accept(accepts)
+        accept = self.api_client.select_header_accept(accepts)
         self.assertEqual(accept, 'application/json')
 
         accepts = ['text/plain', 'application/xml']
-        accept = SwaggerPetstore.ApiClient.select_header_accept(accepts)
+        accept = self.api_client.select_header_accept(accepts)
         self.assertEqual(accept, 'text/plain, application/xml')
 
         accepts = []
-        accept = SwaggerPetstore.ApiClient.select_header_accept(accepts)
+        accept = self.api_client.select_header_accept(accepts)
         self.assertEqual(accept, None)
 
     def test_select_header_content_type(self):
         content_types = ['APPLICATION/JSON', 'APPLICATION/XML']
-        content_type = SwaggerPetstore.ApiClient.select_header_content_type(content_types)
+        content_type = self.api_client.select_header_content_type(content_types)
         self.assertEqual(content_type, 'application/json')
         
         content_types = ['application/json', 'application/xml']
-        content_type = SwaggerPetstore.ApiClient.select_header_content_type(content_types)
+        content_type = self.api_client.select_header_content_type(content_types)
         self.assertEqual(content_type, 'application/json')
         
         content_types = ['application/xml', 'application/json']
-        content_type = SwaggerPetstore.ApiClient.select_header_content_type(content_types)
+        content_type = self.api_client.select_header_content_type(content_types)
         self.assertEqual(content_type, 'application/json')
         
         content_types = ['text/plain', 'application/xml']
-        content_type = SwaggerPetstore.ApiClient.select_header_content_type(content_types)
+        content_type = self.api_client.select_header_content_type(content_types)
         self.assertEqual(content_type, 'text/plain')
         
         content_types = []
-        content_type = SwaggerPetstore.ApiClient.select_header_content_type(content_types)
+        content_type = self.api_client.select_header_content_type(content_types)
         self.assertEqual(content_type, 'application/json')
-        
-

--- a/samples/client/petstore/python/SwaggerPetstore-python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/SwaggerPetstore-python/tests/test_pet_api.py
@@ -13,6 +13,7 @@ import unittest
 
 import SwaggerPetstore
 from SwaggerPetstore.rest import ErrorResponse
+from SwaggerPetstore import config
 
 HOST = 'http://petstore.swagger.io/v2'
 
@@ -48,6 +49,26 @@ class PetApiTests(unittest.TestCase):
         self.test_file_dir = os.path.join(os.path.dirname(__file__), "..", "testfiles")
         self.test_file_dir = os.path.realpath(self.test_file_dir)
         self.foo = os.path.join(self.test_file_dir, "foo.png")
+
+    def test_create_api_instance(self):
+        pet_api = SwaggerPetstore.PetApi()
+        pet_api2 = SwaggerPetstore.PetApi()
+        api_client3 = SwaggerPetstore.ApiClient()
+        api_client3.user_agent = 'api client 3'
+        api_client4 = SwaggerPetstore.ApiClient()
+        api_client4.user_agent = 'api client 4'
+        pet_api3 = SwaggerPetstore.PetApi(api_client3)
+
+        # same default api client
+        self.assertEqual(pet_api.api_client, pet_api2.api_client)
+        # confirm using the default api client in the config module
+        self.assertEqual(pet_api.api_client, config.api_client)
+        # 2 different api clients are not the same
+        self.assertNotEqual(api_client3, api_client4)
+        # customized pet api not using the default api client
+        self.assertNotEqual(pet_api3.api_client, config.api_client)
+        # customized pet api not using the old pet api's api client
+        self.assertNotEqual(pet_api3.api_client, pet_api2.api_client)
 
     def test_add_pet_and_get_pet_by_id(self):
         self.pet_api.add_pet(body=self.pet)


### PR DESCRIPTION
* Allows developers to easily customize APIClient and use it to initialize the API class (e.g. PetApi)

* Allows developers to skip the initialization of a new APIClient as the API class (e.g. PetApi) will automatically construct a new default API client if no client has been initialized). For example, the following line becomes optional:

    ```python
    api_client = SwaggerPetstore.APIClient('http://petstore.swagger.io/v2')
    ```

* Tested without issue
  ```sh
  [INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 26.713 s
[INFO] Finished at: 2015-05-25T14:45:45+08:00
[INFO] Final Memory: 11M/156M
[INFO] ------------------------------------------------------------------------
  ```