### PR TITLE
Use the baseName when referring to path and query parameters.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.mustache
@@ -49,7 +49,7 @@ module {{package}} {
 
 {{/queryParams}}
 {{#headerParams}}
-            headerParams['{{paramName}}'] = {{paramName}};
+            headerParams['{{baseName}}'] = {{paramName}};
 
 {{/headerParams}}
             var httpRequestParams: any = {

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.mustache
@@ -27,7 +27,7 @@ module {{package}} {
             var path = this.basePath + '{{path}}';
 
 {{#pathParams}}
-            path = path.replace('{' + '{{paramName}}' + '}', String({{paramName}}));
+            path = path.replace('{' + '{{baseName}}' + '}', String({{paramName}}));
 
 {{/pathParams}}
             var queryParameters: any = {};
@@ -44,7 +44,7 @@ module {{package}} {
 {{/allParams}}
 {{#queryParams}}
             if ({{paramName}} !== undefined) {
-                queryParameters['{{paramName}}'] = {{paramName}};
+                queryParameters['{{baseName}}'] = {{paramName}};
             }
 
 {{/queryParams}}


### PR DESCRIPTION
Changes the generated API classes to use the baseName instead of the parameter name: for a url specified as /resource/{resource_id}, the following incorrect typescript was generated:

```typescript
var path = this.basePath + '/resource/{resource_id}';

path = path.replace('{' + 'resourceId' + '}', String(resourceId));
```
which obviously fails to replace the parameter.

Query parameters have a similar problem.