### PR TITLE
Make objc client more pluggable

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/SWGApiClient.m
+++ b/modules/swagger-codegen/src/main/resources/objc/SWGApiClient.m
@@ -134,10 +134,12 @@ static bool loggingEnabled = true;
 }
 
 +(NSNumber*) nextRequestId {
-    long nextId = ++requestId;
-    if(loggingEnabled)
-        NSLog(@"got id %ld", nextId);
-    return [NSNumber numberWithLong:nextId];
+    @synchronized(self) {
+        long nextId = ++requestId;
+        if(loggingEnabled)
+            NSLog(@"got id %ld", nextId);
+        return [NSNumber numberWithLong:nextId];
+    }
 }
 
 +(NSNumber*) queueRequest {

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -2,7 +2,6 @@
 #import "{{classname}}.h"
 #import "SWGFile.h"
 #import "SWGQueryParamCollection.h"
-#import "SWGApiClient.h"
 {{#imports}}#import "{{import}}.h"
 {{/imports}}
 {{newline}}
@@ -12,7 +11,33 @@
 @end
 
 @implementation {{classname}}
+
 static NSString * basePath = @"{{basePath}}";
+
+#pragma mark - Initialize methods
+
+- (id) init {
+    self = [super init];
+    if (self) {
+        self.apiClient = [SWGApiClient sharedClientFromPool:basePath];
+        self.defaultHeaders = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (id) initWithApiClient:(SWGApiClient *)apiClient {
+    self = [super init];
+    if (self) {
+        if (apiClient) {
+            self.apiClient = apiClient;
+        }
+        else {
+            self.apiClient = [SWGApiClient sharedClientFromPool:basePath];
+        }
+        self.defaultHeaders = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
 
 +({{classname}}*) apiWithHeader:(NSString*)headerValue key:(NSString*)key {
     static {{classname}}* singletonAPI = nil;
@@ -32,19 +57,8 @@ static NSString * basePath = @"{{basePath}}";
     return basePath;
 }
 
--(SWGApiClient*) apiClient {
-    return [SWGApiClient sharedClientFromPool:basePath];
-}
-
 -(void) addHeader:(NSString*)value forKey:(NSString*)key {
     [self.defaultHeaders setValue:value forKey:key];
-}
-
--(id) init {
-    self = [super init];
-    self.defaultHeaders = [NSMutableDictionary dictionary];
-    [self apiClient];
-    return self;
 }
 
 -(void) setHeaderValue:(NSString*) value
@@ -177,8 +191,6 @@ static NSString * basePath = @"{{basePath}}";
     {{/requiredParams}}
     {{/requiredParamCount}}
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     {{#returnContainer}}
     // response is in a container
     {{>apiBodyResponseWithContainer}}{{/returnContainer}}
@@ -206,3 +218,6 @@ static NSString * basePath = @"{{basePath}}";
 {{newline}}
 {{/operations}}
 @end
+
+
+

--- a/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
@@ -2,10 +2,13 @@
 {{#imports}}#import "{{import}}.h"
 {{/imports}}
 #import "SWGObject.h"
+#import "SWGApiClient.h"
 {{newline}}
 
 {{#operations}}
 @interface {{classname}}: NSObject
+
+@property(nonatomic, assign)SWGApiClient *apiClient;
 
 -(void) addHeader:(NSString*)value forKey:(NSString*)key;
 -(unsigned long) requestQueueSize;

--- a/modules/swagger-codegen/src/main/resources/objc/apiBodyResponseWithContainer.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/apiBodyResponseWithContainer.mustache
@@ -1,5 +1,5 @@
     // {{returnContainer}} container response type
-    return [client dictionary: requestUrl 
+    return [self.apiClient dictionary: requestUrl 
                        method: @"{{httpMethod}}" 
                   queryParams: queryParams 
                          body: bodyDictionary 

--- a/modules/swagger-codegen/src/main/resources/objc/apiNonPrimitiveResponse.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/apiNonPrimitiveResponse.mustache
@@ -1,6 +1,6 @@
     {{^returnTypeIsPrimitive}}
     // comples response type
-    return [client dictionary: requestUrl
+    return [self.apiClient dictionary: requestUrl
                        method: @"{{httpMethod}}"
                   queryParams: queryParams
                          body: bodyDictionary

--- a/modules/swagger-codegen/src/main/resources/objc/apiPrimitiveResponse.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/apiPrimitiveResponse.mustache
@@ -1,5 +1,5 @@
         // primitive response type
-    {{#returnBaseType}}return [client stringWithCompletionBlock: requestUrl 
+    {{#returnBaseType}}return [self.apiClient stringWithCompletionBlock: requestUrl 
                                               method: @"{{httpMethod}}" 
                                          queryParams: queryParams 
                                                 body: bodyDictionary 
@@ -17,7 +17,7 @@
     {{/returnBaseType}}
     {{^returnBaseType}}
     // no return base type
-    return [client stringWithCompletionBlock: requestUrl 
+    return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"{{httpMethod}}" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 

--- a/modules/swagger-codegen/src/main/resources/objc/voidResponse.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/voidResponse.mustache
@@ -1,4 +1,4 @@
-    return [client stringWithCompletionBlock: requestUrl 
+    return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"{{httpMethod}}" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 

--- a/samples/client/petstore/objc/PetstoreClient/PetstoreClientTests/PetApiTest.m
+++ b/samples/client/petstore/objc/PetstoreClient/PetstoreClientTests/PetApiTest.m
@@ -12,6 +12,16 @@
     [super tearDown];
 }
 
+- (void)testCreatePetApi {
+    SWGPetApi *api1 = [[SWGPetApi alloc] init];
+    SWGPetApi *api2 = [[SWGPetApi alloc] init];
+    XCTAssertEqual(api1.apiClient, api2.apiClient);
+    
+    SWGApiClient *client = [[SWGApiClient alloc] init];
+    SWGPetApi *api3 = [[SWGPetApi alloc] initWithApiClient:client];
+    XCTAssertNotEqual(api1.apiClient, api3.apiClient);
+}
+
 - (void)testCreateAndGetPet {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testGetPetById"];
     SWGPet* pet = [self createPet];

--- a/samples/client/petstore/objc/client/SWGApiClient.m
+++ b/samples/client/petstore/objc/client/SWGApiClient.m
@@ -134,10 +134,12 @@ static bool loggingEnabled = true;
 }
 
 +(NSNumber*) nextRequestId {
-    long nextId = ++requestId;
-    if(loggingEnabled)
-        NSLog(@"got id %ld", nextId);
-    return [NSNumber numberWithLong:nextId];
+    @synchronized(self) {
+        long nextId = ++requestId;
+        if(loggingEnabled)
+            NSLog(@"got id %ld", nextId);
+        return [NSNumber numberWithLong:nextId];
+    }
 }
 
 +(NSNumber*) queueRequest {

--- a/samples/client/petstore/objc/client/SWGPetApi.h
+++ b/samples/client/petstore/objc/client/SWGPetApi.h
@@ -2,10 +2,14 @@
 #import "SWGPet.h"
 #import "SWGFile.h"
 #import "SWGObject.h"
+#import "SWGApiClient.h"
 
 
 @interface SWGPetApi: NSObject
 
+@property(nonatomic, assign)SWGApiClient *apiClient;
+
+-(instancetype) initWithApiClient:(SWGApiClient *)apiClient;
 -(void) addHeader:(NSString*)value forKey:(NSString*)key;
 -(unsigned long) requestQueueSize;
 +(SWGPetApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key;

--- a/samples/client/petstore/objc/client/SWGPetApi.m
+++ b/samples/client/petstore/objc/client/SWGPetApi.m
@@ -1,7 +1,6 @@
 #import "SWGPetApi.h"
 #import "SWGFile.h"
 #import "SWGQueryParamCollection.h"
-#import "SWGApiClient.h"
 #import "SWGPet.h"
 #import "SWGFile.h"
 
@@ -11,7 +10,33 @@
 @end
 
 @implementation SWGPetApi
+
 static NSString * basePath = @"http://petstore.swagger.io/v2";
+
+#pragma mark - Initialize methods
+
+- (id) init {
+    self = [super init];
+    if (self) {
+        self.apiClient = [SWGApiClient sharedClientFromPool:basePath];
+        self.defaultHeaders = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (id) initWithApiClient:(SWGApiClient *)apiClient {
+    self = [super init];
+    if (self) {
+        if (apiClient) {
+            self.apiClient = apiClient;
+        }
+        else {
+            self.apiClient = [SWGApiClient sharedClientFromPool:basePath];
+        }
+        self.defaultHeaders = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
 
 +(SWGPetApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key {
     static SWGPetApi* singletonAPI = nil;
@@ -31,19 +56,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     return basePath;
 }
 
--(SWGApiClient*) apiClient {
-    return [SWGApiClient sharedClientFromPool:basePath];
-}
-
 -(void) addHeader:(NSString*)value forKey:(NSString*)key {
     [self.defaultHeaders setValue:value forKey:key];
-}
-
--(id) init {
-    self = [super init];
-    self.defaultHeaders = [NSMutableDictionary dictionary];
-    [self apiClient];
-    return self;
 }
 
 -(void) setHeaderValue:(NSString*) value
@@ -135,15 +149,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"PUT" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -240,15 +252,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"POST" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -328,12 +338,10 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
     // response is in a container
         // array container response type
-    return [client dictionary: requestUrl 
+    return [self.apiClient dictionary: requestUrl 
                        method: @"GET" 
                   queryParams: queryParams 
                          body: bodyDictionary 
@@ -361,6 +369,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
                 
             }];
     
+
 
     
 
@@ -429,12 +438,10 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
     // response is in a container
         // array container response type
-    return [client dictionary: requestUrl 
+    return [self.apiClient dictionary: requestUrl 
                        method: @"GET" 
                   queryParams: queryParams 
                          body: bodyDictionary 
@@ -462,6 +469,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
                 
             }];
     
+
 
     
 
@@ -528,8 +536,6 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
@@ -541,7 +547,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     // complex response
         
     // comples response type
-    return [client dictionary: requestUrl
+    return [self.apiClient dictionary: requestUrl
                        method: @"GET"
                   queryParams: queryParams
                          body: bodyDictionary
@@ -648,15 +654,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"POST" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -738,15 +742,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"DELETE" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -851,15 +853,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"POST" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -880,3 +880,6 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
 
 @end
+
+
+

--- a/samples/client/petstore/objc/client/SWGStoreApi.h
+++ b/samples/client/petstore/objc/client/SWGStoreApi.h
@@ -1,9 +1,12 @@
 #import <Foundation/Foundation.h>
 #import "SWGOrder.h"
 #import "SWGObject.h"
+#import "SWGApiClient.h"
 
 
 @interface SWGStoreApi: NSObject
+
+@property(nonatomic, assign)SWGApiClient *apiClient;
 
 -(void) addHeader:(NSString*)value forKey:(NSString*)key;
 -(unsigned long) requestQueueSize;

--- a/samples/client/petstore/objc/client/SWGStoreApi.m
+++ b/samples/client/petstore/objc/client/SWGStoreApi.m
@@ -1,7 +1,6 @@
 #import "SWGStoreApi.h"
 #import "SWGFile.h"
 #import "SWGQueryParamCollection.h"
-#import "SWGApiClient.h"
 #import "SWGOrder.h"
 
 
@@ -10,7 +9,33 @@
 @end
 
 @implementation SWGStoreApi
+
 static NSString * basePath = @"http://petstore.swagger.io/v2";
+
+#pragma mark - Initialize methods
+
+- (id) init {
+    self = [super init];
+    if (self) {
+        self.apiClient = [SWGApiClient sharedClientFromPool:basePath];
+        self.defaultHeaders = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (id) initWithApiClient:(SWGApiClient *)apiClient {
+    self = [super init];
+    if (self) {
+        if (apiClient) {
+            self.apiClient = apiClient;
+        }
+        else {
+            self.apiClient = [SWGApiClient sharedClientFromPool:basePath];
+        }
+        self.defaultHeaders = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
 
 +(SWGStoreApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key {
     static SWGStoreApi* singletonAPI = nil;
@@ -30,19 +55,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     return basePath;
 }
 
--(SWGApiClient*) apiClient {
-    return [SWGApiClient sharedClientFromPool:basePath];
-}
-
 -(void) addHeader:(NSString*)value forKey:(NSString*)key {
     [self.defaultHeaders setValue:value forKey:key];
-}
-
--(id) init {
-    self = [super init];
-    self.defaultHeaders = [NSMutableDictionary dictionary];
-    [self apiClient];
-    return self;
 }
 
 -(void) setHeaderValue:(NSString*) value
@@ -109,12 +123,10 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
     // response is in a container
         // map container response type
-    return [client dictionary: requestUrl 
+    return [self.apiClient dictionary: requestUrl 
                        method: @"GET" 
                   queryParams: queryParams 
                          body: bodyDictionary 
@@ -135,6 +147,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
                 
             }];
     
+
 
     
 
@@ -220,8 +233,6 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
@@ -233,7 +244,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     // complex response
         
     // comples response type
-    return [client dictionary: requestUrl
+    return [self.apiClient dictionary: requestUrl
                        method: @"POST"
                   queryParams: queryParams
                          body: bodyDictionary
@@ -320,8 +331,6 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
@@ -333,7 +342,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     // complex response
         
     // comples response type
-    return [client dictionary: requestUrl
+    return [self.apiClient dictionary: requestUrl
                        method: @"GET"
                   queryParams: queryParams
                          body: bodyDictionary
@@ -420,15 +429,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"DELETE" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -449,3 +456,6 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
 
 @end
+
+
+

--- a/samples/client/petstore/objc/client/SWGUserApi.h
+++ b/samples/client/petstore/objc/client/SWGUserApi.h
@@ -1,9 +1,12 @@
 #import <Foundation/Foundation.h>
 #import "SWGUser.h"
 #import "SWGObject.h"
+#import "SWGApiClient.h"
 
 
 @interface SWGUserApi: NSObject
+
+@property(nonatomic, assign)SWGApiClient *apiClient;
 
 -(void) addHeader:(NSString*)value forKey:(NSString*)key;
 -(unsigned long) requestQueueSize;

--- a/samples/client/petstore/objc/client/SWGUserApi.m
+++ b/samples/client/petstore/objc/client/SWGUserApi.m
@@ -1,7 +1,6 @@
 #import "SWGUserApi.h"
 #import "SWGFile.h"
 #import "SWGQueryParamCollection.h"
-#import "SWGApiClient.h"
 #import "SWGUser.h"
 
 
@@ -10,7 +9,33 @@
 @end
 
 @implementation SWGUserApi
+
 static NSString * basePath = @"http://petstore.swagger.io/v2";
+
+#pragma mark - Initialize methods
+
+- (id) init {
+    self = [super init];
+    if (self) {
+        self.apiClient = [SWGApiClient sharedClientFromPool:basePath];
+        self.defaultHeaders = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (id) initWithApiClient:(SWGApiClient *)apiClient {
+    self = [super init];
+    if (self) {
+        if (apiClient) {
+            self.apiClient = apiClient;
+        }
+        else {
+            self.apiClient = [SWGApiClient sharedClientFromPool:basePath];
+        }
+        self.defaultHeaders = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
 
 +(SWGUserApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key {
     static SWGUserApi* singletonAPI = nil;
@@ -30,19 +55,8 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     return basePath;
 }
 
--(SWGApiClient*) apiClient {
-    return [SWGApiClient sharedClientFromPool:basePath];
-}
-
 -(void) addHeader:(NSString*)value forKey:(NSString*)key {
     [self.defaultHeaders setValue:value forKey:key];
-}
-
--(id) init {
-    self = [super init];
-    self.defaultHeaders = [NSMutableDictionary dictionary];
-    [self apiClient];
-    return self;
 }
 
 -(void) setHeaderValue:(NSString*) value
@@ -134,15 +148,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"POST" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -239,15 +251,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"POST" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -344,15 +354,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"POST" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -436,8 +444,6 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
@@ -446,7 +452,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     
     // primitive response
             // primitive response type
-    return [client stringWithCompletionBlock: requestUrl 
+    return [self.apiClient stringWithCompletionBlock: requestUrl 
                                               method: @"GET" 
                                          queryParams: queryParams 
                                                 body: bodyDictionary 
@@ -464,6 +470,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     
     
     
+
 
     
     // complex response
@@ -528,15 +535,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"GET" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -614,8 +619,6 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
@@ -627,7 +630,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
     // complex response
         
     // comples response type
-    return [client dictionary: requestUrl
+    return [self.apiClient dictionary: requestUrl
                        method: @"GET"
                   queryParams: queryParams
                          body: bodyDictionary
@@ -739,15 +742,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"PUT" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -825,15 +826,13 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
     
 
-    SWGApiClient* client = [SWGApiClient sharedClientFromPool:basePath];
-
     
 
     
 
     
     // it's void
-        return [client stringWithCompletionBlock: requestUrl 
+        return [self.apiClient stringWithCompletionBlock: requestUrl 
                                       method: @"DELETE" 
                                  queryParams: queryParams 
                                         body: bodyDictionary 
@@ -854,3 +853,6 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 
 
 @end
+
+
+


### PR DESCRIPTION
Allows developers to easily customize APIClient and use it to initialize the API class (e.g. PetApi)

If the user passes the `apiClient` when initialize the `PetApi`:
```objc
SWGPetApi *api = [[SWGPetApi alloc] initWithApiClient: apiClient];
```
will set the `apiClient` to be the customized ApiClient `apiClient`.

If the use doesn't pass `apiClient` when initialize `PetApi`:
```objc
SWGPetApi *api = [[SWGPetApi alloc] init];
```
will get the `apiClient` instance from the pool.

Tested without issue:
```sh
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 48.675 s
[INFO] Finished at: 2015-05-26T17:58:01+08:00
[INFO] Final Memory: 11M/156M
[INFO] ------------------------------------------------------------------------
```