### PR TITLE
[Scala] Fix warnings and upgrade jersey for Scala client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
@@ -20,6 +20,9 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public class ScalaClientCodegen extends DefaultCodegen implements CodegenConfig {
     protected String invokerPackage = "io.swagger.client";
@@ -212,6 +215,19 @@ public class ScalaClientCodegen extends DefaultCodegen implements CodegenConfig 
         }
 
         return camelize(operationId, true);
+    }
+
+    @Override
+    public Map<String, Object> postProcessModels(Map<String, Object> objs) {
+        // remove model imports to avoid warnings for importing class in the same package in Scala
+        List<Map<String, String>> imports = (List<Map<String, String>>) objs.get("imports");
+        final String prefix = modelPackage() + ".";
+        Iterator<Map<String, String>> iterator = imports.iterator();
+        while (iterator.hasNext()) {
+            String _import = iterator.next().get("import");
+            if (_import.startsWith(prefix)) iterator.remove();
+        }
+        return objs;
     }
 
 }

--- a/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
@@ -141,7 +141,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
       }
       case _ => null
     }
-    response.getClientResponseStatus().getStatusCode() match {
+    response.getStatusInfo().getStatusCode() match {
       case 204 => ""
       case code: Int if (Range(200, 299).contains(code)) => {
         response.hasEntity() match {
@@ -155,7 +155,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
           case false => "no data"
         }
         throw new ApiException(
-          response.getClientResponseStatus().getStatusCode(),
+          response.getStatusInfo().getStatusCode(),
           entity)
       }
     }
@@ -172,7 +172,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
       }
     }
   }
-  
+
   def newClient(host: String): Client = asyncHttpClient match {
     case true => {
       import org.sonatype.spice.jersey.client.ahc.config.DefaultAhcConfig
@@ -200,4 +200,3 @@ object ApiInvoker extends ApiInvoker(mapper = ScalaJsonUtil.getJsonMapper,
   authPreemptive = {{authPreemptive}})
 
 class ApiException(val code: Int, msg: String) extends RuntimeException(msg)
-

--- a/modules/swagger-codegen/src/main/resources/scala/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/pom.mustache
@@ -72,6 +72,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add_sources</id>
@@ -208,7 +209,7 @@
     <scala-version>2.10.4</scala-version>
     <joda-version>1.2</joda-version>
     <joda-time-version>2.2</joda-time-version>
-    <jersey-version>1.7</jersey-version>
+    <jersey-version>1.19</jersey-version>
     <swagger-core-version>1.5.0</swagger-core-version>
     <jersey-async-version>1.0.5</jersey-async-version>
     <maven-plugin.version>1.0.0</maven-plugin.version>
@@ -216,6 +217,8 @@
 
     <junit-version>4.8.1</junit-version>
     <scala-maven-plugin-version>3.1.5</scala-maven-plugin-version>
-    <scala-test-version>2.1.3</scala-test-version>
+    <scala-test-version>2.2.4</scala-test-version>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/client/petstore/scala/pom.xml
+++ b/samples/client/petstore/scala/pom.xml
@@ -72,6 +72,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add_sources</id>
@@ -208,7 +209,7 @@
     <scala-version>2.10.4</scala-version>
     <joda-version>1.2</joda-version>
     <joda-time-version>2.2</joda-time-version>
-    <jersey-version>1.7</jersey-version>
+    <jersey-version>1.19</jersey-version>
     <swagger-core-version>1.5.0</swagger-core-version>
     <jersey-async-version>1.0.5</jersey-async-version>
     <maven-plugin.version>1.0.0</maven-plugin.version>
@@ -216,6 +217,8 @@
 
     <junit-version>4.8.1</junit-version>
     <scala-maven-plugin-version>3.1.5</scala-maven-plugin-version>
-    <scala-test-version>2.1.3</scala-test-version>
+    <scala-test-version>2.2.4</scala-test-version>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/ApiInvoker.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/ApiInvoker.scala
@@ -141,7 +141,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
       }
       case _ => null
     }
-    response.getClientResponseStatus().getStatusCode() match {
+    response.getStatusInfo().getStatusCode() match {
       case 204 => ""
       case code: Int if (Range(200, 299).contains(code)) => {
         response.hasEntity() match {
@@ -155,7 +155,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
           case false => "no data"
         }
         throw new ApiException(
-          response.getClientResponseStatus().getStatusCode(),
+          response.getStatusInfo().getStatusCode(),
           entity)
       }
     }
@@ -172,7 +172,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
       }
     }
   }
-  
+
   def newClient(host: String): Client = asyncHttpClient match {
     case true => {
       import org.sonatype.spice.jersey.client.ahc.config.DefaultAhcConfig
@@ -200,4 +200,3 @@ object ApiInvoker extends ApiInvoker(mapper = ScalaJsonUtil.getJsonMapper,
   authPreemptive = false)
 
 class ApiException(val code: Int, msg: String) extends RuntimeException(msg)
-

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala
@@ -1,7 +1,5 @@
 package io.swagger.client.model
 
-import io.swagger.client.model.Category
-import io.swagger.client.model.Tag
 
 
 


### PR DESCRIPTION
* Upgrade jersey to latest version (from 1.7 to 1.19)
* Replace getClientResponseStatus() with getStatusInfo()
* Fix the following maven-build warnings and model-import warnings

```
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 72, column 15
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!

[WARNING]  Expected all dependencies to require Scala version: 2.10.4
[WARNING]  com.fasterxml.jackson.module:jackson-module-scala_2.10:2.4.2 requires scala version: 2.10.4
[WARNING]  org.scala-lang:scala-reflect:2.10.4 requires scala version: 2.10.4
[WARNING]  io.swagger:swagger-scala-client:1.0.0 requires scala version: 2.10.4
[WARNING]  org.scalatest:scalatest_2.10:2.1.3 requires scala version: 2.10.3
[WARNING] Multiple versions of scala libraries detected!

[WARNING] /Users/xhh/projects/swagger-codegen/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala:3: warning: imported `Category' is permanently hidden by definition of object Category in package model
```