### PR TITLE
[PHP, Perl, Silex] fixed variable names starting with number, made LOGGER protected

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -63,7 +63,7 @@ import java.util.regex.Pattern;
 
 
 public class DefaultCodegen {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCodegen.class);
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DefaultCodegen.class);
 
     protected String outputFolder = "";
     protected Set<String> defaultIncludes = new HashSet<String>();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PerlClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PerlClientCodegen.java
@@ -159,15 +159,17 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toVarName(String name) {
+        // return the name in underscore style
+        // PhoneNumber => phone_number
+        name = underscore(name);
+
         // parameter name starting with number won't compile
         // need to escape it by appending _ at the beginning
-        if (name.matches("^[0-9]")) {
+        if (name.matches("^\\d.*")) {
             name = "_" + name;
         }
 
-        // return the name in underscore style
-        // PhoneNumber => phone_number
-        return underscore(name);
+        return name;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -284,15 +284,17 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toVarName(String name) {
+        // return the name in underscore style
+        // PhoneNumber => phone_number
+        name =  underscore(name);
+
         // parameter name starting with number won't compile
         // need to escape it by appending _ at the beginning
-        if (name.matches("^[0-9]")) {
+        if (name.matches("^\\d.*")) {
             name = "_" + name;
         }
 
-        // return the name in underscore style
-        // PhoneNumber => phone_number
-        return underscore(name);
+        return name;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SilexServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SilexServerCodegen.java
@@ -154,15 +154,17 @@ public class SilexServerCodegen extends DefaultCodegen implements CodegenConfig 
 
     @Override
     public String toVarName(String name) {
+        // return the name in underscore style
+        // PhoneNumber => phone_number
+        name = underscore(name);
+
         // parameter name starting with number won't compile
         // need to escape it by appending _ at the beginning
-        if (name.matches("^[0-9]")) {
+        if (name.matches("^\\d.*")) {
             name = "_" + name;
         }
 
-        // return the name in underscore style
-        // PhoneNumber => phone_number
-        return underscore(name);
+        return name;
     }
 
     @Override


### PR DESCRIPTION
- fixed variable names starting with number by appending an underscore at the beginning
- made LOGGER protected (from private) so that code generator can use it for logging
- tested with manually updating a variable name in petstore to start with "00"

```
PHPUnit 4.8.4 by Sebastian Bergmann and contributors.

............

Time: 14.76 seconds, Memory: 6.25Mb

OK (12 tests, 381 assertions)
```