### PR TITLE
[Objc] Fix deserialize nested map error

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -213,21 +213,22 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
             Property inner = ap.getItems();
             String innerType = getSwaggerType(inner);
 
-            // In this codition, type of property p is array of primitive,
-            // return container type with pointer, e.g. `NSArray*'
-            if (languageSpecificPrimitives.contains(innerType)) {
-                return getSwaggerType(p) + "*";
-            }
-
-            // In this codition, type of property p is array of model,
-            // return container type combine inner type with pointer, e.g. `NSArray<SWGTag>*'
             String innerTypeDeclaration = getTypeDeclaration(inner);
 
             if (innerTypeDeclaration.endsWith("*")) {
                 innerTypeDeclaration = innerTypeDeclaration.substring(0, innerTypeDeclaration.length() - 1);
             }
 
-            return getSwaggerType(p) + "<" + innerTypeDeclaration + ">*";
+            // In this codition, type of property p is array of primitive,
+            // return container type with pointer, e.g. `NSArray* /* NSString */'
+            if (languageSpecificPrimitives.contains(innerType)) {
+                return getSwaggerType(p) + "*" + " /* " + innerTypeDeclaration + " */";
+            }
+            // In this codition, type of property p is array of model,
+            // return container type combine inner type with pointer, e.g. `NSArray<SWGTag>*'
+            else {
+                return getSwaggerType(p) + "<" + innerTypeDeclaration + ">*";
+            }
         } else if (p instanceof MapProperty) {
             MapProperty mp = (MapProperty) p;
             Property inner = mp.getAdditionalProperties();

--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -413,7 +413,7 @@ static void (^reachabilityChangeBlock)(int);
     }
 
     // map
-    NSString *dictPat = @"NSDictionary\\* /\\* (.+), (.+) \\*/";
+    NSString *dictPat = @"NSDictionary\\* /\\* (.+?), (.+) \\*/";
     regexp = [NSRegularExpression regularExpressionWithPattern:dictPat
                                                        options:NSRegularExpressionCaseInsensitive
                                                          error:nil];

--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -356,13 +356,14 @@ static void (^reachabilityChangeBlock)(int);
     NSTextCheckingResult *match = nil;
     NSMutableArray *resultArray = nil;
     NSMutableDictionary *resultDict = nil;
+    NSString *innerType = nil;
 
     // return nil if data is nil or class is nil
     if (!data || !class) {
         return nil;
     }
 
-    // remove "*" from class, if ends with "*"
+    // remove "*" from class, if ends with "*"
     if ([class hasSuffix:@"*"]) {
         class = [class substringToIndex:[class length] - 1];
     }
