### PR TITLE
Add a `pathPrefix` key to the `operations` key

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -393,6 +393,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         Map<String, Object> operations = new HashMap<String, Object>();
         Map<String, Object> objs = new HashMap<String, Object>();
         objs.put("classname", config.toApiName(tag));
+        objs.put("pathPrefix", config.toApiVarName(tag));
 
         // check for operationId uniqueness
         Set<String> opIds = new HashSet<String>();


### PR DESCRIPTION
I am developing a servlet container lib in Scala, and at the same time a Swagger plug in for it.

I find it helpful to have this key in `postProcessOperations`.