### PR TITLE
improve static html; add template guards for collections. 

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
@@ -30,6 +30,23 @@ public class CodegenOperation {
     public List<Map<String, String>> examples;
     public ExternalDocs externalDocs;
 
+    private boolean nonempty(List<CodegenParameter> params)
+    {
+        return params != null && params.size() > 0;
+    }
+    public boolean getHasBodyParam() {
+        return nonempty(bodyParams);
+    }
+    public boolean getHasQueryParams() {
+        return nonempty(bodyParams);
+    }
+    public boolean getHasHeaderParams() {
+        return nonempty(bodyParams);
+    }
+    public boolean getHasPathParams() {
+        return nonempty(bodyParams);
+    }
+
     // legacy support
     public String nickname;
 }

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
@@ -1,52 +1,158 @@
-<html lang="en">
+<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta charset="utf-8" />
-    <title>API Reference</title>
+    <title>{{{appName}}}</title>
+    <link rel="stylesheet" type="text/css" href="site.css" media="screen" />
+    <style type="text/css">
+      {{>style.css}}
+    </style>
   </head>
   <body>
   <h1>{{{appName}}}</h1>
-    <div class="app-desc">{{{appDescription}}} for {{partner}}</div>
+    <div class="app-desc">{{{appDescription}}}</div>
     {{#infoUrl}}<div class="app-desc">More information: <a href="{{{infoUrl}}}">{{{infoUrl}}}</a></div>{{/infoUrl}}
     {{#infoEmail}}<div class="app-desc">Contact Info: <a href="{{{infoEmail}}}">{{{infoEmail}}}</a></div>{{/infoEmail}}
     {{#version}}<div class="app-desc">Version: {{{version}}}</div>{{/version}}
     <div class="license-info">{{{licenseInfo}}}</div>
     <div class="license-url">{{{licenseUrl}}}</div>
   <h2>Access</h2>
-  <div class="method-summary">Customize this message as you see fit!</div>
-  <h2>Methods</h2>
+  {{access}}
+
+  <h2><a name="__Methods">Methods</a></h2>
+  [ Jump to <a href="#__Models">Models</a> ]
+
+  {{! for the tables of content, I cheat and don't use CSS styles.... }}
+  <h2>Table of Contents </h2>
+  <div class="method-summary">{{access}}</div>
+  {{#apiInfo}}
+  <ol>
+  {{#apis}}
+  {{#operations}}
+  {{#operation}}
+  <li><a href="#{{nickname}}"><code><span class="http-method">{{httpMethod}}</span> {{path}}</code></a></li>
+  {{/operation}}
+  {{/operations}}
+  {{/apis}}
+  </ol>
+  {{/apiInfo}}
+
   {{#apiInfo}}
   {{#apis}}
-  {{#operations}}{{#operation}}
-  <div class="method">
-    <div class="method-path"><pre class="{{httpMethod}}"><code class="huge"><span>{{httpMethod}}</span>: {{path}}</code></pre></div>
-    <div class="method-tags"> {{#tags}}<span class="method-tag">{{this}}</span>{{/tags}}</div>
-    <div class="method-summary"><span class="nickname">{{nickname}}</span> {{summary}}</div>
+  {{#operations}}
+  {{#operation}}
+  <div class="method"><a name="{{nickname}}"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="{{httpMethod}}"><code class="huge"><span class="http-method">{{httpMethod}}</span> {{path}}</code></pre></div>
+    <div class="method-summary">{{summary}} (<span class="nickname">{{nickname}}</span>)</div>
+    {{! notes is operation.description. So why rename it and make it super confusing???? }}
     <div class="method-notes">{{notes}}</div>
 
-    <h3 class="field-label">Parameters</h3>
+    {{#hasPathParams}}
+    <h3 class="field-label">Path parameters</h3>
     <div class="field-items">
-      {{#allParams}}{{>queryParam}}{{>pathParam}}{{>bodyParam}}{{>headerParam}}{{>formParam}}
-      {{/allParams}}
+      {{#pathParams}}{{>pathParam}}{{/pathParams}}
     </div>  <!-- field-items -->
+    {{/hasPathParams}}
+
+    {{#hasConsumes}}
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    {{#consumes}}
+      <li><code>{{mediaType}}</code></li>
+    {{/consumes}}
+    </ul>
+    {{/hasConsumes}}
+
+    {{#hasBodyParam}}
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      {{#bodyParams}}{{>bodyParam}}{{/bodyParams}}
+    </div>  <!-- field-items -->
+    {{/hasBodyParam}}
+
+    {{#hasHeaderParam}}
+    <h3 class="field-label">Request headers</h3>
+    <div class="field-items">
+      {{#headerParam}}{{>headerParam}}{{/headerParam}}
+    </div>  <!-- field-items -->
+    {{/hasHeaderParam}}
+
+    {{#hasQueryParams}}
+    <h3 class="field-label">Query parameters</h3>
+    <div class="field-items">
+      {{#queryParams}}{{>queryParam}}{{/queryParams}}
+    </div>  <!-- field-items -->
+    {{/hasQueryParams}}
+
+    <!-- Remove Return type... unclear where this comes from;
+         for our swagger.json files, it is always empty and there is no boolean guard or hasReturnType
+         do we end up with a heading but not content
+
+    {{#returnType}}
     <h3 class="field-label">Return type</h3>
-
     <div class="return-type"><a href="#{{returnContainer}}">{{{returnType}}}</a></div>
+    {{/returnType}}
 
+    Todo: process Response Object and its headers, schema, examples
+    -->
+
+    {{#hasExamples}}
+    {{#examples}}
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: {{{contentType}}}</div>
+    <pre class="example"><code>{{{example}}}</code></pre>
+    {{/examples}}
+    {{/hasExamples}}
+
+    {{#hasProduces}}
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    {{#produces}}
+      <li><code>{{mediaType}}</code></li>
+    {{/produces}}
+    </ul>
+    {{/hasProduces}}
+
+    <h3 class="field-label">Responses</h3>
+    {{#responses}}
+    <h4 class="field-label">{{code}}</h4>
+    {{message}}
     {{#examples}}
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: {{{contentType}}}</div>
     <pre class="example"><code>{{example}}</code></pre>
     {{/examples}}
+    {{/responses}}
   </div> <!-- method -->
-  <hr>
-  {{/operation}}{{/operations}}
-  {{/apis}}{{/apiInfo}}
+  <hr/>
+  {{/operation}}
+  {{/operations}}
+  {{/apis}}
+  {{/apiInfo}}
 
-  <h2>Models</h2>
+  <div class="up"><a href="#__Models">Up</a></div>
+  <h2><a name="__Models">Models</a></h2>
+  [ Jump to <a href="#__Methods">Methods</a> ]
+
+  <h2>Table of Contents</h2>
+  <ol>
+  {{#models}}
+  {{#model}}
+    <li><a href="#{{classname}}"><code>{{classname}}</code></a></li>
+  {{/model}}
+  {{/models}}
+  </ol>
+
   {{#models}}
   {{#model}}
   <div class="model">
-    <h3 class="field-label"><a name="{{classname}}">{{classname}}</a></h3>
+    <h3 class="field-label"><a name="{{classname}}">{{classname}}</a> <a class="up" href="#__Models">Up</a></h3>
     <div class="field-items">
       {{#vars}}<div class="param">{{name}} {{#isNotRequired}}(optional){{/isNotRequired}}</div><div class="param-desc"><span class="param-type">{{datatype}}</span> {{description}}</div>
       {{/vars}}
@@ -54,8 +160,5 @@
   </div>
   {{/model}}
   {{/models}}
-  <style>
-{{>style.css}}
-  </style>
   </body>
 </html>

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/style.css.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/style.css.mustache
@@ -57,6 +57,10 @@ pre {
   margin-bottom: 2px;
 }
 
+.http-method {
+ text-transform: uppercase;
+}
+
 pre.get {
   background-color: #0f6ab4;
 }
@@ -94,6 +98,10 @@ code {
 .method-path {
   font-size: 1.5em;
   background-color: #0f6ab4;
+}
+
+.up {
+  float:right;
 }
 
 .parameter {

--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
         <swagger-parser-version>1.0.10-SNAPSHOT</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>2.3.4</felix-version>
-        <swagger-core-version>1.5.3-SNAPSHOT</swagger-core-version>
+        <swagger-core-version>1.5.4-SNAPSHOT</swagger-core-version>
         <scala-test-version>2.1.4</scala-test-version>
         <commons-io-version>2.3</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>


### PR DESCRIPTION
Update static html template to improve navigation, with Up links and jumps between
methods and modules. Added guards around different parameters, to eliminate
empty sections.

See https://gist.github.com/DavidBiesack/a9048b151cd7935c8d76 for sample output from the Uber example shipped with swagger-editor

I also updated the swagger-core dependency to build with most recent as of 2015-08-13