@@ -383,7 +384,7 @@ static void (^reachabilityChangeBlock)(int);
                                  range:NSMakeRange(0, [class length])];
     
     if (match) {
-        NSString *innerType = [class substringWithRange:[match rangeAtIndex:1]];
+        innerType = [class substringWithRange:[match rangeAtIndex:1]];
 
         resultArray = [NSMutableArray arrayWithCapacity:[data count]];
         [data enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
@@ -395,8 +396,8 @@ static void (^reachabilityChangeBlock)(int);
     }
 
     // list of primitives
-    NSString *arrayOfPrimitivesPet = @"NSArray";
-    regexp = [NSRegularExpression regularExpressionWithPattern:arrayOfPrimitivesPet
+    NSString *arrayOfPrimitivesPat = @"NSArray\\* /\\* (.+) \\*/";
+    regexp = [NSRegularExpression regularExpressionWithPattern:arrayOfPrimitivesPat
                                                        options:NSRegularExpressionCaseInsensitive
                                                          error:nil];
     match = [regexp firstMatchInString:class
@@ -404,9 +405,11 @@ static void (^reachabilityChangeBlock)(int);
                                  range:NSMakeRange(0, [class length])];
 
     if (match) {
+        innerType = [class substringWithRange:[match rangeAtIndex:1]];
+        
         resultArray = [NSMutableArray arrayWithCapacity:[data count]];
         [data enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-            [resultArray addObject:[self deserialize:obj class:NSStringFromClass([obj class])]];
+            [resultArray addObject:[self deserialize:obj class:innerType]];
         }];
         
         return resultArray;

--- a/modules/swagger-codegen/src/test/scala/Objc/ObjcModelTest.scala
+++ b/modules/swagger-codegen/src/test/scala/Objc/ObjcModelTest.scala
@@ -90,7 +90,7 @@ class ObjcModelTest extends FlatSpec with Matchers {
     vars.get(0).isNotContainer should equal(true)
 
     vars.get(1).baseName should be("urls")
-    vars.get(1).datatype should be("NSArray*")
+    vars.get(1).datatype should be("NSArray* /* NSString */")
     vars.get(1).name should be("urls")
     // vars.get(1).defaultValue should be ("null")
     vars.get(1).baseType should be("NSArray")

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
@@ -413,7 +413,7 @@ static void (^reachabilityChangeBlock)(int);
     }
 
     // map
-    NSString *dictPat = @"NSDictionary\\* /\\* (.+), (.+) \\*/";
+    NSString *dictPat = @"NSDictionary\\* /\\* (.+?), (.+) \\*/";
     regexp = [NSRegularExpression regularExpressionWithPattern:dictPat
                                                        options:NSRegularExpressionCaseInsensitive
                                                          error:nil];

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
@@ -356,13 +356,14 @@ static void (^reachabilityChangeBlock)(int);
     NSTextCheckingResult *match = nil;
     NSMutableArray *resultArray = nil;
     NSMutableDictionary *resultDict = nil;
+    NSString *innerType = nil;
 
     // return nil if data is nil or class is nil
     if (!data || !class) {
         return nil;
     }
 
-    // remove "*" from class, if ends with "*"
+    // remove "*" from class, if ends with "*"
     if ([class hasSuffix:@"*"]) {
         class = [class substringToIndex:[class length] - 1];
     }
@@ -383,7 +384,7 @@ static void (^reachabilityChangeBlock)(int);
                                  range:NSMakeRange(0, [class length])];
     
     if (match) {
-        NSString *innerType = [class substringWithRange:[match rangeAtIndex:1]];
+        innerType = [class substringWithRange:[match rangeAtIndex:1]];
 
         resultArray = [NSMutableArray arrayWithCapacity:[data count]];
         [data enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
@@ -395,8 +396,8 @@ static void (^reachabilityChangeBlock)(int);
     }
 
     // list of primitives
-    NSString *arrayOfPrimitivesPet = @"NSArray";
-    regexp = [NSRegularExpression regularExpressionWithPattern:arrayOfPrimitivesPet
+    NSString *arrayOfPrimitivesPat = @"NSArray\\* /\\* (.+) \\*/";
+    regexp = [NSRegularExpression regularExpressionWithPattern:arrayOfPrimitivesPat
                                                        options:NSRegularExpressionCaseInsensitive
                                                          error:nil];
     match = [regexp firstMatchInString:class
@@ -404,9 +405,11 @@ static void (^reachabilityChangeBlock)(int);
                                  range:NSMakeRange(0, [class length])];
 
     if (match) {
+        innerType = [class substringWithRange:[match rangeAtIndex:1]];
+        
         resultArray = [NSMutableArray arrayWithCapacity:[data count]];
         [data enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-            [resultArray addObject:[self deserialize:obj class:NSStringFromClass([obj class])]];
+            [resultArray addObject:[self deserialize:obj class:innerType]];
         }];
         
         return resultArray;

--- a/samples/client/petstore/objc/SwaggerClient/SWGPet.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPet.h
@@ -23,7 +23,7 @@
 
 @property(nonatomic) NSString* name;
 
-@property(nonatomic) NSArray* photoUrls;
+@property(nonatomic) NSArray* /* NSString */ photoUrls;
 
 @property(nonatomic) NSArray<SWGTag>* tags;
 /* pet status in the store [optional]

--- a/samples/client/petstore/objc/SwaggerClient/SWGPetApi.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPetApi.h
@@ -59,7 +59,7 @@
 /// 
 ///
 /// @return NSArray<SWGPet>*
--(NSNumber*) findPetsByStatusWithCompletionBlock :(NSArray*) status 
+-(NSNumber*) findPetsByStatusWithCompletionBlock :(NSArray* /* NSString */) status 
     
     completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock;
     
@@ -74,7 +74,7 @@
 /// 
 ///
 /// @return NSArray<SWGPet>*
--(NSNumber*) findPetsByTagsWithCompletionBlock :(NSArray*) tags 
+-(NSNumber*) findPetsByTagsWithCompletionBlock :(NSArray* /* NSString */) tags 
     
     completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock;
     

--- a/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
@@ -260,7 +260,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 ///
 ///  @returns NSArray<SWGPet>*
 ///
--(NSNumber*) findPetsByStatusWithCompletionBlock: (NSArray*) status
+-(NSNumber*) findPetsByStatusWithCompletionBlock: (NSArray* /* NSString */) status
         
         completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock { 
         
@@ -341,7 +341,7 @@ static NSString * basePath = @"http://petstore.swagger.io/v2";
 ///
 ///  @returns NSArray<SWGPet>*
 ///
--(NSNumber*) findPetsByTagsWithCompletionBlock: (NSArray*) tags
+-(NSNumber*) findPetsByTagsWithCompletionBlock: (NSArray* /* NSString */) tags
         
         completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock { 
         

--- a/samples/client/petstore/objc/SwaggerClientTests/Tests/DeserializationTest.m
+++ b/samples/client/petstore/objc/SwaggerClientTests/Tests/DeserializationTest.m
@@ -116,4 +116,19 @@
     XCTAssertEqualObjects([result[@"pet"] _id], @119);
 }
 
+- (void)testDeserializeNestedMap {
+    NSDictionary *data =
+    @{
+      @"foo": @{
+              @"bar": @1
+              }
+    };
+    
+    NSDictionary *result = [apiClient deserialize:data class:@"NSDictionary* /* NSString, NSDictionary* /* NSString, NSNumber */ */"];
+    
+    XCTAssertTrue([result isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue([result[@"foo"] isKindOfClass:[NSDictionary class]]);
+    XCTAssertTrue([result[@"foo"][@"bar"] isKindOfClass:[NSNumber class]]);
+}
+
 @end

--- a/samples/client/petstore/objc/SwaggerClientTests/Tests/DeserializationTest.m
+++ b/samples/client/petstore/objc/SwaggerClientTests/Tests/DeserializationTest.m
@@ -55,6 +55,14 @@
     XCTAssertTrue([result isEqualToString:data]);
 }
 
+- (void)testDeserializeListOfString {
+    NSArray *data = @[@"test string"];
+    NSArray *result = [apiClient deserialize:data class:@"NSArray* /* NSString */"];
+    
+    XCTAssertTrue([result isKindOfClass:[NSArray class]]);
+    XCTAssertTrue([result[0] isKindOfClass:[NSString class]]);
+}
+
 - (void)testDeserializeListOfModels {
     NSArray *data =
     @[
@@ -129,6 +137,16 @@
     XCTAssertTrue([result isKindOfClass:[NSDictionary class]]);
     XCTAssertTrue([result[@"foo"] isKindOfClass:[NSDictionary class]]);
     XCTAssertTrue([result[@"foo"][@"bar"] isKindOfClass:[NSNumber class]]);
+}
+
+- (void)testDeserializeNestedList {
+    NSArray *data = @[@[@"foo"]];
+    
+    NSArray *result = [apiClient deserialize:data class:@"NSArray* /* NSArray* /* NSString */ */"];
+    
+    XCTAssertTrue([result isKindOfClass:[NSArray class]]);
+    XCTAssertTrue([result[0] isKindOfClass:[NSArray class]]);
+    XCTAssertTrue([result[0][0] isKindOfClass:[NSString class]]);
 }
 
 @end


### PR DESCRIPTION
Fixed the issue that deserialize nested map data.

When parse nested data type like `"NSDictionary* /* NSString, NSDictionary* /* NSString, NSNumber */ */`, the pattern `NSString *dictPat = @"NSDictionary\\* /\\* (.+), (.+) \\*/";` will match key `NSString, NSDictionary* /* NSString,` and value `NSNumber`.

But the correct match key should be `NSString` and the correct match value should be `NSDictionary* /* NSString, NSNumber */ `. The issue will be fixed by replace the pattern `NSString *dictPat = @"NSDictionary\\* /\\* (.+), (.+) \\*/";` with `NSString *dictPat = @"NSDictionary\\* /\\* (.+?), (.+) \\*/";`.

By the way, integration test looks fine:
```sh
Test Suite 'All tests' passed at 2015-07-28 02:57:42 +0000.
	 Executed 21 tests, with 0 failures (0 unexpected) in 12.322 (12.338) seconds
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:01 min
[INFO] Finished at: 2015-07-28T10:57:43+08:00
[INFO] Final Memory: 11M/156M
[INFO] ------------------------------------------------------------------------
```