### PR TITLE
[Java okhttp-gson] Add support of file downloading

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import java.net.URLEncoder;
@@ -34,6 +35,9 @@ import java.io.UnsupportedEncodingException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.text.ParseException;
+
+import okio.BufferedSink;
+import okio.Okio;
 
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
@@ -490,6 +494,10 @@ public class ApiClient {
     if (response == null || returnType == null)
       return null;
 
+    // Handle file downloading.
+    if (returnType.equals(File.class))
+      return (T) downloadFileFromResponse(response);
+
     String respBody;
     try {
       if (response.body() != null)
@@ -536,6 +544,53 @@ public class ApiClient {
     } else {
       throw new ApiException("Content type \"" + contentType + "\" is not supported");
     }
+  }
+
+  /**
+   * Download file from the given response.
+   */
+  public File downloadFileFromResponse(Response response) throws ApiException {
+    try {
+        File file = prepareDownloadFile(response);
+        BufferedSink sink = Okio.buffer(Okio.sink(file));
+        sink.writeAll(response.body().source());
+        sink.close();
+        return file;
+    } catch (IOException e) {
+        throw new ApiException(e);
+    }
+  }
+
+  public File prepareDownloadFile(Response response) throws IOException {
+    String filename = null;
+    String contentDisposition = response.header("Content-Disposition");
+    if (contentDisposition != null && !"".equals(contentDisposition)) {
+      // Get filename from the Content-Disposition header.
+      Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+      Matcher matcher = pattern.matcher(contentDisposition);
+      if (matcher.find())
+        filename = matcher.group(1);
+    }
+
+    String prefix = null;
+    String suffix = null;
+    if (filename == null) {
+      prefix = "download-";
+      suffix = "";
+    } else {
+      int pos = filename.lastIndexOf(".");
+      if (pos == -1) {
+        prefix = filename + "-";
+      } else {
+        prefix = filename.substring(0, pos) + "-";
+        suffix = filename.substring(pos);
+      }
+      // File.createTempFile requires the prefix to be at least three characters long
+      if (prefix.length() < 3)
+        prefix = "download-";
+    }
+
+    return File.createTempFile(prefix, suffix);
   }
 
   /**

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -49,6 +49,7 @@ public class ApiClient {
   private boolean lenientOnJson = false;
   private boolean debugging = false;
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  private String tempFolderPath = null;
 
   private Map<String, Authentication> authentications;
 
@@ -364,6 +365,22 @@ public class ApiClient {
   }
 
   /**
+   * The path of temporary folder used to store downloaded files from endpoints
+   * with file response. The default value is <code>null</code>, i.e. using
+   * the system's default tempopary folder.
+   *
+   * @see https://docs.oracle.com/javase/7/docs/api/java/io/File.html#createTempFile(java.lang.String,%20java.lang.String,%20java.io.File)
+   */
+  public String getTempFolderPath() {
+    return tempFolderPath;
+  }
+
+  public ApiClient setTempFolderPath(String tempFolderPath) {
+    this.tempFolderPath = tempFolderPath;
+    return this;
+  }
+
+  /**
    * Format the given parameter object into string.
    */
   public String parameterToString(Object param) {
@@ -590,7 +607,10 @@ public class ApiClient {
         prefix = "download-";
     }
 
-    return File.createTempFile(prefix, suffix);
+    if (tempFolderPath == null)
+      return File.createTempFile(prefix, suffix);
+    else
+      return File.createTempFile(prefix, suffix, new File(tempFolderPath));
   }
 
   /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -49,6 +49,7 @@ public class ApiClient {
   private boolean lenientOnJson = false;
   private boolean debugging = false;
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  private String tempFolderPath = null;
 
   private Map<String, Authentication> authentications;
 
@@ -363,6 +364,22 @@ public class ApiClient {
   }
 
   /**
+   * The path of temporary folder used to store downloaded files from endpoints
+   * with file response. The default value is <code>null</code>, i.e. using
+   * the system's default tempopary folder.
+   *
+   * @see https://docs.oracle.com/javase/7/docs/api/java/io/File.html#createTempFile(java.lang.String,%20java.lang.String,%20java.io.File)
+   */
+  public String getTempFolderPath() {
+    return tempFolderPath;
+  }
+
+  public ApiClient setTempFolderPath(String tempFolderPath) {
+    this.tempFolderPath = tempFolderPath;
+    return this;
+  }
+
+  /**
    * Format the given parameter object into string.
    */
   public String parameterToString(Object param) {
@@ -589,7 +606,10 @@ public class ApiClient {
         prefix = "download-";
     }
 
-    return File.createTempFile(prefix, suffix);
+    if (tempFolderPath == null)
+      return File.createTempFile(prefix, suffix);
+    else
+      return File.createTempFile(prefix, suffix, new File(tempFolderPath));
   }
 
   /**


### PR DESCRIPTION
* For endpoints with [file response](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#response-object), save file from response body and return it
* Allow customizing the folder for file downloading via `ApiClient#setTempFolderPath`

Integration test result of the Petstore sample:

```
-------------------------------------------------------
 T E S T S
 -------------------------------------------------------
 Concurrency config is parallel='methods', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
 Running io.swagger.client.ApiClientTest
 Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.379 sec
 Concurrency config is parallel='methods', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
 Running io.swagger.client.auth.ApiKeyAuthTest
 Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec
 Concurrency config is parallel='methods', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
 Running io.swagger.client.auth.HttpBasicAuthTest
 Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 sec
 Concurrency config is parallel='methods', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
 Running io.swagger.client.ConfigurationTest
 Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.397 sec
 Concurrency config is parallel='methods', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
 Running io.swagger.client.StringUtilTest
 Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec
 Concurrency config is parallel='methods', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
 Running io.swagger.petstore.test.PetApiTest
 Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.412 sec
 Concurrency config is parallel='methods', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
 Running io.swagger.petstore.test.StoreApiTest
 Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.785 sec
 Concurrency config is parallel='methods', perCoreThreadCount=true, threadCount=2, useUnlimitedThreads=false
 Running io.swagger.petstore.test.UserApiTest
 Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.889 sec

 Results :

 Tests run: 34, Failures: 0, Errors: 0, Skipped: 0

 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
 [INFO] Total time: 59.264 s
 [INFO] Finished at: 2015-09-13T21:05:24+08:00
 [INFO] Final Memory: 20M/173M
 [INFO] ------------------------------------------------------------------------
 ```