### PR TITLE
[Android] Enabling cli config options for android generator

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/AndroidClientCodegen.java
@@ -47,26 +47,6 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
         "native", "super", "while")
     );
 
-    additionalProperties.put("invokerPackage", invokerPackage);
-    additionalProperties.put("groupId", groupId);
-    additionalProperties.put("artifactId", artifactId);
-    additionalProperties.put("artifactVersion", artifactVersion);
-
-    supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
-    additionalProperties.put("useAndroidMavenGradlePlugin", useAndroidMavenGradlePlugin);
-    
-    supportingFiles.add(new SupportingFile("settings.gradle.mustache", "", "settings.gradle"));
-    supportingFiles.add(new SupportingFile("build.mustache", "", "build.gradle"));
-    supportingFiles.add(new SupportingFile("manifest.mustache", projectFolder, "AndroidManifest.xml"));
-    supportingFiles.add(new SupportingFile("apiInvoker.mustache", 
-      (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "ApiInvoker.java"));
-    supportingFiles.add(new SupportingFile("httpPatch.mustache", 
-      (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "HttpPatch.java"));
-    supportingFiles.add(new SupportingFile("jsonUtil.mustache", 
-      (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "JsonUtil.java"));
-    supportingFiles.add(new SupportingFile("apiException.mustache", 
-      (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "ApiException.java"));
-
     languageSpecificPrimitives = new HashSet<String>(
       Arrays.asList(
         "String",
@@ -80,6 +60,13 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
       );
     instantiationTypes.put("array", "ArrayList");
     instantiationTypes.put("map", "HashMap");
+    
+    cliOptions.add(new CliOption("invokerPackage", "root package to use for the generated code"));
+    cliOptions.add(new CliOption("groupId", "groupId for use in the generated build.gradle and pom.xml"));
+    cliOptions.add(new CliOption("artifactId", "artifactId for use in the generated build.gradle and pom.xml"));
+    cliOptions.add(new CliOption("artifactVersion", "artifact version for use in the generated build.gradle and pom.xml"));
+    cliOptions.add(new CliOption("sourceFolder", "source folder for generated code"));
+    cliOptions.add(new CliOption("useAndroidMavenGradlePlugin", "A flag to toggle android-maven gradle plugin. Default is true."));
   }
 
   @Override
@@ -177,6 +164,96 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
 
     return camelize(operationId, true);
   }
+  
+  @Override
+  public void processOpts() {
+    super.processOpts();
+    
+    if(additionalProperties.containsKey("invokerPackage")) {
+      this.setInvokerPackage((String)additionalProperties.get("invokerPackage"));
+    }
+    else{
+      //not set, use default to be passed to template
+      additionalProperties.put("invokerPackage", invokerPackage);
+    }
+    
+    if(additionalProperties.containsKey("groupId")) {
+      this.setGroupId((String)additionalProperties.get("groupId"));
+    }
+    else{
+      //not set, use to be passed to template
+      additionalProperties.put("groupId", groupId);
+    }
+    
+    if(additionalProperties.containsKey("artifactId")) {
+      this.setArtifactId((String)additionalProperties.get("artifactId"));
+    }
+    else{
+      //not set, use to be passed to template
+      additionalProperties.put("artifactId", artifactId);
+    }
+    
+    if(additionalProperties.containsKey("artifactVersion")) {
+      this.setArtifactVersion((String)additionalProperties.get("artifactVersion"));
+    }
+    else{
+      //not set, use to be passed to template
+      additionalProperties.put("artifactVersion", artifactVersion);
+    }
+    
+    if(additionalProperties.containsKey("sourceFolder")) {
+      this.setSourceFolder((String)additionalProperties.get("sourceFolder"));
+    }
 
+    if(additionalProperties.containsKey("useAndroidMavenGradlePlugin")) {
+      this.setUseAndroidMavenGradlePlugin((Boolean)additionalProperties.get("useAndroidMavenGradlePlugin"));
+    }
+    else{
+      additionalProperties.put("useAndroidMavenGradlePlugin", useAndroidMavenGradlePlugin);
+    }
+        
+    supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
+    additionalProperties.put("useAndroidMavenGradlePlugin", useAndroidMavenGradlePlugin);
+
+    supportingFiles.add(new SupportingFile("settings.gradle.mustache", "", "settings.gradle"));
+    supportingFiles.add(new SupportingFile("build.mustache", "", "build.gradle"));
+    supportingFiles.add(new SupportingFile("manifest.mustache", projectFolder, "AndroidManifest.xml"));
+    supportingFiles.add(new SupportingFile("apiInvoker.mustache",
+        (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "ApiInvoker.java"));
+    supportingFiles.add(new SupportingFile("httpPatch.mustache",
+        (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "HttpPatch.java"));
+    supportingFiles.add(new SupportingFile("jsonUtil.mustache",
+        (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "JsonUtil.java"));
+    supportingFiles.add(new SupportingFile("apiException.mustache",
+        (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "ApiException.java"));
+  }
+
+  public Boolean getUseAndroidMavenGradlePlugin() {
+    return useAndroidMavenGradlePlugin;
+  }
+
+  public void setUseAndroidMavenGradlePlugin(Boolean useAndroidMavenGradlePlugin) {
+    this.useAndroidMavenGradlePlugin = useAndroidMavenGradlePlugin;
+  }
+
+  public void setInvokerPackage(String invokerPackage) {
+    this.invokerPackage = invokerPackage;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public void setArtifactId(String artifactId) {
+    this.artifactId = artifactId;
+  }
+
+  public void setArtifactVersion(String artifactVersion) {
+    this.artifactVersion = artifactVersion;
+  }
+
+  public void setSourceFolder(String sourceFolder) {
+    this.sourceFolder = sourceFolder;
+  }
 
 }

--- a/modules/swagger-codegen/src/main/resources/android-java/build.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/build.mustache
@@ -60,10 +60,10 @@ dependencies {
     compile "com.google.code.gson:gson:$gson_version"
     compile "org.apache.httpcomponents:httpcore:$httpclient_version"
     compile "org.apache.httpcomponents:httpclient:$httpclient_version"
-    compile ("org.apache.httpcomponents:httpcore:$httpcore_version") {
+    compile ("org.apache.httpcomponents:httpcore:$httpclient_version") {
         exclude(group: 'org.apache.httpcomponents', module: 'httpclient')
     }
-    compile ("org.apache.httpcomponents:httpmime:$httpmime_version") {
+    compile ("org.apache.httpcomponents:httpmime:$httpclient_version") {
         exclude(group: 'org.apache.httpcomponents', module: 'httpclient')
     }
     testCompile "junit:junit:$junit_version"

--- a/modules/swagger-codegen/src/main/resources/android-java/jsonUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/jsonUtil.mustache
@@ -5,7 +5,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.List;
-import io.swagger.client.model.*;
+import {{modelPackage}}.*;
 
 public class JsonUtil {
   public static GsonBuilder gsonBuilder;


### PR DESCRIPTION
Now that https://github.com/swagger-api/swagger-codegen/pull/805 (thanks @hyeghiazaryan !) has been merged to develop_2.0 (thanks @olensmar !), I've updated the android-java generator to use the new config file functionality.

Here's the output of the android-java config-help : 

```
$ swagger-codegen config-help -l android

CONFIG OPTIONS
	modelPackage
	    package for generated models

	apiPackage
	    package for generated api classes

	invokerPackage
	    root package to use for the generated code

	groupId
	    groupId for use in the generated build.gradle and pom.xml

	artifactId
	    artifactId for use in the generated build.gradle and pom.xml

	artifactVersion
	    artifact version for use in the generated build.gradle and pom.xml

	sourceFolder
	    source folder for generated code

	useAndroidMavenGradlePlugin
	    A flag to toggle android-maven gradle plugin. Default is true.

```

I also fixed an issue with gradle variables which was causing build breakages.
