### PR TITLE
Fix compilation error with a newer swagger parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,7 +464,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.8</swagger-parser-version>
+        <swagger-parser-version>1.0.9-SNAPSHOT</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>2.3.4</felix-version>
         <swagger-core-version>1.5.0</swagger-core-version>


### PR DESCRIPTION
Updated pom.xml to use a newer version of swagger-parser: 1.0.9-SNAPSHOT, which contains updated function for `SwaggerParser().read`