### PR TITLE
Issue #1142: sanitize the class name for Java model classes.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -237,6 +237,8 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toModelName(String name) {
+        name = sanitizeName(name);
+
         // model name cannot use reserved keyword, e.g. return
         if (reservedWords.contains(name)) {
             throw new RuntimeException(name + " (reserved word) cannot be used as a model name");


### PR DESCRIPTION
This builds on #1139, calling the new sanitizeName() method before camelizing it when generating model names.

This is still only a partial solution to #1142 → dashes in paths with spring-mvc still lead to class names with dashes. I'll try to solve this in a separate pull request.

--------

I guess there should be some test for this ... it looks like currently all the existing tests are written in Scala. As I don't know Scala at all, I won't try to spend time trying to add a test for this. Should I add a Java test instead, or can we find some other contributor for writing the test?

Here is a file which produces a broken model class (Example-parent) before the change and a "good" one (ExampleParent) after the change:
```
swagger: '2.0'
info:
  title: Swagger Codegen bug trigger
  description: |
     This demonstrates a bug in swagger-codegen.
  version: 0.0.1
basePath: /api
definitions:
  example-parent:
    type: object
    properties:
      foo:
        type: string
paths:
  example-path:
    get:
      responses:
        200:
          description: "blub"
```