### PR TITLE
Add StartAttachListener that fixes #1330

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
                 <version>${surefire-version}</version>
                 <configuration>
                     <testNGArtifactName>none:none</testNGArtifactName>
+                    <argLine>-XX:+StartAttachListener</argLine>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Add `<argLine>-XX:+StartAttachListener</argLine>` to solve the TestNG execution on OSX