### PR TITLE
fix SpringMVCServerCodegen for maps as in JavaClientCodegen

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
@@ -99,21 +99,6 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
     }
 
     @Override
-    public String getTypeDeclaration(Property p) {
-        if (p instanceof ArrayProperty) {
-            ArrayProperty ap = (ArrayProperty) p;
-            Property inner = ap.getItems();
-            return getSwaggerType(p) + "<" + getTypeDeclaration(inner) + ">";
-        } else if (p instanceof MapProperty) {
-            MapProperty mp = (MapProperty) p;
-            Property inner = mp.getAdditionalProperties();
-
-            return getTypeDeclaration(inner);
-        }
-        return super.getTypeDeclaration(p);
-    }
-
-    @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
         String basePath = resourcePath;
         if (basePath.startsWith("/")) {


### PR DESCRIPTION
#952 SpringMVCServer can't handle maps with $ref

Since the ```JavaClientCodegen``` produces compilable code and ```SpringMVCServer``` extends ```JavaClientCodegen```, there is no need to override ```getTypeDeclaration(Property p)```