### PR TITLE
Copy properties from parent models defined with allOf

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -65,6 +65,8 @@ public interface CodegenConfig {
 
     CodegenModel fromModel(String name, Model model);
 
+    CodegenModel fromModel(String name, Model model, Map<String, Model> allDefinitions);
+
     CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation, Map<String, Model> definitions);
 
     List<CodegenSecurity> fromSecurity(Map<String, SecuritySchemeDefinition> schemes);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -529,37 +529,59 @@ public class DefaultCodegen {
             // TODO
         } else if (model instanceof ComposedModel) {
             final ComposedModel composed = (ComposedModel) model;
+            Map<String, Property> properties = new HashMap<String, Property>();
+            List<String> required = new ArrayList<String>();
             // parent model
             final RefModel parent = (RefModel) composed.getParent();
             if (parent != null) {
                 final String parentRef = toModelName(parent.getSimpleRef());
                 m.parent = parentRef;
                 addImport(m, parentRef);
-                final Model parentModel = allDefinitions.get(parentRef);
-                if (parentModel instanceof ModelImpl) {
-                    final ModelImpl _parent = (ModelImpl) parentModel;
-                    addVars(m, _parent.getProperties(), _parent.getRequired());
+                if (allDefinitions != null) {
+                    final Model parentModel = allDefinitions.get(parentRef);
+                    if (parentModel instanceof ModelImpl) {
+                        final ModelImpl _parent = (ModelImpl) parentModel;
+                        if (_parent.getProperties() != null) {
+                            properties.putAll(_parent.getProperties());
+                        }
+                        if (_parent.getRequired() != null) {
+                            required.addAll(_parent.getRequired());
+                        }
+                    }
                 }
             }
             // interfaces (intermediate models)
-            for (RefModel _interface : composed.getInterfaces()) {
-                final String interfaceRef = toModelName(_interface.getSimpleRef());
-                final Model interfaceModel = allDefinitions.get(interfaceRef);
-                if (interfaceModel instanceof ModelImpl) {
-                    final ModelImpl _interfaceModel = (ModelImpl) interfaceModel;
-                    addVars(m, _interfaceModel.getProperties(), _interfaceModel.getRequired());
+            if (allDefinitions != null) {
+                for (RefModel _interface : composed.getInterfaces()) {
+                    final String interfaceRef = toModelName(_interface.getSimpleRef());
+                    final Model interfaceModel = allDefinitions.get(interfaceRef);
+                    if (interfaceModel instanceof ModelImpl) {
+                        final ModelImpl _interfaceModel = (ModelImpl) interfaceModel;
+                        if (_interfaceModel.getProperties() != null) {
+                            properties.putAll(_interfaceModel.getProperties());
+                        }
+                        if (_interfaceModel.getRequired() != null) {
+                            required.addAll(_interfaceModel.getRequired());
+                        }
+                    }
                 }
             }
             // child model (properties owned by the model itself)
             Model child = composed.getChild();
-            if (child != null && child instanceof RefModel) {
+            if (child != null && child instanceof RefModel && allDefinitions != null) {
                 final String childRef = ((RefModel) child).getSimpleRef();
                 child = allDefinitions.get(childRef);
             }
             if (child != null && child instanceof ModelImpl) {
                 final ModelImpl _child = (ModelImpl) child;
-                addVars(m, _child.getProperties(), _child.getRequired());
+                if (_child.getProperties() != null) {
+                    properties.putAll(_child.getProperties());
+                }
+                if (_child.getRequired() != null) {
+                    required.addAll(_child.getRequired());
+                }
             }
+            addVars(m, properties, required);
         } else {
             ModelImpl impl = (ModelImpl) model;
             if (impl.getAdditionalProperties() != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -529,17 +529,28 @@ public class DefaultCodegen {
             // TODO
         } else if (model instanceof ComposedModel) {
             final ComposedModel composed = (ComposedModel) model;
+            // parent model
             final RefModel parent = (RefModel) composed.getParent();
             if (parent != null) {
                 final String parentRef = toModelName(parent.getSimpleRef());
+                m.parent = parentRef;
+                addImport(m, parentRef);
                 final Model parentModel = allDefinitions.get(parentRef);
                 if (parentModel instanceof ModelImpl) {
                     final ModelImpl _parent = (ModelImpl) parentModel;
-                    m.parent = parentRef;
-                    addImport(m, parentRef);
                     addVars(m, _parent.getProperties(), _parent.getRequired());
                 }
             }
+            // interfaces (intermediate models)
+            for (RefModel _interface : composed.getInterfaces()) {
+                final String interfaceRef = toModelName(_interface.getSimpleRef());
+                final Model interfaceModel = allDefinitions.get(interfaceRef);
+                if (interfaceModel instanceof ModelImpl) {
+                    final ModelImpl _interfaceModel = (ModelImpl) interfaceModel;
+                    addVars(m, _interfaceModel.getProperties(), _interfaceModel.getRequired());
+                }
+            }
+            // child model (properties owned by the model itself)
             Model child = composed.getChild();
             if (child != null && child instanceof RefModel) {
                 final String childRef = ((RefModel) child).getSimpleRef();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -122,7 +122,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     Model model = definitions.get(name);
                     Map<String, Model> modelMap = new HashMap<String, Model>();
                     modelMap.put(name, model);
-                    Map<String, Object> models = processModels(config, modelMap);
+                    Map<String, Object> models = processModels(config, modelMap, definitions);
                     models.putAll(config.additionalProperties());
 
                     allModels.add(((List<Object>) models.get("models")).get(0));
@@ -442,14 +442,14 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         return operations;
     }
 
-    public Map<String, Object> processModels(CodegenConfig config, Map<String, Model> definitions) {
+    public Map<String, Object> processModels(CodegenConfig config, Map<String, Model> definitions, Map<String, Model> allDefinitions) {
         Map<String, Object> objs = new HashMap<String, Object>();
         objs.put("package", config.modelPackage());
         List<Object> models = new ArrayList<Object>();
         Set<String> allImports = new LinkedHashSet<String>();
         for (String key : definitions.keySet()) {
             Model mm = definitions.get(key);
-            CodegenModel cm = config.fromModel(key, mm);
+            CodegenModel cm = config.fromModel(key, mm, allDefinitions);
             Map<String, Object> mo = new HashMap<String, Object>();
             mo.put("model", cm);
             mo.put("importPath", config.toModelImport(key));


### PR DESCRIPTION
This PR copies model properties of the parent models that are defined with the `allOf` key (with value of either `$ref` or `properties`), i.e. for composed models.

It also fixes #936.