### PR TITLE
Swift enum names capitalization follows Swift convention.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -15,6 +15,7 @@ import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.WordUtils;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -236,7 +237,7 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
       List<String> values = (List<String>) codegenProperty.allowableValues.get("values");
       for (String value : values) {
         Map<String, String> map = new HashMap<String, String>();
-        map.put("enum", StringUtils.capitalize(value));
+        map.put("enum", toSwiftyEnumName(value));
         map.put("raw", value);
         swiftEnums.add(map);
       }
@@ -249,6 +250,16 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
     }
     return codegenProperty;
   }
+
+    public String toSwiftyEnumName(String value) {
+        // Prevent from breaking properly cased identifier
+        if (value.matches("[A-Z][a-z0-9]+[a-zA-Z0-9]*")) {
+            return value;
+        }
+        char[] separators = {'-', '_', ' '};
+        return WordUtils.capitalizeFully(StringUtils.lowerCase(value), separators).replaceAll("[-_ ]", "");
+    }
+
 
   @Override
   public String toApiName(String name) {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/SwiftCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/SwiftCodegenTest.java
@@ -1,0 +1,45 @@
+package io.swagger.codegen.languages;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SwiftCodegenTest {
+
+    SwiftCodegen swiftCodegen = new SwiftCodegen();
+
+    @Test
+    public void shouldNotBreakCorrectName() throws Exception {
+        Assert.assertEquals(swiftCodegen.toSwiftyEnumName("EntryName"), "EntryName");
+    }
+
+    @Test
+    public void testSingleWordAllCaps() throws Exception {
+        Assert.assertEquals(swiftCodegen.toSwiftyEnumName("VALUE"), "Value");
+    }
+
+    @Test
+    public void testSingleWordLowercase() throws Exception {
+        Assert.assertEquals(swiftCodegen.toSwiftyEnumName("value"), "Value");
+    }
+
+    @Test
+    public void testCapitalsWithUnderscore() throws Exception {
+        Assert.assertEquals(swiftCodegen.toSwiftyEnumName("ENTRY_NAME"), "EntryName");
+    }
+
+    @Test
+    public void testCapitalsWithDash() throws Exception {
+        Assert.assertEquals(swiftCodegen.toSwiftyEnumName("ENTRY-NAME"), "EntryName");
+    }
+
+    @Test
+    public void testCapitalsWithSpace() throws Exception {
+        Assert.assertEquals(swiftCodegen.toSwiftyEnumName("ENTRY NAME"), "EntryName");
+    }
+
+    @Test
+    public void testLowercaseWithUnderscore() throws Exception {
+        Assert.assertEquals(swiftCodegen.toSwiftyEnumName("entry_name"), "EntryName");
+    }
+
+}


### PR DESCRIPTION
Here is a solution for #1420 that I have reported. I introduced unit test for SwiftCodegen which documents the behavior by the way.