### PR TITLE
Add default initializer to Swift model classes.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -21,6 +21,8 @@ public class {{classname}}: JSONEncodable {
     {{/description}}public var {{name}}: {{{datatype}}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{#required}}!{{/required}}{{/unwrapRequired}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{/isEnum}}
     {{/vars}}
 
+    public init() {}
+
     // MARK: JSONEncodable
     func encodeToJSON() -> AnyObject {
         var nillableDictionary = [String:AnyObject?](){{#vars}}{{#isNotContainer}}{{#isPrimitiveType}}{{^isEnum}}


### PR DESCRIPTION
Current Swift model classes cannot be simply instantiated from user's code. I added default parameterless initializer to create objects to use in POST requests, for example.