### PR TITLE
Support for nested lists/maps for the python client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -174,7 +174,7 @@ class ApiClient(object):
         Builds a JSON POST object.
 
         If obj is None, return None.
-        If obj is str, int, float, bool, return directly.
+        If obj is str, unicode, int, float, bool, return directly.
         If obj is datetime.datetime, datetime.date
             convert to string in iso8601 format.
         If obj is list, santize each element in the list.
@@ -186,7 +186,7 @@ class ApiClient(object):
         """
         if isinstance(obj, type(None)):
             return None
-        elif isinstance(obj, (str, int, float, bool, tuple)):
+        elif isinstance(obj, (str, unicode, int, float, bool, tuple)):
             return obj
         elif isinstance(obj, list):
             return [self.sanitize_for_serialization(sub_obj)

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -174,7 +174,7 @@ class ApiClient(object):
         Builds a JSON POST object.
 
         If obj is None, return None.
-        If obj is str, unicode, int, float, bool, return directly.
+        If obj is str, int, float, bool, return directly.
         If obj is datetime.datetime, datetime.date
             convert to string in iso8601 format.
         If obj is list, santize each element in the list.
@@ -186,7 +186,7 @@ class ApiClient(object):
         """
         if isinstance(obj, type(None)):
             return None
-        elif isinstance(obj, (str, unicode, int, float, bool, tuple)):
+        elif isinstance(obj, (str, int, float, bool, tuple)):
             return obj
         elif isinstance(obj, list):
             return [self.sanitize_for_serialization(sub_obj)

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -247,12 +247,12 @@ class ApiClient(object):
             return None
 
         if type(klass) == str:
-            if 'list[' in klass:
+            if klass.startswith('list['):
                 sub_kls = re.match('list\[(.*)\]', klass).group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
-            if 'dict(' in klass:
+            if klass.startswith('dict('):
                 sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in iteritems(data)}


### PR DESCRIPTION
Just using `startswith` instead of `in` allows for nested arrays/maps defined in swagger to be translated to the right list/dict combination on python.

Also added unicode to the list of types `sanitize_for_serialization` just returns.