### PR TITLE
[Python] Change reserved word handling in python client.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -119,7 +119,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
     @Override
     public String escapeReservedWord(String name) {
-        return name + "_";
+        return "_" + name;
     }
 
     @Override
@@ -179,13 +179,13 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         // petId => pet_id
         name = underscore(dropDots(name));
 
+        // remove leading underscore
+        name = name.replaceAll("^_*", "");
+
         // for reserved word or word starting with number, append _
         if (reservedWords.contains(name) || name.matches("^\\d.*")) {
             name = escapeReservedWord(name);
         }
-
-        // remove leading underscore
-        name = name.replaceAll("^_*", "");
 
         return name;
     }

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -202,11 +202,9 @@ class ApiClient(object):
                 # and attributes which value is not None.
                 # Convert attribute name to json key in
                 # model definition for request.
-                obj_dict = {obj.attribute_map[key[1:]]: val
-                            for key, val in iteritems(obj.__dict__)
-                            if key != 'swagger_types'
-                            and key != 'attribute_map'
-                            and val is not None}
+                obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
+                            for attr, _ in iteritems(obj.swagger_types)
+                            if getattr(obj, attr) is not None}
 
             return {key: self.sanitize_for_serialization(val)
                     for key, val in iteritems(obj_dict)}

--- a/modules/swagger-codegen/src/main/resources/python/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/configuration.mustache
@@ -23,9 +23,9 @@ import urllib3
 try:
     import httplib
 except ImportError:
-    # python3
+    # for python3
     import http.client as httplib
-
+    
 import sys
 import logging
 

--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -86,18 +86,17 @@ class {{classname}}(object):
         """
         result = {}
 
-        for name, prop in iteritems(self.__dict__):
-            if name == "attribute_map" or name == "swagger_types":
-                continue
-            if isinstance(prop, list):
-                result[name[1:]] = list(map(
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    prop
+                    value
                 ))
-            elif hasattr(prop, "to_dict"):
-                result[name[1:]] = prop.to_dict()
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             else:
-                result[name[1:]] = prop
+                result[attr] = value
 
         return result
 

--- a/samples/client/petstore/python/swagger_client/api_client.py
+++ b/samples/client/petstore/python/swagger_client/api_client.py
@@ -202,11 +202,9 @@ class ApiClient(object):
                 # and attributes which value is not None.
                 # Convert attribute name to json key in
                 # model definition for request.
-                obj_dict = {obj.attribute_map[key[1:]]: val
-                            for key, val in iteritems(obj.__dict__)
-                            if key != 'swagger_types'
-                            and key != 'attribute_map'
-                            and val is not None}
+                obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
+                            for attr, _ in iteritems(obj.swagger_types)
+                            if getattr(obj, attr) is not None}
 
             return {key: self.sanitize_for_serialization(val)
                     for key, val in iteritems(obj_dict)}

--- a/samples/client/petstore/python/swagger_client/configuration.py
+++ b/samples/client/petstore/python/swagger_client/configuration.py
@@ -23,9 +23,9 @@ import urllib3
 try:
     import httplib
 except ImportError:
-    # python3
+    # for python3
     import http.client as httplib
-
+    
 import sys
 import logging
 

--- a/samples/client/petstore/python/swagger_client/models/category.py
+++ b/samples/client/petstore/python/swagger_client/models/category.py
@@ -97,18 +97,17 @@ class Category(object):
         """
         result = {}
 
-        for name, prop in iteritems(self.__dict__):
-            if name == "attribute_map" or name == "swagger_types":
-                continue
-            if isinstance(prop, list):
-                result[name[1:]] = list(map(
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    prop
+                    value
                 ))
-            elif hasattr(prop, "to_dict"):
-                result[name[1:]] = prop.to_dict()
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             else:
-                result[name[1:]] = prop
+                result[attr] = value
 
         return result
 

--- a/samples/client/petstore/python/swagger_client/models/order.py
+++ b/samples/client/petstore/python/swagger_client/models/order.py
@@ -203,18 +203,17 @@ class Order(object):
         """
         result = {}
 
-        for name, prop in iteritems(self.__dict__):
-            if name == "attribute_map" or name == "swagger_types":
-                continue
-            if isinstance(prop, list):
-                result[name[1:]] = list(map(
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    prop
+                    value
                 ))
-            elif hasattr(prop, "to_dict"):
-                result[name[1:]] = prop.to_dict()
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             else:
-                result[name[1:]] = prop
+                result[attr] = value
 
         return result
 

--- a/samples/client/petstore/python/swagger_client/models/pet.py
+++ b/samples/client/petstore/python/swagger_client/models/pet.py
@@ -203,18 +203,17 @@ class Pet(object):
         """
         result = {}
 
-        for name, prop in iteritems(self.__dict__):
-            if name == "attribute_map" or name == "swagger_types":
-                continue
-            if isinstance(prop, list):
-                result[name[1:]] = list(map(
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    prop
+                    value
                 ))
-            elif hasattr(prop, "to_dict"):
-                result[name[1:]] = prop.to_dict()
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             else:
-                result[name[1:]] = prop
+                result[attr] = value
 
         return result
 

--- a/samples/client/petstore/python/swagger_client/models/tag.py
+++ b/samples/client/petstore/python/swagger_client/models/tag.py
@@ -97,18 +97,17 @@ class Tag(object):
         """
         result = {}
 
-        for name, prop in iteritems(self.__dict__):
-            if name == "attribute_map" or name == "swagger_types":
-                continue
-            if isinstance(prop, list):
-                result[name[1:]] = list(map(
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    prop
+                    value
                 ))
-            elif hasattr(prop, "to_dict"):
-                result[name[1:]] = prop.to_dict()
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             else:
-                result[name[1:]] = prop
+                result[attr] = value
 
         return result
 

--- a/samples/client/petstore/python/swagger_client/models/user.py
+++ b/samples/client/petstore/python/swagger_client/models/user.py
@@ -247,18 +247,17 @@ class User(object):
         """
         result = {}
 
-        for name, prop in iteritems(self.__dict__):
-            if name == "attribute_map" or name == "swagger_types":
-                continue
-            if isinstance(prop, list):
-                result[name[1:]] = list(map(
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
-                    prop
+                    value
                 ))
-            elif hasattr(prop, "to_dict"):
-                result[name[1:]] = prop.to_dict()
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             else:
-                result[name[1:]] = prop
+                result[attr] = value
 
         return result
 


### PR DESCRIPTION
If the variable name is reserved word or number, then append underscore `_`.
`return` will be `_return`.
`123Number` will be `_123_number`.

Test without issue in both python2 and python3:
```sh
________________________________________ summary ________________________________________
  py27: commands succeeded
  py34: commands succeeded
```