### PR TITLE
[Obj-C][Cocoapods] Added extra CLI options to generate a valid podspec file.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -23,6 +23,10 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     protected String podName = "SwaggerClient";
     protected String podVersion = "1.0.0";
     protected String classPrefix = "SWG";
+    protected String authorName = "Swagger";
+    protected String authorEmail = "apiteam@swagger.io";
+    protected String license = "MIT";
+    protected String gitRepoURL = "https://github.com/swagger-api/swagger-codegen";
 
     public ObjcClientCodegen() {
         super();
@@ -112,6 +116,10 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption("classPrefix", "prefix for generated classes (convention: Abbreviation of pod name e.g. `HN` for `HackerNews`), default: `SWG`"));
         cliOptions.add(new CliOption("podName", "cocoapods package name (convention: CameCase), default: `SwaggerClient`"));
         cliOptions.add(new CliOption("podVersion", "cocoapods package version, default: `1.0.0`"));
+        cliOptions.add(new CliOption("authorName", "Name to use in the podspec file, default: `Swagger`"));
+        cliOptions.add(new CliOption("authorEmail", "Email to use in the podspec file, default: `apiteam@swagger.io`"));
+        cliOptions.add(new CliOption("gitRepoURL", "URL for the git repo where this podspec should point to, default: `https://github.com/swagger-api/swagger-codegen`"));
+        cliOptions.add(new CliOption("license", "License to use in the podspec file, default: `MIT`"));
     }
 
     public CodegenType getTag() {
@@ -141,10 +149,30 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey("classPrefix")) {
             setClassPrefix((String) additionalProperties.get("classPrefix"));
         }
+        
+        if (additionalProperties.containsKey("authorName")) {
+            setAuthorName((String) additionalProperties.get("authorName"));
+        }
+        
+        if (additionalProperties.containsKey("authorEmail")) {
+            setAuthorEmail((String) additionalProperties.get("authorEmail"));
+        }
+        
+        if (additionalProperties.containsKey("gitRepoURL")) {
+            setGitRepoURL((String) additionalProperties.get("gitRepoURL"));
+        }
+        
+        if (additionalProperties.containsKey("license")) {
+            setLicense((String) additionalProperties.get("license"));
+        }
 
         additionalProperties.put("podName", podName);
         additionalProperties.put("podVersion", podVersion);
         additionalProperties.put("classPrefix", classPrefix);
+        additionalProperties.put("authorName", authorName);
+        additionalProperties.put("authorEmail", authorEmail);
+        additionalProperties.put("gitRepoURL", gitRepoURL);
+        additionalProperties.put("license", license);
 
         String swaggerFolder = podName;
 
@@ -383,5 +411,21 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     public void setPodVersion(String podVersion) {
         this.podVersion = podVersion;
+    }
+    
+    public void setAuthorEmail(String authorEmail) {
+        this.authorEmail = authorEmail;
+    }
+    
+    public void setAuthorName(String authorName) {
+        this.authorName = authorName;
+    }
+    
+    public void setGitRepoURL(String gitRepoURL) {
+        this.gitRepoURL = gitRepoURL;
+    }
+    
+    public void setLicense(String license) {
+        this.license = license;
     }
 }

--- a/modules/swagger-codegen/src/main/resources/objc/podspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/podspec.mustache
@@ -20,6 +20,11 @@ Pod::Spec.new do |s|
     s.requires_arc = true
 
     s.framework    = 'SystemConfiguration'
+    
+    s.homepage     = "{{gitRepoURL}}"
+    s.license      = "{{license}}"
+    s.source       = { :git => "{{gitRepoURL}}.git", :tag => "#{s.version}" }
+    s.author       = { "{{authorName}}" => "{{authorEmail}}" }
 
     s.source_files = '{{podName}}/**/*'
     s.public_header_files = '{{podName}}/**/*.h'


### PR DESCRIPTION
- For a podspec file to lint, a few extra parameters were required. Specifically:
  - `authorName`: defaults to "Swagger"
  - `authorEmail`: deaults to "apiteam@swagger.io"
  - `license`: defaults to "MIT"
  - `gitRepoURL`: Used for both the homepage and source keys in the podspec file; defaults to "https://github.com/swagger-api/swagger-codegen"

- While additional fields can be added to support all of the possible podspec fields (s.authors instead of s.author, etc), these represent the minimum requirements for the pod to lint without errors (there may still be warnings, but these can be ignored with the --allow-warnings flag).