### PR TITLE
Unreachable Code in Deserialize (type.GetType())

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -133,9 +133,6 @@ namespace {{invokerPackage}} {
     /// <param name="type"> Object type
     /// <returns>Object representation of the JSON string</returns>
     public object Deserialize(string content, Type type) {
-      if (type.GetType() == typeof(Object))
-        return (Object)content;
-
       try
       {
           return JsonConvert.DeserializeObject(content, type);


### PR DESCRIPTION
Removing:

if (type.GetType() == typeof(Object))
        return (Object)content;

Because it is unreachable. When you call .GetType() on an instance of Type, which is being done here, you actually are getting the type of the type, which in this case would be RuntimeType. You don't get the type that the Type object is wrapping. Because you always get the type of RuntimeType, this if statement always evaluates to false.

I'm proposing to remove these lines, because it seems it always evaluates to false, and therefore isn't hit. Their original purpose seems undocumented as well, and I wonder if it's some kind of workaround.

A way to have this functionality and have it evaluate properly would be:

if (type.FullName == typeof(Object).FullName)
        return (Object)content;

Further Reading:
http://stackoverflow.com/questions/7988781/what-does-gettype-return-on-an-instance-of-type