### PR TITLE
[PHP] Fixed deserialization for datetime object

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -191,7 +191,7 @@ class ObjectSerializer
                 $values[] = $this->deserialize($value, $subClass);
             }
             $deserialized = $values;
-        } elseif ($class === 'DateTime') {
+        } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
         } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'object'))) {
             settype($data, $class);

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -191,7 +191,7 @@ class ObjectSerializer
                 $values[] = $this->deserialize($value, $subClass);
             }
             $deserialized = $values;
-        } elseif ($class === 'DateTime') {
+        } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
         } elseif (in_array($class, array('string', 'int', 'float', 'double', 'bool', 'object'))) {
             settype($data, $class);

--- a/samples/client/petstore/php/SwaggerClient-php/tests/OrderApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/OrderApiTest.php
@@ -31,6 +31,31 @@ class OrderApiTest extends \PHPUnit_Framework_TestCase
         $order = new Swagger\Client\Model\Order();
         $order->setStatus("invalid_value");
     }
+
+    // test deseralization of order
+    public function testDeserializationOfOrder()
+    {
+        $order_json = <<<ORDER
+{
+  "id": 10,
+  "petId": 20,
+  "quantity": 30,
+  "shipDate": "2015-08-22T07:13:36.613Z",
+  "status": "placed",
+  "complete": false
+}
+ORDER;
+        $serializer = new Swagger\Client\ObjectSerializer;
+        $order = $serializer->deserialize(json_decode($order_json), 'Swagger\Client\Model\Order');
+        
+        $this->assertInstanceOf('Swagger\Client\Model\Order', $order);
+        $this->assertSame(10, $order->getId());
+        $this->assertSame(20, $order->getPetId());
+        $this->assertSame(30, $order->getQuantity());
+        $this->assertTrue(new DateTime("2015-08-22T07:13:36.613Z") == $order->getShipDate());
+        $this->assertSame("placed", $order->getStatus());
+        $this->assertSame(false, $order->getComplete());
+    }
   
 }
 


### PR DESCRIPTION
- Fixed deserialization for datetime object
- Added a test case to cover deserialization of order (which has a datetime attribute)

```
PHPUnit 4.8.5 by Sebastian Bergmann and contributors.

.............

Time: 9.08 seconds, Memory: 7.50Mb

OK (13 tests, 573 assertions)
```