### PR TITLE
Add @Generated annotation to all generated Java templates

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -16,6 +16,7 @@ import io.swagger.models.auth.SecuritySchemeDefinition;
 import io.swagger.util.Json;
 
 import org.apache.commons.io.IOUtils;
+import org.joda.time.DateTime;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -62,6 +63,10 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         List<File> files = new ArrayList<File>();
         try {
             config.processOpts();
+
+            config.additionalProperties().put("generatedTime", DateTime.now().toString());
+            config.additionalProperties().put("generatorClass", config.getClass().toString());
+
             if (swagger.getInfo() != null) {
                 Info info = swagger.getInfo();
                 if (info.getTitle() != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -64,7 +64,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         try {
             config.processOpts();
 
-            config.additionalProperties().put("generatedTime", DateTime.now().toString());
+            config.additionalProperties().put("generatedDate", DateTime.now().toString());
             config.additionalProperties().put("generatorClass", config.getClass().toString());
 
             if (swagger.getInfo() != null) {

--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -40,6 +40,7 @@ import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
 import {{invokerPackage}}.auth.OAuth;
 
+{{>generatedAnnotation}}
 public class ApiClient {
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();

--- a/modules/swagger-codegen/src/main/resources/Java/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/Configuration.mustache
@@ -1,5 +1,6 @@
 package {{invokerPackage}};
 
+{{>generatedAnnotation}}
 public class Configuration {
   private static ApiClient defaultApiClient = new ApiClient();
 

--- a/modules/swagger-codegen/src/main/resources/Java/JsonUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/JsonUtil.mustache
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonGenerator.Feature;
 
 import com.fasterxml.jackson.datatype.joda.*;
 
+{{>generatedAnnotation}}
 public class JsonUtil {
   public static ObjectMapper mapper;
 

--- a/modules/swagger-codegen/src/main/resources/Java/Pair.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/Pair.mustache
@@ -1,5 +1,6 @@
 package {{invokerPackage}};
 
+{{>generatedAnnotation}}
 public class Pair {
     private String name = "";
     private String value = "";

--- a/modules/swagger-codegen/src/main/resources/Java/StringUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/StringUtil.mustache
@@ -1,5 +1,6 @@
 package {{invokerPackage}};
 
+{{>generatedAnnotation}}
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -21,6 +21,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
 
+{{>generatedAnnotation}}
 {{#operations}}
 public class {{classname}} {
   private ApiClient {{localVariablePrefix}}apiClient;

--- a/modules/swagger-codegen/src/main/resources/Java/apiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/apiException.mustache
@@ -3,6 +3,7 @@ package {{invokerPackage}};
 import java.util.Map;
 import java.util.List;
 
+{{>generatedAnnotation}}
 public class ApiException extends Exception {
   private int code = 0;
   private String message = null;

--- a/modules/swagger-codegen/src/main/resources/Java/auth/ApiKeyAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/auth/ApiKeyAuth.mustache
@@ -5,6 +5,7 @@ import {{invokerPackage}}.Pair;
 import java.util.Map;
 import java.util.List;
 
+{{>generatedAnnotation}}
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/modules/swagger-codegen/src/main/resources/Java/auth/Authentication.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/auth/Authentication.mustache
@@ -5,6 +5,7 @@ import {{invokerPackage}}.Pair;
 import java.util.Map;
 import java.util.List;
 
+{{>generatedAnnotation}}
 public interface Authentication {
   /** Apply authentication settings to header and query params. */
   void applyToParams(List<Pair> queryParams, Map<String, String> headerParams);

--- a/modules/swagger-codegen/src/main/resources/Java/auth/HttpBasicAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/auth/HttpBasicAuth.mustache
@@ -8,6 +8,7 @@ import java.util.List;
 import java.io.UnsupportedEncodingException;
 import javax.xml.bind.DatatypeConverter;
 
+{{>generatedAnnotation}}
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/modules/swagger-codegen/src/main/resources/Java/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/auth/OAuth.mustache
@@ -5,6 +5,7 @@ import {{invokerPackage}}.Pair;
 import java.util.Map;
 import java.util.List;
 
+{{>generatedAnnotation}}
 public class OAuth implements Authentication {
   @Override
   public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {

--- a/modules/swagger-codegen/src/main/resources/Java/generatedAnnotation.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/generatedAnnotation.mustache
@@ -1,0 +1,1 @@
+@javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")

--- a/modules/swagger-codegen/src/main/resources/Java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/model.mustache
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * {{description}}
  **/{{/description}}
 @ApiModel(description = "{{{description}}}")
+{{>generatedAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   {{#vars}}{{#isEnum}}
   public enum {{datatypeWithEnum}} {

--- a/modules/swagger-codegen/src/main/resources/JavaInflector/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaInflector/api.mustache
@@ -13,6 +13,7 @@ import {{modelPackage}}.*;
 {{#imports}}import {{import}};
 {{/imports}}
 
+{{>generatedAnnotation}}
 {{#operations}}
 public class {{classname}}  {
 

--- a/modules/swagger-codegen/src/main/resources/JavaInflector/generatedAnnotation.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaInflector/generatedAnnotation.mustache
@@ -1,0 +1,1 @@
+@javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")

--- a/modules/swagger-codegen/src/main/resources/JavaInflector/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaInflector/model.mustache
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * {{description}}
  **/{{/description}}
 @ApiModel(description = "{{{description}}}")
+{{>generatedAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   {{#vars}}{{#isEnum}}
   public enum {{datatypeWithEnum}} {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/ApiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/ApiException.mustache
@@ -1,5 +1,6 @@
 package {{apiPackage}};
 
+{{>generatedAnnotation}}
 public class ApiException extends Exception{
 	private int code;
 	public ApiException (int code, String msg) {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/ApiOriginFilter.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/ApiOriginFilter.mustache
@@ -5,6 +5,7 @@ import java.io.IOException;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletResponse;
 
+{{>generatedAnnotation}}
 public class ApiOriginFilter implements javax.servlet.Filter {
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response,

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/ApiResponseMessage.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/ApiResponseMessage.mustache
@@ -3,6 +3,7 @@ package {{apiPackage}};
 import javax.xml.bind.annotation.XmlTransient;
 
 @javax.xml.bind.annotation.XmlRootElement
+{{>generatedAnnotation}}
 public class ApiResponseMessage {
 	public static final int ERROR = 1;
 	public static final int WARNING = 2;

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/NotFoundException.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/NotFoundException.mustache
@@ -1,5 +1,6 @@
 package {{apiPackage}};
 
+{{>generatedAnnotation}}
 public class NotFoundException extends ApiException {
 	private int code;
 	public NotFoundException (int code, String msg) {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
@@ -26,6 +26,7 @@ import javax.ws.rs.*;
 {{#hasConsumes}}@Consumes({ {{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}
 {{#hasProduces}}@Produces({ {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
 @io.swagger.annotations.Api(value = "/{{baseName}}", description = "the {{baseName}} API")
+{{>generatedAnnotation}}
 {{#operations}}
 public class {{classname}}  {
 

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/apiService.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/apiService.mustache
@@ -18,6 +18,7 @@ import com.sun.jersey.multipart.FormDataParam;
 
 import javax.ws.rs.core.Response;
 
+{{>generatedAnnotation}}
 {{#operations}}
 public abstract class {{classname}}Service {
   {{#operation}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/apiServiceFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/apiServiceFactory.mustache
@@ -3,6 +3,7 @@ package {{package}}.factories;
 import {{package}}.{{classname}}Service;
 import {{package}}.impl.{{classname}}ServiceImpl;
 
+{{>generatedAnnotation}}
 public class {{classname}}ServiceFactory {
 
    private final static {{classname}}Service service = new {{classname}}ServiceImpl();

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/apiServiceImpl.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/apiServiceImpl.mustache
@@ -18,6 +18,7 @@ import com.sun.jersey.multipart.FormDataParam;
 
 import javax.ws.rs.core.Response;
 
+{{>generatedAnnotation}}
 {{#operations}}
 public class {{classname}}ServiceImpl extends {{classname}}Service {
   {{#operation}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/generatedAnnotation.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/generatedAnnotation.mustache
@@ -1,0 +1,1 @@
+@javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/model.mustache
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * {{description}}
  **/{{/description}}
 @ApiModel(description = "{{{description}}}")
+{{>generatedAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   {{#vars}}{{#isEnum}}
   public enum {{datatypeWithEnum}} {

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/api.mustache
@@ -30,6 +30,7 @@ import static org.springframework.http.MediaType.*;
 @Controller
 @RequestMapping(value = "/{{baseName}}", produces = {APPLICATION_JSON_VALUE})
 @Api(value = "/{{baseName}}", description = "the {{baseName}} API")
+{{>generatedAnnotation}}
 {{#operations}}
 public class {{classname}} {
   {{#operation}}

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/apiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/apiException.mustache
@@ -1,5 +1,6 @@
 package {{apiPackage}};
 
+{{>generatedAnnotation}}
 public class ApiException extends Exception{
 	private int code;
 	public ApiException (int code, String msg) {

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/apiOriginFilter.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/apiOriginFilter.mustache
@@ -5,6 +5,7 @@ import java.io.IOException;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletResponse;
 
+{{>generatedAnnotation}}
 public class ApiOriginFilter implements javax.servlet.Filter {
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response,

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/apiResponseMessage.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/apiResponseMessage.mustache
@@ -3,6 +3,7 @@ package {{apiPackage}};
 import javax.xml.bind.annotation.XmlTransient;
 
 @javax.xml.bind.annotation.XmlRootElement
+{{>generatedAnnotation}}
 public class ApiResponseMessage {
 	public static final int ERROR = 1;
 	public static final int WARNING = 2;

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/generatedAnnotation.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/generatedAnnotation.mustache
@@ -1,0 +1,1 @@
+@javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/model.mustache
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * {{description}}
  **/{{/description}}
 @ApiModel(description = "{{{description}}}")
+{{>generatedAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   {{#vars}}{{#isEnum}}
   public enum {{datatypeWithEnum}} {

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/notFoundException.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/notFoundException.mustache
@@ -1,5 +1,6 @@
 package {{apiPackage}};
 
+{{>generatedAnnotation}}
 public class NotFoundException extends ApiException {
 	private int code;
 	public NotFoundException (int code, String msg) {

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/swaggerConfig.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/swaggerConfig.mustache
@@ -18,6 +18,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2 //Loads the spring beans required by the framework
 @PropertySource("classpath:swagger.properties")
 @Import(SwaggerUiConfiguration.class)
+{{>generatedAnnotation}}
 public class SwaggerConfig {
     @Bean
     ApiInfo apiInfo() {

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/swaggerUiConfiguration.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/swaggerUiConfiguration.mustache
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @Configuration
 @EnableWebMvc
+{{>generatedAnnotation}}
 public class SwaggerUiConfiguration extends WebMvcConfigurerAdapter {
   private static final String[] SERVLET_RESOURCE_LOCATIONS = { "/" };
 

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/webApplication.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/webApplication.mustache
@@ -2,6 +2,7 @@ package {{configPackage}};
 
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
+{{>generatedAnnotation}}
 public class WebApplication extends AbstractAnnotationConfigDispatcherServletInitializer {
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/webMvcConfiguration.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/webMvcConfiguration.mustache
@@ -3,6 +3,7 @@ package {{configPackage}};
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 
+{{>generatedAnnotation}}
 public class WebMvcConfiguration extends WebMvcConfigurationSupport {
     @Override
     public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {


### PR DESCRIPTION
The Java API has an [annotation](http://docs.oracle.com/javase/7/docs/api/javax/annotation/Generated.html) for marking classes that are generated. 

It is often useful to know which class generated the code and and the date-time it was generated at. 

I added a new sub-template in each Java templates directory (i.e. Java, JavaJaxRS, JavaInflector and JavaSpringMVC) and updated each Java class template in the aforementioned directories to use it. 

As always feedback is appreciated.

