### PR TITLE
Removing comment (// do some magic!) that is no longer necessary and …

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
@@ -44,7 +44,6 @@ public class {{classname}}  {
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
     {{/hasMore}}{{/allParams}})
     throws NotFoundException {
-    // do some magic!
     return delegate.{{nickname}}({{#allParams}}{{#isFile}}fileDetail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}},{{/hasMore}}{{/allParams}});
     }
 {{/operation}}


### PR DESCRIPTION
…confusing.  After olensmar refactor of jax-rs codegen, magic/implementation should be placed in the delegate/implementation as opposed to the api itself.  Any logic put in api itself will be overwritten with the next code gen, whereas the delegate implemenation will remain intact.