### PR TITLE
Fix for Issue #1146: escape operation summary and response message

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
@@ -118,17 +118,22 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
         co.baseName = basePath;
     }
 
+    @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         if (operations != null) {
             List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
             for (CodegenOperation operation : ops) {
                 List<CodegenResponse> responses = operation.responses;
+                operation.summary = escapeText(operation.summary.trim());
+
                 if (responses != null) {
                     for (CodegenResponse resp : responses) {
                         if ("0".equals(resp.code)) {
                             resp.code = "200";
                         }
+
+                        resp.message = escapeText(resp.message.trim());
                     }
                 }
                 if (operation.returnType == null) {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
@@ -45,7 +45,7 @@ public class {{classname}}  {
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
     {{/hasMore}}{{/allParams}})
     throws NotFoundException {
-    return delegate.{{nickname}}({{#allParams}}{{#isFile}}fileDetail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}},{{/hasMore}}{{/allParams}});
+        return delegate.{{nickname}}({{#allParams}}{{#isFile}}fileDetail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}},{{/hasMore}}{{/allParams}});
     }
 {{/operation}}
 }


### PR DESCRIPTION
This fixes issue #1146, getting rid of the line breaks in the strings, which broke the Java compilability.
We trim the string before escaping, because trailing `\n` are not useful for anything.

Also, fix a minor indentation problem in the generated file.

-----------

I guess there should be some test for this ... it looks like currently all the existing tests are written in Scala. As I don't know Scala at all, I won't try to spend time trying to add a test for this. Should I add a Java test instead, or can we find some other contributor for writing the test?

Here is an example yaml file which generates a non-compilable class before the fix and compilable classes after the fix. (The relevant part is only the path, not the definitions.)

```
swagger: '2.0'
info:
  title: Example API
  description:
      bla bla
      
      and one more line.
basePath: /api
definitions:
  example:
    description:
      This is an object with a ...
      
      ... multiline description.
    type: object
    properties:
      foo:
        description: |
          even foo has a
          multi-line description.
        type: string
paths:
  /example-path:
    put:
      summary:
         create or update the example.
         
         Another line.
      responses:
        201:
          description: |
            Example was created.

            No content.
          schema:
            $ref: "#/definitions/example"
```