### PR TITLE
[TypeScript] fix parameter name for typescript-node using baseName

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -188,7 +188,7 @@ export class {{classname}} {
 
 {{#formParams}}
         if ({{paramName}} !== undefined) {
-            formParams['{baseName}}'] = {{paramName}};
+            formParams['{{baseName}}'] = {{paramName}};
         }
 {{#isFile}}
         useFormData = true;

--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -160,37 +160,35 @@ export class {{classname}} {
         var path = this.url + this.basePath + '{{path}}';
 
 {{#pathParams}}
-        path = path.replace('{' + '{{paramName}}' + '}', String({{paramName}}));
+        path = path.replace('{' + '{{baseName}}' + '}', String({{paramName}}));
 
 {{/pathParams}}
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
 
-{{#allParams}}
-{{#required}}
+{{#allParams}}{{#required}}
         // verify required parameter '{{paramName}}' is set
         if (!{{paramName}}) {
             throw new Error('Missing required parameter {{paramName}} when calling {{nickname}}');
         }
 
-{{/required}}
-{{/allParams}}
+{{/required}}{{/allParams}}
 {{#queryParams}}
         if ({{paramName}} !== undefined) {
-            queryParameters['{{paramName}}'] = {{paramName}};
+            queryParameters['{{baseName}}'] = {{paramName}};
         }
 
 {{/queryParams}}
 {{#headerParams}}
-        headerParams['{{paramName}}'] = {{paramName}};
+        headerParams['{{baseName}}'] = {{paramName}};
 
 {{/headerParams}}
         var useFormData = false;
 
 {{#formParams}}
         if ({{paramName}} !== undefined) {
-            formParams['{{paramName}}'] = {{paramName}};
+            formParams['{baseName}}'] = {{paramName}};
         }
 {{#isFile}}
         useFormData = true;

--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -172,7 +172,6 @@ export class {{classname}} {
         if (!{{paramName}}) {
             throw new Error('Missing required parameter {{paramName}} when calling {{nickname}}');
         }
-
 {{/required}}{{/allParams}}
 {{#queryParams}}
         if ({{paramName}} !== undefined) {

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -837,11 +837,11 @@ export class PetApi {
         var useFormData = false;
 
         if (name !== undefined) {
-            formParams['{baseName}}'] = name;
+            formParams['name'] = name;
         }
 
         if (status !== undefined) {
-            formParams['{baseName}}'] = status;
+            formParams['status'] = status;
         }
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -957,11 +957,11 @@ export class PetApi {
         var useFormData = false;
 
         if (additionalMetadata !== undefined) {
-            formParams['{baseName}}'] = additionalMetadata;
+            formParams['additionalMetadata'] = additionalMetadata;
         }
 
         if (file !== undefined) {
-            formParams['{baseName}}'] = file;
+            formParams['file'] = file;
         }
         useFormData = true;
 

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -149,6 +149,7 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -193,6 +194,7 @@ export class UserApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
+
 
         var useFormData = false;
 
@@ -239,6 +241,7 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -283,6 +286,7 @@ export class UserApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
+
 
         if (username !== undefined) {
             queryParameters['username'] = username;
@@ -336,6 +340,7 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -382,10 +387,12 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'username' is set
         if (!username) {
             throw new Error('Missing required parameter username when calling getUserByName');
         }
+
 
         var useFormData = false;
 
@@ -433,10 +440,12 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'username' is set
         if (!username) {
             throw new Error('Missing required parameter username when calling updateUser');
         }
+
 
         var useFormData = false;
 
@@ -485,10 +494,12 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'username' is set
         if (!username) {
             throw new Error('Missing required parameter username when calling deleteUser');
         }
+
 
         var useFormData = false;
 
@@ -559,6 +570,7 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -606,6 +618,7 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -652,6 +665,7 @@ export class PetApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
+
 
         if (status !== undefined) {
             queryParameters['status'] = status;
@@ -702,6 +716,7 @@ export class PetApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
+
 
         if (tags !== undefined) {
             queryParameters['tags'] = tags;
@@ -755,10 +770,12 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'petId' is set
         if (!petId) {
             throw new Error('Missing required parameter petId when calling getPetById');
         }
+
 
         var useFormData = false;
 
@@ -810,19 +827,21 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'petId' is set
         if (!petId) {
             throw new Error('Missing required parameter petId when calling updatePetWithForm');
         }
 
+
         var useFormData = false;
 
         if (name !== undefined) {
-            formParams['name'] = name;
+            formParams['{baseName}}'] = name;
         }
 
         if (status !== undefined) {
-            formParams['status'] = status;
+            formParams['{baseName}}'] = status;
         }
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -871,12 +890,14 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'petId' is set
         if (!petId) {
             throw new Error('Missing required parameter petId when calling deletePet');
         }
 
-        headerParams['apiKey'] = apiKey;
+
+        headerParams['api_key'] = apiKey;
 
         var useFormData = false;
 
@@ -926,19 +947,21 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'petId' is set
         if (!petId) {
             throw new Error('Missing required parameter petId when calling uploadFile');
         }
 
+
         var useFormData = false;
 
         if (additionalMetadata !== undefined) {
-            formParams['additionalMetadata'] = additionalMetadata;
+            formParams['{baseName}}'] = additionalMetadata;
         }
 
         if (file !== undefined) {
-            formParams['file'] = file;
+            formParams['{baseName}}'] = file;
         }
         useFormData = true;
 
@@ -1011,6 +1034,7 @@ export class StoreApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse; body: { [key: string]: number; };  }>();
@@ -1056,6 +1080,7 @@ export class StoreApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
+
 
         var useFormData = false;
 
@@ -1104,10 +1129,12 @@ export class StoreApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'orderId' is set
         if (!orderId) {
             throw new Error('Missing required parameter orderId when calling getOrderById');
         }
+
 
         var useFormData = false;
 
@@ -1155,10 +1182,12 @@ export class StoreApi {
         var headerParams: any = {};
         var formParams: any = {};
 
+
         // verify required parameter 'orderId' is set
         if (!orderId) {
             throw new Error('Missing required parameter orderId when calling deleteOrder');
         }
+
 
         var useFormData = false;
 

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -393,7 +393,6 @@ export class UserApi {
             throw new Error('Missing required parameter username when calling getUserByName');
         }
 
-
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse; body: User;  }>();
@@ -445,7 +444,6 @@ export class UserApi {
         if (!username) {
             throw new Error('Missing required parameter username when calling updateUser');
         }
-
 
         var useFormData = false;
 
@@ -499,7 +497,6 @@ export class UserApi {
         if (!username) {
             throw new Error('Missing required parameter username when calling deleteUser');
         }
-
 
         var useFormData = false;
 
@@ -776,7 +773,6 @@ export class PetApi {
             throw new Error('Missing required parameter petId when calling getPetById');
         }
 
-
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse; body: Pet;  }>();
@@ -832,7 +828,6 @@ export class PetApi {
         if (!petId) {
             throw new Error('Missing required parameter petId when calling updatePetWithForm');
         }
-
 
         var useFormData = false;
 
@@ -896,7 +891,6 @@ export class PetApi {
             throw new Error('Missing required parameter petId when calling deletePet');
         }
 
-
         headerParams['api_key'] = apiKey;
 
         var useFormData = false;
@@ -952,7 +946,6 @@ export class PetApi {
         if (!petId) {
             throw new Error('Missing required parameter petId when calling uploadFile');
         }
-
 
         var useFormData = false;
 
@@ -1135,7 +1128,6 @@ export class StoreApi {
             throw new Error('Missing required parameter orderId when calling getOrderById');
         }
 
-
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse; body: Order;  }>();
@@ -1187,7 +1179,6 @@ export class StoreApi {
         if (!orderId) {
             throw new Error('Missing required parameter orderId when calling deleteOrder');
         }
-
 
         var useFormData = false;
 


### PR DESCRIPTION
Similar to #1246, this PR fixes parameter name for typescript-node using {{baseName}} instead of {{paramName}}