### PR TITLE
Swift Alamofire 3.0

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/AlamofireImplementations.mustache
@@ -75,29 +75,26 @@ class AlamofireRequestBuilder<T>: RequestBuilder<T> {
             request.authenticate(usingCredential: credential)
         }
 
-        request.responseJSON(options: .AllowFragments) { (req, res, result) in
+        request.responseJSON(options: .AllowFragments) { response in
             managerStore.removeValueForKey(managerId)
 
-            if result.isFailure {
-                completion(response: nil, erorr: result.error)
+            if response.result.isFailure {
+                completion(response: nil, erorr: response.result.error)
                 return
             }
 
             if () is T {
-                let response = Response(response: res!, body: () as! T)
-                completion(response: response, erorr: nil)
+                completion(response: Response(response: response.response!, body: () as! T), erorr: nil)
                 return
             }
-            if let json: AnyObject = result.value {
+            if let json: AnyObject = response.result.value {
                 let body = Decoders.decode(clazz: T.self, source: json)
-                let response = Response(response: res!, body: body)
-                completion(response: response, erorr: nil)
+                completion(response: Response(response: response.response!, body: body), erorr: nil)
                 return
             } else if "" is T {
                 // swagger-parser currently doesn't support void, which will be fixed in future swagger-parser release
                 // https://github.com/swagger-api/swagger-parser/pull/34
-                let response = Response(response: res!, body: "" as! T)
-                completion(response: response, erorr: nil)
+                completion(response: Response(response: response.response!, body: "" as! T), erorr: nil)
                 return
             }
 
@@ -113,4 +110,3 @@ class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         return httpHeaders
     }
 }
-

--- a/modules/swagger-codegen/src/main/resources/swift/Cartfile.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Cartfile.mustache
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" >= 2.0.0{{#usePromiseKit}}
+github "Alamofire/Alamofire" >= 3.0.0{{#usePromiseKit}}
 github "mxcl/PromiseKit" >=1.5.3{{/usePromiseKit}}

--- a/modules/swagger-codegen/src/main/resources/swift/Podspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Podspec.mustache
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.documentation_url = '{{podDocumentationURL}}'{{/podDocumentationURL}}
   s.source_files = '{{projectName}}/Classes/Swaggers/**/*.swift'{{#usePromiseKit}}
   s.dependency 'PromiseKit', '~> 2.1'{{/usePromiseKit}}
-  s.dependency 'Alamofire', '~> 2.0.0'
+  s.dependency 'Alamofire', '~> 3.0.0'
 end


### PR DESCRIPTION
Upgrades the AlamofireImplementation to [Alamofire](https://github.com/Alamofire/Alamofire) 3.0. This PR should not cause changes in the generated API. I will later create a PR where new features of Alamofire will be used, but this will cause breaking changes to the generated code.