### PR TITLE
updated client to use jersey2, rebuilt samples

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -1,49 +1,42 @@
 package {{invokerPackage}};
 
-import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
-import com.sun.jersey.api.client.filter.LoggingFilter;
-import com.sun.jersey.api.client.WebResource.Builder;
-import com.sun.jersey.multipart.FormDataMultiPart;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
-import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.MediaType;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.filter.LoggingFilter;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Date;
 import java.util.TimeZone;
-
 import java.net.URLEncoder;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.text.ParseException;
 
-import {{invokerPackage}}.auth.Authentication;
-import {{invokerPackage}}.auth.HttpBasicAuth;
-import {{invokerPackage}}.auth.ApiKeyAuth;
-import {{invokerPackage}}.auth.OAuth;
+import io.swagger.client.ApiException;
+import io.swagger.client.auth.Authentication;
+import io.swagger.client.auth.HttpBasicAuth;
+import io.swagger.client.auth.ApiKeyAuth;
+import io.swagger.client.auth.OAuth;
 
 public class ApiClient {
-  private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private boolean debugging = false;
-  private String basePath = "{{basePath}}";
+  private String basePath = "http://petstore.swagger.io/v2";
 
   private Map<String, Authentication> authentications;
 
@@ -61,10 +54,9 @@ public class ApiClient {
     setUserAgent("Java-Swagger");
 
     // Setup authentications (key: authentication name, value: authentication).
-    authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}
-    authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
-    authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
-    authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
+    authentications = new HashMap<String, Authentication>();
+    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
+    authentications.put("petstore_auth", new OAuth());
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }
@@ -341,92 +333,78 @@ public class ApiClient {
    * @param authNames The authentications to apply
    * @return The response body in type of string
    */
-  public String invokeAPI(String path, String method, Map<String, String> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String accept, String contentType, String[] authNames) throws ApiException {
+  public String invokeAPI(String path, String method, Map<String, String> queryParams, Object body, Map<String, String> headerParams, Entity<?> formParams, String accept, String contentType, String[] authNames) throws ApiException {
     updateParamsForAuth(authNames, queryParams, headerParams);
 
-    Client client = getClient();
+    final ClientConfig clientConfig = new ClientConfig();
+    clientConfig.register(MultiPartFeature.class);
+    if(debugging) {
+      clientConfig.register(LoggingFilter.class);
+    }
+    Client client = ClientBuilder.newClient(clientConfig);
 
-    StringBuilder b = new StringBuilder();
+    WebTarget target = client.target(this.basePath).path(path);
+
     for(String key : queryParams.keySet()) {
       String value = queryParams.get(key);
       if (value != null){
-        if(b.toString().length() == 0)
-          b.append("?");
-        else
-          b.append("&");
-        b.append(escapeString(key)).append("=").append(escapeString(value));
+        target = target.queryParam(key, value);
       }
     }
-    String querystring = b.toString();
 
-    Builder builder;
-    if (accept == null)
-      builder = client.resource(basePath + path + querystring).getRequestBuilder();
-    else
-      builder = client.resource(basePath + path + querystring).accept(accept);
+    Invocation.Builder invocationBuilder = target.request(contentType);
 
     for(String key : headerParams.keySet()) {
-      builder = builder.header(key, headerParams.get(key));
+      String value = headerParams.get(key);
+      if(value != null)
+        invocationBuilder = invocationBuilder.header(key, value);      
     }
+
     for(String key : defaultHeaderMap.keySet()) {
       if(!headerParams.containsKey(key)) {
-        builder = builder.header(key, defaultHeaderMap.get(key));
+        String value = defaultHeaderMap.get(key);
+        if(value != null)
+          invocationBuilder = invocationBuilder.header(key, value);
       }
     }
+    Response response = null;
 
-    ClientResponse response = null;
+    invocationBuilder = invocationBuilder.accept(accept);
 
     if("GET".equals(method)) {
-      response = (ClientResponse) builder.get(ClientResponse.class);
+      response = invocationBuilder.get();
     }
     else if ("POST".equals(method)) {
-      if (contentType.startsWith("application/x-www-form-urlencoded")) {
-        String encodedFormParams = this
-            .getXWWWFormUrlencodedParams(formParams);
-        response = builder.type(contentType).post(ClientResponse.class,
-            encodedFormParams);
+      if (formParams != null) {
+        response = invocationBuilder.post(formParams);
       } else if (body == null) {
-        response = builder.post(ClientResponse.class, null);
-      } else if(body instanceof FormDataMultiPart) {
-        response = builder.type(contentType).post(ClientResponse.class, body);
+        response = invocationBuilder.post(null);
       }
       else
-        response = builder.type(contentType).post(ClientResponse.class, serialize(body));
+        response = invocationBuilder.post(Entity.json(serialize(body)));
     }
     else if ("PUT".equals(method)) {
-      if ("application/x-www-form-urlencoded".equals(contentType)) {
-          String encodedFormParams = this
-              .getXWWWFormUrlencodedParams(formParams);
-          response = builder.type(contentType).put(ClientResponse.class,
-              encodedFormParams);
-      } else if(body == null) {
-        response = builder.put(ClientResponse.class, serialize(body));
-      } else {
-          response = builder.type(contentType).put(ClientResponse.class, serialize(body));
+      if (formParams != null) {
+        response = invocationBuilder.put(formParams);
+      } else if (body == null) {
+        response = invocationBuilder.put(null);
       }
+      else
+        response = invocationBuilder.put(Entity.json(serialize(body)));
     }
     else if ("DELETE".equals(method)) {
-      if ("application/x-www-form-urlencoded".equals(contentType)) {
-        String encodedFormParams = this
-            .getXWWWFormUrlencodedParams(formParams);
-        response = builder.type(contentType).delete(ClientResponse.class,
-            encodedFormParams);
-      } else if(body == null) {
-        response = builder.delete(ClientResponse.class);
-      } else {
-        response = builder.type(contentType).delete(ClientResponse.class, serialize(body));
-      }
+      response = invocationBuilder.delete();
     }
     else {
       throw new ApiException(500, "unknown method type " + method);
     }
 
-    if(response.getStatusInfo() == ClientResponse.Status.NO_CONTENT) {
+    if(response.getStatus() == Status.NO_CONTENT.getStatusCode()) {
       return null;
     }
-    else if(response.getStatusInfo().getFamily() == Family.SUCCESSFUL) {
+    else if(response.getStatusInfo().getFamily().equals(Status.Family.SUCCESSFUL)) {
       if(response.hasEntity()) {
-        return (String) response.getEntity(String.class);
+        return (String) response.readEntity(String.class);
       }
       else {
         return "";
@@ -434,21 +412,15 @@ public class ApiClient {
     }
     else {
       String message = "error";
-      String respBody = null;
       if(response.hasEntity()) {
         try{
-          respBody = String.valueOf(response.getEntity(String.class));
-          message = respBody;
+          message = String.valueOf(response.readEntity(String.class));
         }
         catch (RuntimeException e) {
           // e.printStackTrace();
         }
       }
-      throw new ApiException(
-                response.getStatusInfo().getStatusCode(),
-                message,
-                response.getHeaders(),
-                respBody);
+      throw new ApiException(response.getStatus(), message);
     }
   }
 
@@ -463,45 +435,5 @@ public class ApiClient {
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);
       auth.applyToParams(queryParams, headerParams);
     }
-  }
-
-  /**
-   * Encode the given form parameters as request body.
-   */
-  private String getXWWWFormUrlencodedParams(Map<String, String> formParams) {
-    StringBuilder formParamBuilder = new StringBuilder();
-
-    for (Entry<String, String> param : formParams.entrySet()) {
-      String keyStr = parameterToString(param.getKey());
-      String valueStr = parameterToString(param.getValue());
-
-      try {
-        formParamBuilder.append(URLEncoder.encode(keyStr, "utf8"))
-            .append("=")
-            .append(URLEncoder.encode(valueStr, "utf8"));
-        formParamBuilder.append("&");
-      } catch (UnsupportedEncodingException e) {
-        // move on to next
-      }
-    }
-    String encodedFormParams = formParamBuilder.toString();
-    if (encodedFormParams.endsWith("&")) {
-      encodedFormParams = encodedFormParams.substring(0,
-          encodedFormParams.length() - 1);
-    }
-    return encodedFormParams;
-  }
-
-  /**
-   * Get an existing client or create a new client to handle HTTP request.
-   */
-  private Client getClient() {
-    if(!hostMap.containsKey(basePath)) {
-      Client client = Client.create();
-      if (debugging)
-        client.addFilter(new LoggingFilter());
-      hostMap.put(basePath, client);
-    }
-    return hostMap.get(basePath);
   }
 }

--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -28,11 +28,11 @@ import java.io.UnsupportedEncodingException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
-import io.swagger.client.ApiException;
-import io.swagger.client.auth.Authentication;
-import io.swagger.client.auth.HttpBasicAuth;
-import io.swagger.client.auth.ApiKeyAuth;
-import io.swagger.client.auth.OAuth;
+import {{invokerPackage}}.ApiException;
+import {{invokerPackage}}.auth.Authentication;
+import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.ApiKeyAuth;
+import {{invokerPackage}}.auth.OAuth;
 
 public class ApiClient {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();

--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -14,6 +14,7 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.filter.LoggingFilter;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -412,15 +413,33 @@ public class ApiClient {
     }
     else {
       String message = "error";
+      String respBody = null;
+      Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+
       if(response.hasEntity()) {
         try{
           message = String.valueOf(response.readEntity(String.class));
+          for(String key: response.getHeaders().keySet()) {
+            List<Object> values = response.getHeaders().get(key);
+            for(Object o : values) {
+              List<String> headers = responseHeaders.get(key);
+              if(headers == null) {
+                headers = new ArrayList<String>();
+                responseHeaders.put(key, headers);
+              }
+              headers.add(String.valueOf(o));
+            }
+          }
         }
         catch (RuntimeException e) {
           // e.printStackTrace();
         }
       }
-      throw new ApiException(response.getStatus(), message);
+      throw new ApiException(
+                response.getStatusInfo().getStatusCode(),
+                message,
+                responseHeaders,
+                respBody);
     }
   }
 

--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -11,9 +11,13 @@ import java.util.*;
 {{#imports}}import {{import}};
 {{/imports}}
 
-import com.sun.jersey.multipart.FormDataMultiPart;
-import com.sun.jersey.multipart.file.FileDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 
 import java.io.File;
@@ -63,7 +67,7 @@ public class {{classname}} {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     {{#queryParams}}if ({{paramName}} != null)
       queryParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));
@@ -84,32 +88,42 @@ public class {{classname}} {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       {{#formParams}}{{#notFile}}
       if ({{paramName}} != null) {
-        hasFields = true;
-        mp.field("{{baseName}}", apiClient.parameterToString({{paramName}}), MediaType.MULTIPART_FORM_DATA_TYPE);
+        hasParams = true;
+
+        FormDataMultiPart mp = new FormDataMultiPart();
+        mp.bodyPart(new FormDataBodyPart("{{{baseName}}}", apiClient.parameterToString({{paramName}})));
+        multipart.bodyPart(mp, MediaType.MULTIPART_FORM_DATA_TYPE);
       }
       {{/notFile}}{{#isFile}}
       if ({{paramName}} != null) {
-        hasFields = true;
-        mp.field("{{baseName}}", {{paramName}}.getName());
-        mp.bodyPart(new FileDataBodyPart("{{baseName}}", {{paramName}}, MediaType.MULTIPART_FORM_DATA_TYPE));
+        hasParams = true;
+        multipart.bodyPart(new FileDataBodyPart("{{baseName}}", new java.io.File({{paramName}}.getName()), MediaType.APPLICATION_OCTET_STREAM_TYPE));
       }
       {{/isFile}}{{/formParams}}
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
-      {{#formParams}}{{#notFile}}if ({{paramName}} != null)
-        formParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));{{/notFile}}
+      boolean hasValues = false;
+      Form form = new Form();
+      {{#formParams}}{{#notFile}}if ({{paramName}} != null) {
+        form.param("{{baseName}}", apiClient.parameterToString({{paramName}}));
+        hasValues = true;
+      }{{/notFile}}
       {{/formParams}}
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { {{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}} };
-      String response = apiClient.invokeAPI(path, "{{httpMethod}}", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "{{httpMethod}}", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return {{#returnType}}({{{returnType}}}) apiClient.deserialize(response, "{{returnContainer}}", {{returnBaseType}}.class){{/returnType}};
       }

--- a/modules/swagger-codegen/src/main/resources/Java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pom.mustache
@@ -112,16 +112,20 @@
       <artifactId>swagger-annotations</artifactId>
       <version>${swagger-annotations-version}</version>
     </dependency>
+
+    <!-- jersey client -->
     <dependency>
-      <groupId>com.sun.jersey</groupId>
+      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
       <version>${jersey-version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-multipart</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
       <version>${jersey-version}</version>
     </dependency>
+
+    <!-- jackson -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
@@ -141,7 +145,9 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
       <version>2.1.5</version>
-    </dependency>   
+    </dependency>
+
+    <!-- joda -->
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
@@ -158,7 +164,7 @@
   </dependencies>
   <properties>
     <swagger-annotations-version>1.5.0</swagger-annotations-version>
-    <jersey-version>1.18</jersey-version>
+    <jersey-version>2.6</jersey-version>
     <jackson-version>2.4.2</jackson-version>
     <jodatime-version>2.3</jodatime-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/pom.xml
+++ b/samples/client/petstore/java/pom.xml
@@ -112,16 +112,20 @@
       <artifactId>swagger-annotations</artifactId>
       <version>${swagger-annotations-version}</version>
     </dependency>
+
+    <!-- jersey client -->
     <dependency>
-      <groupId>com.sun.jersey</groupId>
+      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
       <version>${jersey-version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-multipart</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
       <version>${jersey-version}</version>
     </dependency>
+
+    <!-- jackson -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
@@ -141,7 +145,9 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
       <version>2.1.5</version>
-    </dependency>   
+    </dependency>
+
+    <!-- joda -->
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
@@ -158,7 +164,7 @@
   </dependencies>
   <properties>
     <swagger-annotations-version>1.5.0</swagger-annotations-version>
-    <jersey-version>1.18</jersey-version>
+    <jersey-version>2.6</jersey-version>
     <jackson-version>2.4.2</jackson-version>
     <jodatime-version>2.3</jodatime-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/ApiClient.java
@@ -14,6 +14,7 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.filter.LoggingFilter;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -412,15 +413,33 @@ public class ApiClient {
     }
     else {
       String message = "error";
+      String respBody = null;
+      Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+
       if(response.hasEntity()) {
         try{
           message = String.valueOf(response.readEntity(String.class));
+          for(String key: response.getHeaders().keySet()) {
+            List<Object> values = response.getHeaders().get(key);
+            for(Object o : values) {
+              List<String> headers = responseHeaders.get(key);
+              if(headers == null) {
+                headers = new ArrayList<String>();
+                responseHeaders.put(key, headers);
+              }
+              headers.add(String.valueOf(o));
+            }
+          }
         }
         catch (RuntimeException e) {
           // e.printStackTrace();
         }
       }
-      throw new ApiException(response.getStatus(), message);
+      throw new ApiException(
+                response.getStatusInfo().getStatusCode(),
+                message,
+                responseHeaders,
+                respBody);
     }
   }
 

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/ApiClient.java
@@ -1,46 +1,39 @@
 package io.swagger.client;
 
-import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
-import com.sun.jersey.api.client.filter.LoggingFilter;
-import com.sun.jersey.api.client.WebResource.Builder;
-import com.sun.jersey.multipart.FormDataMultiPart;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
-import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.MediaType;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.filter.LoggingFilter;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Date;
 import java.util.TimeZone;
-
 import java.net.URLEncoder;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.text.ParseException;
 
+import io.swagger.client.ApiException;
 import io.swagger.client.auth.Authentication;
 import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
 public class ApiClient {
-  private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private boolean debugging = false;
   private String basePath = "http://petstore.swagger.io/v2";
@@ -340,92 +333,78 @@ public class ApiClient {
    * @param authNames The authentications to apply
    * @return The response body in type of string
    */
-  public String invokeAPI(String path, String method, Map<String, String> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String accept, String contentType, String[] authNames) throws ApiException {
+  public String invokeAPI(String path, String method, Map<String, String> queryParams, Object body, Map<String, String> headerParams, Entity<?> formParams, String accept, String contentType, String[] authNames) throws ApiException {
     updateParamsForAuth(authNames, queryParams, headerParams);
 
-    Client client = getClient();
+    final ClientConfig clientConfig = new ClientConfig();
+    clientConfig.register(MultiPartFeature.class);
+    if(debugging) {
+      clientConfig.register(LoggingFilter.class);
+    }
+    Client client = ClientBuilder.newClient(clientConfig);
 
-    StringBuilder b = new StringBuilder();
+    WebTarget target = client.target(this.basePath).path(path);
+
     for(String key : queryParams.keySet()) {
       String value = queryParams.get(key);
       if (value != null){
-        if(b.toString().length() == 0)
-          b.append("?");
-        else
-          b.append("&");
-        b.append(escapeString(key)).append("=").append(escapeString(value));
+        target = target.queryParam(key, value);
       }
     }
-    String querystring = b.toString();
 
-    Builder builder;
-    if (accept == null)
-      builder = client.resource(basePath + path + querystring).getRequestBuilder();
-    else
-      builder = client.resource(basePath + path + querystring).accept(accept);
+    Invocation.Builder invocationBuilder = target.request(contentType);
 
     for(String key : headerParams.keySet()) {
-      builder = builder.header(key, headerParams.get(key));
+      String value = headerParams.get(key);
+      if(value != null)
+        invocationBuilder = invocationBuilder.header(key, value);      
     }
+
     for(String key : defaultHeaderMap.keySet()) {
       if(!headerParams.containsKey(key)) {
-        builder = builder.header(key, defaultHeaderMap.get(key));
+        String value = defaultHeaderMap.get(key);
+        if(value != null)
+          invocationBuilder = invocationBuilder.header(key, value);
       }
     }
+    Response response = null;
 
-    ClientResponse response = null;
+    invocationBuilder = invocationBuilder.accept(accept);
 
     if("GET".equals(method)) {
-      response = (ClientResponse) builder.get(ClientResponse.class);
+      response = invocationBuilder.get();
     }
     else if ("POST".equals(method)) {
-      if (contentType.startsWith("application/x-www-form-urlencoded")) {
-        String encodedFormParams = this
-            .getXWWWFormUrlencodedParams(formParams);
-        response = builder.type(contentType).post(ClientResponse.class,
-            encodedFormParams);
+      if (formParams != null) {
+        response = invocationBuilder.post(formParams);
       } else if (body == null) {
-        response = builder.post(ClientResponse.class, null);
-      } else if(body instanceof FormDataMultiPart) {
-        response = builder.type(contentType).post(ClientResponse.class, body);
+        response = invocationBuilder.post(null);
       }
       else
-        response = builder.type(contentType).post(ClientResponse.class, serialize(body));
+        response = invocationBuilder.post(Entity.json(serialize(body)));
     }
     else if ("PUT".equals(method)) {
-      if ("application/x-www-form-urlencoded".equals(contentType)) {
-          String encodedFormParams = this
-              .getXWWWFormUrlencodedParams(formParams);
-          response = builder.type(contentType).put(ClientResponse.class,
-              encodedFormParams);
-      } else if(body == null) {
-        response = builder.put(ClientResponse.class, serialize(body));
-      } else {
-          response = builder.type(contentType).put(ClientResponse.class, serialize(body));
+      if (formParams != null) {
+        response = invocationBuilder.put(formParams);
+      } else if (body == null) {
+        response = invocationBuilder.put(null);
       }
+      else
+        response = invocationBuilder.put(Entity.json(serialize(body)));
     }
     else if ("DELETE".equals(method)) {
-      if ("application/x-www-form-urlencoded".equals(contentType)) {
-        String encodedFormParams = this
-            .getXWWWFormUrlencodedParams(formParams);
-        response = builder.type(contentType).delete(ClientResponse.class,
-            encodedFormParams);
-      } else if(body == null) {
-        response = builder.delete(ClientResponse.class);
-      } else {
-        response = builder.type(contentType).delete(ClientResponse.class, serialize(body));
-      }
+      response = invocationBuilder.delete();
     }
     else {
       throw new ApiException(500, "unknown method type " + method);
     }
 
-    if(response.getStatusInfo() == ClientResponse.Status.NO_CONTENT) {
+    if(response.getStatus() == Status.NO_CONTENT.getStatusCode()) {
       return null;
     }
-    else if(response.getStatusInfo().getFamily() == Family.SUCCESSFUL) {
+    else if(response.getStatusInfo().getFamily().equals(Status.Family.SUCCESSFUL)) {
       if(response.hasEntity()) {
-        return (String) response.getEntity(String.class);
+        return (String) response.readEntity(String.class);
       }
       else {
         return "";
@@ -433,21 +412,15 @@ public class ApiClient {
     }
     else {
       String message = "error";
-      String respBody = null;
       if(response.hasEntity()) {
         try{
-          respBody = String.valueOf(response.getEntity(String.class));
-          message = respBody;
+          message = String.valueOf(response.readEntity(String.class));
         }
         catch (RuntimeException e) {
           // e.printStackTrace();
         }
       }
-      throw new ApiException(
-                response.getStatusInfo().getStatusCode(),
-                message,
-                response.getHeaders(),
-                respBody);
+      throw new ApiException(response.getStatus(), message);
     }
   }
 
@@ -462,45 +435,5 @@ public class ApiClient {
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);
       auth.applyToParams(queryParams, headerParams);
     }
-  }
-
-  /**
-   * Encode the given form parameters as request body.
-   */
-  private String getXWWWFormUrlencodedParams(Map<String, String> formParams) {
-    StringBuilder formParamBuilder = new StringBuilder();
-
-    for (Entry<String, String> param : formParams.entrySet()) {
-      String keyStr = parameterToString(param.getKey());
-      String valueStr = parameterToString(param.getValue());
-
-      try {
-        formParamBuilder.append(URLEncoder.encode(keyStr, "utf8"))
-            .append("=")
-            .append(URLEncoder.encode(valueStr, "utf8"));
-        formParamBuilder.append("&");
-      } catch (UnsupportedEncodingException e) {
-        // move on to next
-      }
-    }
-    String encodedFormParams = formParamBuilder.toString();
-    if (encodedFormParams.endsWith("&")) {
-      encodedFormParams = encodedFormParams.substring(0,
-          encodedFormParams.length() - 1);
-    }
-    return encodedFormParams;
-  }
-
-  /**
-   * Get an existing client or create a new client to handle HTTP request.
-   */
-  private Client getClient() {
-    if(!hostMap.containsKey(basePath)) {
-      Client client = Client.create();
-      if (debugging)
-        client.addFilter(new LoggingFilter());
-      hostMap.put(basePath, client);
-    }
-    return hostMap.get(basePath);
   }
 }

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/api/PetApi.java
@@ -11,9 +11,13 @@ import java.util.*;
 import io.swagger.client.model.Pet;
 import java.io.File;
 
-import com.sun.jersey.multipart.FormDataMultiPart;
-import com.sun.jersey.multipart.file.FileDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 
 import java.io.File;
@@ -56,7 +60,7 @@ public class PetApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -73,19 +77,25 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "PUT", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "PUT", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -113,7 +123,7 @@ public class PetApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -130,19 +140,25 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -170,7 +186,7 @@ public class PetApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     if (status != null)
       queryParams.put("status", apiClient.parameterToString(status));
@@ -189,19 +205,25 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return (List<Pet>) apiClient.deserialize(response, "array", Pet.class);
       }
@@ -229,7 +251,7 @@ public class PetApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     if (tags != null)
       queryParams.put("tags", apiClient.parameterToString(tags));
@@ -248,19 +270,25 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return (List<Pet>) apiClient.deserialize(response, "array", Pet.class);
       }
@@ -294,7 +322,7 @@ public class PetApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -311,19 +339,25 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "api_key", "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return (Pet) apiClient.deserialize(response, "", Pet.class);
       }
@@ -359,7 +393,7 @@ public class PetApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -376,33 +410,49 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
       if (name != null) {
-        hasFields = true;
-        mp.field("name", apiClient.parameterToString(name), MediaType.MULTIPART_FORM_DATA_TYPE);
+        hasParams = true;
+
+        FormDataMultiPart mp = new FormDataMultiPart();
+        mp.bodyPart(new FormDataBodyPart("name", apiClient.parameterToString(name)));
+        multipart.bodyPart(mp, MediaType.MULTIPART_FORM_DATA_TYPE);
       }
       
       if (status != null) {
-        hasFields = true;
-        mp.field("status", apiClient.parameterToString(status), MediaType.MULTIPART_FORM_DATA_TYPE);
+        hasParams = true;
+
+        FormDataMultiPart mp = new FormDataMultiPart();
+        mp.bodyPart(new FormDataBodyPart("status", apiClient.parameterToString(status)));
+        multipart.bodyPart(mp, MediaType.MULTIPART_FORM_DATA_TYPE);
       }
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
-      if (name != null)
-        formParams.put("name", apiClient.parameterToString(name));
-      if (status != null)
-        formParams.put("status", apiClient.parameterToString(status));
+      boolean hasValues = false;
+      Form form = new Form();
+      if (name != null) {
+        form.param("name", apiClient.parameterToString(name));
+        hasValues = true;
+      }
+      if (status != null) {
+        form.param("status", apiClient.parameterToString(status));
+        hasValues = true;
+      }
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -437,7 +487,7 @@ public class PetApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -456,19 +506,25 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -504,7 +560,7 @@ public class PetApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -521,33 +577,43 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
       if (additionalMetadata != null) {
-        hasFields = true;
-        mp.field("additionalMetadata", apiClient.parameterToString(additionalMetadata), MediaType.MULTIPART_FORM_DATA_TYPE);
+        hasParams = true;
+
+        FormDataMultiPart mp = new FormDataMultiPart();
+        mp.bodyPart(new FormDataBodyPart("additionalMetadata", apiClient.parameterToString(additionalMetadata)));
+        multipart.bodyPart(mp, MediaType.MULTIPART_FORM_DATA_TYPE);
       }
       
       if (file != null) {
-        hasFields = true;
-        mp.field("file", file.getName());
-        mp.bodyPart(new FileDataBodyPart("file", file, MediaType.MULTIPART_FORM_DATA_TYPE));
+        hasParams = true;
+        multipart.bodyPart(new FileDataBodyPart("file", new java.io.File(file.getName()), MediaType.APPLICATION_OCTET_STREAM_TYPE));
       }
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
-      if (additionalMetadata != null)
-        formParams.put("additionalMetadata", apiClient.parameterToString(additionalMetadata));
+      boolean hasValues = false;
+      Form form = new Form();
+      if (additionalMetadata != null) {
+        form.param("additionalMetadata", apiClient.parameterToString(additionalMetadata));
+        hasValues = true;
+      }
       
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "petstore_auth" };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/api/StoreApi.java
@@ -11,9 +11,13 @@ import java.util.*;
 import java.util.Map;
 import io.swagger.client.model.Order;
 
-import com.sun.jersey.multipart.FormDataMultiPart;
-import com.sun.jersey.multipart.file.FileDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 
 import java.io.File;
@@ -55,7 +59,7 @@ public class StoreApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -72,19 +76,25 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] { "api_key" };
-      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return (Map<String, Integer>) apiClient.deserialize(response, "map", Map.class);
       }
@@ -112,7 +122,7 @@ public class StoreApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -129,19 +139,25 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return (Order) apiClient.deserialize(response, "", Order.class);
       }
@@ -175,7 +191,7 @@ public class StoreApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -192,19 +208,25 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return (Order) apiClient.deserialize(response, "", Order.class);
       }
@@ -238,7 +260,7 @@ public class StoreApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -255,19 +277,25 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }

--- a/samples/client/petstore/java/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/src/main/java/io/swagger/client/api/UserApi.java
@@ -11,9 +11,13 @@ import java.util.*;
 import io.swagger.client.model.User;
 import java.util.*;
 
-import com.sun.jersey.multipart.FormDataMultiPart;
-import com.sun.jersey.multipart.file.FileDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 
 import java.io.File;
@@ -56,7 +60,7 @@ public class UserApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -73,19 +77,25 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -113,7 +123,7 @@ public class UserApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -130,19 +140,25 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -170,7 +186,7 @@ public class UserApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -187,19 +203,25 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -228,7 +250,7 @@ public class UserApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     if (username != null)
       queryParams.put("username", apiClient.parameterToString(username));
@@ -249,19 +271,25 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return (String) apiClient.deserialize(response, "", String.class);
       }
@@ -288,7 +316,7 @@ public class UserApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -305,19 +333,25 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -351,7 +385,7 @@ public class UserApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -368,19 +402,25 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return (User) apiClient.deserialize(response, "", User.class);
       }
@@ -415,7 +455,7 @@ public class UserApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -432,19 +472,25 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "PUT", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "PUT", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }
@@ -478,7 +524,7 @@ public class UserApi {
     // query params
     Map<String, String> queryParams = new HashMap<String, String>();
     Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, String> formParams = new HashMap<String, String>();
+    Entity<?> formEntity = null;
 
     
 
@@ -495,19 +541,25 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     if(contentType.startsWith("multipart/form-data")) {
-      boolean hasFields = false;
-      FormDataMultiPart mp = new FormDataMultiPart();
+      boolean hasParams = false;
+      MultiPart multipart = new MultiPart();
+
       
-      if(hasFields)
-        postBody = mp;
+      if(hasParams)
+        formEntity = Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
     }
     else {
+      boolean hasValues = false;
+      Form form = new Form();
       
+      if(hasValues) {
+        formEntity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+      }
     }
 
     try {
       String[] authNames = new String[] {  };
-      String response = apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames);
+      String response = apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formEntity, accept, contentType, authNames);
       if(response != null){
         return ;
       }


### PR DESCRIPTION
This PR add support for #949.  Before merging, there are some decisions to make.

1) The jersey client is quite heavy for this use case.  Sure it's fluent, etc., but we can't really take advantage of that for this codegen (as-is)
2) There will be users who still need jersey 1.x client support because they're using a combined client/server with jersey 1.x, which is very popular
3) There will be more client libraries needed (plain apache-http 3.x, 4.x, etc).

How should we support these options?  We could have an uber-java client target that takes the supporting library as an argument, where you could specify jersey1, jersey2, commons-http-3.x, etc.  There are other options such as synchronous, asynchronous (supported by Jersey2 via `Future`).  Or we can have many client options when generating.

Before merging, we should come up with a plan for the above, it'll be the same for each client language, to some degree.