### PR TITLE
Catch all exceptions on Deserialize

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -235,7 +235,7 @@ namespace {{packageName}}.Client
             {
                 return JsonConvert.DeserializeObject(content, type);
             }
-            catch (IOException e)
+            catch (Exception e)
             {
                 throw new ApiException(500, e.Message);
             }


### PR DESCRIPTION
If you look at the source of NewtonSoft.Json, you'll see that DeserializeObject never throws an IOException. All exceptions should be caught in this method, just like Serialize.