### PR TITLE
[ObjC] Response Headers are now passed back to the caller & unused variable warnings have been fixed.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-body.mustache
@@ -268,7 +268,7 @@ static bool loggingEnabled = true;
         for(NSString * key in [queryParams keyEnumerator]){
             if(counter == 0) separator = @"?";
             else separator = @"&";
-            NSString * value;
+            
             id queryParam = [queryParams valueForKey:key];
             if([queryParam isKindOfClass:[NSString class]]){
                 [requestUrl appendString:[NSString stringWithFormat:@"%@%@=%@", separator,

--- a/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-body.mustache
@@ -483,7 +483,7 @@ static bool loggingEnabled = true;
                             authSettings: (NSArray *) authSettings
                       requestContentType: (NSString*) requestContentType
                      responseContentType: (NSString*) responseContentType
-                         completionBlock: (void (^)(id, NSError *))completionBlock {
+                         completionBlock: (void (^)(NSDictionary *, id, NSError *))completionBlock {
     // setting request serializer
     if ([requestContentType isEqualToString:@"application/json"]) {
         self.requestSerializer = [AFJSONRequestSerializer serializer];
@@ -613,7 +613,8 @@ static bool loggingEnabled = true;
              if(self.logServerResponses) {
                  [self logResponse:response forRequest:request error:nil];
              }
-             completionBlock(response, nil);
+             NSDictionary *responseHeaders = [[operation response] allHeaderFields];
+             completionBlock(responseHeaders, response, nil);
          }
      } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
          if([self executeRequestWithId:requestId]) {
@@ -623,10 +624,10 @@ static bool loggingEnabled = true;
                  userInfo[SWGResponseObjectErrorKey] = operation.responseObject;
              }
              NSError *augmentedError = [error initWithDomain:error.domain code:error.code userInfo:userInfo];
-
+             NSDictionary *responseHeaders = [[operation response] allHeaderFields];
              if(self.logServerResponses)
                  [self logResponse:nil forRequest:request error:augmentedError];
-             completionBlock(nil, augmentedError);
+             completionBlock(responseHeaders, nil, augmentedError);
          }
      }];
 

--- a/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-body.mustache
@@ -3,6 +3,13 @@
 #import "SWGQueryParamCollection.h"
 #import "SWGConfiguration.h"
 
+
+@interface SWGApiClient () 
+
+@property (readwrite, nonatomic, strong) NSDictionary *httpResponseHeaders;
+
+@end
+
 @implementation SWGApiClient
 
 NSString *const SWGResponseObjectErrorKey = @"SWGResponseObject";
@@ -483,7 +490,7 @@ static bool loggingEnabled = true;
                             authSettings: (NSArray *) authSettings
                       requestContentType: (NSString*) requestContentType
                      responseContentType: (NSString*) responseContentType
-                         completionBlock: (void (^)(NSDictionary *, id, NSError *))completionBlock {
+                         completionBlock: (void (^)(id, NSError *))completionBlock {
     // setting request serializer
     if ([requestContentType isEqualToString:@"application/json"]) {
         self.requestSerializer = [AFJSONRequestSerializer serializer];
@@ -614,7 +621,8 @@ static bool loggingEnabled = true;
                  [self logResponse:response forRequest:request error:nil];
              }
              NSDictionary *responseHeaders = [[operation response] allHeaderFields];
-             completionBlock(responseHeaders, response, nil);
+             self.httpResponseHeaders = responseHeaders;
+             completionBlock(response, nil);
          }
      } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
          if([self executeRequestWithId:requestId]) {
@@ -627,7 +635,8 @@ static bool loggingEnabled = true;
              NSDictionary *responseHeaders = [[operation response] allHeaderFields];
              if(self.logServerResponses)
                  [self logResponse:nil forRequest:request error:augmentedError];
-             completionBlock(responseHeaders, nil, augmentedError);
+             self.httpResponseHeaders = responseHeaders;
+             completionBlock(nil, augmentedError);
          }
      }];
 

