### PR TITLE
trim strings before escaping

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -126,6 +126,7 @@ public class DefaultCodegen {
     // override with any special text escaping logic
     public String escapeText(String input) {
         if (input != null) {
+            input = input.trim();
             String output = input.replaceAll("\n", "\\\\n");
             output = output.replace("\"", "\\\"");
             return output;


### PR DESCRIPTION
Related to Issue #1146, this removes leading and trailing whitespace before escaping strings. This gets rid of annoying `\n` in some string literals (e.g. in annotations used in jaxrs).

Before (extract):

```
/**
 * This is an object with a ...\n\n... multiline description.\n
 **/
@ApiModel(description = "This is an object with a ...\n\n... multiline description.\n")
@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JaxRSServerCodegen", date = "2015-08-28T20:04:46.661+02:00")
public class Example  {
  
  private String foo = null;

  
  /**
   * even foo has a\nmulti-line description.\n
   **/
  @ApiModelProperty(value = "even foo has a\nmulti-line description.\n")
  @JsonProperty("foo")
  public String getFoo() {
    return foo;
  }
  public void setFoo(String foo) {
    this.foo = foo;
  }
```

After:

```
/**
 * This is an object with a ...\n\n... multiline description.
 **/
@ApiModel(description = "This is an object with a ...\n\n... multiline description.")
@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JaxRSServerCodegen", date = "2015-08-28T19:55:09.579+02:00")
public class Example  {
  
  private String foo = null;

  
  /**
   * even foo has a\nmulti-line description.
   **/
  @ApiModelProperty(value = "even foo has a\nmulti-line description.")
  @JsonProperty("foo")
  public String getFoo() {
    return foo;
  }
  public void setFoo(String foo) {
    this.foo = foo;
  }
```

I strongly suspect that those trailing `\n` are not needed by anyone, therefore this pull request.
**I did only try this with the jaxrs language, not with any other language (though I did run the tests which are included in the build, all still pass). Please check that this doesn't break anything.**

---------

I guess there should be some test for this ... it looks like currently all the existing tests are written in Scala. As I don't know Scala at all, I won't try to spend time trying to add a test for this. Should I add a Java test instead, or can we find some other contributor for writing the test?

Here is the example file from which the output above (and more) was generated:

```
swagger: '2.0'
info:
  title: Example API
  description: |
      bla bla
      
      and one more line.
basePath: /api
definitions:
  example:
    description: |
      This is an object with a ...
      
      ... multiline description.
      
    type: object
    properties:
      foo:
        description: |
          even foo has a
          multi-line description.
        type: string
paths: {}
```