### PR TITLE
jaxrs: escape line breaks in response description

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -963,7 +963,7 @@ public class DefaultCodegen {
         } else {
             r.code = responseCode;
         }
-        r.message = response.getDescription();
+        r.message = escapeText(response.getDescription());
         r.schema = response.getSchema();
         r.examples = toExamples(response.getExamples());
         r.jsonSchema = Json.pretty(response);

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
@@ -45,7 +45,7 @@ public class {{classname}}  {
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
     {{/hasMore}}{{/allParams}})
     throws NotFoundException {
-    return delegate.{{nickname}}({{#allParams}}{{#isFile}}fileDetail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}},{{/hasMore}}{{/allParams}});
+        return delegate.{{nickname}}({{#allParams}}{{#isFile}}fileDetail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}},{{/hasMore}}{{/allParams}});
     }
 {{/operation}}
 }


### PR DESCRIPTION
This is the fix for #1146: line breaks in response descriptions are now escaped, so they don't create invalid Java string literals anymore.

In addition, fix the indentation in the generated API operation method.

**I did only test this with with the jaxrs generator (and did run the tests which are included in the build). Please check whether this breaks anything for other languages.**

-----------

I guess there should be some test for this ... it looks like currently all the existing tests are written in Scala. As I don't know Scala at all, I won't try to spend time trying to add a Scala test for this. Should I add a Java test instead, or can we find some other contributor for writing the test?

Here is an example yaml file which generates a non-compilable class before the fix and compilable classes after the fix. 

```
swagger: '2.0'
info:
  title: Example API
  description:
      bla bla
      
      and one more line.
basePath: /api
paths:
  /example-path:
    put:
      summary:
         create or update the example.
         
         Another line.
      responses:
        201:
          description: |
            Example was created.

            No content.
```