### PR TITLE
Don't change param names when generating retrofit interfaces

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RetrofitClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RetrofitClientCodegen.java
@@ -116,8 +116,9 @@ public class RetrofitClientCodegen extends DefaultCodegen implements CodegenConf
 
     @Override
     public String toParamName(String name) {
-        // should be the same as variable name
-        return toVarName(name);
+        // param name needs to be the same as in the spec,
+        //otherwise the api tries to access a wrong field
+        return name;
     }
 
     @Override


### PR DESCRIPTION
At the moment param names are changed from snake_case to camelCase when generating Retrofit interfaces.

So when generating client code for this spec:
```js
parameters: [
    {
        name: "grant_type",
        in: "formData",
        description: "client_credentials",
        required: true,
        type: "string",
        default: "client_credentials"
    }
]
```
your body ends up like this:
```js
{
    grandType: "XXXX"
}
```
when it actually should look like this:
```js
{
    grand_type: "XXXX"
}
```