### PR TITLE
implement form parameter support using Angular $httpParamSerializer

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
@@ -77,4 +77,13 @@ public class CodegenOperation {
         return nonempty(pathParams);
     }
 
+    /**
+     * Check if there's at least one form parameter
+     *
+     * @return true if any form parameter exists, false otherwise
+     */
+    public boolean getHasFormParams() {
+        return nonempty(formParams);
+    }
+
 }

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.mustache
@@ -16,7 +16,7 @@ module {{package}} {
 
         static $inject: string[] = ['$http', '$httpParamSerializer'];
 
-        constructor(private $http: ng.IHttpService, private $httpParamSerializer: (any) => any, basePath?: string) {
+        constructor(private $http: ng.IHttpService, basePath?: string, private $httpParamSerializer?: (any) => any) {
             if (basePath) {
                 this.basePath = basePath;
             }

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Angular/api.mustache
@@ -14,9 +14,9 @@ module {{package}} {
     export class {{classname}} {
         private basePath = '{{basePath}}';
 
-        static $inject: string[] = ['$http'];
+        static $inject: string[] = ['$http', '$httpParamSerializer'];
 
-        constructor(private $http: ng.IHttpService, basePath?: string) {
+        constructor(private $http: ng.IHttpService, private $httpParamSerializer: (any) => any, basePath?: string) {
             if (basePath) {
                 this.basePath = basePath;
             }
@@ -32,7 +32,10 @@ module {{package}} {
 {{/pathParams}}
             var queryParameters: any = {};
             var headerParams: any = {};
+{{#hasFormParams}}
+            var formParams: any = {};
 
+{{/hasFormParams}}
 {{#allParams}}
 {{#required}}
             // verify required parameter '{{paramName}}' is set
@@ -52,12 +55,22 @@ module {{package}} {
             headerParams['{{baseName}}'] = {{paramName}};
 
 {{/headerParams}}
+{{#hasFormParams}}
+            headerParams['Content-Type'] = 'application/x-www-form-urlencoded';
+
+{{/hasFormParams}}
+{{#formParams}}
+            formParams['{{baseName}}'] = {{paramName}};
+            
+{{/formParams}}
             var httpRequestParams: any = {
                 method: '{{httpMethod}}',
                 url: path,
-                json: true,
+                json: {{#hasFormParams}}false{{/hasFormParams}}{{^hasFormParams}}true{{/hasFormParams}},
                 {{#bodyParam}}data: {{paramName}},
                 {{/bodyParam}}
+                {{#hasFormParams}}data: this.$httpParamSerializer(formParams),
+                {{/hasFormParams}}
                 params: queryParameters,
                 headers: headerParams
             };

--- a/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
@@ -8,9 +8,9 @@ module API.Client {
     export class PetApi {
         private basePath = 'http://petstore.swagger.io/v2';
 
-        static $inject: string[] = ['$http'];
+        static $inject: string[] = ['$http', '$httpParamSerializer'];
 
-        constructor(private $http: ng.IHttpService, basePath?: string) {
+        constructor(private $http: ng.IHttpService, basePath?: string, private $httpParamSerializer?: (any) => any) {
             if (basePath) {
                 this.basePath = basePath;
             }
@@ -21,12 +21,12 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             var httpRequestParams: any = {
                 method: 'PUT',
                 url: path,
                 json: true,
                 data: body,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -48,12 +48,12 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             var httpRequestParams: any = {
                 method: 'POST',
                 url: path,
                 json: true,
                 data: body,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -75,7 +75,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             if (status !== undefined) {
                 queryParameters['status'] = status;
             }
@@ -84,6 +83,7 @@ module API.Client {
                 method: 'GET',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -105,7 +105,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             if (tags !== undefined) {
                 queryParameters['tags'] = tags;
             }
@@ -114,6 +113,7 @@ module API.Client {
                 method: 'GET',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -137,7 +137,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             // verify required parameter 'petId' is set
             if (!petId) {
                 throw new Error('Missing required parameter petId when calling getPetById');
@@ -147,6 +146,7 @@ module API.Client {
                 method: 'GET',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -170,16 +170,25 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
+            var formParams: any = {};
 
             // verify required parameter 'petId' is set
             if (!petId) {
                 throw new Error('Missing required parameter petId when calling updatePetWithForm');
             }
 
+            headerParams['Content-Type'] = 'application/x-www-form-urlencoded';
+
+            formParams['name'] = name;
+            
+            formParams['status'] = status;
+            
             var httpRequestParams: any = {
                 method: 'POST',
                 url: path,
-                json: true,
+                json: false,
+                
+                data: this.$httpParamSerializer(formParams),
                 
                 params: queryParameters,
                 headers: headerParams
@@ -203,18 +212,18 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             // verify required parameter 'petId' is set
             if (!petId) {
                 throw new Error('Missing required parameter petId when calling deletePet');
             }
 
-            headerParams['apiKey'] = apiKey;
+            headerParams['api_key'] = apiKey;
 
             var httpRequestParams: any = {
                 method: 'DELETE',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -238,16 +247,25 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
+            var formParams: any = {};
 
             // verify required parameter 'petId' is set
             if (!petId) {
                 throw new Error('Missing required parameter petId when calling uploadFile');
             }
 
+            headerParams['Content-Type'] = 'application/x-www-form-urlencoded';
+
+            formParams['additionalMetadata'] = additionalMetadata;
+            
+            formParams['file'] = file;
+            
             var httpRequestParams: any = {
                 method: 'POST',
                 url: path,
-                json: true,
+                json: false,
+                
+                data: this.$httpParamSerializer(formParams),
                 
                 params: queryParameters,
                 headers: headerParams

--- a/samples/client/petstore/typescript-angular/API/Client/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/StoreApi.ts
@@ -8,9 +8,9 @@ module API.Client {
     export class StoreApi {
         private basePath = 'http://petstore.swagger.io/v2';
 
-        static $inject: string[] = ['$http'];
+        static $inject: string[] = ['$http', '$httpParamSerializer'];
 
-        constructor(private $http: ng.IHttpService, basePath?: string) {
+        constructor(private $http: ng.IHttpService, basePath?: string, private $httpParamSerializer?: (any) => any) {
             if (basePath) {
                 this.basePath = basePath;
             }
@@ -21,11 +21,11 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             var httpRequestParams: any = {
                 method: 'GET',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -47,12 +47,12 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             var httpRequestParams: any = {
                 method: 'POST',
                 url: path,
                 json: true,
                 data: body,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -76,7 +76,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             // verify required parameter 'orderId' is set
             if (!orderId) {
                 throw new Error('Missing required parameter orderId when calling getOrderById');
@@ -86,6 +85,7 @@ module API.Client {
                 method: 'GET',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -109,7 +109,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             // verify required parameter 'orderId' is set
             if (!orderId) {
                 throw new Error('Missing required parameter orderId when calling deleteOrder');
@@ -119,6 +118,7 @@ module API.Client {
                 method: 'DELETE',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams

--- a/samples/client/petstore/typescript-angular/API/Client/UserApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/UserApi.ts
@@ -8,9 +8,9 @@ module API.Client {
     export class UserApi {
         private basePath = 'http://petstore.swagger.io/v2';
 
-        static $inject: string[] = ['$http'];
+        static $inject: string[] = ['$http', '$httpParamSerializer'];
 
-        constructor(private $http: ng.IHttpService, basePath?: string) {
+        constructor(private $http: ng.IHttpService, basePath?: string, private $httpParamSerializer?: (any) => any) {
             if (basePath) {
                 this.basePath = basePath;
             }
@@ -21,12 +21,12 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             var httpRequestParams: any = {
                 method: 'POST',
                 url: path,
                 json: true,
                 data: body,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -48,12 +48,12 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             var httpRequestParams: any = {
                 method: 'POST',
                 url: path,
                 json: true,
                 data: body,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -75,12 +75,12 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             var httpRequestParams: any = {
                 method: 'POST',
                 url: path,
                 json: true,
                 data: body,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -102,7 +102,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             if (username !== undefined) {
                 queryParameters['username'] = username;
             }
@@ -115,6 +114,7 @@ module API.Client {
                 method: 'GET',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -136,11 +136,11 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             var httpRequestParams: any = {
                 method: 'GET',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -164,7 +164,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             // verify required parameter 'username' is set
             if (!username) {
                 throw new Error('Missing required parameter username when calling getUserByName');
@@ -174,6 +173,7 @@ module API.Client {
                 method: 'GET',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -197,7 +197,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             // verify required parameter 'username' is set
             if (!username) {
                 throw new Error('Missing required parameter username when calling updateUser');
@@ -208,6 +207,7 @@ module API.Client {
                 url: path,
                 json: true,
                 data: body,
+                
                 
                 params: queryParameters,
                 headers: headerParams
@@ -231,7 +231,6 @@ module API.Client {
 
             var queryParameters: any = {};
             var headerParams: any = {};
-
             // verify required parameter 'username' is set
             if (!username) {
                 throw new Error('Missing required parameter username when calling deleteUser');
@@ -241,6 +240,7 @@ module API.Client {
                 method: 'DELETE',
                 url: path,
                 json: true,
+                
                 
                 params: queryParameters,
                 headers: headerParams

--- a/samples/client/petstore/typescript-angular/API/Client/api.d.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/api.d.ts
@@ -5,5 +5,5 @@
 /// <reference path="Order.ts" />
 
 /// <reference path="UserApi.ts" />
-/// <reference path="PetApi.ts" />
 /// <reference path="StoreApi.ts" />
+/// <reference path="PetApi.ts" />

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -149,7 +149,6 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -194,7 +193,6 @@ export class UserApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
-
 
         var useFormData = false;
 
@@ -241,7 +239,6 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -286,7 +283,6 @@ export class UserApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
-
 
         if (username !== undefined) {
             queryParameters['username'] = username;
@@ -340,7 +336,6 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -386,7 +381,6 @@ export class UserApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
-
 
         // verify required parameter 'username' is set
         if (!username) {
@@ -438,7 +432,6 @@ export class UserApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
-
 
         // verify required parameter 'username' is set
         if (!username) {
@@ -492,10 +485,227 @@ export class UserApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         // verify required parameter 'username' is set
         if (!username) {
             throw new Error('Missing required parameter username when calling deleteUser');
+        }
+
+        var useFormData = false;
+
+        var deferred = promise.defer<{ response: http.ClientResponse;  }>();
+
+        var requestOptions: request.Options = {
+            method: 'DELETE',
+            qs: queryParameters,
+            headers: headerParams,
+            uri: path,
+            json: true,
+        }
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+
+        request(requestOptions, (error, response, body) => {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                if (response.statusCode >= 200 && response.statusCode <= 299) {
+                    deferred.resolve({ response: response, body: body });
+                } else {
+                    deferred.reject({ response: response, body: body });
+                }
+            }
+        });
+
+        return deferred.promise;
+    }
+}
+export class StoreApi {
+    private basePath = 'http://petstore.swagger.io/v2';
+    public authentications = {
+        'default': <Authentication>new VoidAuth(),
+        'api_key': new ApiKeyAuth('header', 'api_key'),
+        'petstore_auth': new OAuth(),
+    }
+
+    constructor(url: string, basePath?: string);
+    constructor(private url: string, basePathOrUsername: string, password?: string, basePath?: string) {
+        if (password) {
+            if (basePath) {
+                this.basePath = basePath;
+            }
+        } else {
+            if (basePathOrUsername) {
+                this.basePath = basePathOrUsername
+            }
+        }
+    }
+
+    set apiKey(key: string) {
+        this.authentications.api_key.apiKey = key;
+    }
+
+    public getInventory () : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
+        var path = this.url + this.basePath + '/store/inventory';
+
+        var queryParameters: any = {};
+        var headerParams: any = {};
+        var formParams: any = {};
+
+        var useFormData = false;
+
+        var deferred = promise.defer<{ response: http.ClientResponse; body: { [key: string]: number; };  }>();
+
+        var requestOptions: request.Options = {
+            method: 'GET',
+            qs: queryParameters,
+            headers: headerParams,
+            uri: path,
+            json: true,
+        }
+
+        this.authentications.api_key.applyToRequest(requestOptions);
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+
+        request(requestOptions, (error, response, body) => {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                if (response.statusCode >= 200 && response.statusCode <= 299) {
+                    deferred.resolve({ response: response, body: body });
+                } else {
+                    deferred.reject({ response: response, body: body });
+                }
+            }
+        });
+
+        return deferred.promise;
+    }
+
+    public placeOrder (body?: Order) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+        var path = this.url + this.basePath + '/store/order';
+
+        var queryParameters: any = {};
+        var headerParams: any = {};
+        var formParams: any = {};
+
+        var useFormData = false;
+
+        var deferred = promise.defer<{ response: http.ClientResponse; body: Order;  }>();
+
+        var requestOptions: request.Options = {
+            method: 'POST',
+            qs: queryParameters,
+            headers: headerParams,
+            uri: path,
+            json: true,
+            body: body,
+        }
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+
+        request(requestOptions, (error, response, body) => {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                if (response.statusCode >= 200 && response.statusCode <= 299) {
+                    deferred.resolve({ response: response, body: body });
+                } else {
+                    deferred.reject({ response: response, body: body });
+                }
+            }
+        });
+
+        return deferred.promise;
+    }
+
+    public getOrderById (orderId: string) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+        var path = this.url + this.basePath + '/store/order/{orderId}';
+
+        path = path.replace('{' + 'orderId' + '}', String(orderId));
+
+        var queryParameters: any = {};
+        var headerParams: any = {};
+        var formParams: any = {};
+
+        // verify required parameter 'orderId' is set
+        if (!orderId) {
+            throw new Error('Missing required parameter orderId when calling getOrderById');
+        }
+
+        var useFormData = false;
+
+        var deferred = promise.defer<{ response: http.ClientResponse; body: Order;  }>();
+
+        var requestOptions: request.Options = {
+            method: 'GET',
+            qs: queryParameters,
+            headers: headerParams,
+            uri: path,
+            json: true,
+        }
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+
+        request(requestOptions, (error, response, body) => {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                if (response.statusCode >= 200 && response.statusCode <= 299) {
+                    deferred.resolve({ response: response, body: body });
+                } else {
+                    deferred.reject({ response: response, body: body });
+                }
+            }
+        });
+
+        return deferred.promise;
+    }
+
+    public deleteOrder (orderId: string) : Promise<{ response: http.ClientResponse;  }> {
+        var path = this.url + this.basePath + '/store/order/{orderId}';
+
+        path = path.replace('{' + 'orderId' + '}', String(orderId));
+
+        var queryParameters: any = {};
+        var headerParams: any = {};
+        var formParams: any = {};
+
+        // verify required parameter 'orderId' is set
+        if (!orderId) {
+            throw new Error('Missing required parameter orderId when calling deleteOrder');
         }
 
         var useFormData = false;
@@ -567,7 +777,6 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -615,7 +824,6 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         var useFormData = false;
 
         var deferred = promise.defer<{ response: http.ClientResponse;  }>();
@@ -662,7 +870,6 @@ export class PetApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
-
 
         if (status !== undefined) {
             queryParameters['status'] = status;
@@ -713,7 +920,6 @@ export class PetApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
-
 
         if (tags !== undefined) {
             queryParameters['tags'] = tags;
@@ -767,7 +973,6 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         // verify required parameter 'petId' is set
         if (!petId) {
             throw new Error('Missing required parameter petId when calling getPetById');
@@ -785,9 +990,9 @@ export class PetApi {
             json: true,
         }
 
-        this.authentications.api_key.applyToRequest(requestOptions);
-
         this.authentications.petstore_auth.applyToRequest(requestOptions);
+
+        this.authentications.api_key.applyToRequest(requestOptions);
 
         this.authentications.default.applyToRequest(requestOptions);
 
@@ -822,7 +1027,6 @@ export class PetApi {
         var queryParameters: any = {};
         var headerParams: any = {};
         var formParams: any = {};
-
 
         // verify required parameter 'petId' is set
         if (!petId) {
@@ -885,13 +1089,12 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         // verify required parameter 'petId' is set
         if (!petId) {
             throw new Error('Missing required parameter petId when calling deletePet');
         }
 
-        headerParams['api_key'] = apiKey;
+        headerParams['apiKey'] = apiKey;
 
         var useFormData = false;
 
@@ -941,7 +1144,6 @@ export class PetApi {
         var headerParams: any = {};
         var formParams: any = {};
 
-
         // verify required parameter 'petId' is set
         if (!petId) {
             throw new Error('Missing required parameter petId when calling uploadFile');
@@ -969,228 +1171,6 @@ export class PetApi {
         }
 
         this.authentications.petstore_auth.applyToRequest(requestOptions);
-
-        this.authentications.default.applyToRequest(requestOptions);
-
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
-            } else {
-                requestOptions.form = formParams;
-            }
-        }
-
-        request(requestOptions, (error, response, body) => {
-            if (error) {
-                deferred.reject(error);
-            } else {
-                if (response.statusCode >= 200 && response.statusCode <= 299) {
-                    deferred.resolve({ response: response, body: body });
-                } else {
-                    deferred.reject({ response: response, body: body });
-                }
-            }
-        });
-
-        return deferred.promise;
-    }
-}
-export class StoreApi {
-    private basePath = 'http://petstore.swagger.io/v2';
-    public authentications = {
-        'default': <Authentication>new VoidAuth(),
-        'api_key': new ApiKeyAuth('header', 'api_key'),
-        'petstore_auth': new OAuth(),
-    }
-
-    constructor(url: string, basePath?: string);
-    constructor(private url: string, basePathOrUsername: string, password?: string, basePath?: string) {
-        if (password) {
-            if (basePath) {
-                this.basePath = basePath;
-            }
-        } else {
-            if (basePathOrUsername) {
-                this.basePath = basePathOrUsername
-            }
-        }
-    }
-
-    set apiKey(key: string) {
-        this.authentications.api_key.apiKey = key;
-    }
-
-    public getInventory () : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
-        var path = this.url + this.basePath + '/store/inventory';
-
-        var queryParameters: any = {};
-        var headerParams: any = {};
-        var formParams: any = {};
-
-
-        var useFormData = false;
-
-        var deferred = promise.defer<{ response: http.ClientResponse; body: { [key: string]: number; };  }>();
-
-        var requestOptions: request.Options = {
-            method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
-            uri: path,
-            json: true,
-        }
-
-        this.authentications.api_key.applyToRequest(requestOptions);
-
-        this.authentications.default.applyToRequest(requestOptions);
-
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
-            } else {
-                requestOptions.form = formParams;
-            }
-        }
-
-        request(requestOptions, (error, response, body) => {
-            if (error) {
-                deferred.reject(error);
-            } else {
-                if (response.statusCode >= 200 && response.statusCode <= 299) {
-                    deferred.resolve({ response: response, body: body });
-                } else {
-                    deferred.reject({ response: response, body: body });
-                }
-            }
-        });
-
-        return deferred.promise;
-    }
-
-    public placeOrder (body?: Order) : Promise<{ response: http.ClientResponse; body: Order;  }> {
-        var path = this.url + this.basePath + '/store/order';
-
-        var queryParameters: any = {};
-        var headerParams: any = {};
-        var formParams: any = {};
-
-
-        var useFormData = false;
-
-        var deferred = promise.defer<{ response: http.ClientResponse; body: Order;  }>();
-
-        var requestOptions: request.Options = {
-            method: 'POST',
-            qs: queryParameters,
-            headers: headerParams,
-            uri: path,
-            json: true,
-            body: body,
-        }
-
-        this.authentications.default.applyToRequest(requestOptions);
-
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
-            } else {
-                requestOptions.form = formParams;
-            }
-        }
-
-        request(requestOptions, (error, response, body) => {
-            if (error) {
-                deferred.reject(error);
-            } else {
-                if (response.statusCode >= 200 && response.statusCode <= 299) {
-                    deferred.resolve({ response: response, body: body });
-                } else {
-                    deferred.reject({ response: response, body: body });
-                }
-            }
-        });
-
-        return deferred.promise;
-    }
-
-    public getOrderById (orderId: string) : Promise<{ response: http.ClientResponse; body: Order;  }> {
-        var path = this.url + this.basePath + '/store/order/{orderId}';
-
-        path = path.replace('{' + 'orderId' + '}', String(orderId));
-
-        var queryParameters: any = {};
-        var headerParams: any = {};
-        var formParams: any = {};
-
-
-        // verify required parameter 'orderId' is set
-        if (!orderId) {
-            throw new Error('Missing required parameter orderId when calling getOrderById');
-        }
-
-        var useFormData = false;
-
-        var deferred = promise.defer<{ response: http.ClientResponse; body: Order;  }>();
-
-        var requestOptions: request.Options = {
-            method: 'GET',
-            qs: queryParameters,
-            headers: headerParams,
-            uri: path,
-            json: true,
-        }
-
-        this.authentications.default.applyToRequest(requestOptions);
-
-        if (Object.keys(formParams).length) {
-            if (useFormData) {
-                (<any>requestOptions).formData = formParams;
-            } else {
-                requestOptions.form = formParams;
-            }
-        }
-
-        request(requestOptions, (error, response, body) => {
-            if (error) {
-                deferred.reject(error);
-            } else {
-                if (response.statusCode >= 200 && response.statusCode <= 299) {
-                    deferred.resolve({ response: response, body: body });
-                } else {
-                    deferred.reject({ response: response, body: body });
-                }
-            }
-        });
-
-        return deferred.promise;
-    }
-
-    public deleteOrder (orderId: string) : Promise<{ response: http.ClientResponse;  }> {
-        var path = this.url + this.basePath + '/store/order/{orderId}';
-
-        path = path.replace('{' + 'orderId' + '}', String(orderId));
-
-        var queryParameters: any = {};
-        var headerParams: any = {};
-        var formParams: any = {};
-
-
-        // verify required parameter 'orderId' is set
-        if (!orderId) {
-            throw new Error('Missing required parameter orderId when calling deleteOrder');
-        }
-
-        var useFormData = false;
-
-        var deferred = promise.defer<{ response: http.ClientResponse;  }>();
-
-        var requestOptions: request.Options = {
-            method: 'DELETE',
-            qs: queryParameters,
-            headers: headerParams,
-            uri: path,
-            json: true,
-        }
 
         this.authentications.default.applyToRequest(requestOptions);
 


### PR DESCRIPTION
Follow up on #1246.

I ended up extending the CodegenOperation as formParams.length does not work as expected.

Note that this changes the constructor signature of API classes.