### PR TITLE
[Python] Support client certificate file and client key file in TLS/SSL

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/configuration.mustache
@@ -92,6 +92,10 @@ class Configuration(object):
         self.verify_ssl = True
         # Set this to customize the certificate file to verify the peer.
         self.ssl_ca_cert = None
+        # client certificate file
+        self.cert_file = None
+        # client key file
+        self.key_file = None
 
     @property
     def logger_file(self):

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -72,22 +72,38 @@ class RESTResponse(io.IOBase):
 class RESTClientObject(object):
 
     def __init__(self, pools_size=4):
+        # urllib3.PoolManager will pass all kw parameters to connectionpool
+        # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75
+        # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680
+        # ca_certs vs cert_file vs key_file
+        # http://stackoverflow.com/a/23957365/2985775
+
+        # cert_reqs
         if Configuration().verify_ssl:
             cert_reqs = ssl.CERT_REQUIRED
         else:
             cert_reqs = ssl.CERT_NONE
 
+        # ca_certs
         if Configuration().ssl_ca_cert:
             ca_certs = Configuration().ssl_ca_cert
         else:
             # if not set certificate file, use Mozilla's root certificates.
             ca_certs = certifi.where()
 
+        # cert_file
+        cert_file = Configuration().cert_file
+
+        # key file
+        key_file = Configuration().key_file
+
         # https pool manager
         self.pool_manager = urllib3.PoolManager(
             num_pools=pools_size,
             cert_reqs=cert_reqs,
-            ca_certs=ca_certs
+            ca_certs=ca_certs,
+            cert_file=cert_file,
+            key_file=key_file
         )
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore/python/swagger_client/configuration.py
+++ b/samples/client/petstore/python/swagger_client/configuration.py
@@ -92,6 +92,10 @@ class Configuration(object):
         self.verify_ssl = True
         # Set this to customize the certificate file to verify the peer.
         self.ssl_ca_cert = None
+        # client certificate file
+        self.cert_file = None
+        # client key file
+        self.key_file = None
 
     @property
     def logger_file(self):

--- a/samples/client/petstore/python/swagger_client/rest.py
+++ b/samples/client/petstore/python/swagger_client/rest.py
@@ -72,22 +72,38 @@ class RESTResponse(io.IOBase):
 class RESTClientObject(object):
 
     def __init__(self, pools_size=4):
+        # urllib3.PoolManager will pass all kw parameters to connectionpool
+        # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75
+        # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680
+        # ca_certs vs cert_file vs key_file
+        # http://stackoverflow.com/a/23957365/2985775
+
+        # cert_reqs
         if Configuration().verify_ssl:
             cert_reqs = ssl.CERT_REQUIRED
         else:
             cert_reqs = ssl.CERT_NONE
 
+        # ca_certs
         if Configuration().ssl_ca_cert:
             ca_certs = Configuration().ssl_ca_cert
         else:
             # if not set certificate file, use Mozilla's root certificates.
             ca_certs = certifi.where()
 
+        # cert_file
+        cert_file = Configuration().cert_file
+
+        # key file
+        key_file = Configuration().key_file
+
         # https pool manager
         self.pool_manager = urllib3.PoolManager(
             num_pools=pools_size,
             cert_reqs=cert_reqs,
-            ca_certs=ca_certs
+            ca_certs=ca_certs,
+            cert_file=cert_file,
+            key_file=key_file
         )
 
     def request(self, method, url, query_params=None, headers=None,


### PR DESCRIPTION
* Added configuration options `cert_file` and `key_file`.
* Tested without issue:
```
-----------------------------------------------------------------
TOTAL                                1257    467    63%
----------------------------------------------------------------------
Ran 28 tests in 37.456s

OK
________________________________________ summary ________________________________________
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)
```