### PR TITLE
jaxrs (and other Java generators): do not escape newlines in generated javadocs.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -10,6 +10,7 @@ import java.util.Set;
 public class CodegenModel {
     public String parent;
     public String name, classname, description, classVarName, modelJson;
+    public String unescapedDescription;
     public String defaultValue;
     public List<CodegenProperty> vars = new ArrayList<CodegenProperty>();
     public Set<String> imports = new HashSet<String>();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -7,6 +7,8 @@ public class CodegenProperty {
     public String baseName, complexType, getter, setter, description, datatype, datatypeWithEnum,
             name, min, max, defaultValue, baseType, containerType;
 
+    public String unescapedDescription;
+
     /**
      * maxLength validation for strings, see http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.2.1
      */

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -533,6 +533,7 @@ public class DefaultCodegen {
             m.name = name;
         }
         m.description = escapeText(model.getDescription());
+        m.unescapedDescription = model.getDescription();
         m.classname = toModelName(name);
         m.classVarName = toVarName(name);
         m.modelJson = Json.pretty(model);
@@ -629,6 +630,7 @@ public class DefaultCodegen {
         property.name = toVarName(name);
         property.baseName = name;
         property.description = escapeText(p.getDescription());
+        property.unescapedDescription = p.getDescription();
         property.getter = "get" + getterAndSetterCapitalize(name);
         property.setter = "set" + getterAndSetterCapitalize(name);
         property.example = p.getExample();

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/model.mustache
@@ -7,10 +7,10 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 {{#models}}
 
-{{#model}}{{#description}}
+{{#model}}{{#unescapedDescription}}
 /**
- * {{description}}
- **/{{/description}}
+ * {{unescapedDescription}}
+ **/{{/unescapedDescription}}
 @ApiModel(description = "{{{description}}}")
 {{>generatedAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
@@ -22,8 +22,8 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   private {{{datatype}}} {{name}} = {{{defaultValue}}};{{/isEnum}}{{/vars}}
 
   {{#vars}}
-  /**{{#description}}
-   * {{{description}}}{{/description}}{{#minimum}}
+  /**{{#unescapedDescription}}
+   * {{{unescapedDescription}}}{{/unescapedDescription}}{{#minimum}}
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}
    * maximum: {{maximum}}{{/maximum}}
    **/


### PR DESCRIPTION
Previously, the description strings for models and properties were escaped (replacing newlines with a literal `\n`).

This resulted in files like this (see below for an example swagger yaml file):

```
/**
 * This is an object with a ...\n... multiline description.
 **/
@ApiModel(description = "This is an object with a ...\n... multiline description.")
@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JaxRSServerCodegen", date = "2015-08-28T18:54:37.200+02:00")
public class Example  {
  
  private String foo = null;

  
  /**
   * even foo has a\nmulti-line description.\n
   **/
  @ApiModelProperty(value = "even foo has a\nmulti-line description.\n")
  @JsonProperty("foo")
  public String getFoo() {
    return foo;
  }
  public void setFoo(String foo) {
    this.foo = foo;
  }
```
These `\n` in the Javadocs are ugly (even more if one actually looks at the generated HTML page).

This pull requests changes this, so it now looks like this:

```
/**
 * This is an object with a ...
... multiline description.
 **/
@ApiModel(description = "This is an object with a ...\n... multiline description.")
@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JaxRSServerCodegen", date = "2015-08-28T18:44:53.323+02:00")
public class Example  {
  
  private String foo = null;

  
  /**
   * even foo has a
multi-line description.

   **/
  @ApiModelProperty(value = "even foo has a\nmulti-line description.\n")
  @JsonProperty("foo")
  public String getFoo() {
    return foo;
  }
  public void setFoo(String foo) {
    this.foo = foo;
  }
```

For doing this, I added a property `unescapedDescription` to CodegenModel + CodegenProperty, and use them for the Javadoc generation, while the annotation still uses the escaped `description`.

(I got the idea to do this from issue #1146.)

-----------

I guess there should be some test for this ... it looks like currently all the existing tests are written in Scala. As I don't know Scala at all, I won't try to spend time trying to add a test for this. Should I add a Java test instead, or can we find some other contributor for writing the test?

Here is an example yaml file which generates a non-compilable class before the fix and compilable classes after the fix. (The relevant part is only the definitions, the path is not needed here.)

```
swagger: '2.0'
info:
  title: Example API
  description:
      bla bla
      
      and one more line.
basePath: /api
definitions:
  example:
    description:
      This is an object with a ...
      
      ... multiline description.
    type: object
    properties:
      foo:
        description: |
          even foo has a
          multi-line description.
        type: string
paths:
  /example-path:
    put:
      summary:
         create or update the example.
         
         Another line.
      responses:
        201:
          description: |
            Example was created.

            No content.
          schema:
            $ref: "#/definitions/example"
```