### PR TITLE
Codegen should honor path level parameters

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -423,10 +423,12 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             }
 
             //need to propagate path level down to the operation
-            for (Parameter parameter : path.getParameters()) {
-                //skip propagation if a parameter with the same name is already defined at the operation level
-                if (!operationParameters.contains(generateParameterId(parameter))) {
-                    operation.addParameter(parameter);
+            if(path.getParameters() != null) {
+                for (Parameter parameter : path.getParameters()) {
+                    //skip propagation if a parameter with the same name is already defined at the operation level
+                    if (!operationParameters.contains(generateParameterId(parameter))) {
+                        operation.addParameter(parameter);
+                    }
                 }
             }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
@@ -90,21 +90,6 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
     }
 
     @Override
-    public String getTypeDeclaration(Property p) {
-        if (p instanceof ArrayProperty) {
-            ArrayProperty ap = (ArrayProperty) p;
-            Property inner = ap.getItems();
-            return getSwaggerType(p) + "<" + getTypeDeclaration(inner) + ">";
-        } else if (p instanceof MapProperty) {
-            MapProperty mp = (MapProperty) p;
-            Property inner = mp.getAdditionalProperties();
-
-            return getTypeDeclaration(inner);
-        }
-        return super.getTypeDeclaration(p);
-    }
-
-    @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
         String basePath = resourcePath;
         if (basePath.startsWith("/")) {


### PR DESCRIPTION
Currently the codegen ignores Path level params. For example, the following Path and Operation would get converted into a Codegen operation with no parameters, even though there is a path level header parameter.

```yaml
swager: 2.0
paths:
  /people :
    parameters:
      name: "Authorization"
      in: "header"
      description: "authorization ticket"
      required: true
      type: "string"
    get:
       description: Get all the people entities
       response:
         200:
           schema:
             $ref: #/definitions/People
```

Additionally, included a fix for #996 while I was at it.

As always feedback on my code is appreciated.


       
