### PR TITLE
Add null check to fix issue #1143

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -342,6 +342,8 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
                     continue;
                 List<String> values = (List<String>) allowableValues.get("values");
                 // put "enumVars" map into `allowableValues", including `name` and `value`
+                if (values == null)
+                    continue;
                 List<Map<String, String>> enumVars = new ArrayList<Map<String, String>>();
                 for (String value : values) {
                     Map<String, String> enumVar = new HashMap<String, String>();


### PR DESCRIPTION
* fix issue #1143: add another null check.

  The problem was trying to iterate over a null list.

----

I guess there should be some test for this ... it looks like currently all the existing tests are written in Scala. As I don't know Scala at all, I won't try to spend time trying to add a test for this. Should I add a Java test instead, or can we find some other contributor for writing the test?

Here is an example yaml file which breaks before the fix, and runs after the fix (though I did not check if the generated classes are fully sensible).
```
swagger: '2.0'
info:
  title: Swagger Codegen bug trigger
  description: |
     This demonstrates a bug in swagger-codegen.
  version: 0.0.1
basePath: /api
definitions:
  manual_discount:
    type: object
    properties:
      percent_value:
        type: number
        minimum: 0.0
        maximum: 100.0
paths: {}
```