### PR TITLE
[Swift] Support use in Framework

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
@@ -6,13 +6,13 @@
 
 import Foundation
 
-class {{projectName}}API {
+public class {{projectName}}API {
     static let basePath = "{{basePath}}"
     static var credential: NSURLCredential?
     static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
 }
 
-class APIBase {
+public class APIBase {
     func toParameters(encodable: JSONEncodable?) -> [String: AnyObject]? {
         let encoded: AnyObject? = encodable?.encodeToJSON()
 
@@ -28,7 +28,7 @@ class APIBase {
     }
 }
 
-class RequestBuilder<T> {
+public class RequestBuilder<T> {
     var credential: NSURLCredential?
     var headers: [String:String] = [:]
     let parameters: [String:AnyObject]?
@@ -36,23 +36,23 @@ class RequestBuilder<T> {
     let method: String
     let URLString: String
     
-    required init(method: String, URLString: String, parameters: [String:AnyObject]?, isBody: Bool) {
+    required public init(method: String, URLString: String, parameters: [String:AnyObject]?, isBody: Bool) {
         self.method = method
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody
     }
     
-    func execute(completion: (response: Response<T>?, erorr: NSError?) -> Void) { }
+    public func execute(completion: (response: Response<T>?, erorr: NSError?) -> Void) { }
 
-    func addHeader(#name: String, value: String) -> Self {
+    public func addHeader(#name: String, value: String) -> Self {
         if !value.isEmpty {
             headers[name] = value
         }
         return self
     }
     
-    func addCredential() -> Self {
+    public func addCredential() -> Self {
         self.credential = {{projectName}}API.credential
         return self
     }

--- a/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
@@ -53,7 +53,7 @@ class RequestBuilder<T> {
     }
     
     func addCredential() -> Self {
-        self.credential = OneteamAPI.credential
+        self.credential = {{projectName}}API.credential
         return self
     }
 }

--- a/modules/swagger-codegen/src/main/resources/swift/Extensions.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Extensions.mustache
@@ -65,7 +65,7 @@ extension NSDate: JSONEncodable {
 }
 
 {{#usePromiseKit}}extension RequestBuilder {
-    func execute() -> Promise<Response<T>>  {
+    public func execute() -> Promise<Response<T>>  {
         let deferred = Promise<Response<T>>.defer()
         self.execute { (response: Response<T>?, error: NSError?) in
             if let response = response {

--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -10,18 +10,18 @@ protocol JSONEncodable {
     func encodeToJSON() -> AnyObject
 }
 
-class Response<T> {
-    let statusCode: Int
-    let header: [String: String]
-    let body: T
+public class Response<T> {
+    public let statusCode: Int
+    public let header: [String: String]
+    public let body: T
 
-    init(statusCode: Int, header: [String: String], body: T) {
+    public init(statusCode: Int, header: [String: String], body: T) {
         self.statusCode = statusCode
         self.header = header
         self.body = body
     }
 
-    convenience init(response: NSHTTPURLResponse, body: T) {
+    public convenience init(response: NSHTTPURLResponse, body: T) {
         let rawHeader = response.allHeaderFields
         var header = [String:String]()
         for (key, value) in rawHeader {

--- a/modules/swagger-codegen/src/main/resources/swift/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/api.mustache
@@ -38,14 +38,16 @@ extension {{projectName}}API {
             let url = {{projectName}}API.basePath + path
             {{#bodyParam}}
             let parameters = {{paramName}}{{^required}}?{{/required}}.encodeToJSON() as? [String:AnyObject]{{/bodyParam}}{{^bodyParam}}
-            let nillableParameters: [String:AnyObject?] = {{^queryParams}}[:]{{/queryParams}}{{#queryParams}}{{^secondaryParam}}[{{/secondaryParam}}
+            let nillableParameters: [String:AnyObject?] = {{^queryParams}}{{^formParams}}[:]{{/formParams}}{{#formParams}}{{^secondaryParam}}[{{/secondaryParam}}
+                "{{paramName}}": {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
+            ]{{/hasMore}}{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}[{{/secondaryParam}}
                 "{{paramName}}": {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
             ]{{/hasMore}}{{/queryParams}}
             let parameters = APIHelper.rejectNil(nillableParameters){{/bodyParam}}
 
             let requestBuilder: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = {{projectName}}API.requestBuilderFactory.getBuilder()
 
-            return requestBuilder(method: "{{httpMethod}}", URLString: url, parameters: parameters, isBody: {{^queryParams}}true{{/queryParams}}{{#queryParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/queryParams}})
+            return requestBuilder(method: "{{httpMethod}}", URLString: url, parameters: parameters, isBody: {{^queryParams}}{{^formParams}}true{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/queryParams}}{{#formParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/formParams}})
         }
     {{/operation}}
     }

--- a/modules/swagger-codegen/src/main/resources/swift/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/api.mustache
@@ -11,7 +11,7 @@ import PromiseKit
 extension {{projectName}}API {
     {{#description}}
     /** {{description}} */{{/description}}
-    class {{classname}}: APIBase {
+    public class {{classname}}: APIBase {
     {{#operation}}
         /**
          {{#summary}}
@@ -32,7 +32,7 @@ extension {{projectName}}API {
 
          :returns: Promise<Response<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>> {{description}}
          */
-        func {{operationId}}({{#allParams}}{{^secondaryParam}}#{{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+        public class func {{operationId}}({{#allParams}}{{^secondaryParam}}#{{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
             {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{^secondaryParam}}var{{/secondaryParam}}{{/pathParams}} path = "{{path}}"{{#pathParams}}
             path = path.stringByReplacingOccurrencesOfString("{{=<% %>=}}{<%paramName%>}<%={{ }}=%>", withString: "\({{paramName}})", options: .LiteralSearch, range: nil){{/pathParams}}
             let url = {{projectName}}API.basePath + path

--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -10,15 +10,15 @@ import Foundation
 {{#description}}
 
 /** {{description}} */{{/description}}
-class {{classname}}: JSONEncodable {
+public class {{classname}}: JSONEncodable {
 {{#vars}}{{#isEnum}}
-    enum {{datatypeWithEnum}}: String { {{#allowableValues}}{{#values}}
+    public enum {{datatypeWithEnum}}: String { {{#allowableValues}}{{#values}}
         case {{enum}} = "{{raw}}"{{/values}}{{/allowableValues}}
     }
     {{/isEnum}}{{/vars}}
     {{#vars}}{{#isEnum}}{{#description}}/** {{description}} */
-    {{/description}}var {{name}}: {{{datatypeWithEnum}}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{#required}}!{{/required}}{{/unwrapRequired}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{/isEnum}}{{^isEnum}}{{#description}}/** {{description}} */
-    {{/description}}var {{name}}: {{{datatype}}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{#required}}!{{/required}}{{/unwrapRequired}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{/isEnum}}
+    {{/description}}public var {{name}}: {{{datatypeWithEnum}}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{#required}}!{{/required}}{{/unwrapRequired}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{/isEnum}}{{^isEnum}}{{#description}}/** {{description}} */
+    {{/description}}public var {{name}}: {{{datatype}}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{#required}}!{{/required}}{{/unwrapRequired}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{/isEnum}}
     {{/vars}}
 
     // MARK: JSONEncodable


### PR DESCRIPTION
As discussed in #901 I added explicit access control to classes, methods and members to support the use in a Framework, e.g. when using it in a CocoaPod.

cc: @tkQubo