### PR TITLE
java support inheritance

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -39,6 +39,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
     
     public JavaClientCodegen() {
         super();
+        supportsInheritance = true;
         outputFolder = "generated-code/java";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");


### PR DESCRIPTION
as per #1015 (and #946) this is now optional and disabled by default.
this results in extra unnecessary code, masking fields in some cases, and
breaks code generated for jax-rs in certain cases (enums with inheritance).

(this is a resubmission of #1094 targetting `master` branch -- see comments there)
