### PR TITLE
[C#] Api.mustache - Remove the parameter in the BasePath getter

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -68,9 +68,8 @@ namespace {{packageName}}.Api
         /// <summary>
         /// Gets the base path of the API client.
         /// </summary>
-        /// <param name="basePath">The base path</param>
         /// <value>The base path</value>
-        public String GetBasePath(String basePath)
+        public String GetBasePath()
         {
             return this.ApiClient.BasePath;
         }


### PR DESCRIPTION
The parameter in the BasePath getter is not needed.