### PR TITLE
Replace hard-coded with dynamic languagespecificPrimitives in PhpClientCodegen

### DIFF
--- a/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/com/wordnik/swagger/codegen/languages/PhpClientCodegen.java
@@ -7,6 +7,8 @@ import com.wordnik.swagger.models.properties.*;
 import java.util.*;
 import java.io.File;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
   protected String invokerPackage = "com.wordnik.client";
   protected String groupId = "com.wordnik";
@@ -64,6 +66,10 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         "number")
     );
 
+    // provide primitives to mustache template
+    String primitives = "'" + StringUtils.join(languageSpecificPrimitives, "', '") + "'";
+    additionalProperties.put("primitives", primitives);
+    
     instantiationTypes.put("array", "array");
     instantiationTypes.put("map", "map");
 

--- a/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/APIClient.mustache
@@ -395,7 +395,8 @@ class ApiClient {
       $deserialized = $values;
     } elseif ($class == 'DateTime') {
       $deserialized = new \DateTime($data);
-    } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'object'))) {
+    // before: hard-coded (and inconsistent with languageSpecificPrimitives } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'object'))) {
+    } elseif (in_array($class, array({{&primitives}}))) {
       settype($data, $class);
       $deserialized = $data;
     } else {


### PR DESCRIPTION
PHP Generator:
php\APIClient.mustache currently lists the following language specific primitives (hard-coded):
```java
...
} elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'object'))) {
```

However, PhpClientCodegen.java also defines language specific primitives:
```java
languageSpecificPrimitives = new HashSet<String>(
      Arrays.asList(
        "boolean",
        "int",
        "integer",
        "double",
        "float",
        "string",
        "object",
        "DateTime",
        "mixed",
        "number")
    );
```

1.) The primitive "boolean" can't be found in the generated code (as it is hard-coded with bool), resulting in the following error:
Fatal error: Class 'SwaggerClient\models\boolean' not found in C:\projects\swagg
er-spring-demo\user-rest-service-1.0.2-client-php-codegen-develop-2.0\SwaggerCli
ent-php\lib\ApiClient.php on line 400

2.) The defined languageSpecificPrimitives can be reused in the Mustache templates, making the hard-coded values obsolete.