### PR TITLE
Fix possible NullPointerException

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
@@ -128,7 +128,7 @@ public class XmlExampleGenerator {
             ArrayProperty p = (ArrayProperty) property;
             Property inner = p.getItems();
             boolean wrapped = false;
-            if (property.getXml() != null && property.getXml().getWrapped()) {
+            if (property.getXml() != null && property.getXml().getWrapped() != null && property.getXml().getWrapped()) {
                 wrapped = true;
             }
             if (wrapped) {


### PR DESCRIPTION
As requested in #1098 re-submitting this PR with the master branch.

Issue which is solved: getWrapped() returns a Boolean which can be null

With https://zeef.io/api/swagger.json the problem is there. Since the merge from develop_2.0 to master it does not display the NPE anymore while generating the (in my case Swift) library, but it generates an incomplete one.