### PR TITLE
[Java] Support primitive string response in Java clients

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -385,8 +385,15 @@ public class ApiClient {
 
     if (contentType.startsWith("application/json")) {
       return json.deserialize(body, returnType);
+    } else if (returnType.getType().equals(String.class)) {
+      // Expecting string, return the raw response body.
+      return (T) body;
     } else {
-      throw new ApiException(500, "can not deserialize Content-Type: " + contentType);
+      throw new ApiException(
+        500,
+        "Content type \"" + contentType + "\" is not supported for type: "
+          + returnType.getType()
+      );
     }
   }
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -389,8 +389,15 @@ public class ApiClient {
 
     if (contentType.startsWith("application/json")) {
       return json.deserialize(body, returnType);
+    } else if (returnType.getType().equals(String.class)) {
+      // Expecting string, return the raw response body.
+      return (T) body;
     } else {
-      throw new ApiException(500, "can not deserialize Content-Type: " + contentType);
+      throw new ApiException(
+        500,
+        "Content type \"" + contentType + "\" is not supported for type: "
+          + returnType.getType()
+      );
     }
   }
 
@@ -429,7 +436,7 @@ public class ApiClient {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request(contentType).accept(accept);
+    Invocation.Builder invocationBuilder = target.request().accept(accept);
 
     for (String key : headerParams.keySet()) {
       String value = headerParams.get(key);

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -536,9 +536,12 @@ public class ApiClient {
     }
     if (contentType.startsWith("application/json")) {
       return json.deserialize(respBody, returnType);
+    } else if (returnType.equals(String.class)) {
+      // Expecting string, return the raw response body.
+      return (T) respBody;
     } else {
       throw new ApiException(
-        "Content type \"" + contentType + "\" is not supported",
+        "Content type \"" + contentType + "\" is not supported for type: " + returnType,
         response.code(),
         response.headers().toMultimap(),
         respBody);

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
@@ -39,7 +39,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:58.351+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-23T12:52:56.012+08:00")
 public class ApiClient {
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -384,8 +384,15 @@ public class ApiClient {
 
     if (contentType.startsWith("application/json")) {
       return json.deserialize(body, returnType);
+    } else if (returnType.getType().equals(String.class)) {
+      // Expecting string, return the raw response body.
+      return (T) body;
     } else {
-      throw new ApiException(500, "can not deserialize Content-Type: " + contentType);
+      throw new ApiException(
+        500,
+        "Content type \"" + contentType + "\" is not supported for type: "
+          + returnType.getType()
+      );
     }
   }
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
@@ -43,7 +43,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-11T11:35:51.678+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-09-23T12:52:46.364+08:00")
 public class ApiClient {
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -388,8 +388,15 @@ public class ApiClient {
 
     if (contentType.startsWith("application/json")) {
       return json.deserialize(body, returnType);
+    } else if (returnType.getType().equals(String.class)) {
+      // Expecting string, return the raw response body.
+      return (T) body;
     } else {
-      throw new ApiException(500, "can not deserialize Content-Type: " + contentType);
+      throw new ApiException(
+        500,
+        "Content type \"" + contentType + "\" is not supported for type: "
+          + returnType.getType()
+      );
     }
   }
 
@@ -428,7 +435,7 @@ public class ApiClient {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request(contentType).accept(accept);
+    Invocation.Builder invocationBuilder = target.request().accept(accept);
 
     for (String key : headerParams.keySet()) {
       String value = headerParams.get(key);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -535,9 +535,12 @@ public class ApiClient {
     }
     if (contentType.startsWith("application/json")) {
       return json.deserialize(respBody, returnType);
+    } else if (returnType.equals(String.class)) {
+      // Expecting string, return the raw response body.
+      return (T) respBody;
     } else {
       throw new ApiException(
-        "Content type \"" + contentType + "\" is not supported",
+        "Content type \"" + contentType + "\" is not supported for type: " + returnType,
         response.code(),
         response.headers().toMultimap(),
         respBody);


### PR DESCRIPTION
Return raw response body as string for API endpoints with string response, i.e. `{"type": "string"}`.

The integration tests are fine:

(default)
> Tests run: 33, Failures: 0, Errors: 0, Skipped: 0

library: jersey2
> Tests run: 33, Failures: 0, Errors: 0, Skipped: 0

library: okhttp-gson
> Tests run: 34, Failures: 0, Errors: 0, Skipped: 0
