### PR TITLE
[Java okhttp-gson, Android] Set source and target compatibility to 1.7 in build.gradle

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 repositories {
     mavenCentral()
 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -1,8 +1,8 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
 
 repositories {
     mavenCentral()

--- a/modules/swagger-codegen/src/main/resources/android-java/build.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/build.mustache
@@ -34,6 +34,10 @@ android {
         minSdkVersion 14
         targetSdkVersion 22
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 
     // Rename the aar correctly
     libraryVariants.all { variant ->

--- a/samples/client/petstore/android-java/build.gradle
+++ b/samples/client/petstore/android-java/build.gradle
@@ -30,6 +30,10 @@ android {
         minSdkVersion 14
         targetSdkVersion 22
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 
     // Rename the aar correctly
     libraryVariants.all { variant ->

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 repositories {
     mavenCentral()
 }

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
In the okhttp-gson library template, set source and target compatibility to 1.7 in build.gradle to make it work with Android