### PR TITLE
[Objc] Add test cases for sanitizeForSerialization method in objc client

### DIFF
--- a/samples/client/petstore/objc/SwaggerClientTests/Tests/SWGApiClientTest.m
+++ b/samples/client/petstore/objc/SwaggerClientTests/Tests/SWGApiClientTest.m
@@ -152,6 +152,12 @@
     result = [self.apiClient sanitizeForSerialization:data];
     XCTAssertEqualObjects(result, data);
     
+    // NSArray of models
+    NSArray *arrayOfPetDict = @[petDict];
+    data = [NSArray arrayWithObject:[[SWGPet alloc] initWithDictionary:petDict error:nil]];
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, arrayOfPetDict);
+    
     // NSDictionary
     data = @{@"test key": @"test value"};
     result = [self.apiClient sanitizeForSerialization:data];

--- a/samples/client/petstore/objc/SwaggerClientTests/Tests/SWGApiClientTest.m
+++ b/samples/client/petstore/objc/SwaggerClientTests/Tests/SWGApiClientTest.m
@@ -1,7 +1,12 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import <ISO8601/ISO8601.h>
 #import <SwaggerClient/SWGApiClient.h>
 #import <SwaggerClient/SWGConfiguration.h>
+#import <SwaggerClient/SWGQueryParamCollection.h>
+#import <SwaggerClient/SWGPet.h>
+#import <SwaggerClient/SWGTag.h>
+#import <SwaggerClient/SWGCategory.h>
 
 @interface SWGApiClientTest : XCTestCase
 
@@ -96,6 +101,76 @@
     basicAuthCredentials = [NSString stringWithFormat:@"Basic %@", [data base64EncodedStringWithOptions:0]];
     
     XCTAssertEqualObjects(basicAuthCredentials, [config getBasicAuthToken]);
+}
+
+- (void)testSanitizeForDeserialization {
+    id result;
+    id data;
+    
+    // nil
+    data = nil;
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, data);
+    
+    // NSString
+    data = @"test string";
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, data);
+    
+    // NSNumber
+    data = @1;
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, data);
+    
+    // SWGQueryParamCollection
+    data = [[SWGQueryParamCollection alloc] init];
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, data);
+    
+    // NSDate
+    data = [NSDate dateWithISO8601String:@"1997-07-16T19:20:30.45+01:0"];
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, [data ISO8601String]);
+    
+    // model
+    data = [self createPet];
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, [data toDictionary]);
+    
+    // NSArray
+    data = @[@1];
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, data);
+    
+    // NSDictionary
+    data = @{@"test key": @"test value"};
+    result = [self.apiClient sanitizeForSerialization:data];
+    XCTAssertEqualObjects(result, data);
+}
+
+- (SWGPet*) createPet {
+    SWGPet * pet = [[SWGPet alloc] init];
+    pet._id = [[NSNumber alloc] initWithLong:[[NSDate date] timeIntervalSince1970]];
+    pet.name = @"monkey";
+    
+    SWGCategory * category = [[SWGCategory alloc] init];
+    category._id = [[NSNumber alloc] initWithInteger:arc4random_uniform(100000)];
+    category.name = @"super-happy";
+    pet.category = category;
+    
+    SWGTag *tag1 = [[SWGTag alloc] init];
+    tag1._id = [[NSNumber alloc] initWithInteger:arc4random_uniform(100000)];
+    tag1.name = @"test tag 1";
+    SWGTag *tag2 = [[SWGTag alloc] init];
+    tag2._id = [[NSNumber alloc] initWithInteger:arc4random_uniform(100000)];
+    tag2.name = @"test tag 2";
+    pet.tags = (NSArray<SWGTag> *)[[NSArray alloc] initWithObjects:tag1, tag2, nil];
+
+    pet.status = @"available";
+
+    NSArray * photos = [[NSArray alloc] initWithObjects:@"http://foo.bar.com/3", @"http://foo.bar.com/4", nil];
+    pet.photoUrls = photos;
+    return pet;
 }
 
 @end


### PR DESCRIPTION
Add test cases for `sanitizeForSerialization` method.

Integration test looks fine:
```
Test Suite 'All tests' passed at 2015-08-25 01:40:25 +0000.
	 Executed 25 tests, with 0 failures (0 unexpected) in 10.826 (10.848) seconds
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:39 min
[INFO] Finished at: 2015-08-25T09:40:25+08:00
[INFO] Final Memory: 11M/155M
[INFO] ------------------------------------------------------------------------
```