### PR TITLE
[Java] Improvements on enum var name in Java client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -366,7 +366,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
                 // put "enumVars" map into `allowableValues", including `name` and `value`
                 List<Map<String, String>> enumVars = new ArrayList<Map<String, String>>();
                 String commonPrefix = findCommonPrefixOfVars(values);
-                int truncateIdx = "".equals(commonPrefix) ? 0 : commonPrefix.length();
+                int truncateIdx = commonPrefix.length();
                 for (String value : values) {
                     Map<String, String> enumVar = new HashMap<String, String>();
                     String enumName;

--- a/modules/swagger-codegen/src/main/resources/Java/enumClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/enumClass.mustache
@@ -1,5 +1,6 @@
 public enum {{datatypeWithEnum}} {
-  {{#allowableValues}}{{#enumVars}}{{name}}("{{value}}"){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+  {{#allowableValues}}{{#enumVars}}{{name}}("{{value}}"){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
 
   private String value;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-21T17:24:54.566+08:00")
 public class Order   {
   
   private Long id = null;
@@ -19,7 +19,9 @@ public class Order   {
   private Date shipDate = null;
 
 public enum StatusEnum {
-  PLACED("placed"), APPROVED("approved"), DELIVERED("delivered");
+  PLACED("placed"),
+  APPROVED("approved"),
+  DELIVERED("delivered");
 
   private String value;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-21T17:24:54.566+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -22,7 +22,9 @@ public class Pet   {
   private List<Tag> tags = new ArrayList<Tag>();
 
 public enum StatusEnum {
-  AVAILABLE("available"), PENDING("pending"), SOLD("sold");
+  AVAILABLE("available"),
+  PENDING("pending"),
+  SOLD("sold");
 
   private String value;
 


### PR DESCRIPTION
* [Nicer normalization on enum var name](https://github.com/swagger-api/swagger-codegen/issues/1229#issuecomment-141129940). For example:  
  `http://example.com/status/OK` => `HTTP_EXAMPLE_COM_STATUS_OK`  
  (was using `HTTPEXAMPLE_COMSTATUSOK` before)
* [Place each enum var in a separate line](https://github.com/swagger-api/swagger-codegen/issues/1229#issuecomment-141134764)
* [Truncate enum name by removing common prefix when present](https://github.com/swagger-api/swagger-codegen/issues/1229#issuecomment-141925993)

The integration test of the Petstore sample is fine:

```
Results :

Tests run: 33, Failures: 0, Errors: 0, Skipped: 0
```