### PR TITLE
[Obj-C] Added ability to access HTTP Response headers 

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -9,6 +9,13 @@ static bool cacheEnabled = false;
 static AFNetworkReachabilityStatus reachabilityStatus = AFNetworkReachabilityStatusNotReachable;
 static void (^reachabilityChangeBlock)(int);
 
+
+@interface {{classPrefix}}ApiClient ()
+
+@property (readwrite, nonatomic) NSDictionary *HTTPResponseHeaders;
+
+@end
+
 @implementation {{classPrefix}}ApiClient
 
 - (instancetype)init {
@@ -385,6 +392,8 @@ static void (^reachabilityChangeBlock)(int);
                                                                        if([[{{classPrefix}}Configuration sharedConfig] debug]) {
                                                                            [self logResponse:operation forRequest:request error:nil];
                                                                        }
+                                                                       NSDictionary *responseHeaders = [[operation response] allHeaderFields];
+                                                                       self.HTTPResponseHeaders = responseHeaders;
                                                                        completionBlock(response, nil);
                                                                    }
                                                                } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
@@ -398,6 +407,10 @@ static void (^reachabilityChangeBlock)(int);
 
                                                                        if([[{{classPrefix}}Configuration sharedConfig] debug])
                                                                            [self logResponse:nil forRequest:request error:augmentedError];
+                                                                       
+                                                                       NSDictionary *responseHeaders = [[operation response] allHeaderFields];
+                                                                       self.HTTPResponseHeaders = responseHeaders;
+
                                                                        completionBlock(nil, augmentedError);
                                                                    }
                                                                }];
@@ -441,6 +454,7 @@ static void (^reachabilityChangeBlock)(int);
                                                                    NSURL *file = [NSURL fileURLWithPath:filepath];
 
                                                                    [operation.responseData writeToURL:file atomically:YES];
+                                                                   self.HTTPResponseHeaders = headers;
                                                                    completionBlock(file, nil);
                                                                } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
 
@@ -455,7 +469,8 @@ static void (^reachabilityChangeBlock)(int);
                                                                        if ([[{{classPrefix}}Configuration sharedConfig] debug]) {
                                                                            [self logResponse:nil forRequest:request error:augmentedError];
                                                                        }
-
+                                                                       NSDictionary *responseHeaders = [[operation response] allHeaderFields];
+                                                                       self.HTTPResponseHeaders = responseHeaders;
                                                                        completionBlock(nil, augmentedError);
                                                                    }
                                                                }];

--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
@@ -31,6 +31,9 @@ extern NSString *const {{classPrefix}}ResponseObjectErrorKey;
 @property(nonatomic, assign) NSTimeInterval timeoutInterval;
 @property(nonatomic, readonly) NSOperationQueue* queue;
 
+/// In order to ensure the HTTPResponseHeaders are correct, it is recommended to initialize one {{classPrefix}}ApiClient instance per thread.
+@property(nonatomic, readonly) NSDictionary* HTTPResponseHeaders;
+
 /**
  * Clears Cache
  */

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -11,6 +11,8 @@
 
 @implementation {{classname}}
 
