### PR TITLE
[Bug fix] Fix path inside JAR for non-template files

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/AbstractGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/AbstractGenerator.java
@@ -60,7 +60,7 @@ public abstract class AbstractGenerator {
         throw new RuntimeException("can't load template " + name);
     }
 
-    private String getCPResourcePath(String name) {
+    public String getCPResourcePath(String name) {
         if (!"/".equals(File.separator)) {
             return name.replaceAll(Pattern.quote(File.separator), "/");
         }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -268,7 +268,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         // continue
                     }
                     if (in == null) {
-                        in = this.getClass().getClassLoader().getResourceAsStream(config.templateDir() + File.separator + support.templateFile);
+                        in = this.getClass().getClassLoader().getResourceAsStream(getCPResourcePath(config.templateDir() + File.separator + support.templateFile));
                     }
                     File outputFile = new File(outputFilename);
                     OutputStream out = new FileOutputStream(outputFile, false);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -273,6 +273,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     File outputFile = new File(outputFilename);
                     OutputStream out = new FileOutputStream(outputFile, false);
                     if (in != null && out != null) {
+                        System.out.println("writing file " + outputFile);
                         IOUtils.copy(in, out);
                     } else {
                         if (in == null) {


### PR DESCRIPTION
Template files (*.mustache) uses `getCPResourcePath` to get the correct path in all platforms.

This PR also leverages `getCPResourcePath` for non-template files to address the file not found issue in Windows as Path inside JAR should use backslash.

The fix has been tested in Windows and Mac. 