### PR TITLE
Raw Binary for File Output

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -214,12 +214,14 @@ namespace {{packageName}}.Client
         /// <summary>
         /// Deserialize the JSON string into a proper object.
         /// </summary>
-        /// <param name="content">HTTP body (e.g. string, JSON).</param>
+        /// <param name="response">The HTTP response.</param>
         /// <param name="type">Object type.</param>
-        /// <param name="headers"></param>
         /// <returns>Object representation of the JSON string.</returns>
-        public object Deserialize(string content, Type type, IList<Parameter> headers=null)
+        public object Deserialize(IRestResponse response, Type type)
         {
+            byte[] data = response.RawBytes;
+            string content = response.Content;
+            IList<Parameter> headers = response.Headers;
             if (type == typeof(Object)) // return an object
             {
                 return content;
@@ -227,21 +229,22 @@ namespace {{packageName}}.Client
 
             if (type == typeof(Stream))
             {
-                var filePath = String.IsNullOrEmpty(Configuration.TempFolderPath)
-                    ? Path.GetTempPath()
-                    : Configuration.TempFolderPath;
-
-                var fileName = filePath + Guid.NewGuid();
                 if (headers != null)
                 {
+                    var filePath = String.IsNullOrEmpty(Configuration.TempFolderPath)
+                        ? Path.GetTempPath()
+                        : Configuration.TempFolderPath;
                     var regex = new Regex(@"Content-Disposition:.*filename=['""]?([^'""\s]+)['""]?$");
                     var match = regex.Match(headers.ToString());
                     if (match.Success)
-                        fileName = filePath + match.Value.Replace("\"", "").Replace("'", "");
+                    {
+                        string fileName = filePath + match.Value.Replace("\"", "").Replace("'", "");
+                        File.WriteAllBytes(fileName, data);
+                        return new FileStream(fileName, FileMode.Open);
+                    }
                 }
-                File.WriteAllText(fileName, content);
-                return new FileStream(fileName, FileMode.Open);
-
+                var stream = new MemoryStream(data);
+                return stream;
             }
 
             if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -144,7 +144,7 @@ namespace {{packageName}}.Api
             else if (((int)response.StatusCode) == 0)
                 throw new ApiException ((int)response.StatusCode, "Error calling {{nickname}}: " + response.ErrorMessage, response.ErrorMessage);
     
-            {{#returnType}}return ({{{returnType}}}) ApiClient.Deserialize(response.Content, typeof({{{returnType}}}), response.Headers);{{/returnType}}{{^returnType}}return;{{/returnType}}
+            {{#returnType}}return ({{{returnType}}}) ApiClient.Deserialize(response, typeof({{{returnType}}}));{{/returnType}}{{^returnType}}return;{{/returnType}}
         }
     
         /// <summary>
@@ -197,7 +197,7 @@ namespace {{packageName}}.Api
             if (((int)response.StatusCode) >= 400)
                 throw new ApiException ((int)response.StatusCode, "Error calling {{nickname}}: " + response.Content, response.Content);
 
-            {{#returnType}}return ({{{returnType}}}) ApiClient.Deserialize(response.Content, typeof({{{returnType}}}), response.Headers);{{/returnType}}{{^returnType}}
+            {{#returnType}}return ({{{returnType}}}) ApiClient.Deserialize(response, typeof({{{returnType}}}));{{/returnType}}{{^returnType}}
             return;{{/returnType}}
         }
         {{/operation}}


### PR DESCRIPTION
Changing Stream deserialization to use raw bytes from response, rather than UTF-8 decoded text.

Specifically, when an endpoint returns a PDF as a byte stream in the response, decoding as UTF-8 (as in RestResponse.Contents) will cause the results to be mangled.