### PR TITLE
Expose readOnly attribute on model properties to templates

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -32,6 +32,7 @@ public class CodegenProperty {
     public Boolean hasMore = null, required = null, secondaryParam = null;
     public Boolean isPrimitiveType, isContainer, isNotContainer;
     public boolean isEnum;
+    public Boolean isReadOnly = false;
     public List<String> _enum;
     public Map<String, Object> allowableValues;
     public CodegenProperty items;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -628,6 +628,7 @@ public class DefaultCodegen {
         property.example = p.getExample();
         property.defaultValue = toDefaultValue(p);
         property.jsonSchema = Json.pretty(p);
+        property.isReadOnly = p.getReadOnly();
 
         String type = getSwaggerType(p);
         if (p instanceof AbstractNumericProperty) {


### PR DESCRIPTION
Swagger codegen doesn't read the readOnly attribute on model properties from the swagger json, now the codegen engine will read the property and expose it to the templates as "isReadOnly" in model.mustache. 

This only exposes the attribute to the template but doesnt actually do anything with it.