### PR TITLE
[PHP] Added support for object, removed null in serialized JSON string

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -82,6 +82,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
     typeMapping.put("map", "map");
     typeMapping.put("array", "array");
     typeMapping.put("list", "array");
+    typeMapping.put("object", "object");
 
     supportingFiles.add(new SupportingFile("composer.mustache", packagePath, "composer.json"));
     supportingFiles.add(new SupportingFile("configuration.mustache", packagePath + "/lib", "Configuration.php"));

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -182,7 +182,7 @@ class APIClient {
     $this->updateParamsForAuth($headerParams, $queryParams, $authSettings);
 
     # construct the http header
-    if ($headerParams != null) {
+    if ($headerParams !== null) {
       # add default header
       $headerParams = array_merge((array)self::$default_header, $headerParams);
 

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -278,7 +278,9 @@ class APIClient {
     } else if (is_object($data)) {
       $values = array();
       foreach (array_keys($data::$swaggerTypes) as $property) {
-        $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$property);
+        if ($data->$property !== null) {
+          $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$property);
+        }
       }
       $sanitized = $values;
     } else {
@@ -383,7 +385,7 @@ class APIClient {
       $deserialized = $values;
     } elseif ($class == 'DateTime') {
       $deserialized = new \DateTime($data);
-    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool'))) {
+    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'object'))) {
       settype($data, $class);
       $deserialized = $data;
     } else {

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -182,13 +182,10 @@ class APIClient {
     $this->updateParamsForAuth($headerParams, $queryParams, $authSettings);
 
     # construct the http header
-    if ($headerParams !== null) {
-      # add default header
-      $headerParams = array_merge((array)self::$default_header, $headerParams);
+    $headerParams = array_merge((array)self::$default_header, (array)$headerParams);
 
-      foreach ($headerParams as $key => $val) {
-        $headers[] = "$key: $val";
-      }
+    foreach ($headerParams as $key => $val) {
+      $headers[] = "$key: $val";
     }
 
     // form data

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -187,13 +187,10 @@ class APIClient {
     $this->updateParamsForAuth($headerParams, $queryParams, $authSettings);
 
     # construct the http header
-    if ($headerParams != null) {
-      # add default header
-      $headerParams = array_merge((array)self::$default_header, $headerParams);
+    $headerParams = array_merge((array)self::$default_header, (array)$headerParams);
 
-      foreach ($headerParams as $key => $val) {
-        $headers[] = "$key: $val";
-      }
+    foreach ($headerParams as $key => $val) {
+      $headers[] = "$key: $val";
     }
 
     // form data
@@ -390,7 +387,7 @@ class APIClient {
       $deserialized = $values;
     } elseif ($class == 'DateTime') {
       $deserialized = new \DateTime($data);
-    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool'))) {
+    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'object'))) {
       settype($data, $class);
       $deserialized = $data;
     } else {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/APIClient.php
@@ -283,7 +283,9 @@ class APIClient {
     } else if (is_object($data)) {
       $values = array();
       foreach (array_keys($data::$swaggerTypes) as $property) {
-        $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$property);
+        if ($data->$property !== null) {
+          $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$property);
+        }
       }
       $sanitized = $values;
     } else {

--- a/samples/client/petstore/php/test.php
+++ b/samples/client/petstore/php/test.php
@@ -2,6 +2,8 @@
 //require_once('vendor/autoload.php');
 require_once('SwaggerClient-php/SwaggerClient.php');
 
+$c = array_merge((array)$a, (array)$b);
+
 // initialize the API client
 //$api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
 //$api_client->addDefaultHeader("test1", "value1");
@@ -11,6 +13,8 @@ try {
     // get pet by id
     //$pet_api = new SwaggerClient\PetAPI($api_client);
     $pet_api = new SwaggerClient\PetAPI();
+    // test default header
+    $pet_api->getApiClient()->addDefaultHeader("TEST_API_KEY", "09182sdkanafndsl903");
     // return Pet (model)
     $response = $pet_api->getPetById($petId);
     var_dump($response);

--- a/samples/client/petstore/php/test.php
+++ b/samples/client/petstore/php/test.php
@@ -8,13 +8,37 @@ require_once('SwaggerClient-php/SwaggerClient.php');
 
 $petId = 10005; // ID of pet that needs to be fetched
 try {
+    // get pet by id
     //$pet_api = new SwaggerClient\PetAPI($api_client);
     $pet_api = new SwaggerClient\PetAPI();
     // return Pet (model)
     $response = $pet_api->getPetById($petId);
     var_dump($response);
+
+    // add pet (post json)
+    $new_pet_id = 10005;
+    $new_pet = new SwaggerClient\models\Pet;
+    $new_pet->id = $new_pet_id;
+    $new_pet->name = "PHP Unit Test";
+    // new tag
+    $tag= new SwaggerClient\models\Tag;
+    $tag->id = $new_pet_id; // use the same id as pet
+    //$tag->name = "test php tag";
+    // new category
+    $category = new SwaggerClient\models\Category;
+    $category->id = 0; // use the same id as pet
+    //$category->name = "test php category";
+
+    $new_pet->tags = array($tag);
+    $new_pet->category = $category;
+
+    $pet_api = new SwaggerClient\PetAPI();
+    // add a new pet (model)
+    $add_response = $pet_api->addPet($new_pet);
+
 } catch (Exception $e) {
     echo 'Caught exception: ', $e->getMessage(), "\n";
 }
+
 
 ?>

--- a/samples/client/petstore/php/test.php
+++ b/samples/client/petstore/php/test.php
@@ -2,8 +2,6 @@
 //require_once('vendor/autoload.php');
 require_once('SwaggerClient-php/SwaggerClient.php');
 
-$c = array_merge((array)$a, (array)$b);
-
 // initialize the API client
 //$api_client = new SwaggerClient\APIClient('http://petstore.swagger.io/v2');
 //$api_client->addDefaultHeader("test1", "value1");


### PR DESCRIPTION
- Added support for Object (currently, response set to object would result in error)
- Removed null elements in the serialised JSON string
- Fixed default header in API client