### PR TITLE
Fix asset loading when generating `dynamic-html` on windows

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -268,7 +268,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         // continue
                     }
                     if (in == null) {
-                        in = this.getClass().getClassLoader().getResourceAsStream(config.templateDir() + File.separator + support.templateFile);
+                        in = this.getClass().getClassLoader().getResourceAsStream(config.templateDir() + '/' + support.templateFile);
                     }
                     File outputFile = new File(outputFilename);
                     OutputStream out = new FileOutputStream(outputFile, false);


### PR DESCRIPTION
In this specific case the use of `File.separator` is wrong, see here:
https://docs.oracle.com/javase/7/docs/api/java/lang/ClassLoader.html#getResource(java.lang.String)

> The name of a resource is a '/'-separated path name that identifies the resource.

In effect, this breaks the generation of "dynamic-html" on windows based systems, e.g. I get his in the output:
```
...
[INFO] Generate for language : dynamic-html
...
writing file Y:\workspace\aurora.core\aua-sl-rest-api\target\generated-sources\swagger\package.json
writing file Y:\workspace\aurora.core\aua-sl-rest-api\target\generated-sources\swagger\main.js
can't open swagger-static\assets/css/bootstrap-responsive.css for input
can't open swagger-static\assets/css/bootstrap.css for input
can't open swagger-static\assets/css/style.css for input
can't open swagger-static\assets/images/logo.png for input
can't open swagger-static\assets/js/bootstrap.js for input
can't open swagger-static\assets/js/jquery-1.8.3.min.js for input
can't open swagger-static\assets/js/main.js for input
writing file Y:\workspace\aurora.core\aua-sl-rest-api\target\generated-sources\swagger\docs\index.html
...
```

...and the files above where it says `can't open <file> for input` end up being zero byte empty files.

This PR fixes it by always using a `/`, independent of the platform