### PR TITLE
Support to array of enums

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -34,4 +34,6 @@ public class CodegenProperty {
     public boolean isEnum;
     public List<String> _enum;
     public Map<String, Object> allowableValues;
+    public CodegenProperty items;
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -683,9 +683,9 @@ public class DefaultCodegen {
 				}
 				property.items = cp;
 				if (property.items.isEnum) {
-					property.datatypeWithEnum = property.datatypeWithEnum.replace("String",
+					property.datatypeWithEnum = property.datatypeWithEnum.replace(property.items.baseType,
 							property.items.datatypeWithEnum);
-					property.defaultValue = property.defaultValue.replace("String", property.items.datatypeWithEnum);
+					property.defaultValue = property.defaultValue.replace(property.items.baseType, property.items.datatypeWithEnum);
 				}
 			}
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -667,22 +667,29 @@ public class DefaultCodegen {
 
         property.baseType = getSwaggerType(p);
 
-        if (p instanceof ArrayProperty) {
-            property.isContainer = true;
-            property.containerType = "array";
-            ArrayProperty ap = (ArrayProperty) p;
-            CodegenProperty cp = fromProperty("inner", ap.getItems());
-            if (cp == null) {
-                LOGGER.warn("skipping invalid property " + Json.pretty(p));
-            } else {
-                property.baseType = getSwaggerType(p);
-                if (!languageSpecificPrimitives.contains(cp.baseType)) {
-                    property.complexType = cp.baseType;
-                } else {
-                    property.isPrimitiveType = true;
-                }
-            }
-        } else if (p instanceof MapProperty) {
+		if (p instanceof ArrayProperty) {
+			property.isContainer = true;
+			property.containerType = "array";
+			ArrayProperty ap = (ArrayProperty) p;
+			CodegenProperty cp = fromProperty(property.name, ap.getItems());
+			if (cp == null) {
+				LOGGER.warn("skipping invalid property " + Json.pretty(p));
+			} else {
+				property.baseType = getSwaggerType(p);
+				if (!languageSpecificPrimitives.contains(cp.baseType)) {
+					property.complexType = cp.baseType;
+				} else {
+					property.isPrimitiveType = true;
+				}
+				property.items = cp;
+				if (property.items.isEnum) {
+					property.datatypeWithEnum = property.datatypeWithEnum.replace("String",
+							property.items.datatypeWithEnum);
+					property.defaultValue = property.defaultValue.replace("String", property.items.datatypeWithEnum);
+				}
+			}
+
+		} else if (p instanceof MapProperty) {
             property.isContainer = true;
             property.containerType = "map";
             MapProperty ap = (MapProperty) p;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -667,29 +667,28 @@ public class DefaultCodegen {
 
         property.baseType = getSwaggerType(p);
 
-		if (p instanceof ArrayProperty) {
-			property.isContainer = true;
-			property.containerType = "array";
-			ArrayProperty ap = (ArrayProperty) p;
-			CodegenProperty cp = fromProperty(property.name, ap.getItems());
-			if (cp == null) {
-				LOGGER.warn("skipping invalid property " + Json.pretty(p));
+	if (p instanceof ArrayProperty) {
+		property.isContainer = true;
+		property.containerType = "array";
+		ArrayProperty ap = (ArrayProperty) p;
+		CodegenProperty cp = fromProperty(property.name, ap.getItems());
+		if (cp == null) {
+			LOGGER.warn("skipping invalid property " + Json.pretty(p));
+		} else {
+			property.baseType = getSwaggerType(p);
+			if (!languageSpecificPrimitives.contains(cp.baseType)) {
+				property.complexType = cp.baseType;
 			} else {
-				property.baseType = getSwaggerType(p);
-				if (!languageSpecificPrimitives.contains(cp.baseType)) {
-					property.complexType = cp.baseType;
-				} else {
-					property.isPrimitiveType = true;
-				}
-				property.items = cp;
-				if (property.items.isEnum) {
-					property.datatypeWithEnum = property.datatypeWithEnum.replace(property.items.baseType,
-							property.items.datatypeWithEnum);
-					property.defaultValue = property.defaultValue.replace(property.items.baseType, property.items.datatypeWithEnum);
-				}
+				property.isPrimitiveType = true;
 			}
-
-		} else if (p instanceof MapProperty) {
+			property.items = cp;
+			if (property.items.isEnum) {
+				property.datatypeWithEnum = property.datatypeWithEnum.replace(property.items.baseType,
+						property.items.datatypeWithEnum);
+				property.defaultValue = property.defaultValue.replace(property.items.baseType, property.items.datatypeWithEnum);
+			}
+		}
+	} else if (p instanceof MapProperty) {
             property.isContainer = true;
             property.containerType = "map";
             MapProperty ap = (MapProperty) p;

--- a/modules/swagger-codegen/src/main/resources/Java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/model.mustache
@@ -16,9 +16,12 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   {{#vars}}{{#isEnum}}
   public enum {{datatypeWithEnum}} {
     {{#allowableValues}}{{#values}} {{.}}, {{/values}}{{/allowableValues}}
+  };{{/isEnum}}{{#items.isEnum}}{{#items}}
+  public enum {{datatypeWithEnum}} {
+    {{#allowableValues}}{{#values}} {{.}}, {{/values}}{{/allowableValues}}
   };
-  private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/isEnum}}{{^isEnum}}
-  private {{{datatype}}} {{name}} = {{{defaultValue}}};{{/isEnum}}{{/vars}}
+{{/items}}{{/items.isEnum}}
+  private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/vars}}
 
   {{#vars}}
   /**{{#description}}


### PR DESCRIPTION
Added support to array of enums in the DefaultCodegen (it used to generate an array of strings instead) and updated the java template to use it.
Tested only in Java and it is working fine. I don't think there will be issues with the other languages (they won't use my changes and will just ignore it).