### PR TITLE
Default Generator Status

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -1,8 +1,14 @@
 package io.swagger.codegen;
 
+import static io.swagger.codegen.languages.CodeGenStatus.Status.FAILED;
+import static io.swagger.codegen.languages.CodeGenStatus.Status.SUCCESSFUL;
+import static io.swagger.codegen.languages.CodeGenStatus.Status.UNRUN;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
-
+import io.swagger.codegen.languages.CodeGenStatus;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Contact;
 import io.swagger.models.Info;
@@ -14,7 +20,6 @@ import io.swagger.models.Swagger;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import io.swagger.util.Json;
-
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -34,13 +39,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-
 public class DefaultGenerator extends AbstractGenerator implements Generator {
     protected CodegenConfig config;
     protected ClientOptInput opts = null;
     protected Swagger swagger = null;
+
+    public CodeGenStatus status = new CodeGenStatus(UNRUN);
 
     public Generator opts(ClientOptInput opts) {
         this.opts = opts;
@@ -305,8 +309,10 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             }
 
             config.processSwagger(swagger);
+
+            status.setStatus(SUCCESSFUL);
         } catch (Exception e) {
-            e.printStackTrace();
+            status.setStatus(FAILED);
         }
         return files;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -1,8 +1,5 @@
 package io.swagger.codegen;
 
-import static io.swagger.codegen.languages.CodeGenStatus.Status.FAILED;
-import static io.swagger.codegen.languages.CodeGenStatus.Status.SUCCESSFUL;
-import static io.swagger.codegen.languages.CodeGenStatus.Status.UNRUN;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
@@ -44,7 +41,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     protected ClientOptInput opts = null;
     protected Swagger swagger = null;
 
-    public CodeGenStatus status = new CodeGenStatus(UNRUN);
+    public CodeGenStatus status = CodeGenStatus.UNRUN;
 
     public Generator opts(ClientOptInput opts) {
         this.opts = opts;
@@ -310,9 +307,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
             config.processSwagger(swagger);
 
-            status.setStatus(SUCCESSFUL);
+            status = CodeGenStatus.SUCCESSFUL;
         } catch (Exception e) {
-            status.setStatus(FAILED);
+            status = CodeGenStatus.FAILED;
         }
         return files;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CodeGenStatus.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CodeGenStatus.java
@@ -1,0 +1,21 @@
+package io.swagger.codegen.languages;
+
+public class CodeGenStatus {
+  public enum Status {
+    UNRUN, SUCCESSFUL, FAILED
+  };
+
+  private Status status;
+
+  public CodeGenStatus(Status status) {
+    this.status = status;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public void setStatus(Status status) {
+    this.status = status;
+  }
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CodeGenStatus.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CodeGenStatus.java
@@ -1,21 +1,5 @@
 package io.swagger.codegen.languages;
 
-public class CodeGenStatus {
-  public enum Status {
+public enum CodeGenStatus {
     UNRUN, SUCCESSFUL, FAILED
-  };
-
-  private Status status;
-
-  public CodeGenStatus(Status status) {
-    this.status = status;
-  }
-
-  public Status getStatus() {
-    return status;
-  }
-
-  public void setStatus(Status status) {
-    this.status = status;
-  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.9-SNAPSHOT</swagger-parser-version>
+        <swagger-parser-version>1.0.9</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>2.3.4</felix-version>
         <swagger-core-version>1.5.0</swagger-core-version>

--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.9</swagger-parser-version>
+        <swagger-parser-version>1.0.9-SNAPSHOT</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>2.3.4</felix-version>
         <swagger-core-version>1.5.0</swagger-core-version>


### PR DESCRIPTION
Change to DefaultGenerator:
When the generate() method throw an exception, the exception is caught and a stack trace is printed. Due to the way this exception is caught, it is difficult to detect if code generation has failed when we aren't generating code through the command line. 

For this reason, I added enum CodeGenStatus, so a status can be set for each instance of the DefaultGenerator.

This change is inspired by our needs at Wikia, where we are using Swagger to generate code progammatically and would like to easily detect when generation fails.

Please let us know if we've missed anything or didn't take any factors into account with this change.