### PR TITLE
[Sinatra] fix sinatra type (tag)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SinatraServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SinatraServerCodegen.java
@@ -76,7 +76,7 @@ public class SinatraServerCodegen extends DefaultCodegen implements CodegenConfi
     }
 
     public CodegenType getTag() {
-        return CodegenType.CLIENT;
+        return CodegenType.SERVER;
     }
 
     public String getName() {


### PR DESCRIPTION
It should return CodegenType.SERVER instead of CodegenType.CLIENT similar to other server-side code generator.