### PR TITLE
[Java] Support special characters in enum values

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -318,6 +318,31 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         return codegenModel;
     }
 
+    @Override
+    public Map<String, Object> postProcessModels(Map<String, Object> objs) {
+        List<Object> models = (List<Object>) objs.get("models");
+        for (Object _mo : models) {
+            Map<String, Object> mo = (Map<String, Object>) _mo;
+            CodegenModel cm = (CodegenModel) mo.get("model");
+            for (CodegenProperty var : cm.vars) {
+                Map<String, Object> allowableValues = var.allowableValues;
+                if (allowableValues == null)
+                    continue;
+                List<String> values = (List<String>) allowableValues.get("values");
+                // put "enumVars" map into `allowableValues", including `name` and `value`
+                List<Map<String, String>> enumVars = new ArrayList<Map<String, String>>();
+                for (String value : values) {
+                    Map<String, String> enumVar = new HashMap<String, String>();
+                    enumVar.put("name", toVarName(value.toUpperCase()));
+                    enumVar.put("value", value);
+                    enumVars.add(enumVar);
+                }
+                allowableValues.put("enumVars", enumVars);
+            }
+        }
+        return objs;
+    }
+
     private CodegenModel reconcileInlineEnums(CodegenModel codegenModel, CodegenModel parentCodegenModel) {
         // This generator uses inline classes to define enums, which breaks when
         // dealing with models that have subTypes. To clean this up, we will analyze

--- a/modules/swagger-codegen/src/main/resources/Java/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/JSON.mustache
@@ -14,6 +14,8 @@ public class JSON {
     mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+    mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JodaModule());
 	}
 

