### PR TITLE
Fix for issue #964, correctly call urllib3.util.parse_url

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -67,7 +67,7 @@ class RESTClientObject(object):
         """
         Return proper pool manager for the http\https schemes.
         """
-        url = urllib3.util.url.parse_url(url)
+        url = urllib3.util.parse_url(url)
         scheme = url.scheme
         if scheme == 'https':
             return self.ssl_pool_manager


### PR DESCRIPTION
Fixed the issue that I started at #964. I don't know what process there is for testing, but it fixed the crashing code I am using internally at my company. It would probably be helpful to have upstream so making a PR