### PR TITLE
Allow overriding of only some templates when using --template-dir option

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/AbstractGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/AbstractGenerator.java
@@ -70,11 +70,22 @@ public abstract class AbstractGenerator {
             String libTemplateFile = config.templateDir() + File.separator +
                 "libraries" + File.separator + library + File.separator +
                 templateFile;
+            String libTemplateFileEmbedded = config.embeddedTemplateDir() + File.separator +
+                "libraries" + File.separator + library + File.separator +
+                templateFile;
             if (templateExists(libTemplateFile)) {
                 return libTemplateFile;
+            } else if (templateExists(libTemplateFileEmbedded)) {
+                // Fall back to the template file embedded/packaged in the JAR file...
+                return libTemplateFileEmbedded;
             }
         }
-        return config.templateDir() + File.separator + templateFile;
+        if (templateExists(config.templateDir() + File.separator + templateFile)) {
+            return config.templateDir() + File.separator + templateFile;
+        } else {
+            // Fall back to the template file embedded/packaged in the JAR file...
+            return config.embeddedTemplateDir() + File.separator + templateFile;
+        }
     }
 
     public boolean templateExists(String name) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -29,6 +29,8 @@ public interface CodegenConfig {
 
     String templateDir();
 
+    String embeddedTemplateDir();
+
     String modelFileFolder();
 
     String modelPackage();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -78,6 +78,7 @@ public class DefaultCodegen {
     protected Map<String, String> apiTemplateFiles = new HashMap<String, String>();
     protected Map<String, String> modelTemplateFiles = new HashMap<String, String>();
     protected String templateDir;
+    protected String embeddedTemplateDir;
     protected Map<String, Object> additionalProperties = new HashMap<String, Object>();
     protected List<SupportingFile> supportingFiles = new ArrayList<SupportingFile>();
     protected List<CliOption> cliOptions = new ArrayList<CliOption>();
@@ -181,6 +182,14 @@ public class DefaultCodegen {
 
     public String templateDir() {
         return templateDir;
+    }
+
+    public String embeddedTemplateDir() {
+        if (embeddedTemplateDir != null) {
+            return embeddedTemplateDir;
+        } else {
+            return templateDir;
+        }
     }
 
     public Map<String, String> apiTemplateFiles() {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AkkaScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AkkaScalaClientCodegen.java
@@ -68,7 +68,7 @@ public class AkkaScalaClientCodegen extends DefaultCodegen implements CodegenCon
         outputFolder = "generated-code/scala";
         modelTemplateFiles.put("model.mustache", ".scala");
         apiTemplateFiles.put("api.mustache", ".scala");
-        templateDir = "akka-scala";
+        embeddedTemplateDir = templateDir = "akka-scala";
         apiPackage = mainPackage + ".api";
         modelPackage = mainPackage + ".model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
@@ -30,7 +30,7 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
         outputFolder = "generated-code/android";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
-        templateDir = "android-java";
+        embeddedTemplateDir = templateDir = "android-java";
         apiPackage = "io.swagger.client.api";
         modelPackage = "io.swagger.client.model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AsyncScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AsyncScalaClientCodegen.java
@@ -40,7 +40,7 @@ public class AsyncScalaClientCodegen extends DefaultCodegen implements CodegenCo
         outputFolder = "generated-code/async-scala";
         modelTemplateFiles.put("model.mustache", ".scala");
         apiTemplateFiles.put("api.mustache", ".scala");
-        templateDir = "asyncscala";
+        embeddedTemplateDir = templateDir = "asyncscala";
         apiPackage = "io.swagger.client.api";
         modelPackage = "io.swagger.client.model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -27,7 +27,7 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         outputFolder = "generated-code" + File.separator + "csharp";
         modelTemplateFiles.put("model.mustache", ".cs");
         apiTemplateFiles.put("api.mustache", ".cs");
-        templateDir = "csharp";
+        embeddedTemplateDir = templateDir = "csharp";
         apiPackage = "IO.Swagger.Api";
         modelPackage = "IO.Swagger.Model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CsharpDotNet2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CsharpDotNet2ClientCodegen.java
@@ -25,7 +25,7 @@ public class CsharpDotNet2ClientCodegen extends DefaultCodegen implements Codege
         outputFolder = "generated-code" + File.separator + "CsharpDotNet2";
         modelTemplateFiles.put("model.mustache", ".cs");
         apiTemplateFiles.put("api.mustache", ".cs");
-        templateDir = "CsharpDotNet2";
+        embeddedTemplateDir = templateDir = "CsharpDotNet2";
         apiPackage = "IO.Swagger.Api";
         modelPackage = "IO.Swagger.Model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/DartClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/DartClientCodegen.java
@@ -26,7 +26,7 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         outputFolder = "generated-code/dart";
         modelTemplateFiles.put("model.mustache", ".dart");
         apiTemplateFiles.put("api.mustache", ".dart");
-        templateDir = "dart";
+        embeddedTemplateDir = templateDir = "dart";
         apiPackage = "lib.api";
         modelPackage = "lib.model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlashClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlashClientCodegen.java
@@ -40,7 +40,7 @@ public class FlashClientCodegen extends DefaultCodegen implements CodegenConfig 
         modelTemplateFiles.put("model.mustache", ".as");
         modelTemplateFiles.put("modelList.mustache", "List.as");
         apiTemplateFiles.put("api.mustache", ".as");
-        templateDir = "flash";
+        embeddedTemplateDir = templateDir = "flash";
 
         languageSpecificPrimitives.clear();
         languageSpecificPrimitives.add("Number");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -44,7 +44,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         outputFolder = "generated-code/java";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
-        templateDir = "Java";
+        embeddedTemplateDir = templateDir = "Java";
         apiPackage = "io.swagger.client.api";
         modelPackage = "io.swagger.client.model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
@@ -34,7 +34,7 @@ public class JavaInflectorServerCodegen extends JavaClientCodegen implements Cod
         sourceFolder = "src/main/java";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
-        templateDir = "JavaInflector";
+        embeddedTemplateDir = templateDir = "JavaInflector";
 
         apiPackage = System.getProperty("swagger.codegen.inflector.apipackage", "io.swagger.handler");
         modelPackage = System.getProperty("swagger.codegen.inflector.modelpackage", "io.swagger.model");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
@@ -33,7 +33,7 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
         apiTemplateFiles.put("apiService.mustache", ".java");
         apiTemplateFiles.put("apiServiceImpl.mustache", ".java");
         apiTemplateFiles.put("apiServiceFactory.mustache", ".java");
-        templateDir = "JavaJaxRS";
+        embeddedTemplateDir = templateDir = "JavaJaxRS";
         apiPackage = System.getProperty("swagger.codegen.jaxrs.apipackage", "io.swagger.api");
         modelPackage = System.getProperty("swagger.codegen.jaxrs.modelpackage", "io.swagger.model");
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -55,7 +55,7 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
          * Template Location.  This is the location which templates will be read from.  The generator
          * will use the resource stream to attempt to read the templates.
          */
-        templateDir = "nodejs";
+        embeddedTemplateDir = templateDir = "nodejs";
 
         /**
          * Reserved words.  Override this with reserved words specific to your language

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -36,7 +36,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         modelTemplateFiles.put("model-body.mustache", ".m");
         apiTemplateFiles.put("api-header.mustache", ".h");
         apiTemplateFiles.put("api-body.mustache", ".m");
-        templateDir = "objc";
+        embeddedTemplateDir = templateDir = "objc";
 
         defaultIncludes.clear();
         defaultIncludes.add("bool");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PerlClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PerlClientCodegen.java
@@ -25,7 +25,7 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
         outputFolder = "generated-code" + File.separatorChar + "perl";
         modelTemplateFiles.put("object.mustache", ".pm");
         apiTemplateFiles.put("api.mustache", ".pm");
-        templateDir = "perl";
+        embeddedTemplateDir = templateDir = "perl";
 
 
         reservedWords = new HashSet<String>(

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -33,7 +33,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         outputFolder = "generated-code" + File.separator + "php";
         modelTemplateFiles.put("model.mustache", ".php");
         apiTemplateFiles.put("api.mustache", ".php");
-        templateDir = "php";
+        embeddedTemplateDir = templateDir = "php";
         apiPackage = invokerPackage + "\\Api";
         modelPackage = invokerPackage + "\\Model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -27,7 +27,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         outputFolder = "generated-code" + File.separatorChar + "python";
         modelTemplateFiles.put("model.mustache", ".py");
         apiTemplateFiles.put("api.mustache", ".py");
-        templateDir = "python";
+        embeddedTemplateDir = templateDir = "python";
 
         languageSpecificPrimitives.clear();
         languageSpecificPrimitives.add("int");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -71,7 +71,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
          * Template Location.  This is the location which templates will be read from.  The generator
          * will use the resource stream to attempt to read the templates.
          */
-        templateDir = "qt5cpp";
+        embeddedTemplateDir = templateDir = "qt5cpp";
 
         /**
          * Reserved words.  Override this with reserved words specific to your language

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -28,7 +28,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
         outputFolder = "generated-code" + File.separator + "ruby";
         modelTemplateFiles.put("model.mustache", ".rb");
         apiTemplateFiles.put("api.mustache", ".rb");
-        templateDir = "ruby";
+        embeddedTemplateDir = templateDir = "ruby";
 
         typeMapping.clear();
         languageSpecificPrimitives.clear();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
@@ -42,7 +42,7 @@ public class ScalaClientCodegen extends DefaultCodegen implements CodegenConfig 
         outputFolder = "generated-code/scala";
         modelTemplateFiles.put("model.mustache", ".scala");
         apiTemplateFiles.put("api.mustache", ".scala");
-        templateDir = "scala";
+        embeddedTemplateDir = templateDir = "scala";
         apiPackage = "io.swagger.client.api";
         modelPackage = "io.swagger.client.model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalatraServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalatraServerCodegen.java
@@ -29,7 +29,7 @@ public class ScalatraServerCodegen extends DefaultCodegen implements CodegenConf
         outputFolder = "generated-code/scalatra";
         modelTemplateFiles.put("model.mustache", ".scala");
         apiTemplateFiles.put("api.mustache", ".scala");
-        templateDir = "scalatra";
+        embeddedTemplateDir = templateDir = "scalatra";
         apiPackage = "com.wordnik.client.api";
         modelPackage = "com.wordnik.client.model";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SilexServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SilexServerCodegen.java
@@ -35,7 +35,7 @@ public class SilexServerCodegen extends DefaultCodegen implements CodegenConfig 
         modelTemplateFiles.clear();
         apiTemplateFiles.clear();
 
-        templateDir = "silex";
+        embeddedTemplateDir = templateDir = "silex";
 
         reservedWords = new HashSet<String>(
                 Arrays.asList(

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SinatraServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SinatraServerCodegen.java
@@ -29,7 +29,7 @@ public class SinatraServerCodegen extends DefaultCodegen implements CodegenConfi
         // no model
         modelTemplateFiles.clear();
         apiTemplateFiles.put("api.mustache", ".rb");
-        templateDir = "sinatra";
+        embeddedTemplateDir = templateDir = "sinatra";
 
         typeMapping.clear();
         languageSpecificPrimitives.clear();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
@@ -29,7 +29,7 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
         outputFolder = "generated-code/javaSpringMVC";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
-        templateDir = "JavaSpringMVC";
+        embeddedTemplateDir = templateDir = "JavaSpringMVC";
         apiPackage = "io.swagger.api";
         modelPackage = "io.swagger.model";
         configPackage = "io.swagger.configuration";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticDocCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticDocCodegen.java
@@ -20,7 +20,7 @@ public class StaticDocCodegen extends DefaultCodegen implements CodegenConfig {
         outputFolder = "docs";
         modelTemplateFiles.put("model.mustache", ".html");
         apiTemplateFiles.put("operation.mustache", ".html");
-        templateDir = "swagger-static";
+        embeddedTemplateDir = templateDir = "swagger-static";
 
         additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
         additionalProperties.put(CodegenConstants.GROUP_ID, groupId);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtmlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtmlGenerator.java
@@ -28,7 +28,7 @@ public class StaticHtmlGenerator extends DefaultCodegen implements CodegenConfig
     public StaticHtmlGenerator() {
         super();
         outputFolder = "docs";
-        templateDir = "htmlDocs";
+        embeddedTemplateDir = templateDir = "htmlDocs";
 
         defaultIncludes = new HashSet<String>();
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerGenerator.java
@@ -13,7 +13,7 @@ import java.io.File;
 public class SwaggerGenerator extends DefaultCodegen implements CodegenConfig {
     public SwaggerGenerator() {
         super();
-        templateDir = "swagger";
+        embeddedTemplateDir = templateDir = "swagger";
         outputFolder = "generated-code/swagger";
 
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
@@ -13,7 +13,7 @@ import java.io.File;
 public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfig {
     public SwaggerYamlGenerator() {
         super();
-        templateDir = "swagger";
+        embeddedTemplateDir = templateDir = "swagger";
         outputFolder = "generated-code/swagger";
 
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -46,7 +46,7 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
     outputFolder = "generated-code" + File.separator + "swift";
     modelTemplateFiles.put("model.mustache", ".swift");
     apiTemplateFiles.put("api.mustache", ".swift");
-    templateDir = "swift";
+    embeddedTemplateDir = templateDir = "swift";
     apiPackage = File.separator + "APIs";
     modelPackage = File.separator + "Models";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TizenClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TizenClientCodegen.java
@@ -40,7 +40,7 @@ public class TizenClientCodegen extends DefaultCodegen implements CodegenConfig 
         modelTemplateFiles.put("model-body.mustache", ".cpp");
         apiTemplateFiles.put("api-header.mustache", ".h");
         apiTemplateFiles.put("api-body.mustache", ".cpp");
-        templateDir = "tizen";
+        embeddedTemplateDir = templateDir = "tizen";
         modelPackage = "";
 
         defaultIncludes = new HashSet<String>(

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -20,7 +20,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 	    outputFolder = "generated-code/typescript-angular";
 	    modelTemplateFiles.put("model.mustache", ".ts");
 	    apiTemplateFiles.put("api.mustache", ".ts");
-	    templateDir = "TypeScript-Angular";
+	    embeddedTemplateDir = templateDir = "TypeScript-Angular";
 	    apiPackage = "API.Client";
 	    modelPackage = "API.Client";
 	    supportingFiles.add(new SupportingFile("api.d.mustache", apiPackage().replace('.', File.separatorChar), "api.d.ts"));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -17,7 +17,7 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
     public TypeScriptNodeClientCodegen() {
         super();
         outputFolder = "generated-code/typescript-node";
-        templateDir = "TypeScript-node";
+        embeddedTemplateDir = templateDir = "TypeScript-node";
         supportingFiles.add(new SupportingFile("api.mustache", null, "api.ts"));
     }
 


### PR DESCRIPTION
Templates which aren't found in the template directory will fall back to the ones packaged/distributed with Swagger