--- a/modules/swagger-codegen/src/main/resources/Java/enumClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/enumClass.mustache
@@ -1,0 +1,14 @@
+public enum {{datatypeWithEnum}} {
+  {{#allowableValues}}{{#enumVars}}{{name}}("{{value}}"){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private String value;
+
+  StatusEnum(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/modules/swagger-codegen/src/main/resources/Java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/model.mustache
@@ -18,13 +18,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 {{>generatedAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
   {{#vars}}{{#isEnum}}
-  public enum {{datatypeWithEnum}} {
-    {{#allowableValues}}{{#values}} {{.}}, {{/values}}{{/allowableValues}}
-  };{{/isEnum}}{{#items.isEnum}}{{#items}}
-  public enum {{datatypeWithEnum}} {
-    {{#allowableValues}}{{#values}} {{.}}, {{/values}}{{/allowableValues}}
-  };
-{{/items}}{{/items.isEnum}}
+
+{{>enumClass}}{{/isEnum}}{{#items.isEnum}}{{#items}}
+
+{{>enumClass}}{{/items}}{{/items.isEnum}}
   private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/vars}}
 
   {{#vars}}

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/JSON.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.datatype.joda.*;
 
 import java.io.IOException;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T18:19:30.060+08:00")
 public class JSON {
   private ObjectMapper mapper;
 
@@ -14,6 +14,8 @@ public class JSON {
     mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+    mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JodaModule());
 	}
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
@@ -9,16 +9,29 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T18:19:30.060+08:00")
 public class Order   {
   
   private Long id = null;
   private Long petId = null;
   private Integer quantity = null;
   private Date shipDate = null;
-  public enum StatusEnum {
-     placed,  approved,  delivered, 
-  };
+
+public enum StatusEnum {
+  PLACED("placed"), APPROVED("approved"), DELIVERED("delivered");
+
+  private String value;
+
+  StatusEnum(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}
+
   private StatusEnum status = null;
   private Boolean complete = null;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
@@ -1,8 +1,8 @@
 package io.swagger.client.model;
 
 import io.swagger.client.model.Category;
-import io.swagger.client.model.Tag;
 import java.util.*;
+import io.swagger.client.model.Tag;
 
 
 
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T18:19:30.060+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -19,9 +19,22 @@ public class Pet   {
   private String name = null;
   private List<String> photoUrls = new ArrayList<String>();
   private List<Tag> tags = new ArrayList<Tag>();
-  public enum StatusEnum {
-     available,  pending,  sold, 
-  };
+
+public enum StatusEnum {
+  AVAILABLE("available"), PENDING("pending"), SOLD("sold");
+
+  private String value;
+
+  StatusEnum(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}
+
   private StatusEnum status = null;
 
   

--- a/samples/client/petstore/java/default/src/test/java/io/swagger/petstore/test/PetApiTest.java
+++ b/samples/client/petstore/java/default/src/test/java/io/swagger/petstore/test/PetApiTest.java
@@ -86,7 +86,7 @@ public class PetApiTest {
     public void testFindPetsByStatus() throws Exception {
         Pet pet = createRandomPet();
         pet.setName("programmer");
-        pet.setStatus(Pet.StatusEnum.available);
+        pet.setStatus(Pet.StatusEnum.AVAILABLE);
 
         api.updatePet(pet);
 
@@ -108,7 +108,7 @@ public class PetApiTest {
     public void testFindPetsByTags() throws Exception {
         Pet pet = createRandomPet();
         pet.setName("monster");
-        pet.setStatus(Pet.StatusEnum.available);
+        pet.setStatus(Pet.StatusEnum.AVAILABLE);
 
         List<Tag> tags = new ArrayList<Tag>();
         Tag tag1 = new Tag();
@@ -183,7 +183,7 @@ public class PetApiTest {
         category.setName("really-happy");
 
         pet.setCategory(category);
-        pet.setStatus(Pet.StatusEnum.available);
+        pet.setStatus(Pet.StatusEnum.AVAILABLE);
         List<String> photos = Arrays.asList(new String[]{"http://foo.bar.com/1", "http://foo.bar.com/2"});
         pet.setPhotoUrls(photos);
 

--- a/samples/client/petstore/java/default/src/test/java/io/swagger/petstore/test/StoreApiTest.java
+++ b/samples/client/petstore/java/default/src/test/java/io/swagger/petstore/test/StoreApiTest.java
@@ -64,7 +64,7 @@ public class StoreApiTest {
         order.setPetId(new Long(200));
         order.setQuantity(new Integer(13));
         order.setShipDate(new java.util.Date());
-        order.setStatus(Order.StatusEnum.placed);
+        order.setStatus(Order.StatusEnum.PLACED);
         order.setComplete(true);
 
         return order;

--- a/samples/client/petstore/java/jersey2/hello.txt
+++ b/samples/client/petstore/java/jersey2/hello.txt
@@ -1,1 +1,0 @@
-Hello world!

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/JSON.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.datatype.joda.*;
 
 import java.io.IOException;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T16:42:49.539+08:00")
 public class JSON {
   private ObjectMapper mapper;
 
@@ -14,6 +14,8 @@ public class JSON {
     mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+    mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JodaModule());
 	}
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
@@ -2,21 +2,36 @@ package io.swagger.client.model;
 
 import java.util.Date;
 
+
+
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
-public class Order  {
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T16:42:49.539+08:00")
+public class Order   {
   
   private Long id = null;
   private Long petId = null;
   private Integer quantity = null;
   private Date shipDate = null;
-  public enum StatusEnum {
-     placed,  approved,  delivered, 
-  };
+
+public enum StatusEnum {
+  PLACED("placed"), APPROVED("approved"), DELIVERED("delivered");
+
+  private String value;
+
+  StatusEnum(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}
+
   private StatusEnum status = null;
   private Boolean complete = null;
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
@@ -4,22 +4,37 @@ import io.swagger.client.model.Category;
 import java.util.*;
 import io.swagger.client.model.Tag;
 
+
+
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
-public class Pet  {
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T16:42:49.539+08:00")
+public class Pet   {
   
   private Long id = null;
   private Category category = null;
   private String name = null;
   private List<String> photoUrls = new ArrayList<String>();
   private List<Tag> tags = new ArrayList<Tag>();
-  public enum StatusEnum {
-     available,  pending,  sold, 
-  };
+
+public enum StatusEnum {
+  AVAILABLE("available"), PENDING("pending"), SOLD("sold");
+
+  private String value;
+
+  StatusEnum(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}
+
   private StatusEnum status = null;
 
   

--- a/samples/client/petstore/java/jersey2/src/test/java/io/swagger/petstore/test/PetApiTest.java
+++ b/samples/client/petstore/java/jersey2/src/test/java/io/swagger/petstore/test/PetApiTest.java
@@ -86,7 +86,7 @@ public class PetApiTest {
     public void testFindPetsByStatus() throws Exception {
         Pet pet = createRandomPet();
         pet.setName("programmer");
-        pet.setStatus(Pet.StatusEnum.available);
+        pet.setStatus(Pet.StatusEnum.AVAILABLE);
 
         api.updatePet(pet);
 
@@ -108,7 +108,7 @@ public class PetApiTest {
     public void testFindPetsByTags() throws Exception {
         Pet pet = createRandomPet();
         pet.setName("monster");
-        pet.setStatus(Pet.StatusEnum.available);
+        pet.setStatus(Pet.StatusEnum.AVAILABLE);
 
         List<Tag> tags = new ArrayList<Tag>();
         Tag tag1 = new Tag();
@@ -183,7 +183,7 @@ public class PetApiTest {
         category.setName("really-happy");
 
         pet.setCategory(category);
-        pet.setStatus(Pet.StatusEnum.available);
+        pet.setStatus(Pet.StatusEnum.AVAILABLE);
         List<String> photos = Arrays.asList(new String[]{"http://foo.bar.com/1", "http://foo.bar.com/2"});
         pet.setPhotoUrls(photos);
 

--- a/samples/client/petstore/java/jersey2/src/test/java/io/swagger/petstore/test/StoreApiTest.java
+++ b/samples/client/petstore/java/jersey2/src/test/java/io/swagger/petstore/test/StoreApiTest.java
@@ -64,7 +64,7 @@ public class StoreApiTest {
         order.setPetId(new Long(200));
         order.setQuantity(new Integer(13));
         order.setShipDate(new java.util.Date());
-        order.setStatus(Order.StatusEnum.placed);
+        order.setStatus(Order.StatusEnum.PLACED);
         order.setComplete(true);
 
         return order;


### PR DESCRIPTION
Fix #1102: "Need to avoid language keywords in enums"

* Use upper case for enum names to comply with [convention](https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html)
* Prepend enum name with underscore if it starts with number

Example code:

```java
public enum StatusEnum {
  AVAILABLE("available"), PENDING("pending"), SOLD("sold"), SWITCH("switch"), _1M("1m");

  private String value;

  StatusEnum(String value) {
    this.value = value;
  }

  @Override
  public String toString() {
    return value;
  }
}
```