### PR TITLE
[Java] Assign default value for primitive properties

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -13,6 +13,9 @@ import io.swagger.codegen.SupportingFile;
 import io.swagger.models.Model;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
@@ -349,17 +352,36 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
                 pattern = "new HashMap<String, %s>()";
             }
             return String.format(pattern, getTypeDeclaration(ap.getAdditionalProperties()));
+        } else if (p instanceof IntegerProperty) {
+            IntegerProperty dp = (IntegerProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+            return "null";
         } else if (p instanceof LongProperty) {
             LongProperty dp = (LongProperty) p;
             if (dp.getDefault() != null) {
                 return dp.getDefault().toString()+"l";
             }
            return "null";
+        } else if (p instanceof DoubleProperty) {
+            DoubleProperty dp = (DoubleProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString() + "d";
+            }
+            return "null";
+        } else if (p instanceof FloatProperty) {
+            FloatProperty dp = (FloatProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString() + "f";
+            }
+            return "null";
         } else if (p instanceof BooleanProperty) {
             BooleanProperty bp = (BooleanProperty) p;
             if (bp.getDefault() != null) {
                 return bp.getDefault().toString();
             }
+            return "null";
         } else if (p instanceof StringProperty) {
             StringProperty sp = (StringProperty) p;
             if (sp.getDefault() != null) {
@@ -371,6 +393,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
                     return _default;
                 }
             }
+            return "null";
         }
         return super.toDefaultValue(p);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
@@ -2,7 +2,9 @@ package io.swagger.codegen.languages;
 
 import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.models.Operation;
@@ -119,6 +121,22 @@ public class JavaInflectorServerCodegen extends JavaClientCodegen implements Cod
         }
         opList.add(co);
         co.baseName = basePath;
+    }
+
+    @Override
+    public Map<String, Object> postProcessModels(Map<String, Object> objs) {
+        List<Object> models = (List<Object>) objs.get("models");
+        for (Object _mo : models) {
+            Map<String, Object> mo = (Map<String, Object>) _mo;
+            CodegenModel cm = (CodegenModel) mo.get("model");
+            for (CodegenProperty var : cm.vars) {
+                // handle default value for enum, e.g. available => StatusEnum.available
+                if (var.isEnum && var.defaultValue != null && !"null".equals(var.defaultValue)) {
+                    var.defaultValue = var.datatypeWithEnum + "." + var.defaultValue;
+                }
+            }
+        }
+        return objs;
     }
 
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
@@ -2,11 +2,15 @@ package io.swagger.codegen.languages;
 
 import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.CodegenResponse;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.models.Operation;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -112,6 +116,22 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
         }
         opList.add(co);
         co.baseName = basePath;
+    }
+
+    @Override
+    public Map<String, Object> postProcessModels(Map<String, Object> objs) {
+        List<Object> models = (List<Object>) objs.get("models");
+        for (Object _mo : models) {
+            Map<String, Object> mo = (Map<String, Object>) _mo;
+            CodegenModel cm = (CodegenModel) mo.get("model");
+            for (CodegenProperty var : cm.vars) {
+                // handle default value for enum, e.g. available => StatusEnum.available
+                if (var.isEnum && var.defaultValue != null && !"null".equals(var.defaultValue)) {
+                    var.defaultValue = var.datatypeWithEnum + "." + var.defaultValue;
+                }
+            }
+        }
+        return objs;
     }
 
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
@@ -193,6 +193,17 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
             String _import = iterator.next().get("import");
             if (_import.endsWith(".Object")) iterator.remove();
         }
+        List<Object> models = (List<Object>) objs.get("models");
+        for (Object _mo : models) {
+            Map<String, Object> mo = (Map<String, Object>) _mo;
+            CodegenModel cm = (CodegenModel) mo.get("model");
+            for (CodegenProperty var : cm.vars) {
+                // handle default value for enum, e.g. available => StatusEnum.available
+                if (var.isEnum && var.defaultValue != null && !"null".equals(var.defaultValue)) {
+                    var.defaultValue = var.datatypeWithEnum + "." + var.defaultValue;
+                }
+            }
+        }
         return objs;
     }
 }


### PR DESCRIPTION
Assign default value (if present)  for primitive properties in Java-related client and server codegen. See  #1448
For example:

```java
Integer pageSize = 100;
Long max = 10000l;
Float myFloat = 1.2f;
Double myDouble = 3.4d;
String message = "Hello";
Boolean published = false;
StatusEnum status = StatunEnum.AVAILABLE;
```