### PR TITLE
Fix syntax issue when no auth methods defined

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
@@ -49,16 +49,16 @@ public class ApiClient {
         for(String authName : authNames) {
             if (apiAuthorizations.containsKey(authName)) {
                 throw new RuntimeException("auth name \"" + authName + "\" already in api authorizations");
-            }
-            Interceptor auth;{{#authMethods}}
+            }{{#authMethods}}
+            Interceptor auth;
             if (authName == "{{name}}") { {{#isBasic}}
                 auth = new HttpBasicAuth();{{/isBasic}}{{#isApiKey}}
                 auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}{{#isOAuth}}
                 auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{^-first}}, {{/-first}}{{this}}{{/scopes}}");{{/isOAuth}}
-            } else {{/authMethods}}{
+            } else {
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
             }
-            apiAuthorizations.put(authName, auth);
+            apiAuthorizations.put(authName, auth);{{/authMethods}}
         }
         addAuthsToOkClient(okClient);
     }


### PR DESCRIPTION
When no authentication methods are defined, the generated code does not compile due to where the authMethods closing tag is located. Moved the closing tag further down and opening tag further up so that the generated code is correct both when authentication are and aren't present.