### PR TITLE
ApiException doesn't use deserialized data

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
@@ -246,7 +246,7 @@ class ApiClient
 
             throw new ApiException(
                 "[".$response_info['http_code']."] Error connecting to the API ($url)",
-                $response_info['http_code'], $http_header, $http_body
+                $response_info['http_code'], $http_header, $data
             );
         }
         return array($data, $http_header);


### PR DESCRIPTION
This is a fix for #1394. I had not merged the data correctly after the rebase