### PR TITLE
made selective generation of models

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -36,6 +36,7 @@ import config.Config;
 import config.ConfigParser;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
@@ -112,6 +113,9 @@ public class CodeGenMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private boolean addCompileSourceRoot = true;
 
+    @Parameter
+    protected Map<String, String> environmentVariables = new HashMap<String, String>();
+
     /**
      * The project being built.
      */
@@ -124,6 +128,12 @@ public class CodeGenMojo extends AbstractMojo {
 
         CodegenConfig config = CodegenConfigLoader.forName(language);
         config.setOutputDir(output.getAbsolutePath());
+
+        if (environmentVariables != null) {
+            for(String key : environmentVariables.keySet()) {
+                System.setProperty(key, environmentVariables.get(key));
+            }
+        }
 
         if (null != templateDirectory) {
             config.additionalProperties().put(TEMPLATE_DIR_PARAM, templateDirectory.getAbsolutePath());

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -62,27 +62,27 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         // allows generating only models by specifying a CSV of models to generate, or empty for all
         if(System.getProperty("models") != null) {
             String modelNames = System.getProperty("models");
+            generateModels = true;
             if(!modelNames.isEmpty()) {
-                generateModels = true;
                 modelsToGenerate = new HashSet<String>(Arrays.asList(modelNames.split(",")));
             }
         }
         if(System.getProperty("apis") != null) {
             String apiNames = System.getProperty("apis");
+            generateApis = true;
             if(!apiNames.isEmpty()) {
-                generateApis = true;
                 apisToGenerate = new HashSet<String>(Arrays.asList(apiNames.split(",")));
             }
         }
         if(System.getProperty("supportingFiles") != null) {
             String supportingFiles = System.getProperty("supportingFiles");
+            generateSupportingFiles = true;
             if(!supportingFiles.isEmpty()) {
-                generateSupportingFiles = true;
                 supportingFilesToGenerate = new HashSet<String>(Arrays.asList(supportingFiles.split(",")));
             }
         }
 
-        if(generateApis == null && apisToGenerate == null && supportingFilesToGenerate == null) {
+        if(generateApis == null && generateModels == null && generateSupportingFiles == null) {
             // no specifics are set, generate everything
             generateApis = true; generateModels = true; generateSupportingFiles = true;
         }
@@ -178,7 +178,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         	List<String> sortedModelKeys = sortModelsByInheritance(definitions);
 
             if(generateModels) {
-                if(modelsToGenerate != null) {
+                if(modelsToGenerate != null && modelsToGenerate.size() > 0) {
                     List<String> updatedKeys = new ArrayList<String>();
                     for(String m : sortedModelKeys) {
                         if(modelsToGenerate.contains(m)) {
@@ -237,7 +237,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         // apis
         Map<String, List<CodegenOperation>> paths = processPaths(swagger.getPaths());
         if(generateApis) {
-            if(apisToGenerate != null) {
+            if(apisToGenerate != null && apisToGenerate.size() > 0) {
                 Map<String, List<CodegenOperation>> updatedPaths = new TreeMap<String, List<CodegenOperation>>();
                 for(String m : paths.keySet()) {
                     if(apisToGenerate.contains(m)) {
@@ -359,7 +359,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     String templateFile = getFullTemplateFile(config, support.templateFile);
 
                     boolean shouldGenerate = true;
-                    if(supportingFilesToGenerate != null) {
+                    if(supportingFilesToGenerate != null && supportingFilesToGenerate.size() > 0) {
                         if(supportingFilesToGenerate.contains(support.destinationFilename)) {
                             shouldGenerate = true;
                         }


### PR DESCRIPTION
You can now generate code for a specific model by passing `-Dmodels=User,Pet,Category` to the generator.  When specifying a set of models only, operations and supporting files are *not* generated.