### PR TITLE
Update csharp ApiClient.mustache RestSharp extension

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -170,7 +170,7 @@ namespace {{packageName}}.Client
         /// <returns>Escaped string.</returns>
         public string EscapeString(string str)
         {
-            return RestSharp.Contrib.HttpUtility.UrlEncode(str);
+            return RestSharp.Extensions.MonoHttp.HttpUtility.UrlEncode(str);
         }
     
         /// <summary>


### PR DESCRIPTION
The escape string method is using the wrong namespace for accessing HttpUtility.UrlEncode()

The changes in RestSharp for the RestSharp.Contrib namespace is made here: https://github.com/restsharp/RestSharp/pull/677