### PR TITLE
[Java, Android] Fix path variable name

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -58,7 +58,7 @@ public class {{classname}} {
 
     // create path and map variables
     String path = "{{path}}".replaceAll("\\{format\\}","json"){{#pathParams}}
-      .replaceAll("\\{" + "{{paramName}}" + "\\}", apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+      .replaceAll("\\{" + "{{baseName}}" + "\\}", apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();

--- a/modules/swagger-codegen/src/main/resources/android-java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/api.mustache
@@ -55,7 +55,7 @@ public class {{classname}} {
     {{/required}}{{/allParams}}
 
     // create path and map variables
-    String path = "{{path}}".replaceAll("\\{format\\}","json"){{#pathParams}}.replaceAll("\\{" + "{{paramName}}" + "\\}", apiInvoker.escapeString({{{paramName}}}.toString())){{/pathParams}};
+    String path = "{{path}}".replaceAll("\\{format\\}","json"){{#pathParams}}.replaceAll("\\{" + "{{baseName}}" + "\\}", apiInvoker.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();

--- a/samples/client/petstore/android-java/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/android-java/src/main/java/io/swagger/client/model/Pet.java
@@ -1,8 +1,8 @@
 package io.swagger.client.model;
 
 import io.swagger.client.model.Category;
-import java.util.*;
 import io.swagger.client.model.Tag;
+import java.util.*;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/api/PetApi.java
@@ -273,6 +273,85 @@ public class PetApi {
   }
   
   /**
+   * uploads an image
+   * 
+   * @param petId ID of pet to update
+   * @param additionalMetadata Additional data to pass to server
+   * @param file file to upload
+   * @return void
+   */
+  public void uploadFile (Long petId, String additionalMetadata, File file) throws ApiException {
+    Object postBody = null;
+    
+    // verify the required parameter 'petId' is set
+    if (petId == null) {
+       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
+    }
+    
+
+    // create path and map variables
+    String path = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+
+    // query params
+    Map<String, String> queryParams = new HashMap<String, String>();
+    Map<String, String> headerParams = new HashMap<String, String>();
+    Map<String, String> formParams = new HashMap<String, String>();
+
+    
+
+    
+
+    final String[] accepts = {
+      "application/json", "application/xml"
+    };
+    final String accept = apiClient.selectHeaderAccept(accepts);
+
+    final String[] contentTypes = {
+      "multipart/form-data"
+    };
+    final String contentType = apiClient.selectHeaderContentType(contentTypes);
+
+    if(contentType.startsWith("multipart/form-data")) {
+      boolean hasFields = false;
+      FormDataMultiPart mp = new FormDataMultiPart();
+      
+      if (additionalMetadata != null) {
+        hasFields = true;
+        mp.field("additionalMetadata", apiClient.parameterToString(additionalMetadata), MediaType.MULTIPART_FORM_DATA_TYPE);
+      }
+      
+      if (file != null) {
+        hasFields = true;
+        mp.field("file", file.getName());
+        mp.bodyPart(new FileDataBodyPart("file", file, MediaType.MULTIPART_FORM_DATA_TYPE));
+      }
+      
+      if(hasFields)
+        postBody = mp;
+    }
+    else {
+      if (additionalMetadata != null)
+        formParams.put("additionalMetadata", apiClient.parameterToString(additionalMetadata));
+      
+      
+    }
+
+    try {
+      String[] authNames = new String[] { "petstore_auth" };
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      if(response != null){
+        return ;
+      }
+      else {
+        return ;
+      }
+    } catch (ApiException ex) {
+      throw ex;
+    }
+  }
+  
+  /**
    * Find pet by ID
    * Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
    * @param petId ID of pet that needs to be fetched
@@ -288,8 +367,8 @@ public class PetApi {
     
 
     // create path and map variables
-    String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+    String path = "/pet/{pet_id}".replaceAll("\\{format\\}","json")
+      .replaceAll("\\{" + "pet_id" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
@@ -353,7 +432,7 @@ public class PetApi {
     
 
     // create path and map variables
-    String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String path = "/pet/{pet_id}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -431,7 +510,7 @@ public class PetApi {
     
 
     // create path and map variables
-    String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String path = "/pet/{pet_id}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -469,85 +548,6 @@ public class PetApi {
     try {
       String[] authNames = new String[] { "petstore_auth" };
       String response = apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
-      if(response != null){
-        return ;
-      }
-      else {
-        return ;
-      }
-    } catch (ApiException ex) {
-      throw ex;
-    }
-  }
-  
-  /**
-   * uploads an image
-   * 
-   * @param petId ID of pet to update
-   * @param additionalMetadata Additional data to pass to server
-   * @param file file to upload
-   * @return void
-   */
-  public void uploadFile (Long petId, String additionalMetadata, File file) throws ApiException {
-    Object postBody = null;
-    
-    // verify the required parameter 'petId' is set
-    if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
-    }
-    
-
-    // create path and map variables
-    String path = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
-
-    // query params
-    Map<String, String> queryParams = new HashMap<String, String>();
-    Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
-
-    
-
-    
-
-    final String[] accepts = {
-      "application/json", "application/xml"
-    };
-    final String accept = apiClient.selectHeaderAccept(accepts);
-
-    final String[] contentTypes = {
-      "multipart/form-data"
-    };
-    final String contentType = apiClient.selectHeaderContentType(contentTypes);
-
-    if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
-      
-      if (additionalMetadata != null) {
-        hasFields = true;
-        mp.field("additionalMetadata", apiClient.parameterToString(additionalMetadata), MediaType.MULTIPART_FORM_DATA_TYPE);
-      }
-      
-      if (file != null) {
-        hasFields = true;
-        mp.field("file", file.getName());
-        mp.bodyPart(new FileDataBodyPart("file", file, MediaType.MULTIPART_FORM_DATA_TYPE));
-      }
-      
-      if(hasFields)
-        postBody = mp;
-    }
-    else {
-      if (additionalMetadata != null)
-        formParams.put("additionalMetadata", apiClient.parameterToString(additionalMetadata));
-      
-      
-    }
-
-    try {
-      String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
       if(response != null){
         return ;
       }

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/api/PetApi.java
@@ -273,85 +273,6 @@ public class PetApi {
   }
   
   /**
-   * uploads an image
-   * 
-   * @param petId ID of pet to update
-   * @param additionalMetadata Additional data to pass to server
-   * @param file file to upload
-   * @return void
-   */
-  public void uploadFile (Long petId, String additionalMetadata, File file) throws ApiException {
-    Object postBody = null;
-    
-    // verify the required parameter 'petId' is set
-    if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
-    }
-    
-
-    // create path and map variables
-    String path = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
-
-    // query params
-    Map<String, String> queryParams = new HashMap<String, String>();
-    Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
-
-    
-
-    
-
-    final String[] accepts = {
-      "application/json", "application/xml"
-    };
-    final String accept = apiClient.selectHeaderAccept(accepts);
-
-    final String[] contentTypes = {
-      "multipart/form-data"
-    };
-    final String contentType = apiClient.selectHeaderContentType(contentTypes);
-
-    if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
-      
-      if (additionalMetadata != null) {
-        hasFields = true;
-        mp.field("additionalMetadata", apiClient.parameterToString(additionalMetadata), MediaType.MULTIPART_FORM_DATA_TYPE);
-      }
-      
-      if (file != null) {
-        hasFields = true;
-        mp.field("file", file.getName());
-        mp.bodyPart(new FileDataBodyPart("file", file, MediaType.MULTIPART_FORM_DATA_TYPE));
-      }
-      
-      if(hasFields)
-        postBody = mp;
-    }
-    else {
-      if (additionalMetadata != null)
-        formParams.put("additionalMetadata", apiClient.parameterToString(additionalMetadata));
-      
-      
-    }
-
-    try {
-      String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
-      if(response != null){
-        return ;
-      }
-      else {
-        return ;
-      }
-    } catch (ApiException ex) {
-      throw ex;
-    }
-  }
-  
-  /**
    * Find pet by ID
    * Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
    * @param petId ID of pet that needs to be fetched
@@ -367,8 +288,8 @@ public class PetApi {
     
 
     // create path and map variables
-    String path = "/pet/{pet_id}".replaceAll("\\{format\\}","json")
-      .replaceAll("\\{" + "pet_id" + "\\}", apiClient.escapeString(petId.toString()));
+    String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
@@ -432,7 +353,7 @@ public class PetApi {
     
 
     // create path and map variables
-    String path = "/pet/{pet_id}".replaceAll("\\{format\\}","json")
+    String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -510,7 +431,7 @@ public class PetApi {
     
 
     // create path and map variables
-    String path = "/pet/{pet_id}".replaceAll("\\{format\\}","json")
+    String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -548,6 +469,85 @@ public class PetApi {
     try {
       String[] authNames = new String[] { "petstore_auth" };
       String response = apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      if(response != null){
+        return ;
+      }
+      else {
+        return ;
+      }
+    } catch (ApiException ex) {
+      throw ex;
+    }
+  }
+  
+  /**
+   * uploads an image
+   * 
+   * @param petId ID of pet to update
+   * @param additionalMetadata Additional data to pass to server
+   * @param file file to upload
+   * @return void
+   */
+  public void uploadFile (Long petId, String additionalMetadata, File file) throws ApiException {
+    Object postBody = null;
+    
+    // verify the required parameter 'petId' is set
+    if (petId == null) {
+       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
+    }
+    
+
+    // create path and map variables
+    String path = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
+      .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+
+    // query params
+    Map<String, String> queryParams = new HashMap<String, String>();
+    Map<String, String> headerParams = new HashMap<String, String>();
+    Map<String, String> formParams = new HashMap<String, String>();
+
+    
+
+    
+
+    final String[] accepts = {
+      "application/json", "application/xml"
+    };
+    final String accept = apiClient.selectHeaderAccept(accepts);
+
+    final String[] contentTypes = {
+      "multipart/form-data"
+    };
+    final String contentType = apiClient.selectHeaderContentType(contentTypes);
+
+    if(contentType.startsWith("multipart/form-data")) {
+      boolean hasFields = false;
+      FormDataMultiPart mp = new FormDataMultiPart();
+      
+      if (additionalMetadata != null) {
+        hasFields = true;
+        mp.field("additionalMetadata", apiClient.parameterToString(additionalMetadata), MediaType.MULTIPART_FORM_DATA_TYPE);
+      }
+      
+      if (file != null) {
+        hasFields = true;
+        mp.field("file", file.getName());
+        mp.bodyPart(new FileDataBodyPart("file", file, MediaType.MULTIPART_FORM_DATA_TYPE));
+      }
+      
+      if(hasFields)
+        postBody = mp;
+    }
+    else {
+      if (additionalMetadata != null)
+        formParams.put("additionalMetadata", apiClient.parameterToString(additionalMetadata));
+      
+      
+    }
+
+    try {
+      String[] authNames = new String[] { "petstore_auth" };
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
       if(response != null){
         return ;
       }


### PR DESCRIPTION
Currently, the path variable name in underscore case won't work in Java and Android client.

This PR fixed the issue by using `baseName`.

Tested with manually changing petId to pet_id and the result is good. 