### PR TITLE
[Python, Ruby] Fix issues in python and ruby clients

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -199,7 +199,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
     @Override
     public String toModelName(String name) {
-        name = name.replaceAll("\\W", "_");
+        name = sanitizeName(name);
 
         // model name cannot use reserved keyword, e.g. return
         if (reservedWords.contains(name)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -199,6 +199,8 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
     @Override
     public String toModelName(String name) {
+        name = name.replaceAll("\\W", "_");
+
         // model name cannot use reserved keyword, e.g. return
         if (reservedWords.contains(name)) {
             throw new RuntimeException(name + " (reserved word) cannot be used as a model name");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -224,7 +224,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toModelName(String name) {
-        name = name.replaceAll("\\W", "_");
+        name = sanitizeName(name);
 
         // model name cannot use reserved keyword, e.g. return
         if (reservedWords.contains(name)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -224,6 +224,8 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toModelName(String name) {
+        name = name.replaceAll("\\W", "_");
+
         // model name cannot use reserved keyword, e.g. return
         if (reservedWords.contains(name)) {
             throw new RuntimeException(name + " (reserved word) cannot be used as a model name");

--- a/samples/client/petstore/python/swagger_client/apis/user_api.py
+++ b/samples/client/petstore/python/swagger_client/apis/user_api.py
@@ -435,7 +435,7 @@ class UserApi(object):
 
         :param callback function: The callback function
             for asynchronous request. (optional)
-        :param str username: The name that needs to be fetched. Use user1 for testing.  (required)
+        :param str username: The name that needs to be fetched. Use user1 for testing. (required)
         :return: User
                  If the method is called asynchronously,
                  returns the request thread.


### PR DESCRIPTION
* Fixed issue that model name not camelized in python client and ruby client.
* Tested without issue:

`ruby`
```
Finished in 26.47 seconds (files took 0.18982 seconds to load)
21 examples, 0 failures

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 29.888 s
[INFO] Finished at: 2015-09-24T16:09:34+08:00
[INFO] Final Memory: 11M/155M
[INFO] ------------------------------------------------------------------------
```

`python`
```
-----------------------------------------------------------------
TOTAL                                1245    471    62%
----------------------------------------------------------------------
Ran 28 tests in 29.579s

OK
________________________________________ summary ________________________________________
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)
```