### PR TITLE
[Obj-C] Fixed an issue where NSNumber parameters would cause a crash in multipart/form-data upload endpoints

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -115,6 +115,9 @@ static {{classname}}* singletonAPI = nil;
     NSMutableDictionary* headerParams = [NSMutableDictionary dictionaryWithDictionary:self.defaultHeaders];
 
     {{#headerParams}}if({{paramName}} != nil)
+        if([{{paramName}} isKindOfClass:[NSNumber class]]){
+            headerParams[@"{{baseName}}"] = [((NSNumber *){{paramName}}) stringValue];
+        }
         headerParams[@"{{baseName}}"] = {{paramName}};
     {{/headerParams}}
 
@@ -148,6 +151,9 @@ static {{classname}}* singletonAPI = nil;
     {{#formParams}}
     {{#notFile}}
     if ({{paramName}}) {
+        if([{{paramName}} isKindOfClass:[NSNumber class]]){
+            formParams[@"{{baseName}}"] = [((NSNumber *){{paramName}}) stringValue];
+        }
         formParams[@"{{baseName}}"] = {{paramName}};
     }
     {{/notFile}}{{#isFile}}

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -117,8 +117,9 @@ static {{classname}}* singletonAPI = nil;
     {{#headerParams}}if({{paramName}} != nil)
         if([{{paramName}} isKindOfClass:[NSNumber class]]){
             headerParams[@"{{baseName}}"] = [((NSNumber *){{paramName}}) stringValue];
+        }else{
+            headerParams[@"{{baseName}}"] = {{paramName}};
         }
-        headerParams[@"{{baseName}}"] = {{paramName}};
     {{/headerParams}}
 
     // HTTP header `Accept`
@@ -153,8 +154,9 @@ static {{classname}}* singletonAPI = nil;
     if ({{paramName}}) {
         if([{{paramName}} isKindOfClass:[NSNumber class]]){
             formParams[@"{{baseName}}"] = [((NSNumber *){{paramName}}) stringValue];
+        }else{
+            formParams[@"{{baseName}}"] = {{paramName}};
         }
-        formParams[@"{{baseName}}"] = {{paramName}};
     }
     {{/notFile}}{{#isFile}}
     files[@"{{paramName}}"] = {{paramName}};

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -100,7 +100,11 @@ static {{classname}}* singletonAPI = nil;
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     {{#pathParams}}if ({{paramName}} != nil) {
-        pathParams[@"{{baseName}}"] = {{paramName}};
+        if([{{paramName}} isKindOfClass:[NSNumber class]]){
+            pathParams[@"{{baseName}}"] = [((NSNumber *){{paramName}}) stringValue];
+        }else{
+            pathParams[@"{{baseName}}"] = {{paramName}};
+        }
     }
     {{/pathParams}}
 
@@ -114,12 +118,13 @@ static {{classname}}* singletonAPI = nil;
     {{/queryParams}}
     NSMutableDictionary* headerParams = [NSMutableDictionary dictionaryWithDictionary:self.defaultHeaders];
 
-    {{#headerParams}}if({{paramName}} != nil)
+    {{#headerParams}}if({{paramName}} != nil){
         if([{{paramName}} isKindOfClass:[NSNumber class]]){
             headerParams[@"{{baseName}}"] = [((NSNumber *){{paramName}}) stringValue];
         }else{
             headerParams[@"{{baseName}}"] = {{paramName}};
         }
+    }
     {{/headerParams}}
 
     // HTTP header `Accept`


### PR DESCRIPTION
The method `-dataUsingEncoding` cannot be called on NSNumber objects so we need to convert them into NSStrings before adding them to the formParams, pathParams, and bodyParams arrays. 