+static {{classname}}* singletonAPI = nil;
+
 #pragma mark - Initialize methods
 
 - (id) init {
@@ -38,11 +40,18 @@
 #pragma mark -
 
 +({{classname}}*) apiWithHeader:(NSString*)headerValue key:(NSString*)key {
-    static {{classname}}* singletonAPI = nil;
 
     if (singletonAPI == nil) {
         singletonAPI = [[{{classname}} alloc] init];
         [singletonAPI addHeader:headerValue forKey:key];
+    }
+    return singletonAPI;
+}
+
++({{classname}}*) sharedAPI {
+
+    if (singletonAPI == nil) {
+        singletonAPI = [[{{classname}} alloc] init];
     }
     return singletonAPI;
 }

--- a/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
@@ -20,6 +20,7 @@
 -(void) addHeader:(NSString*)value forKey:(NSString*)key;
 -(unsigned long) requestQueueSize;
 +({{classname}}*) apiWithHeader:(NSString*)headerValue key:(NSString*)key;
++({{classname}}*) sharedAPI;
 {{#operation}}
 ///
 ///

--- a/samples/client/petstore/objc/README.md
+++ b/samples/client/petstore/objc/README.md
@@ -12,6 +12,10 @@ To install it, put the API client library in your project and then simply add th
 pod "SwaggerClient", :path => "/path/to/lib"
 ```
 
+## Recommendation
+
+It's recommended to create an instance of ApiClient per thread in a multithreaded environment to avoid any potential issue.
+
 ## Author
 
 apiteam@swagger.io

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.h
@@ -35,6 +35,9 @@ extern NSString *const SWGResponseObjectErrorKey;
 @property(nonatomic, assign) NSTimeInterval timeoutInterval;
 @property(nonatomic, readonly) NSOperationQueue* queue;
 
+/// In order to ensure the HTTPResponseHeaders are correct, it is recommended to initialize one SWGApiClient instance per thread.
+@property(nonatomic, readonly) NSDictionary* HTTPResponseHeaders;
+
 /**
  * Clears Cache
  */

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
@@ -9,6 +9,13 @@ static bool cacheEnabled = false;
 static AFNetworkReachabilityStatus reachabilityStatus = AFNetworkReachabilityStatusNotReachable;
 static void (^reachabilityChangeBlock)(int);
 
+
+@interface SWGApiClient ()
+
+@property (readwrite, nonatomic) NSDictionary *HTTPResponseHeaders;
+
+@end
+
 @implementation SWGApiClient
 
 - (instancetype)init {
@@ -385,6 +392,8 @@ static void (^reachabilityChangeBlock)(int);
                                                                        if([[SWGConfiguration sharedConfig] debug]) {
                                                                            [self logResponse:operation forRequest:request error:nil];
                                                                        }
+                                                                       NSDictionary *responseHeaders = [[operation response] allHeaderFields];
+                                                                       self.HTTPResponseHeaders = responseHeaders;
                                                                        completionBlock(response, nil);
                                                                    }
                                                                } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
@@ -398,6 +407,10 @@ static void (^reachabilityChangeBlock)(int);
 
                                                                        if([[SWGConfiguration sharedConfig] debug])
                                                                            [self logResponse:nil forRequest:request error:augmentedError];
+                                                                       
+                                                                       NSDictionary *responseHeaders = [[operation response] allHeaderFields];
+                                                                       self.HTTPResponseHeaders = responseHeaders;
+
                                                                        completionBlock(nil, augmentedError);
                                                                    }
                                                                }];
@@ -441,6 +454,7 @@ static void (^reachabilityChangeBlock)(int);
                                                                    NSURL *file = [NSURL fileURLWithPath:filepath];
 
                                                                    [operation.responseData writeToURL:file atomically:YES];
+                                                                   self.HTTPResponseHeaders = headers;
                                                                    completionBlock(file, nil);
                                                                } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
 
@@ -455,7 +469,8 @@ static void (^reachabilityChangeBlock)(int);
                                                                        if ([[SWGConfiguration sharedConfig] debug]) {
                                                                            [self logResponse:nil forRequest:request error:augmentedError];
                                                                        }
-
+                                                                       NSDictionary *responseHeaders = [[operation response] allHeaderFields];
+                                                                       self.HTTPResponseHeaders = responseHeaders;
                                                                        completionBlock(nil, augmentedError);
                                                                    }
                                                                }];

--- a/samples/client/petstore/objc/SwaggerClient/SWGPetApi.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPetApi.h
@@ -18,6 +18,7 @@
 -(void) addHeader:(NSString*)value forKey:(NSString*)key;
 -(unsigned long) requestQueueSize;
 +(SWGPetApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key;
++(SWGPetApi*) sharedAPI;
 ///
 ///
 /// Update an existing pet

--- a/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
@@ -9,6 +9,8 @@
 
 @implementation SWGPetApi
 
+static SWGPetApi* singletonAPI = nil;
+
 #pragma mark - Initialize methods
 
 - (id) init {
@@ -36,11 +38,18 @@
 #pragma mark -
 
 +(SWGPetApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key {
-    static SWGPetApi* singletonAPI = nil;
 
     if (singletonAPI == nil) {
         singletonAPI = [[SWGPetApi alloc] init];
         [singletonAPI addHeader:headerValue forKey:key];
+    }
+    return singletonAPI;
+}
+
++(SWGPetApi*) sharedAPI {
+
+    if (singletonAPI == nil) {
+        singletonAPI = [[SWGPetApi alloc] init];
     }
     return singletonAPI;
 }

--- a/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.h
@@ -18,6 +18,7 @@
 -(void) addHeader:(NSString*)value forKey:(NSString*)key;
 -(unsigned long) requestQueueSize;
 +(SWGStoreApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key;
++(SWGStoreApi*) sharedAPI;
 ///
 ///
 /// Returns pet inventories by status

--- a/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.m
@@ -9,6 +9,8 @@
 
 @implementation SWGStoreApi
 
+static SWGStoreApi* singletonAPI = nil;
+
 #pragma mark - Initialize methods
 
 - (id) init {
@@ -36,11 +38,18 @@
 #pragma mark -
 
 +(SWGStoreApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key {
-    static SWGStoreApi* singletonAPI = nil;
 
     if (singletonAPI == nil) {
         singletonAPI = [[SWGStoreApi alloc] init];
         [singletonAPI addHeader:headerValue forKey:key];
+    }
+    return singletonAPI;
+}
+
++(SWGStoreApi*) sharedAPI {
+
+    if (singletonAPI == nil) {
+        singletonAPI = [[SWGStoreApi alloc] init];
     }
     return singletonAPI;
 }

--- a/samples/client/petstore/objc/SwaggerClient/SWGUserApi.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGUserApi.h
@@ -18,6 +18,7 @@
 -(void) addHeader:(NSString*)value forKey:(NSString*)key;
 -(unsigned long) requestQueueSize;
 +(SWGUserApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key;
++(SWGUserApi*) sharedAPI;
 ///
 ///
 /// Create user
@@ -98,7 +99,7 @@
 /// Get user by user name
 /// 
 ///
-/// @param username The name that needs to be fetched. Use user1 for testing. 
+/// @param username The name that needs to be fetched. Use user1 for testing.
 /// 
 ///
 /// @return SWGUser*

--- a/samples/client/petstore/objc/SwaggerClient/SWGUserApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGUserApi.m
@@ -9,6 +9,8 @@
 
 @implementation SWGUserApi
 
+static SWGUserApi* singletonAPI = nil;
+
 #pragma mark - Initialize methods
 
 - (id) init {
@@ -36,11 +38,18 @@
 #pragma mark -
 
 +(SWGUserApi*) apiWithHeader:(NSString*)headerValue key:(NSString*)key {
-    static SWGUserApi* singletonAPI = nil;
 
     if (singletonAPI == nil) {
         singletonAPI = [[SWGUserApi alloc] init];
         [singletonAPI addHeader:headerValue forKey:key];
+    }
+    return singletonAPI;
+}
+
++(SWGUserApi*) sharedAPI {
+
+    if (singletonAPI == nil) {
+        singletonAPI = [[SWGUserApi alloc] init];
     }
     return singletonAPI;
 }
@@ -461,7 +470,7 @@
 ///
 /// Get user by user name
 /// 
-///  @param username The name that needs to be fetched. Use user1 for testing. 
+///  @param username The name that needs to be fetched. Use user1 for testing.
 ///
 ///  @returns SWGUser*
 ///


### PR DESCRIPTION
- Added a property on the ApiClient class that is set before any operation's completionBlock. This allows access to the HTTP response headers by calling `.apiClient.HTTPResponseHeaders` in any of the API-bodies' completion blocks. 

  - Note: It is recommended to only have one ApiClient per thread to ensure that there is no concurrency issues with the HTTPResponseHeaders property across multiple threads.

- Also added a `+sharedAPI` class method on the API-Body classes that allows quick initialization of a singleton API instance. I added this because calling `+apiWithHeader:key:` would not actually add the header and key values unless the singleton was previously nil, and it was the only way to retrieve an existing singleton instance (i.e. if I wanted to access the singleton multiple times, I would have to call `+apiWithHeader:key:` each time, but the values I passed in for the header and key would only be set the first time, and ignored on each subsequent call). This makes it easier to access the singleton, and also makes it more clear that `+apiWithHeader:key:` is designed to initialize a new API instance, and not retrieve an existing one. In order to add a header to an existing singleton instance, call `[[SWGExampleApi sharedAPI] addHeader:@"exampleHeader" forKey:@"exampleKey"];`