### PR TITLE
Better error message for empty operationId

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -531,7 +531,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         + "  Tag: " + tag + "\n"//
                         + "  Operation: " + operation.getOperationId() + "\n" //
                         + "  Resource: " + httpMethod + " " + resourcePath + "\n"//
-                        + "  Definitions: " + swagger.getDefinitions();
+                        + "  Definitions: " + swagger.getDefinitions() + "\n"  //
+                        + "  Exception: " + ex.getMessage();
                     throw new RuntimeException(msg, ex);
                 }
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -378,7 +378,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
     public String toOperationId(String operationId) {
         // throw exception if method name is empty
         if (StringUtils.isEmpty(operationId)) {
-            throw new RuntimeException("Empty method name (operationId) not allowed");
+            throw new RuntimeException("Empty method/operation name (operationId) not allowed");
         }
 
         // method name cannot use reserved keyword, e.g. return


### PR DESCRIPTION
Include exception message showing `Empty method/operation name (operationId) not allowed`:
```
reading from https://raw.githubusercontent.com/kinlane/api-stack/gh-pages/data/google/google-spreadsheets-swagger.json
Exception in thread "main" java.lang.RuntimeException: Could not process operation:
  Tag: 
  Operation: 
  Resource: get /accounts
  Definitions: {}
  Exception: Empty method/operation name (operationId) not allowed
	at io.swagger.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:536)
	at io.swagger.codegen.DefaultGenerator.processPaths(DefaultGenerator.java:423)
	at io.swagger.codegen.DefaultGenerator.generate(DefaultGenerator.java:189)
	at io.swagger.codegen.cmd.Generate.run(Generate.java:188)
	at io.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:35)
Caused by: java.lang.RuntimeException: Empty method/operation name (operationId) not allowed
	at io.swagger.codegen.languages.JavaClientCodegen.toOperationId(JavaClientCodegen.java:381)
	at io.swagger.codegen.DefaultCodegen.fromOperation(DefaultCodegen.java:907)
	at io.swagger.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:478)
	... 4 more
```

