### PR TITLE
Add CLI option to sort method arguments

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -37,4 +37,7 @@ public class CodegenConstants {
     public static final String LIBRARY = "library";
     public static final String LIBRARY_DESC = "library template (sub-template)";
 
+    public static final String SORT_PARAMS_BY_REQUIRED_FLAG = "sortParamsByRequiredFlag";
+    public static final String SORT_PARAMS_BY_REQUIRED_FLAG_DESC = "Sort method arguments to place required parameters before optional parameters. Default: true";
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -103,6 +103,10 @@ public class DefaultCodegen {
         if (additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
             this.setApiPackage((String) additionalProperties.get(CodegenConstants.API_PACKAGE));
         }
+
+        if (additionalProperties.containsKey(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG)) {
+            this.setSortParamsByRequiredFlag(Boolean.valueOf((String)additionalProperties.get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG).toString()));
+        }
     }
 
     // override with any special post-processing
@@ -227,6 +231,10 @@ public class DefaultCodegen {
         this.apiPackage = apiPackage;
     }
 
+    public void setSortParamsByRequiredFlag(Boolean sortParamsByRequiredFlag) {
+        this.sortParamsByRequiredFlag = sortParamsByRequiredFlag;
+    }
+
     public String toApiFilename(String name) {
         return toApiName(name);
     }
@@ -344,6 +352,7 @@ public class DefaultCodegen {
 
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG_DESC));
     }
 
 
@@ -1033,8 +1042,8 @@ public class DefaultCodegen {
         }
         op.bodyParam = bodyParam;
         op.httpMethod = httpMethod.toUpperCase();
-        // move "required" parameters in front of "optional" parameters
 
+        // move "required" parameters in front of "optional" parameters
         if(sortParamsByRequiredFlag) {
           Collections.sort(allParams, new Comparator<CodegenParameter>() {
               @Override

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -409,7 +409,7 @@ class UserApi
      *
      * Get user by user name
      *
-     * @param string $username The name that needs to be fetched. Use user1 for testing.  (required)
+     * @param string $username The name that needs to be fetched. Use user1 for testing. (required)
      * @return \Swagger\Client\Model\User
      * @throws \Swagger\Client\ApiException on non-2xx response
      */

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php
@@ -48,6 +48,8 @@ class ApiClient
     public static $PATCH = "PATCH";
     public static $POST = "POST";
     public static $GET = "GET";
+    public static $HEAD = "HEAD";
+    public static $OPTIONS = "OPTIONS";
     public static $PUT = "PUT";
     public static $DELETE = "DELETE";
   
@@ -169,6 +171,11 @@ class ApiClient
   
         if ($method == self::$POST) {
             curl_setopt($curl, CURLOPT_POST, true);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
+        } else if ($method == self::$HEAD) {
+            curl_setopt($curl, CURLOPT_NOBODY, true);
+        } else if ($method == self::$OPTIONS) {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } else if ($method == self::$PATCH) {
             curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PATCH");


### PR DESCRIPTION
Provide CLI option `sortParamsByRequiredFlag ` to optionally sort method arguments based on required/optional.

Tested with true, false and option not provided.