### PR TITLE
Add status code and response headers of the last request to java and c#

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -49,6 +49,9 @@ public class ApiClient {
 
   private Map<String, Authentication> authentications;
 
+  private int statusCode;
+  private Map<String, List<String>> responseHeaders;
+
   private DateFormat dateFormat;
 
   public ApiClient() {
@@ -78,6 +81,20 @@ public class ApiClient {
   public ApiClient setBasePath(String basePath) {
     this.basePath = basePath;
     return this;
+  }
+
+  /**
+   * Gets the status code of the previous request
+   */
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  /**
+   * Gets the response headers of the previous request
+   */
+  public Map<String, List<String>> getResponseHeaders() {
+    return responseHeaders;
   }
 
   /**
@@ -493,6 +510,9 @@ public class ApiClient {
    public <T> T invokeAPI(String path, String method, List<Pair> queryParams, Object body, byte[] binaryBody, Map<String, String> headerParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, TypeRef returnType) throws ApiException {
 
     ClientResponse response = getAPIResponse(path, method, queryParams, body, binaryBody, headerParams, formParams, accept, contentType, authNames);
+
+    statusCode = response.getStatusInfo().getStatusCode();
+    responseHeaders = response.getHeaders();
 
     if(response.getStatusInfo() == ClientResponse.Status.NO_CONTENT) {
       return null;

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -49,6 +49,16 @@ namespace {{packageName}}.Client
         {
             get { return _defaultHeaderMap; }
         }
+
+        /// <summary>
+        /// Gets the status code of the previous request
+        /// </summary>
+        public int StatusCode { get; private set; }
+
+        /// <summary>
+        /// Gets the response headers of the previous request
+        /// </summary>
+        public Dictionary<String, String> ResponseHeaders { get; private set; } 
     
         // Creates and sets up a RestRequest prior to a call.
         private RestRequest PrepareRequest(
@@ -110,7 +120,10 @@ namespace {{packageName}}.Client
         {
             var request = PrepareRequest(
                 path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, authSettings);
-            return (Object)RestClient.Execute(request);
+            var response = RestClient.Execute(request);
+            StatusCode = (int) response.StatusCode;
+            ResponseHeaders = response.Headers.ToDictionary(x => x.Name, x => x.Value.ToString());
+            return (Object) response;
         }
 
         /// <summary>
@@ -133,7 +146,10 @@ namespace {{packageName}}.Client
         {
             var request = PrepareRequest(
                 path, method, queryParams, postBody, headerParams, formParams, fileParams, pathParams, authSettings);
-            return (Object) await RestClient.ExecuteTaskAsync(request);
+            var response = await RestClient.ExecuteTaskAsync(request);
+            StatusCode = (int)response.StatusCode;
+            ResponseHeaders = response.Headers.ToDictionary(x => x.Name, x => x.Value.ToString());
+            return (Object)response;
         }
     
         /// <summary>


### PR DESCRIPTION
Per #990 

I would like to add the ability to return the status code and response headers from the previous API call from java and csharp. The python client already provides this ability via the last_response variable. This is necessary for our API, as we need the value of the Location header after a POST request.

Approach: Before returning the response body, set the non-body parts of the response on ApiClient.