### PR TITLE
Issue #1142: sanitize api name before camelizing.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
@@ -163,7 +163,7 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
         if (name.length() == 0) {
             return "DefaultApi";
         }
-        name = name.replaceAll("[^a-zA-Z0-9]+", "_");
+        name = sanitizeName(name);
         return camelize(name) + "Api";
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
@@ -175,6 +175,15 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
         return objs;
     }
 
+    @Override
+    public String toApiName(String name) {
+        if (name.length() == 0) {
+            return "DefaultApi";
+        }
+        name = sanitizeName(name);
+        return camelize(name) + "Api";
+    }
+
     public void setConfigPackage(String configPackage) {
         this.configPackage = configPackage;
     }


### PR DESCRIPTION
This builds on #1139 in order to solve another part of #1142:
When the first component of a path contained a dash, the generated class name contained this dash too (for the "language" spring-mvc).

The same problem for model names is solved by #1163.