### PR TITLE
[Java] Handle enum names starting with number in Java client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -426,7 +426,12 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     private String toEnumVarName(String value) {
-        return value.replaceAll("\\W+", "_").toUpperCase();
+        String var = value.replaceAll("\\W+", "_").toUpperCase();
+        if (var.matches("\\d.*")) {
+            return "_" + var;
+        } else {
+            return var;
+        }
     }
 
     private CodegenModel reconcileInlineEnums(CodegenModel codegenModel, CodegenModel parentCodegenModel) {


### PR DESCRIPTION
Add `_` in front of enum names that start with number, e.g.

```java
public enum PeriodEnum {
  _30M("30m"),
  // ...
}
```