### PR TITLE
Optional is used in PHP template although not available

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -70,7 +70,7 @@ class {{classname}} {
 {{#allParams}}   * @param {{dataType}} ${{paramName}} {{description}} {{#required}}(required){{/required}}{{^required}}(optional){{/required}}
 {{/allParams}}   * @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
    */
-   public function {{nickname}}({{#allParams}}${{paramName}}{{#required}}=null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+   public function {{nickname}}({{#allParams}}${{paramName}}{{^required}}=null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
       {{#allParams}}{{#required}}
       // verify the required parameter '{{paramName}}' is set
       if (${{paramName}} === null) {

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -67,10 +67,10 @@ class {{classname}} {
    *
    * {{{summary}}}
    *
-{{#allParams}}   * @param {{dataType}} ${{paramName}} {{description}} {{^optional}}(required){{/optional}}{{#optional}}(optional){{/optional}}
+{{#allParams}}   * @param {{dataType}} ${{paramName}} {{description}} {{#required}}(required){{/required}}{{^required}}(optional){{/required}}
 {{/allParams}}   * @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
    */
-   public function {{nickname}}({{#allParams}}${{paramName}}{{#optional}}=null{{/optional}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+   public function {{nickname}}({{#allParams}}${{paramName}}{{#required}}=null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
       {{#allParams}}{{#required}}
       // verify the required parameter '{{paramName}}' is set
       if (${{paramName}} === null) {


### PR DESCRIPTION
I changed it to `required` and now it works for me. Why was `optional` used and where did it come from?