### PR TITLE
Add support for handling ComposedModel 

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/DefaultCodegen.java
@@ -451,8 +451,24 @@ public class DefaultCodegen {
     else if (model instanceof RefModel) {
       // TODO
     }
+    else if (model instanceof ComposedModel) {
+      ModelImpl derrived = (ModelImpl) ((ComposedModel)model).getChild();
+      processModelImpl(name, derrived, m, count);
+      String reference = ((RefModel)((ComposedModel)model).getParent()).getSimpleRef();
+      if (reference != null && reference.length()>0) {
+        int i = reference.lastIndexOf("/");
+        m.parent = reference.substring(i+1);
+      }
+    }
     else {
-      ModelImpl impl = (ModelImpl) model;
+      processModelImpl(name, model, m, count);
+    }
+      
+    return m;
+  }
+
+  private void processModelImpl(String name, Model model, CodegenModel m, int count) {
+	  ModelImpl impl = (ModelImpl) model;
       if(impl.getAdditionalProperties() != null) {
         MapProperty mapProperty = new MapProperty(impl.getAdditionalProperties());
         CodegenProperty cp = fromProperty(name, mapProperty);
@@ -522,10 +538,8 @@ public class DefaultCodegen {
       else {
         m.emptyVars = true;
       }
-    }
-    return m;
   }
-
+  
   public String getterAndSetterCapitalize(String name) {
     if (name == null || name.length() == 0) {
       return name;


### PR DESCRIPTION
If the swagger spec file contains allOf model composition the codegenerator would fail with a class cast exception. This commit fixes the issue.