### PR TITLE
{{serverPort}} ---to--> serverPort

### DIFF
--- a/modules/swagger-codegen/src/main/resources/nodejs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/nodejs/index.mustache
@@ -31,8 +31,8 @@ swaggerTools.initializeMiddleware(swaggerDoc, function (middleware) {
   app.use(middleware.swaggerUi());
 
   // Start the server
-  http.createServer(app).listen({{serverPort}}, function () {
-    console.log('Your server is listening on port %d (http://localhost:%d)', {{serverPort}}, {{serverPort}});
-    console.log('Swagger-ui is available on http://localhost:%d/docs', {{serverPort}});
+  http.createServer(app).listen(serverPort, function () {
+    console.log('Your server is listening on port %d (http://localhost:%d)', serverPort, serverPort);
+    console.log('Swagger-ui is available on http://localhost:%d/docs', serverPort);
   });
 });


### PR DESCRIPTION
It was inline-ing the serverPort into the generated template, so you'd see 

```js
var serverPort = 8080;
//...
http.createServer(app).listen(8080, function () {
  console.log('Your server is listening on port %d (http://localhost:%d)', 8080, 8080);
  console.log('Swagger-ui is available on http://localhost:%d/docs', 8080);
});
```