### PR TITLE
Use the swagger property names in all Java models.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaInflector/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaInflector/model.mustache
@@ -28,7 +28,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * maximum: {{maximum}}{{/maximum}}
    **/
   @ApiModelProperty({{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/model.mustache
@@ -28,7 +28,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * maximum: {{maximum}}{{/maximum}}
    **/
   @ApiModelProperty({{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/model.mustache
@@ -28,7 +28,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
    * maximum: {{maximum}}{{/maximum}}
    **/
   @ApiModelProperty({{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
-  @JsonProperty("{{name}}")
+  @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }


### PR DESCRIPTION
This changes `@JsonProperty({{name}})` to `@JsonProperty({{baseName}})` in model.mustache for JavaInflector, JavaJaxRS and JavaSpringMVC.
In pull request #535 this was already done for the plain Java files (which get used on client side).

This replaces the sanitized names in the generated code by the original property names from the swagger document.