### PR TITLE
update swagger-parser-version to 1.0.10 (removed snapshot)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.10-SNAPSHOT</swagger-parser-version>
+        <swagger-parser-version>1.0.10</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>2.3.4</felix-version>
         <swagger-core-version>1.5.4-SNAPSHOT</swagger-core-version>


### PR DESCRIPTION
update swagger-parser-version to 1.0.10 (removed snapshot) to resolve CI build error