--- a/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-header.mustache
@@ -194,7 +194,7 @@ extern NSString *const SWGResponseObjectErrorKey;
                             authSettings: (NSArray *) authSettings
                       requestContentType:(NSString*) requestContentType
                      responseContentType:(NSString*) responseContentType
-                         completionBlock:(void (^)(id, NSError *))completionBlock;
+                         completionBlock:(void (^)(NSDictionary *, id, NSError *))completionBlock;
 
 
 @end

--- a/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/SWGApiClient-header.mustache
@@ -24,6 +24,7 @@ extern NSString *const SWGResponseObjectErrorKey;
 @property(nonatomic, assign) BOOL logJSON;
 @property(nonatomic, assign) BOOL logHTTP;
 @property(nonatomic, readonly) NSOperationQueue* queue;
+@property(nonatomic, readonly, strong) NSDictionary* httpResponseHeaders;
 
 /**
  * Get the Api Client instance from pool
@@ -194,7 +195,7 @@ extern NSString *const SWGResponseObjectErrorKey;
                             authSettings: (NSArray *) authSettings
                       requestContentType:(NSString*) requestContentType
                      responseContentType:(NSString*) responseContentType
-                         completionBlock:(void (^)(NSDictionary *, id, NSError *))completionBlock;
+                         completionBlock:(void (^)(id, NSError *))completionBlock;
 
 
 @end

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -84,8 +84,8 @@ static NSString * basePath = @"{{basePath}}";
 ///
 -(NSNumber*) {{nickname}}WithCompletionBlock{{^allParams}}: {{/allParams}}{{#allParams}}{{#secondaryParam}} {{paramName}}{{/secondaryParam}}: ({{{dataType}}}) {{paramName}}
         {{/allParams}}
-        {{#returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSDictionary *responseHeaders, {{{returnType}}} output, NSError* error))completionBlock{{/returnBaseType}}
-        {{^returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSDictionary *responseHeaders, NSError* error))completionBlock{{/returnBaseType}} {
+        {{#returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)({{{returnType}}} output, NSError* error))completionBlock{{/returnBaseType}}
+        {{^returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock{{/returnBaseType}} {
 
     {{#allParams}}{{#required}}
     // verify the required parameter '{{paramName}}' is set
@@ -211,9 +211,9 @@ static NSString * basePath = @"{{basePath}}";
                                          authSettings: authSettings
                                    requestContentType: requestContentType
                                   responseContentType: responseContentType
-                                      completionBlock: ^(NSDictionary *responseHeaders, id data, NSError *error) {
-                  {{^returnType}}completionBlock(responseHeaders, error);{{/returnType}}
-                  {{#returnType}}completionBlock(responseHeaders, [self.apiClient deserialize: data class:@"{{{returnType}}}"], error);{{/returnType}}
+                                      completionBlock: ^(id data, NSError *error) {
+                  {{^returnType}}completionBlock(error);{{/returnType}}
+                  {{#returnType}}completionBlock([self.apiClient deserialize: data class:@"{{{returnType}}}"], error);{{/returnType}}
               }
           ];
 }

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -188,6 +188,11 @@ static NSString * basePath = @"{{basePath}}";
     }
     [bodyDictionary addObject:formParams];
     {{/formParams}}
+
+    // removes warnings in case formParams is unused
+    if (formParams.count == 0) {
+        formParams = nil;
+    }
     {{/bodyParam}}
 
     {{#requiredParamCount}}
@@ -197,6 +202,7 @@ static NSString * basePath = @"{{basePath}}";
     }
     {{/requiredParams}}
     {{/requiredParamCount}}
+
     return [self.apiClient requestWithCompletionBlock: requestUrl
                                                method: @"{{httpMethod}}"
                                           queryParams: queryParams

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -84,8 +84,8 @@ static NSString * basePath = @"{{basePath}}";
 ///
 -(NSNumber*) {{nickname}}WithCompletionBlock{{^allParams}}: {{/allParams}}{{#allParams}}{{#secondaryParam}} {{paramName}}{{/secondaryParam}}: ({{{dataType}}}) {{paramName}}
         {{/allParams}}
-        {{#returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)({{{returnType}}} output, NSError* error))completionBlock{{/returnBaseType}}
-        {{^returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock{{/returnBaseType}} {
+        {{#returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSDictionary *responseHeaders, {{{returnType}}} output, NSError* error))completionBlock{{/returnBaseType}}
+        {{^returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSDictionary *responseHeaders, NSError* error))completionBlock{{/returnBaseType}} {
 
     {{#allParams}}{{#required}}
     // verify the required parameter '{{paramName}}' is set
@@ -205,9 +205,9 @@ static NSString * basePath = @"{{basePath}}";
                                          authSettings: authSettings
                                    requestContentType: requestContentType
                                   responseContentType: responseContentType
-                                      completionBlock: ^(id data, NSError *error) {
-                  {{^returnType}}completionBlock(error);{{/returnType}}
-                  {{#returnType}}completionBlock([self.apiClient deserialize: data class:@"{{{returnType}}}"], error);{{/returnType}}
+                                      completionBlock: ^(NSDictionary *responseHeaders, id data, NSError *error) {
+                  {{^returnType}}completionBlock(responseHeaders, error);{{/returnType}}
+                  {{#returnType}}completionBlock(responseHeaders, [self.apiClient deserialize: data class:@"{{{returnType}}}"], error);{{/returnType}}
               }
           ];
 }

--- a/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
@@ -29,9 +29,9 @@
 -(NSNumber*) {{nickname}}WithCompletionBlock {{^allParams}}:{{/allParams}}{{#allParams}}{{#secondaryParam}}     {{paramName}}{{/secondaryParam}}:({{{dataType}}}) {{paramName}} {{#hasMore}}
 {{/hasMore}}{{/allParams}}
     {{#returnBaseType}}{{#hasParams}}
-    completionHandler: {{/hasParams}}(void (^)(NSDictionary *responseHeaders, {{{returnType}}} output, NSError* error))completionBlock;{{/returnBaseType}}
+    completionHandler: {{/hasParams}}(void (^)({{{returnType}}} output, NSError* error))completionBlock;{{/returnBaseType}}
     {{^returnBaseType}}{{#hasParams}}
-    completionHandler: {{/hasParams}}(void (^)(NSDictionary *responseHeaders, NSError* error))completionBlock;{{/returnBaseType}}
+    completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock;{{/returnBaseType}}
 
 {{newline}}
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
@@ -29,9 +29,9 @@
 -(NSNumber*) {{nickname}}WithCompletionBlock {{^allParams}}:{{/allParams}}{{#allParams}}{{#secondaryParam}}     {{paramName}}{{/secondaryParam}}:({{{dataType}}}) {{paramName}} {{#hasMore}}
 {{/hasMore}}{{/allParams}}
     {{#returnBaseType}}{{#hasParams}}
-    completionHandler: {{/hasParams}}(void (^)({{{returnType}}} output, NSError* error))completionBlock;{{/returnBaseType}}
+    completionHandler: {{/hasParams}}(void (^)(NSDictionary *responseHeaders, {{{returnType}}} output, NSError* error))completionBlock;{{/returnBaseType}}
     {{^returnBaseType}}{{#hasParams}}
-    completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock;{{/returnBaseType}}
+    completionHandler: {{/hasParams}}(void (^)(NSDictionary *responseHeaders, NSError* error))completionBlock;{{/returnBaseType}}
 
 {{newline}}
 {{/operation}}


### PR DESCRIPTION
- [ObjC] Response headers are now passed down from the network call to the caller in the same completionBlock as the data/error objects
- [ObjC] Removed an unused "value" variable in SWGApiClient.
- [ObjC] Added check for formParams and set it to nil if its object count is 0. This also removes unused variable warnings.