### PR TITLE
Fix issue that using temp_folder_path from ApiClient in ruby client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -160,7 +160,7 @@ module {{moduleName}}
     # @see Configuration#temp_folder_path
     # @return [File] the file downloaded
     def download_file(response)
-      tmp_file = Tempfile.new '', @temp_folder_path
+      tmp_file = Tempfile.new '', Configuration.temp_folder_path
       content_disposition = response.headers['Content-Disposition']
       if content_disposition
         filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
@@ -172,7 +172,8 @@ module {{moduleName}}
       tmp_file.close!
 
       File.open(path, 'w') { |file| file.write(response.body) }
-      logger.info "File written to #{path}. Please move the file to a proper folder for further processing and delete the temp afterwards"
+      Configuration.logger.info "File written to #{path}. Please move the file to a proper "\
+                                "folder for further processing and delete the temp afterwards"
       File.new(path)
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -160,7 +160,7 @@ module Petstore
     # @see Configuration#temp_folder_path
     # @return [File] the file downloaded
     def download_file(response)
-      tmp_file = Tempfile.new '', @temp_folder_path
+      tmp_file = Tempfile.new '', Configuration.temp_folder_path
       content_disposition = response.headers['Content-Disposition']
       if content_disposition
         filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
@@ -172,7 +172,8 @@ module Petstore
       tmp_file.close!
 
       File.open(path, 'w') { |file| file.write(response.body) }
-      logger.info "File written to #{path}. Please move the file to a proper folder for further processing and delete the temp afterwards"
+      Configuration.logger.info "File written to #{path}. Please move the file to a proper "\
+                                "folder for further processing and delete the temp afterwards"
       File.new(path)
     end
 


### PR DESCRIPTION
It should use the one from the Configuration object.

Integration test looks fine:
```
Finished in 45.89 seconds (files took 0.36945 seconds to load)
21 examples, 0 failures

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 49.643 s
[INFO] Finished at: 2015-09-15T15:10:11+08:00
[INFO] Final Memory: 11M/155M
[INFO] ------------------------------------------------------------------------
```