### PR TITLE
[Java jersey2 okhttp-gson] Fix compilation error, record status code and response headers of last request

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -53,6 +53,9 @@ public class ApiClient {
 
   private Map<String, Authentication> authentications;
 
+  private int statusCode;
+  private Map<String, List<String>> responseHeaders;
+
   private DateFormat dateFormat;
 
   public ApiClient() {
@@ -82,6 +85,20 @@ public class ApiClient {
   public ApiClient setBasePath(String basePath) {
     this.basePath = basePath;
     return this;
+  }
+
+  /**
+   * Gets the status code of the previous request
+   */
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  /**
+   * Gets the response headers of the previous request
+   */
+  public Map<String, List<String>> getResponseHeaders() {
+    return responseHeaders;
   }
 
   /**
@@ -484,6 +501,9 @@ public class ApiClient {
       throw new ApiException(500, "unknown method type " + method);
     }
 
+    statusCode = response.getStatusInfo().getStatusCode();
+    responseHeaders = buildResponseHeaders(response);
+
     if (response.getStatus() == Status.NO_CONTENT.getStatusCode()) {
       return null;
     } else if (response.getStatusInfo().getFamily().equals(Status.Family.SUCCESSFUL)) {
@@ -502,21 +522,25 @@ public class ApiClient {
           // e.printStackTrace();
         }
       }
-      Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
-      for (String key: response.getHeaders().keySet()) {
-        List<Object> values = response.getHeaders().get(key);
-        List<String> headers = new ArrayList<String>();
-        for (Object o : values) {
-          headers.add(String.valueOf(o));
-        }
-        responseHeaders.put(key, headers);
-      }
       throw new ApiException(
         response.getStatus(),
         message,
-        responseHeaders,
+        buildResponseHeaders(response),
         respBody);
     }
+  }
+
+  private Map<String, List<String>> buildResponseHeaders(Response response) {
+    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
+      List<Object> values = entry.getValue();
+      List<String> headers = new ArrayList<String>();
+      for (Object o : values) {
+        headers.add(String.valueOf(o));
+      }
+      responseHeaders.put(entry.getKey(), headers);
+    }
+    return responseHeaders;
   }
 
   /**

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -1,0 +1,98 @@
+package {{package}};
+
+import {{invokerPackage}}.ApiException;
+import {{invokerPackage}}.ApiClient;
+import {{invokerPackage}}.Configuration;
+import {{invokerPackage}}.Pair;
+import {{invokerPackage}}.TypeRef;
+
+import {{modelPackage}}.*;
+
+import java.util.*;
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import java.io.File;
+import java.util.Map;
+import java.util.HashMap;
+
+{{>generatedAnnotation}}
+{{#operations}}
+public class {{classname}} {
+  private ApiClient {{localVariablePrefix}}apiClient;
+
+  public {{classname}}() {
+    this(Configuration.getDefaultApiClient());
+  }
+
+  public {{classname}}(ApiClient apiClient) {
+    this.{{localVariablePrefix}}apiClient = apiClient;
+  }
+
+  public ApiClient getApiClient() {
+    return {{localVariablePrefix}}apiClient;
+  }
+
+  public void setApiClient(ApiClient apiClient) {
+    this.{{localVariablePrefix}}apiClient = apiClient;
+  }
+
+  {{#operation}}
+  /**
+   * {{summary}}
+   * {{notes}}
+{{#allParams}}   * @param {{paramName}} {{description}}
+{{/allParams}}   * @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
+   */
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
+    Object {{localVariablePrefix}}postBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
+    {{#allParams}}{{#required}}
+    // verify the required parameter '{{paramName}}' is set
+    if ({{paramName}} == null) {
+      throw new ApiException(400, "Missing the required parameter '{{paramName}}' when calling {{nickname}}");
+    }
+    {{/required}}{{/allParams}}
+    // create path and map variables
+    String {{localVariablePrefix}}path = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
+      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+
+    // query params
+    List<Pair> {{localVariablePrefix}}queryParams = new ArrayList<Pair>();
+    Map<String, String> {{localVariablePrefix}}headerParams = new HashMap<String, String>();
+    Map<String, Object> {{localVariablePrefix}}formParams = new HashMap<String, Object>();
+
+    {{#queryParams}}
+    {{localVariablePrefix}}queryParams.addAll({{localVariablePrefix}}apiClient.parameterToPairs("{{#collectionFormat}}{{{collectionFormat}}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}));
+    {{/queryParams}}
+
+    {{#headerParams}}if ({{paramName}} != null)
+    {{localVariablePrefix}}headerParams.put("{{baseName}}", {{localVariablePrefix}}apiClient.parameterToString({{paramName}}));
+    {{/headerParams}}
+
+    {{#formParams}}if ({{paramName}} != null)
+      {{localVariablePrefix}}formParams.put("{{baseName}}", {{paramName}});
+    {{/formParams}}
+
+    final String[] {{localVariablePrefix}}accepts = {
+      {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}}
+    };
+    final String {{localVariablePrefix}}accept = {{localVariablePrefix}}apiClient.selectHeaderAccept({{localVariablePrefix}}accepts);
+
+    final String[] {{localVariablePrefix}}contentTypes = {
+      {{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}}
+    };
+    final String {{localVariablePrefix}}contentType = {{localVariablePrefix}}apiClient.selectHeaderContentType({{localVariablePrefix}}contentTypes);
+
+    String[] {{localVariablePrefix}}authNames = new String[] { {{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}} };
+
+    {{#returnType}}
+    TypeRef {{localVariablePrefix}}returnType = new TypeRef<{{{returnType}}}>() {};
+    return {{localVariablePrefix}}apiClient.invokeAPI({{localVariablePrefix}}path, "{{httpMethod}}", {{localVariablePrefix}}queryParams, {{localVariablePrefix}}postBody, {{localVariablePrefix}}headerParams, {{localVariablePrefix}}formParams, {{localVariablePrefix}}accept, {{localVariablePrefix}}contentType, {{localVariablePrefix}}authNames, {{localVariablePrefix}}returnType);
+    {{/returnType}}{{^returnType}}
+    {{localVariablePrefix}}apiClient.invokeAPI({{localVariablePrefix}}path, "{{httpMethod}}", {{localVariablePrefix}}queryParams, {{localVariablePrefix}}postBody, {{localVariablePrefix}}headerParams, {{localVariablePrefix}}formParams, {{localVariablePrefix}}accept, {{localVariablePrefix}}contentType, {{localVariablePrefix}}authNames, null);
+    {{/returnType}}
+  }
+  {{/operation}}
+}
+{{/operations}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiCallback.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiCallback.mustache
@@ -2,6 +2,9 @@ package {{invokerPackage}};
 
 import java.io.IOException;
 
+import java.util.Map;
+import java.util.List;
+
 /**
  * Callback for asynchronous API call.
  *
@@ -10,13 +13,19 @@ import java.io.IOException;
 public interface ApiCallback<T> {
   /**
    * This is called when the API call fails.
+   *
+   * @param e The exception causing the failure
+   * @param statusCode Status code of the response if available, otherwise it would be 0
+   * @param responseHeaders Headers of the response if available, otherwise it would be null
    */
-  void onFailure(ApiException e);
+  void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders);
 
   /**
    * This is called when the API call succeeded.
    *
    * @param result The result deserialized from response
+   * @param statusCode Status code of the response
+   * @param responseHeaders Headers of the response
    */
-  void onSuccess(T result);
+  void onSuccess(T result, int statusCode, Map<String, List<String>> responseHeaders);
 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -48,6 +48,9 @@ public class ApiClient {
 
   private Map<String, Authentication> authentications;
 
+  private int statusCode;
+  private Map<String, List<String>> responseHeaders;
+
   private String dateFormat;
   private DateFormat dateFormatter;
   private int dateLength;
@@ -105,6 +108,24 @@ public class ApiClient {
   public ApiClient setJSON(JSON json) {
     this.json = json;
     return this;
+  }
+
+  /**
+   * Gets the status code of the previous request.
+   * NOTE: Status code of last async response is not recorded here, it is
+   * passed to the callback methods instead.
+   */
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  /**
+   * Gets the response headers of the previous request.
+   * NOTE: Headers of last async response is not recorded here, it is passed
+   * to callback methods instead.
+   */
+  public Map<String, List<String>> getResponseHeaders() {
+    return responseHeaders;
   }
 
   public String getDateFormat() {
@@ -534,6 +555,8 @@ public class ApiClient {
   public <T> T execute(Call call, Type returnType) throws ApiException {
     try {
       Response response = call.execute();
+      this.statusCode = response.code();
+      this.responseHeaders = response.headers().toMultimap();
       return handleResponse(response, returnType);
     } catch (IOException e) {
       throw new ApiException(e);
@@ -557,7 +580,7 @@ public class ApiClient {
     call.enqueue(new Callback() {
       @Override
       public void onFailure(Request request, IOException e) {
-        callback.onFailure(new ApiException(e));
+        callback.onFailure(new ApiException(e), 0, null);
       }
 
       @Override
@@ -566,10 +589,10 @@ public class ApiClient {
         try {
           result = (T) handleResponse(response, returnType);
         } catch (ApiException e) {
-          callback.onFailure(e);
+          callback.onFailure(e, response.code(), response.headers().toMultimap());
           return;
         }
-        callback.onSuccess(result);
+        callback.onSuccess(result, response.code(), response.headers().toMultimap());
       }
     });
   }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiException.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiException.java
@@ -3,33 +3,54 @@ package io.swagger.client;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class ApiException extends Exception {
   private int code = 0;
-  private String message = null;
   private Map<String, List<String>> responseHeaders = null;
   private String responseBody = null;
 
   public ApiException() {}
 
-  public ApiException(int code, String message) {
+  public ApiException(Throwable throwable) {
+    super(throwable);
+  }
+
+  public ApiException(String message) {
+    super(message);
+  }
+
+  public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, String responseBody) {
+    super(message, throwable);
     this.code = code;
-    this.message = message;
+    this.responseHeaders = responseHeaders;
+    this.responseBody = responseBody;
+  }
+
+  public ApiException(String message, int code, Map<String, List<String>> responseHeaders, String responseBody) {
+    this(message, (Throwable) null, code, responseHeaders, responseBody);
+  }
+
+  public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders) {
+    this(message, throwable, code, responseHeaders, null);
+  }
+
+  public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
+    this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+  }
+
+  public ApiException(int code, String message) {
+    super(message);
+    this.code = code;
   }
 
   public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody) {
-    this.code = code;
-    this.message = message;
+    this(code, message);
     this.responseHeaders = responseHeaders;
     this.responseBody = responseBody;
   }
 
   public int getCode() {
     return code;
-  }
-
-  public String getMessage() {
-    return message;
   }
 
   /**

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/Configuration.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/Configuration.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class Configuration {
   private static ApiClient defaultApiClient = new ApiClient();
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/JSON.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.datatype.joda.*;
 
 import java.io.IOException;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T18:19:30.060+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class JSON {
   private ObjectMapper mapper;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/Pair.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/Pair.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/StringUtil.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/StringUtil.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).
@@ -38,5 +38,14 @@ public class StringUtil {
       out.append(separator).append(array[i]);
     }
     return out.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  public static String toIndentedString(Object o) {
+    if (o == null) return "null";
+    return o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/TypeRef.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/TypeRef.java
@@ -3,7 +3,7 @@ package io.swagger.client;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class TypeRef<T> {
     private final Type type;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class PetApi {
   private ApiClient apiClient;
 
@@ -46,8 +46,8 @@ public class PetApi {
    */
   public void updatePet (Pet body) throws ApiException {
     Object postBody = body;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/pet".replaceAll("\\{format\\}","json");
 
@@ -73,9 +73,16 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
-    apiClient.invokeAPI(path, "PUT", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "PUT", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
@@ -86,8 +93,8 @@ public class PetApi {
    */
   public void addPet (Pet body) throws ApiException {
     Object postBody = body;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/pet".replaceAll("\\{format\\}","json");
 
@@ -113,9 +120,16 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
-    apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "POST", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
@@ -126,8 +140,8 @@ public class PetApi {
    */
   public List<Pet> findPetsByStatus (List<String> status) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/pet/findByStatus".replaceAll("\\{format\\}","json");
 
@@ -155,10 +169,17 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
+    
+
+    
     
     TypeRef returnType = new TypeRef<List<Pet>>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
+    
+
+
   }
   
   /**
@@ -169,8 +190,8 @@ public class PetApi {
    */
   public List<Pet> findPetsByTags (List<String> tags) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/pet/findByTags".replaceAll("\\{format\\}","json");
 
@@ -198,10 +219,17 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
+    
+
+    
     
     TypeRef returnType = new TypeRef<List<Pet>>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
+    
+
+
   }
   
   /**
@@ -212,13 +240,13 @@ public class PetApi {
    */
   public Pet getPetById (Long petId) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'petId' is set
-    if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
-    }
-    
-
+     // verify the required parameter 'petId' is set
+     if (petId == null) {
+        throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
+     }
+     
     // create path and map variables
     String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -244,11 +272,18 @@ public class PetApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] { "api_key", "petstore_auth" };
+    String[] authNames = new String[] { "petstore_auth", "api_key" };
+
+    
+
+    
     
     TypeRef returnType = new TypeRef<Pet>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
+    
+
+
   }
   
   /**
@@ -261,13 +296,13 @@ public class PetApi {
    */
   public void updatePetWithForm (String petId, String name, String status) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'petId' is set
-    if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
-    }
-    
-
+     // verify the required parameter 'petId' is set
+     if (petId == null) {
+        throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
+     }
+     
     // create path and map variables
     String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -298,9 +333,16 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
-    apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "POST", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
@@ -312,13 +354,13 @@ public class PetApi {
    */
   public void deletePet (Long petId, String apiKey) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'petId' is set
-    if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
-    }
-    
-
+     // verify the required parameter 'petId' is set
+     if (petId == null) {
+        throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
+     }
+     
     // create path and map variables
     String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -347,9 +389,16 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
-    apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "DELETE", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
@@ -362,13 +411,13 @@ public class PetApi {
    */
   public void uploadFile (Long petId, String additionalMetadata, File file) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'petId' is set
-    if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
-    }
-    
-
+     // verify the required parameter 'petId' is set
+     if (petId == null) {
+        throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
+     }
+     
     // create path and map variables
     String path = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -399,9 +448,16 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
-    apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "POST", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
 }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/StoreApi.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class StoreApi {
   private ApiClient apiClient;
 
@@ -45,8 +45,8 @@ public class StoreApi {
    */
   public Map<String, Integer> getInventory () throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/store/inventory".replaceAll("\\{format\\}","json");
 
@@ -72,10 +72,17 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "api_key" };
+
+    
+
+    
     
     TypeRef returnType = new TypeRef<Map<String, Integer>>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
+    
+
+
   }
   
   /**
@@ -86,8 +93,8 @@ public class StoreApi {
    */
   public Order placeOrder (Order body) throws ApiException {
     Object postBody = body;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/store/order".replaceAll("\\{format\\}","json");
 
@@ -113,10 +120,17 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
+    
+
+    
     
     TypeRef returnType = new TypeRef<Order>() {};
-    return apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return apiClient.invokeAPI(path, "POST", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
+    
+
+
   }
   
   /**
@@ -127,13 +141,13 @@ public class StoreApi {
    */
   public Order getOrderById (String orderId) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'orderId' is set
-    if (orderId == null) {
-       throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
-    }
-    
-
+     // verify the required parameter 'orderId' is set
+     if (orderId == null) {
+        throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
+     }
+     
     // create path and map variables
     String path = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
@@ -160,10 +174,17 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
+    
+
+    
     
     TypeRef returnType = new TypeRef<Order>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
+    
+
+
   }
   
   /**
@@ -174,13 +195,13 @@ public class StoreApi {
    */
   public void deleteOrder (String orderId) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'orderId' is set
-    if (orderId == null) {
-       throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
-    }
-    
-
+     // verify the required parameter 'orderId' is set
+     if (orderId == null) {
+        throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
+     }
+     
     // create path and map variables
     String path = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
@@ -207,9 +228,16 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
-    apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "DELETE", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
 }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/UserApi.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class UserApi {
   private ApiClient apiClient;
 
@@ -46,8 +46,8 @@ public class UserApi {
    */
   public void createUser (User body) throws ApiException {
     Object postBody = body;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/user".replaceAll("\\{format\\}","json");
 
@@ -73,9 +73,16 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
-    apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "POST", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
@@ -86,8 +93,8 @@ public class UserApi {
    */
   public void createUsersWithArrayInput (List<User> body) throws ApiException {
     Object postBody = body;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/user/createWithArray".replaceAll("\\{format\\}","json");
 
@@ -113,9 +120,16 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
-    apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "POST", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
@@ -126,8 +140,8 @@ public class UserApi {
    */
   public void createUsersWithListInput (List<User> body) throws ApiException {
     Object postBody = body;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/user/createWithList".replaceAll("\\{format\\}","json");
 
@@ -153,9 +167,16 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
-    apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "POST", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
@@ -167,8 +188,8 @@ public class UserApi {
    */
   public String loginUser (String username, String password) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/user/login".replaceAll("\\{format\\}","json");
 
@@ -198,10 +219,17 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
+    
+
+    
     
     TypeRef returnType = new TypeRef<String>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
+    
+
+
   }
   
   /**
@@ -211,8 +239,8 @@ public class UserApi {
    */
   public void logoutUser () throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-
     // create path and map variables
     String path = "/user/logout".replaceAll("\\{format\\}","json");
 
@@ -238,26 +266,33 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
-    apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
    * Get user by user name
    * 
-   * @param username The name that needs to be fetched. Use user1 for testing. 
+   * @param username The name that needs to be fetched. Use user1 for testing.
    * @return User
    */
   public User getUserByName (String username) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'username' is set
-    if (username == null) {
-       throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
-    }
-    
-
+     // verify the required parameter 'username' is set
+     if (username == null) {
+        throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
+     }
+     
     // create path and map variables
     String path = "/user/{username}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -284,10 +319,17 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
+    
+
+    
     
     TypeRef returnType = new TypeRef<User>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
+    
+
+
   }
   
   /**
@@ -299,13 +341,13 @@ public class UserApi {
    */
   public void updateUser (String username, User body) throws ApiException {
     Object postBody = body;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'username' is set
-    if (username == null) {
-       throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
-    }
-    
-
+     // verify the required parameter 'username' is set
+     if (username == null) {
+        throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
+     }
+     
     // create path and map variables
     String path = "/user/{username}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -332,9 +374,16 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
-    apiClient.invokeAPI(path, "PUT", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "PUT", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
   /**
@@ -345,13 +394,13 @@ public class UserApi {
    */
   public void deleteUser (String username) throws ApiException {
     Object postBody = null;
+    byte[] postBinaryBody = null;
     
-    // verify the required parameter 'username' is set
-    if (username == null) {
-       throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
-    }
-    
-
+     // verify the required parameter 'username' is set
+     if (username == null) {
+        throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
+     }
+     
     // create path and map variables
     String path = "/user/{username}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -378,9 +427,16 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
-    apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+
     
+    
+    apiClient.invokeAPI(path, "DELETE", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+    
+
+
   }
   
 }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/Authentication.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/Authentication.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public interface Authentication {
   /** Apply authentication settings to header and query params. */
   void applyToParams(List<Pair> queryParams, Map<String, String> headerParams);

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/HttpBasicAuth.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.io.UnsupportedEncodingException;
 import javax.xml.bind.DatatypeConverter;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class OAuth implements Authentication {
   @Override
   public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
@@ -1,5 +1,6 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
 
 
 
@@ -8,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class Category   {
   
   private Long id = null;
@@ -45,9 +46,9 @@ public class Category   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Category {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  name: ").append(name).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    name: ").append(StringUtil.toIndentedString(name)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
@@ -1,5 +1,6 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
 import java.util.Date;
 
 
@@ -9,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T18:19:30.060+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class Order   {
   
   private Long id = null;
@@ -115,13 +116,13 @@ public enum StatusEnum {
     StringBuilder sb = new StringBuilder();
     sb.append("class Order {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  petId: ").append(petId).append("\n");
-    sb.append("  quantity: ").append(quantity).append("\n");
-    sb.append("  shipDate: ").append(shipDate).append("\n");
-    sb.append("  status: ").append(status).append("\n");
-    sb.append("  complete: ").append(complete).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    petId: ").append(StringUtil.toIndentedString(petId)).append("\n");
+    sb.append("    quantity: ").append(StringUtil.toIndentedString(quantity)).append("\n");
+    sb.append("    shipDate: ").append(StringUtil.toIndentedString(shipDate)).append("\n");
+    sb.append("    status: ").append(StringUtil.toIndentedString(status)).append("\n");
+    sb.append("    complete: ").append(StringUtil.toIndentedString(complete)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
@@ -1,5 +1,6 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
 import io.swagger.client.model.Category;
 import java.util.*;
 import io.swagger.client.model.Tag;
@@ -11,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T18:19:30.060+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -117,13 +118,13 @@ public enum StatusEnum {
     StringBuilder sb = new StringBuilder();
     sb.append("class Pet {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  category: ").append(category).append("\n");
-    sb.append("  name: ").append(name).append("\n");
-    sb.append("  photoUrls: ").append(photoUrls).append("\n");
-    sb.append("  tags: ").append(tags).append("\n");
-    sb.append("  status: ").append(status).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    category: ").append(StringUtil.toIndentedString(category)).append("\n");
+    sb.append("    name: ").append(StringUtil.toIndentedString(name)).append("\n");
+    sb.append("    photoUrls: ").append(StringUtil.toIndentedString(photoUrls)).append("\n");
+    sb.append("    tags: ").append(StringUtil.toIndentedString(tags)).append("\n");
+    sb.append("    status: ").append(StringUtil.toIndentedString(status)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
@@ -1,5 +1,6 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
 
 
 
@@ -8,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class Tag   {
   
   private Long id = null;
@@ -45,9 +46,9 @@ public class Tag   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Tag {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  name: ").append(name).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    name: ").append(StringUtil.toIndentedString(name)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
@@ -1,5 +1,6 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
 
 
 
@@ -8,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T11:46:58.447+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
 public class User   {
   
   private Long id = null;
@@ -124,15 +125,15 @@ public class User   {
     StringBuilder sb = new StringBuilder();
     sb.append("class User {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  username: ").append(username).append("\n");
-    sb.append("  firstName: ").append(firstName).append("\n");
-    sb.append("  lastName: ").append(lastName).append("\n");
-    sb.append("  email: ").append(email).append("\n");
-    sb.append("  password: ").append(password).append("\n");
-    sb.append("  phone: ").append(phone).append("\n");
-    sb.append("  userStatus: ").append(userStatus).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    username: ").append(StringUtil.toIndentedString(username)).append("\n");
+    sb.append("    firstName: ").append(StringUtil.toIndentedString(firstName)).append("\n");
+    sb.append("    lastName: ").append(StringUtil.toIndentedString(lastName)).append("\n");
+    sb.append("    email: ").append(StringUtil.toIndentedString(email)).append("\n");
+    sb.append("    password: ").append(StringUtil.toIndentedString(password)).append("\n");
+    sb.append("    phone: ").append(StringUtil.toIndentedString(phone)).append("\n");
+    sb.append("    userStatus: ").append(StringUtil.toIndentedString(userStatus)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/jersey2/hello.txt
+++ b/samples/client/petstore/java/jersey2/hello.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
@@ -43,7 +43,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class ApiClient {
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -52,6 +52,9 @@ public class ApiClient {
   private JSON json = new JSON();
 
   private Map<String, Authentication> authentications;
+
+  private int statusCode;
+  private Map<String, List<String>> responseHeaders;
 
   private DateFormat dateFormat;
 
@@ -81,6 +84,20 @@ public class ApiClient {
   public ApiClient setBasePath(String basePath) {
     this.basePath = basePath;
     return this;
+  }
+
+  /**
+   * Gets the status code of the previous request
+   */
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  /**
+   * Gets the response headers of the previous request
+   */
+  public Map<String, List<String>> getResponseHeaders() {
+    return responseHeaders;
   }
 
   /**
@@ -483,6 +500,9 @@ public class ApiClient {
       throw new ApiException(500, "unknown method type " + method);
     }
 
+    statusCode = response.getStatusInfo().getStatusCode();
+    responseHeaders = buildResponseHeaders(response);
+
     if (response.getStatus() == Status.NO_CONTENT.getStatusCode()) {
       return null;
     } else if (response.getStatusInfo().getFamily().equals(Status.Family.SUCCESSFUL)) {
@@ -501,21 +521,25 @@ public class ApiClient {
           // e.printStackTrace();
         }
       }
-      Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
-      for (String key: response.getHeaders().keySet()) {
-        List<Object> values = response.getHeaders().get(key);
-        List<String> headers = new ArrayList<String>();
-        for (Object o : values) {
-          headers.add(String.valueOf(o));
-        }
-        responseHeaders.put(key, headers);
-      }
       throw new ApiException(
         response.getStatus(),
         message,
-        responseHeaders,
+        buildResponseHeaders(response),
         respBody);
     }
+  }
+
+  private Map<String, List<String>> buildResponseHeaders(Response response) {
+    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
+      List<Object> values = entry.getValue();
+      List<String> headers = new ArrayList<String>();
+      for (Object o : values) {
+        headers.add(String.valueOf(o));
+      }
+      responseHeaders.put(entry.getKey(), headers);
+    }
+    return responseHeaders;
   }
 
   /**

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiException.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiException.java
@@ -3,33 +3,54 @@ package io.swagger.client;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class ApiException extends Exception {
   private int code = 0;
-  private String message = null;
   private Map<String, List<String>> responseHeaders = null;
   private String responseBody = null;
 
   public ApiException() {}
 
-  public ApiException(int code, String message) {
+  public ApiException(Throwable throwable) {
+    super(throwable);
+  }
+
+  public ApiException(String message) {
+    super(message);
+  }
+
+  public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, String responseBody) {
+    super(message, throwable);
     this.code = code;
-    this.message = message;
+    this.responseHeaders = responseHeaders;
+    this.responseBody = responseBody;
+  }
+
+  public ApiException(String message, int code, Map<String, List<String>> responseHeaders, String responseBody) {
+    this(message, (Throwable) null, code, responseHeaders, responseBody);
+  }
+
+  public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders) {
+    this(message, throwable, code, responseHeaders, null);
+  }
+
+  public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
+    this((String) null, (Throwable) null, code, responseHeaders, responseBody);
+  }
+
+  public ApiException(int code, String message) {
+    super(message);
+    this.code = code;
   }
 
   public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody) {
-    this.code = code;
-    this.message = message;
+    this(code, message);
     this.responseHeaders = responseHeaders;
     this.responseBody = responseBody;
   }
 
   public int getCode() {
     return code;
-  }
-
-  public String getMessage() {
-    return message;
   }
 
   /**

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/Configuration.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/Configuration.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class Configuration {
   private static ApiClient defaultApiClient = new ApiClient();
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/JSON.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.datatype.joda.*;
 
 import java.io.IOException;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T16:42:49.539+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class JSON {
   private ObjectMapper mapper;
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/Pair.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/Pair.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/StringUtil.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/StringUtil.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).
@@ -38,5 +38,14 @@ public class StringUtil {
       out.append(separator).append(array[i]);
     }
     return out.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  public static String toIndentedString(Object o) {
+    if (o == null) return "null";
+    return o.toString().replace("\n", "\n    ");
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/TypeRef.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/TypeRef.java
@@ -3,7 +3,7 @@ package io.swagger.client;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class TypeRef<T> {
     private final Type type;
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class PetApi {
   private ApiClient apiClient;
 
@@ -47,7 +47,6 @@ public class PetApi {
   public void updatePet (Pet body) throws ApiException {
     Object postBody = body;
     
-
     // create path and map variables
     String path = "/pet".replaceAll("\\{format\\}","json");
 
@@ -73,6 +72,7 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
     apiClient.invokeAPI(path, "PUT", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -87,7 +87,6 @@ public class PetApi {
   public void addPet (Pet body) throws ApiException {
     Object postBody = body;
     
-
     // create path and map variables
     String path = "/pet".replaceAll("\\{format\\}","json");
 
@@ -113,6 +112,7 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
     apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -127,7 +127,6 @@ public class PetApi {
   public List<Pet> findPetsByStatus (List<String> status) throws ApiException {
     Object postBody = null;
     
-
     // create path and map variables
     String path = "/pet/findByStatus".replaceAll("\\{format\\}","json");
 
@@ -155,6 +154,7 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
     TypeRef returnType = new TypeRef<List<Pet>>() {};
     return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
@@ -170,7 +170,6 @@ public class PetApi {
   public List<Pet> findPetsByTags (List<String> tags) throws ApiException {
     Object postBody = null;
     
-
     // create path and map variables
     String path = "/pet/findByTags".replaceAll("\\{format\\}","json");
 
@@ -198,6 +197,7 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
     TypeRef returnType = new TypeRef<List<Pet>>() {};
     return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
@@ -215,10 +215,9 @@ public class PetApi {
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
+      throw new ApiException(400, "Missing the required parameter 'petId' when calling getPetById");
     }
     
-
     // create path and map variables
     String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -245,6 +244,7 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth", "api_key" };
+
     
     TypeRef returnType = new TypeRef<Pet>() {};
     return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
@@ -264,10 +264,9 @@ public class PetApi {
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
+      throw new ApiException(400, "Missing the required parameter 'petId' when calling updatePetWithForm");
     }
     
-
     // create path and map variables
     String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -298,6 +297,7 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
     apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -315,10 +315,9 @@ public class PetApi {
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
+      throw new ApiException(400, "Missing the required parameter 'petId' when calling deletePet");
     }
     
-
     // create path and map variables
     String path = "/pet/{petId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -347,6 +346,7 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
     apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -365,10 +365,9 @@ public class PetApi {
     
     // verify the required parameter 'petId' is set
     if (petId == null) {
-       throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
+      throw new ApiException(400, "Missing the required parameter 'petId' when calling uploadFile");
     }
     
-
     // create path and map variables
     String path = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
@@ -399,6 +398,7 @@ public class PetApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "petstore_auth" };
+
     
     apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/StoreApi.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class StoreApi {
   private ApiClient apiClient;
 
@@ -46,7 +46,6 @@ public class StoreApi {
   public Map<String, Integer> getInventory () throws ApiException {
     Object postBody = null;
     
-
     // create path and map variables
     String path = "/store/inventory".replaceAll("\\{format\\}","json");
 
@@ -72,6 +71,7 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] { "api_key" };
+
     
     TypeRef returnType = new TypeRef<Map<String, Integer>>() {};
     return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
@@ -87,7 +87,6 @@ public class StoreApi {
   public Order placeOrder (Order body) throws ApiException {
     Object postBody = body;
     
-
     // create path and map variables
     String path = "/store/order".replaceAll("\\{format\\}","json");
 
@@ -113,6 +112,7 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     TypeRef returnType = new TypeRef<Order>() {};
     return apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
@@ -130,10 +130,9 @@ public class StoreApi {
     
     // verify the required parameter 'orderId' is set
     if (orderId == null) {
-       throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
+      throw new ApiException(400, "Missing the required parameter 'orderId' when calling getOrderById");
     }
     
-
     // create path and map variables
     String path = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
@@ -160,6 +159,7 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     TypeRef returnType = new TypeRef<Order>() {};
     return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
@@ -177,10 +177,9 @@ public class StoreApi {
     
     // verify the required parameter 'orderId' is set
     if (orderId == null) {
-       throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
+      throw new ApiException(400, "Missing the required parameter 'orderId' when calling deleteOrder");
     }
     
-
     // create path and map variables
     String path = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
@@ -207,6 +206,7 @@ public class StoreApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/UserApi.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class UserApi {
   private ApiClient apiClient;
 
@@ -47,7 +47,6 @@ public class UserApi {
   public void createUser (User body) throws ApiException {
     Object postBody = body;
     
-
     // create path and map variables
     String path = "/user".replaceAll("\\{format\\}","json");
 
@@ -73,6 +72,7 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -87,7 +87,6 @@ public class UserApi {
   public void createUsersWithArrayInput (List<User> body) throws ApiException {
     Object postBody = body;
     
-
     // create path and map variables
     String path = "/user/createWithArray".replaceAll("\\{format\\}","json");
 
@@ -113,6 +112,7 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -127,7 +127,6 @@ public class UserApi {
   public void createUsersWithListInput (List<User> body) throws ApiException {
     Object postBody = body;
     
-
     // create path and map variables
     String path = "/user/createWithList".replaceAll("\\{format\\}","json");
 
@@ -153,6 +152,7 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     apiClient.invokeAPI(path, "POST", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -168,7 +168,6 @@ public class UserApi {
   public String loginUser (String username, String password) throws ApiException {
     Object postBody = null;
     
-
     // create path and map variables
     String path = "/user/login".replaceAll("\\{format\\}","json");
 
@@ -198,6 +197,7 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     TypeRef returnType = new TypeRef<String>() {};
     return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
@@ -212,7 +212,6 @@ public class UserApi {
   public void logoutUser () throws ApiException {
     Object postBody = null;
     
-
     // create path and map variables
     String path = "/user/logout".replaceAll("\\{format\\}","json");
 
@@ -238,6 +237,7 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -246,7 +246,7 @@ public class UserApi {
   /**
    * Get user by user name
    * 
-   * @param username The name that needs to be fetched. Use user1 for testing. 
+   * @param username The name that needs to be fetched. Use user1 for testing.
    * @return User
    */
   public User getUserByName (String username) throws ApiException {
@@ -254,10 +254,9 @@ public class UserApi {
     
     // verify the required parameter 'username' is set
     if (username == null) {
-       throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
+      throw new ApiException(400, "Missing the required parameter 'username' when calling getUserByName");
     }
     
-
     // create path and map variables
     String path = "/user/{username}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -284,6 +283,7 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     TypeRef returnType = new TypeRef<User>() {};
     return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
@@ -302,10 +302,9 @@ public class UserApi {
     
     // verify the required parameter 'username' is set
     if (username == null) {
-       throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
+      throw new ApiException(400, "Missing the required parameter 'username' when calling updateUser");
     }
     
-
     // create path and map variables
     String path = "/user/{username}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -332,6 +331,7 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     apiClient.invokeAPI(path, "PUT", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     
@@ -348,10 +348,9 @@ public class UserApi {
     
     // verify the required parameter 'username' is set
     if (username == null) {
-       throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
+      throw new ApiException(400, "Missing the required parameter 'username' when calling deleteUser");
     }
     
-
     // create path and map variables
     String path = "/user/{username}".replaceAll("\\{format\\}","json")
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
@@ -378,6 +377,7 @@ public class UserApi {
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
     String[] authNames = new String[] {  };
+
     
     apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
     

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/Authentication.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/Authentication.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public interface Authentication {
   /** Apply authentication settings to header and query params. */
   void applyToParams(List<Pair> queryParams, Map<String, String> headerParams);

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/HttpBasicAuth.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.io.UnsupportedEncodingException;
 import javax.xml.bind.DatatypeConverter;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class OAuth implements Authentication {
   @Override
   public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Category.java
@@ -1,13 +1,16 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
+
+
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
-public class Category  {
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
+public class Category   {
   
   private Long id = null;
   private String name = null;
@@ -43,9 +46,9 @@ public class Category  {
     StringBuilder sb = new StringBuilder();
     sb.append("class Category {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  name: ").append(name).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    name: ").append(StringUtil.toIndentedString(name)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
@@ -1,5 +1,6 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
 import java.util.Date;
 
 
@@ -9,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T16:42:49.539+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class Order   {
   
   private Long id = null;
@@ -115,13 +116,13 @@ public enum StatusEnum {
     StringBuilder sb = new StringBuilder();
     sb.append("class Order {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  petId: ").append(petId).append("\n");
-    sb.append("  quantity: ").append(quantity).append("\n");
-    sb.append("  shipDate: ").append(shipDate).append("\n");
-    sb.append("  status: ").append(status).append("\n");
-    sb.append("  complete: ").append(complete).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    petId: ").append(StringUtil.toIndentedString(petId)).append("\n");
+    sb.append("    quantity: ").append(StringUtil.toIndentedString(quantity)).append("\n");
+    sb.append("    shipDate: ").append(StringUtil.toIndentedString(shipDate)).append("\n");
+    sb.append("    status: ").append(StringUtil.toIndentedString(status)).append("\n");
+    sb.append("    complete: ").append(StringUtil.toIndentedString(complete)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
@@ -1,5 +1,6 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
 import io.swagger.client.model.Category;
 import java.util.*;
 import io.swagger.client.model.Tag;
@@ -11,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-24T16:42:49.539+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -117,13 +118,13 @@ public enum StatusEnum {
     StringBuilder sb = new StringBuilder();
     sb.append("class Pet {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  category: ").append(category).append("\n");
-    sb.append("  name: ").append(name).append("\n");
-    sb.append("  photoUrls: ").append(photoUrls).append("\n");
-    sb.append("  tags: ").append(tags).append("\n");
-    sb.append("  status: ").append(status).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    category: ").append(StringUtil.toIndentedString(category)).append("\n");
+    sb.append("    name: ").append(StringUtil.toIndentedString(name)).append("\n");
+    sb.append("    photoUrls: ").append(StringUtil.toIndentedString(photoUrls)).append("\n");
+    sb.append("    tags: ").append(StringUtil.toIndentedString(tags)).append("\n");
+    sb.append("    status: ").append(StringUtil.toIndentedString(status)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Tag.java
@@ -1,13 +1,16 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
+
+
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
-public class Tag  {
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
+public class Tag   {
   
   private Long id = null;
   private String name = null;
@@ -43,9 +46,9 @@ public class Tag  {
     StringBuilder sb = new StringBuilder();
     sb.append("class Tag {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  name: ").append(name).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    name: ").append(StringUtil.toIndentedString(name)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/User.java
@@ -1,13 +1,16 @@
 package io.swagger.client.model;
 
+import io.swagger.client.StringUtil;
+
+
 
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-22T21:47:05.989+08:00")
-public class User  {
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
+public class User   {
   
   private Long id = null;
   private String username = null;
@@ -122,15 +125,15 @@ public class User  {
     StringBuilder sb = new StringBuilder();
     sb.append("class User {\n");
     
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  username: ").append(username).append("\n");
-    sb.append("  firstName: ").append(firstName).append("\n");
-    sb.append("  lastName: ").append(lastName).append("\n");
-    sb.append("  email: ").append(email).append("\n");
-    sb.append("  password: ").append(password).append("\n");
-    sb.append("  phone: ").append(phone).append("\n");
-    sb.append("  userStatus: ").append(userStatus).append("\n");
-    sb.append("}\n");
+    sb.append("    id: ").append(StringUtil.toIndentedString(id)).append("\n");
+    sb.append("    username: ").append(StringUtil.toIndentedString(username)).append("\n");
+    sb.append("    firstName: ").append(StringUtil.toIndentedString(firstName)).append("\n");
+    sb.append("    lastName: ").append(StringUtil.toIndentedString(lastName)).append("\n");
+    sb.append("    email: ").append(StringUtil.toIndentedString(email)).append("\n");
+    sb.append("    password: ").append(StringUtil.toIndentedString(password)).append("\n");
+    sb.append("    phone: ").append(StringUtil.toIndentedString(phone)).append("\n");
+    sb.append("    userStatus: ").append(StringUtil.toIndentedString(userStatus)).append("\n");
+    sb.append("}");
     return sb.toString();
   }
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiCallback.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiCallback.java
@@ -2,6 +2,9 @@ package io.swagger.client;
 
 import java.io.IOException;
 
+import java.util.Map;
+import java.util.List;
+
 /**
  * Callback for asynchronous API call.
  *
@@ -10,13 +13,19 @@ import java.io.IOException;
 public interface ApiCallback<T> {
   /**
    * This is called when the API call fails.
+   *
+   * @param e The exception causing the failure
+   * @param statusCode Status code of the response if available, otherwise it would be 0
+   * @param responseHeaders Headers of the response if available, otherwise it would be null
    */
-  void onFailure(ApiException e);
+  void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders);
 
   /**
    * This is called when the API call succeeded.
    *
    * @param result The result deserialized from response
+   * @param statusCode Status code of the response
+   * @param responseHeaders Headers of the response
    */
-  void onSuccess(T result);
+  void onSuccess(T result, int statusCode, Map<String, List<String>> responseHeaders);
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiException.java
@@ -3,7 +3,7 @@ package io.swagger.client;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-31T19:27:38.337+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T13:13:26.059+08:00")
 public class ApiException extends Exception {
   private int code = 0;
   private Map<String, List<String>> responseHeaders = null;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/Configuration.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/Configuration.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-31T19:27:38.337+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T13:13:26.059+08:00")
 public class Configuration {
   private static ApiClient defaultApiClient = new ApiClient();
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/Pair.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/Pair.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-31T19:27:38.337+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T13:13:26.059+08:00")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/StringUtil.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/StringUtil.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-31T19:27:38.337+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T13:13:26.059+08:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
@@ -354,7 +354,7 @@ public class UserApi {
   /**
    * Get user by user name
    * 
-   * @param username The name that needs to be fetched. Use user1 for testing. 
+   * @param username The name that needs to be fetched. Use user1 for testing.
    * @return User
    */
   public User getUserByName(String username) throws ApiException {
@@ -366,7 +366,7 @@ public class UserApi {
   /**
    * Get user by user name (asynchronously)
    * 
-   * @param username The name that needs to be fetched. Use user1 for testing. 
+   * @param username The name that needs to be fetched. Use user1 for testing.
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
    */

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-31T19:27:38.337+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T13:13:26.059+08:00")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/Authentication.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/Authentication.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-31T19:27:38.337+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T13:13:26.059+08:00")
 public interface Authentication {
   /** Apply authentication settings to header and query params. */
   void applyToParams(List<Pair> queryParams, Map<String, String> headerParams);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-08-31T19:27:38.337+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T13:13:26.059+08:00")
 public class OAuth implements Authentication {
   @Override
   public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {


### PR DESCRIPTION
* Fix compilation error in the `jersey2` template regarding binary support  
  Binary input & output support was added to the default Java client codegen (see PR #1124) which changed the signature of the `invokeAPI` method in "api.mustache", causing the "jersey2" client fail to compile. Here an separate version of `api.mustache` is added for "jersey2" client which does not handle binary support (for now).
* Record (allow access to) status code and response headers of last request in Java clients generated with the `jersey2` and `okhttp-gson` library templates (it has been done for the default template in PR #1127).
* Rebuild Java clients for the petstore sample