### PR TITLE
Fix NPE in JavaClientCodegen when model has no properties of its own

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1439,6 +1439,8 @@ public class DefaultCodegen {
             }
         } else {
             m.emptyVars = true;
+            m.hasVars = false;
+            m.hasEnums = false;
         }
     }
 


### PR DESCRIPTION
A model that inherits from another model and does not add its own properties
causes JavaClientCodegen to crash silently with an NPE.

Fixes #1141