### PR TITLE
DefaultGenerator Exception

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -93,7 +93,7 @@ public class Generate implements Runnable {
     }
 
     @Override
-    public void run() {
+    public void run() throws Exception {
         verbosed(verbose);
 
         setSystemProperties();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/Codegen.java
@@ -29,7 +29,7 @@ public class Codegen extends DefaultGenerator {
             "\n -DdebugOperations prints operations passed to the template engine" +
             "\n -DdebugSupportingFiles prints additional data passed to the template engine";
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
 
         StringBuilder sb = new StringBuilder();
 
@@ -97,7 +97,7 @@ public class Codegen extends DefaultGenerator {
                     .swagger(swagger);
             new Codegen().opts(clientOptInput).generate();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new Exception("Code generation failed");
         }
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -1,8 +1,10 @@
 package io.swagger.codegen;
 
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
-
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Contact;
 import io.swagger.models.Info;
@@ -14,7 +16,6 @@ import io.swagger.models.Swagger;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import io.swagger.util.Json;
-
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -34,9 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-
 public class DefaultGenerator extends AbstractGenerator implements Generator {
     protected CodegenConfig config;
     protected ClientOptInput opts = null;
@@ -52,7 +50,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         return this;
     }
 
-    public List<File> generate() {
+    public List<File> generate() throws Exception {
         if (swagger == null || config == null) {
             throw new RuntimeException("missing swagger input or config!");
         }
@@ -306,7 +304,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
             config.processSwagger(swagger);
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new Exception("Code generation failed");
         }
         return files;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/Generator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/Generator.java
@@ -6,5 +6,5 @@ import java.util.List;
 public interface Generator {
     Generator opts(ClientOptInput opts);
 
-    List<File> generate();
+    List<File> generate() throws Exception;
 }


### PR DESCRIPTION
Change to DefaultGenerator:
When the generate() method throws an exception, the exception is caught and a stack trace is printed. Due to the way this exception is caught, it is difficult to detect if code generation has failed when we aren't generating code through the command line.

This change is inspired by our needs at Wikia, where we are using Swagger to generate code progammatically, so we would like to easily detect when generation fails.

Please let us know if we’ve missed anything or didn’t take any factors into account with this change.