### PR TITLE
The replacement of '{}' charachters in operationId, nickname

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -869,12 +869,9 @@ public class DefaultCodegen {
 
         String operationId = operation.getOperationId();
         if (operationId == null) {
-            String tmpPath = path;
-            tmpPath = tmpPath.replaceAll("\\{", "");
-            tmpPath = tmpPath.replaceAll("\\}", "");
-            String[] parts = (tmpPath + "/" + httpMethod).split("/");
+            String[] parts = (path + "/" + httpMethod).split("/");
             StringBuilder builder = new StringBuilder();
-            if ("/".equals(tmpPath)) {
+            if ("/".equals(path)) {
                 // must be root tmpPath
                 builder.append("root");
             }


### PR DESCRIPTION
The replacement of '{}' charachters was introduced, to get rid of '{}' characters in java names. This code is misplaced here, 'camelize' and 'sanitizeName' methods of 'DefaultCodegen' will take care of this.