### PR TITLE
[C#] fix invokerPackage with packageName in compile.mustache

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/compile.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/compile.mustache
@@ -1,3 +1,3 @@
 SET CSCPATH=%SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319
-%CSCPATH%\csc /reference:bin/Newtonsoft.Json.dll;bin/RestSharp.dll /target:library /out:bin/{{invokerPackage}}.dll /recurse:src\*.cs /doc:bin/{{invokerPackage}}.xml
+%CSCPATH%\csc /reference:bin/Newtonsoft.Json.dll;bin/RestSharp.dll /target:library /out:bin/{{packageName}}.dll /recurse:src\*.cs /doc:bin/{{packageName}}.xml
 

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/compile.bat
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/compile.bat
@@ -1,3 +1,3 @@
 SET CSCPATH=%SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319
-%CSCPATH%\csc /reference:bin/Newtonsoft.Json.dll;bin/RestSharp.dll /target:library /out:bin/.dll /recurse:src\*.cs /doc:bin/.xml
+%CSCPATH%\csc /reference:bin/Newtonsoft.Json.dll;bin/RestSharp.dll /target:library /out:bin/IO.Swagger.dll /recurse:src\*.cs /doc:bin/IO.Swagger.xml
 


### PR DESCRIPTION
invokerPackage is no longer used and it's replaced by packageName instead.