### PR TITLE
[Objc] Sanitize request parameters in objc client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
@@ -168,6 +168,7 @@ extern NSString *const {{classPrefix}}ResponseObjectErrorKey;
  *
  * @param path Request url.
  * @param method Request method.
+ * @param pathParams Request path parameters.
  * @param queryParams Request query parameters.
  * @param body Request body.
  * @param headerParams Request header parameters.
@@ -180,6 +181,7 @@ extern NSString *const {{classPrefix}}ResponseObjectErrorKey;
  */
 -(NSNumber*)  requestWithCompletionBlock:(NSString*) path
                                   method:(NSString*) method
+                              pathParams:(NSDictionary *) pathParams
                              queryParams:(NSDictionary*) queryParams
                               formParams:(NSDictionary *) formParams
                                    files:(NSDictionary *) files
@@ -190,5 +192,12 @@ extern NSString *const {{classPrefix}}ResponseObjectErrorKey;
                      responseContentType:(NSString*) responseContentType
                             responseType:(NSString *) responseType
                          completionBlock:(void (^)(id, NSError *))completionBlock;
+
+/**
+ * Sanitize object for request
+ *
+ * @param object The query/path/header/form/body param to be sanitized.
+ */
+- (id) sanitizeForSerialization:(id) object;
 
 @end

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -88,8 +88,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    {{#pathParams}}[resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"{{baseName}}", @"}"]] withString: [{{classPrefix}}ApiClient escape:{{paramName}}]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    {{#pathParams}}if ({{paramName}} != nil) {
+        pathParams[@"{{baseName}}"] = {{paramName}};
+    }
     {{/pathParams}}
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -132,22 +135,6 @@
     NSMutableDictionary *files = [[NSMutableDictionary alloc] init];
     {{#bodyParam}}
     bodyParam = {{paramName}};
-
-    if(bodyParam != nil && [bodyParam isKindOfClass:[NSArray class]]){
-        NSMutableArray *objs = [[NSMutableArray alloc] init];
-        for (id dict in (NSArray*)bodyParam) {
-            if([dict respondsToSelector:@selector(toDictionary)]) {
-                [objs addObject:[({{classPrefix}}Object*)dict toDictionary]];
-            }
-            else{
-                [objs addObject:dict];
-            }
-        }
-        bodyParam = objs;
-    }
-    else if([bodyParam respondsToSelector:@selector(toDictionary)]) {
-        bodyParam = [({{classPrefix}}Object*)bodyParam toDictionary];
-    }
     {{/bodyParam}}{{^bodyParam}}
     {{#formParams}}
     {{#notFile}}
@@ -167,6 +154,7 @@
     {{/requiredParamCount}}
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"{{httpMethod}}"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -138,7 +138,9 @@
     {{/bodyParam}}{{^bodyParam}}
     {{#formParams}}
     {{#notFile}}
-    formParams[@"{{paramName}}"] = {{paramName}};
+    if ({{paramName}}) {
+        formParams[@"{{paramName}}"] = {{paramName}};
+    }
     {{/notFile}}{{#isFile}}
     files[@"{{paramName}}"] = {{paramName}};
     {{/isFile}}

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -139,7 +139,7 @@
     {{#formParams}}
     {{#notFile}}
     if ({{paramName}}) {
-        formParams[@"{{paramName}}"] = {{paramName}};
+        formParams[@"{{baseName}}"] = {{paramName}};
     }
     {{/notFile}}{{#isFile}}
     files[@"{{paramName}}"] = {{paramName}};

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.h
@@ -172,6 +172,7 @@ extern NSString *const SWGResponseObjectErrorKey;
  *
  * @param path Request url.
  * @param method Request method.
+ * @param pathParams Request path parameters.
  * @param queryParams Request query parameters.
  * @param body Request body.
  * @param headerParams Request header parameters.
@@ -184,6 +185,7 @@ extern NSString *const SWGResponseObjectErrorKey;
  */
 -(NSNumber*)  requestWithCompletionBlock:(NSString*) path
                                   method:(NSString*) method
+                              pathParams:(NSDictionary *) pathParams
                              queryParams:(NSDictionary*) queryParams
                               formParams:(NSDictionary *) formParams
                                    files:(NSDictionary *) files
@@ -194,5 +196,12 @@ extern NSString *const SWGResponseObjectErrorKey;
                      responseContentType:(NSString*) responseContentType
                             responseType:(NSString *) responseType
                          completionBlock:(void (^)(id, NSError *))completionBlock;
+
+/**
+ * Sanitize object for request
+ *
+ * @param object The query/path/header/form/body param to be sanitized.
+ */
+- (id) sanitizeForSerialization:(id) object;
 
 @end

--- a/samples/client/petstore/objc/SwaggerClient/SWGPet.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPet.h
@@ -7,8 +7,8 @@
  * Do not edit the class manually.
  */
 
-#import "SWGTag.h"
 #import "SWGCategory.h"
+#import "SWGTag.h"
 
 
 @protocol SWGPet

--- a/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
@@ -80,7 +80,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -115,27 +116,12 @@
     NSMutableDictionary *files = [[NSMutableDictionary alloc] init];
     
     bodyParam = body;
-
-    if(bodyParam != nil && [bodyParam isKindOfClass:[NSArray class]]){
-        NSMutableArray *objs = [[NSMutableArray alloc] init];
-        for (id dict in (NSArray*)bodyParam) {
-            if([dict respondsToSelector:@selector(toDictionary)]) {
-                [objs addObject:[(SWGObject*)dict toDictionary]];
-            }
-            else{
-                [objs addObject:dict];
-            }
-        }
-        bodyParam = objs;
-    }
-    else if([bodyParam respondsToSelector:@selector(toDictionary)]) {
-        bodyParam = [(SWGObject*)bodyParam toDictionary];
-    }
     
 
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"PUT"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -172,7 +158,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -207,27 +194,12 @@
     NSMutableDictionary *files = [[NSMutableDictionary alloc] init];
     
     bodyParam = body;
-
-    if(bodyParam != nil && [bodyParam isKindOfClass:[NSArray class]]){
-        NSMutableArray *objs = [[NSMutableArray alloc] init];
-        for (id dict in (NSArray*)bodyParam) {
-            if([dict respondsToSelector:@selector(toDictionary)]) {
-                [objs addObject:[(SWGObject*)dict toDictionary]];
-            }
-            else{
-                [objs addObject:dict];
-            }
-        }
-        bodyParam = objs;
-    }
-    else if([bodyParam respondsToSelector:@selector(toDictionary)]) {
-        bodyParam = [(SWGObject*)bodyParam toDictionary];
-    }
     
 
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"POST"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -264,7 +236,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -310,6 +283,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"GET"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -346,7 +320,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -392,6 +367,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"GET"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -433,8 +409,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"petId", @"}"]] withString: [SWGApiClient escape:petId]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (petId != nil) {
+        pathParams[@"petId"] = petId;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -462,7 +441,7 @@
     NSString *requestContentType = [SWGApiClient selectHeaderContentType:@[]];
 
     // Authentication setting
-    NSArray *authSettings = @[@"api_key", @"petstore_auth"];
+    NSArray *authSettings = @[@"petstore_auth", @"api_key"];
 
     id bodyParam = nil;
     NSMutableDictionary *formParams = [[NSMutableDictionary alloc] init];
@@ -474,6 +453,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"GET"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -521,8 +501,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"petId", @"}"]] withString: [SWGApiClient escape:petId]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (petId != nil) {
+        pathParams[@"petId"] = petId;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -570,6 +553,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"POST"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -614,8 +598,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"petId", @"}"]] withString: [SWGApiClient escape:petId]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (petId != nil) {
+        pathParams[@"petId"] = petId;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -657,6 +644,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"DELETE"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -704,8 +692,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"petId", @"}"]] withString: [SWGApiClient escape:petId]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (petId != nil) {
+        pathParams[@"petId"] = petId;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -753,6 +744,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"POST"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files

--- a/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
@@ -541,11 +541,15 @@
     
     
     
-    formParams[@"name"] = name;
+    if (name) {
+        formParams[@"name"] = name;
+    }
     
     
     
-    formParams[@"status"] = status;
+    if (status) {
+        formParams[@"status"] = status;
+    }
     
     
     
@@ -732,7 +736,9 @@
     
     
     
-    formParams[@"additionalMetadata"] = additionalMetadata;
+    if (additionalMetadata) {
+        formParams[@"additionalMetadata"] = additionalMetadata;
+    }
     
     
     

--- a/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.m
@@ -77,7 +77,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -117,6 +118,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"GET"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -153,7 +155,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -188,27 +191,12 @@
     NSMutableDictionary *files = [[NSMutableDictionary alloc] init];
     
     bodyParam = body;
-
-    if(bodyParam != nil && [bodyParam isKindOfClass:[NSArray class]]){
-        NSMutableArray *objs = [[NSMutableArray alloc] init];
-        for (id dict in (NSArray*)bodyParam) {
-            if([dict respondsToSelector:@selector(toDictionary)]) {
-                [objs addObject:[(SWGObject*)dict toDictionary]];
-            }
-            else{
-                [objs addObject:dict];
-            }
-        }
-        bodyParam = objs;
-    }
-    else if([bodyParam respondsToSelector:@selector(toDictionary)]) {
-        bodyParam = [(SWGObject*)bodyParam toDictionary];
-    }
     
 
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"POST"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -250,8 +238,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"orderId", @"}"]] withString: [SWGApiClient escape:orderId]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (orderId != nil) {
+        pathParams[@"orderId"] = orderId;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -291,6 +282,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"GET"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -332,8 +324,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"orderId", @"}"]] withString: [SWGApiClient escape:orderId]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (orderId != nil) {
+        pathParams[@"orderId"] = orderId;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -373,6 +368,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"DELETE"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files

--- a/samples/client/petstore/objc/SwaggerClient/SWGUserApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGUserApi.m
@@ -80,7 +80,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -115,27 +116,12 @@
     NSMutableDictionary *files = [[NSMutableDictionary alloc] init];
     
     bodyParam = body;
-
-    if(bodyParam != nil && [bodyParam isKindOfClass:[NSArray class]]){
-        NSMutableArray *objs = [[NSMutableArray alloc] init];
-        for (id dict in (NSArray*)bodyParam) {
-            if([dict respondsToSelector:@selector(toDictionary)]) {
-                [objs addObject:[(SWGObject*)dict toDictionary]];
-            }
-            else{
-                [objs addObject:dict];
-            }
-        }
-        bodyParam = objs;
-    }
-    else if([bodyParam respondsToSelector:@selector(toDictionary)]) {
-        bodyParam = [(SWGObject*)bodyParam toDictionary];
-    }
     
 
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"POST"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -172,7 +158,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -207,27 +194,12 @@
     NSMutableDictionary *files = [[NSMutableDictionary alloc] init];
     
     bodyParam = body;
-
-    if(bodyParam != nil && [bodyParam isKindOfClass:[NSArray class]]){
-        NSMutableArray *objs = [[NSMutableArray alloc] init];
-        for (id dict in (NSArray*)bodyParam) {
-            if([dict respondsToSelector:@selector(toDictionary)]) {
-                [objs addObject:[(SWGObject*)dict toDictionary]];
-            }
-            else{
-                [objs addObject:dict];
-            }
-        }
-        bodyParam = objs;
-    }
-    else if([bodyParam respondsToSelector:@selector(toDictionary)]) {
-        bodyParam = [(SWGObject*)bodyParam toDictionary];
-    }
     
 
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"POST"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -264,7 +236,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -299,27 +272,12 @@
     NSMutableDictionary *files = [[NSMutableDictionary alloc] init];
     
     bodyParam = body;
-
-    if(bodyParam != nil && [bodyParam isKindOfClass:[NSArray class]]){
-        NSMutableArray *objs = [[NSMutableArray alloc] init];
-        for (id dict in (NSArray*)bodyParam) {
-            if([dict respondsToSelector:@selector(toDictionary)]) {
-                [objs addObject:[(SWGObject*)dict toDictionary]];
-            }
-            else{
-                [objs addObject:dict];
-            }
-        }
-        bodyParam = objs;
-    }
-    else if([bodyParam respondsToSelector:@selector(toDictionary)]) {
-        bodyParam = [(SWGObject*)bodyParam toDictionary];
-    }
     
 
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"POST"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -359,7 +317,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -407,6 +366,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"GET"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -440,7 +400,8 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -480,6 +441,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"GET"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -521,8 +483,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"username", @"}"]] withString: [SWGApiClient escape:username]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (username != nil) {
+        pathParams[@"username"] = username;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -562,6 +527,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"GET"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -606,8 +572,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"username", @"}"]] withString: [SWGApiClient escape:username]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (username != nil) {
+        pathParams[@"username"] = username;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -642,27 +611,12 @@
     NSMutableDictionary *files = [[NSMutableDictionary alloc] init];
     
     bodyParam = body;
-
-    if(bodyParam != nil && [bodyParam isKindOfClass:[NSArray class]]){
-        NSMutableArray *objs = [[NSMutableArray alloc] init];
-        for (id dict in (NSArray*)bodyParam) {
-            if([dict respondsToSelector:@selector(toDictionary)]) {
-                [objs addObject:[(SWGObject*)dict toDictionary]];
-            }
-            else{
-                [objs addObject:dict];
-            }
-        }
-        bodyParam = objs;
-    }
-    else if([bodyParam respondsToSelector:@selector(toDictionary)]) {
-        bodyParam = [(SWGObject*)bodyParam toDictionary];
-    }
     
 
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"PUT"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files
@@ -704,8 +658,11 @@
     if ([resourcePath rangeOfString:@".{format}"].location != NSNotFound) {
         [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:@".{format}"] withString:@".json"];
     }
-    
-    [resourcePath replaceCharactersInRange: [resourcePath rangeOfString:[NSString stringWithFormat:@"%@%@%@", @"{", @"username", @"}"]] withString: [SWGApiClient escape:username]];
+
+    NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
+    if (username != nil) {
+        pathParams[@"username"] = username;
+    }
     
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -745,6 +702,7 @@
     
     return [self.apiClient requestWithCompletionBlock: resourcePath
                                                method: @"DELETE"
+                                           pathParams: pathParams
                                           queryParams: queryParams
                                            formParams: formParams
                                                 files: files


### PR DESCRIPTION
Add `sanitizeForSerialization` method to sanitize request parameters.
If the parameter is model, return properties hash.
If the parameter is date/datetime, return iso8601 string.
Otherwise return the parameter directly.
Fix issue that it will throw error if not pass optional form parameter.

```sh
Test Suite 'All tests' passed at 2015-08-21 01:55:55 +0000.
	 Executed 24 tests, with 0 failures (0 unexpected) in 11.356 (11.371) seconds
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 39.814 s
[INFO] Finished at: 2015-08-21T09:55:56+08:00
[INFO] Final Memory: 11M/155M
[INFO] ------------------------------------------------------------------------
```