### PR TITLE
Issue #1142: replace dashes with underscores before camelizing

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1357,6 +1357,9 @@ public class DefaultCodegen {
     }
 
     public static String camelize(String word, boolean lowercaseFirstLetter) {
+        // Replace all dashes with underscores (which will be handled later).
+        word = word.replace('-', '_');
+
         // Replace all slashes with dots (package separator)
         Pattern p = Pattern.compile("\\/(.?)");
         Matcher m = p.matcher(word);


### PR DESCRIPTION
Replace dashes with underscores before camelizing.
This gets rid of dashes in model class names (at least for Java).

This is still only a partial fix for #1142: dashes in path names (for spring-mvc) still result in dashes in the Api class names.

**I did test this only with spring-mvc and jaxrs (and did run the tests included in the build, they all pass). I do not know how this effects other languages, specifically those which actually allow dashes in class names. Please verify that this doesn't break anything.**

Obviously this breaks APIs which use names only differing by `-` vs. `_`, but similar cases (`_` versus camelCase) already exist.

Maybe doing this in a Java-specific class (JavaClientCodegen) might be a better idea?

--------

I guess there should be some test for this ... it looks like currently all the existing tests are written in Scala. As I don't know Scala at all, I won't try to spend time trying to add a test for this. Should I add a Java test instead, or can we find some other contributor for writing the test?

Here is a file which produces a broken model class (Example-parent) before the change and a "good" one (ExampleParent) after the change:
```
swagger: '2.0'
info:
  title: Swagger Codegen bug trigger
  description: |
     This demonstrates a bug in swagger-codegen.
  version: 0.0.1
basePath: /api
definitions:
  example-parent:
    type: object
    properties:
      foo:
        type: string
paths:
  example-path:
    get:
      responses:
        200:
          description: "blub"
```

(The path still causes a broken file with spring-mvc, but is okay for jaxrs.)