### PR TITLE
[Python] Fix issue that missing query parameters in python client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -338,16 +338,19 @@ class ApiClient(object):
                                    headers=headers)
         elif method == "POST":
             return RESTClient.POST(url,
+                                   query_params=query_params,
                                    headers=headers,
                                    post_params=post_params,
                                    body=body)
         elif method == "PUT":
             return RESTClient.PUT(url,
+                                  query_params=query_params,
                                   headers=headers,
                                   post_params=post_params,
                                   body=body)
         elif method == "PATCH":
             return RESTClient.PATCH(url,
+                                    query_params=query_params,
                                     headers=headers,
                                     post_params=post_params,
                                     body=body)

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -176,21 +176,24 @@ class RESTClientObject(object):
                             headers=headers,
                             query_params=query_params)
 
-    def POST(self, url, headers=None, post_params=None, body=None):
+    def POST(self, url, headers=None, query_params=None, post_params=None, body=None):
         return self.request("POST", url,
                             headers=headers,
+                            query_params=query_params,
                             post_params=post_params,
                             body=body)
 
-    def PUT(self, url, headers=None, post_params=None, body=None):
+    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None):
         return self.request("PUT", url,
                             headers=headers,
+                            query_params=query_params,
                             post_params=post_params,
                             body=body)
 
-    def PATCH(self, url, headers=None, post_params=None, body=None):
+    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None):
         return self.request("PATCH", url,
                             headers=headers,
+                            query_params=query_params,
                             post_params=post_params,
                             body=body)
 

--- a/samples/client/petstore/python/swagger_client/__init__.py
+++ b/samples/client/petstore/python/swagger_client/__init__.py
@@ -9,8 +9,8 @@ from .models.order import Order
 
 # import apis into sdk package
 from .apis.user_api import UserApi
-from .apis.pet_api import PetApi
 from .apis.store_api import StoreApi
+from .apis.pet_api import PetApi
 
 # import ApiClient
 from .api_client import ApiClient

--- a/samples/client/petstore/python/swagger_client/api_client.py
+++ b/samples/client/petstore/python/swagger_client/api_client.py
@@ -338,16 +338,19 @@ class ApiClient(object):
                                    headers=headers)
         elif method == "POST":
             return RESTClient.POST(url,
+                                   query_params=query_params,
                                    headers=headers,
                                    post_params=post_params,
                                    body=body)
         elif method == "PUT":
             return RESTClient.PUT(url,
+                                  query_params=query_params,
                                   headers=headers,
                                   post_params=post_params,
                                   body=body)
         elif method == "PATCH":
             return RESTClient.PATCH(url,
+                                    query_params=query_params,
                                     headers=headers,
                                     post_params=post_params,
                                     body=body)

--- a/samples/client/petstore/python/swagger_client/apis/__init__.py
+++ b/samples/client/petstore/python/swagger_client/apis/__init__.py
@@ -2,5 +2,5 @@ from __future__ import absolute_import
 
 # import apis into api package
 from .user_api import UserApi
-from .pet_api import PetApi
 from .store_api import StoreApi
+from .pet_api import PetApi

--- a/samples/client/petstore/python/swagger_client/apis/pet_api.py
+++ b/samples/client/petstore/python/swagger_client/apis/pet_api.py
@@ -408,7 +408,7 @@ class PetApi(object):
             select_header_content_type([])
 
         # Authentication setting
-        auth_settings = ['api_key', 'petstore_auth']
+        auth_settings = ['petstore_auth', 'api_key']
 
         response = self.api_client.call_api(resource_path, method,
                                             path_params,

--- a/samples/client/petstore/python/swagger_client/rest.py
+++ b/samples/client/petstore/python/swagger_client/rest.py
@@ -176,21 +176,24 @@ class RESTClientObject(object):
                             headers=headers,
                             query_params=query_params)
 
-    def POST(self, url, headers=None, post_params=None, body=None):
+    def POST(self, url, headers=None, query_params=None, post_params=None, body=None):
         return self.request("POST", url,
                             headers=headers,
+                            query_params=query_params,
                             post_params=post_params,
                             body=body)
 
-    def PUT(self, url, headers=None, post_params=None, body=None):
+    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None):
         return self.request("PUT", url,
                             headers=headers,
+                            query_params=query_params,
                             post_params=post_params,
                             body=body)
 
-    def PATCH(self, url, headers=None, post_params=None, body=None):
+    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None):
         return self.request("PATCH", url,
                             headers=headers,
+                            query_params=query_params,
                             post_params=post_params,
                             body=body)
 


### PR DESCRIPTION
When the http method is `post`, the request will miss query parameters.

```
--------------------------------------------------------------
TOTAL                             1250    472    62%
----------------------------------------------------------------------
Ran 27 tests in 41.420s

OK
________________________________________ summary ________________________________________
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)
```