### PR TITLE
Ensure hasMore is updated when reconciling enum properties from parent

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -507,6 +507,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
             List<CodegenProperty> codegenProperties = codegenModel.vars;
 
             // Iterate over all of the parent model properties
+            boolean removedChildEnum = false;
             for (CodegenProperty parentModelCodegenPropery : parentModelCodegenProperties) {
                 // Look for enums
                 if (parentModelCodegenPropery.isEnum) {
@@ -519,12 +520,21 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
                             // We found an enum in the child class that is
                             // a duplicate of the one in the parent, so remove it.
                             iterator.remove();
+                            removedChildEnum = true;
                         }
                     }
                 }
             }
-
-            codegenModel.vars = codegenProperties;
+            
+            if(removedChildEnum) {
+                // If we removed an entry from this model's vars, we need to ensure hasMore is updated
+                int count = 0, numVars = codegenProperties.size();
+                for(CodegenProperty codegenProperty : codegenProperties) {
+                    count += 1;
+                    codegenProperty.hasMore = (count < numVars) ? true : null;
+                }
+                codegenModel.vars = codegenProperties;
+            }
         }
 
         return codegenModel;


### PR DESCRIPTION
Fixes #1429 

Using the spec from the issue, Child now looks like:

```json
{
  "model" : {
    "parent" : "Parent",
    "name" : "Child",
    "classname" : "Child",
    "classVarName" : "child",
    "modelJson" : "{\n  \"allOf\" : [ {\n    \"$ref\" : \"#/definitions/Parent\"\n  }, {\n    \"properties\" : {\n      \"childProp\" : {\n        \"type\" : \"string\"\n      }\n    }\n  } ]\n}",
    "vars" : [ {
      "baseName" : "id",
      "getter" : "getId",
      "setter" : "setId",
      "datatype" : "String",
      "datatypeWithEnum" : "String",
      "name" : "id",
      "defaultValue" : "null",
      "baseType" : "String",
      "jsonSchema" : "{\n  \"type\" : \"string\"\n}",
      "hasMore" : true,
      "isPrimitiveType" : true,
      "isNotContainer" : true,
      "isEnum" : false
    }, {
      "baseName" : "childProp",
      "getter" : "getChildProp",
      "setter" : "setChildProp",
      "datatype" : "String",
      "datatypeWithEnum" : "String",
      "name" : "childProp",
      "defaultValue" : "null",
      "baseType" : "String",
      "jsonSchema" : "{\n  \"type\" : \"string\"\n}",
      "hasMore" : true,
      "isPrimitiveType" : true,
      "isNotContainer" : true,
      "isEnum" : false
    }, {
      "baseName" : "error",
      "getter" : "getError",
      "setter" : "setError",
      "datatype" : "String",
      "datatypeWithEnum" : "String",
      "name" : "error",
      "defaultValue" : "null",
      "baseType" : "String",
      "jsonSchema" : "{\n  \"type\" : \"string\"\n}",
      "isPrimitiveType" : true,
      "isNotContainer" : true,
      "isEnum" : false
    } ],
    "imports" : [ "Parent" ],
    "hasVars" : true,
    "hasEnums" : true
  },
  "importPath" : "io.swagger.model.Child"
}
```

Notice the `hasMore` attribute on the error var is now gone. 