### PR TITLE
processOptions tests have been added for the rest of languages

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -42,4 +42,5 @@ public class CodegenConstants {
 
     public static final String PACKAGE_NAME = "packageName";
     public static final String PACKAGE_VERSION = "packageVersion";
+    public static final String POD_VERSION = "podVersion";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -2,6 +2,7 @@ package io.swagger.codegen.languages;
 
 import io.swagger.codegen.CliOption;
 import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.DefaultCodegen;
@@ -19,6 +20,12 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 
 public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
+    public static final String CLASS_PREFIX = "classPrefix";
+    public static final String POD_NAME = "podName";
+    public static final String AUTHOR_NAME = "authorName";
+    public static final String AUTHOR_EMAIL = "authorEmail";
+    public static final String GIT_REPO_URL = "gitRepoURL";
+    public static final String LICENSE = "license";
     protected Set<String> foundationClasses = new HashSet<String>();
     protected String podName = "SwaggerClient";
     protected String podVersion = "1.0.0";
@@ -113,13 +120,13 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         instantiationTypes.put("map", "NSMutableDictionary");
 
         cliOptions.clear();
-        cliOptions.add(new CliOption("classPrefix", "prefix for generated classes (convention: Abbreviation of pod name e.g. `HN` for `HackerNews`), default: `SWG`"));
-        cliOptions.add(new CliOption("podName", "cocoapods package name (convention: CameCase), default: `SwaggerClient`"));
-        cliOptions.add(new CliOption("podVersion", "cocoapods package version, default: `1.0.0`"));
-        cliOptions.add(new CliOption("authorName", "Name to use in the podspec file, default: `Swagger`"));
-        cliOptions.add(new CliOption("authorEmail", "Email to use in the podspec file, default: `apiteam@swagger.io`"));
-        cliOptions.add(new CliOption("gitRepoURL", "URL for the git repo where this podspec should point to, default: `https://github.com/swagger-api/swagger-codegen`"));
-        cliOptions.add(new CliOption("license", "License to use in the podspec file, default: `MIT`"));
+        cliOptions.add(new CliOption(CLASS_PREFIX, "prefix for generated classes (convention: Abbreviation of pod name e.g. `HN` for `HackerNews`), default: `SWG`"));
+        cliOptions.add(new CliOption(POD_NAME, "cocoapods package name (convention: CameCase), default: `SwaggerClient`"));
+        cliOptions.add(new CliOption(CodegenConstants.POD_VERSION, "cocoapods package version, default: `1.0.0`"));
+        cliOptions.add(new CliOption(AUTHOR_NAME, "Name to use in the podspec file, default: `Swagger`"));
+        cliOptions.add(new CliOption(AUTHOR_EMAIL, "Email to use in the podspec file, default: `apiteam@swagger.io`"));
+        cliOptions.add(new CliOption(GIT_REPO_URL, "URL for the git repo where this podspec should point to, default: `https://github.com/swagger-api/swagger-codegen`"));
+        cliOptions.add(new CliOption(LICENSE, "License to use in the podspec file, default: `MIT`"));
     }
 
     public CodegenType getTag() {
@@ -138,41 +145,41 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.containsKey("podName")) {
-            setPodName((String) additionalProperties.get("podName"));
+        if (additionalProperties.containsKey(POD_NAME)) {
+            setPodName((String) additionalProperties.get(POD_NAME));
         }
 
-        if (additionalProperties.containsKey("podVersion")) {
-            setPodVersion((String) additionalProperties.get("podVersion"));
+        if (additionalProperties.containsKey(CodegenConstants.POD_VERSION)) {
+            setPodVersion((String) additionalProperties.get(CodegenConstants.POD_VERSION));
         }
 
-        if (additionalProperties.containsKey("classPrefix")) {
-            setClassPrefix((String) additionalProperties.get("classPrefix"));
+        if (additionalProperties.containsKey(CLASS_PREFIX)) {
+            setClassPrefix((String) additionalProperties.get(CLASS_PREFIX));
         }
         
-        if (additionalProperties.containsKey("authorName")) {
-            setAuthorName((String) additionalProperties.get("authorName"));
+        if (additionalProperties.containsKey(AUTHOR_NAME)) {
+            setAuthorName((String) additionalProperties.get(AUTHOR_NAME));
         }
         
-        if (additionalProperties.containsKey("authorEmail")) {
-            setAuthorEmail((String) additionalProperties.get("authorEmail"));
+        if (additionalProperties.containsKey(AUTHOR_EMAIL)) {
+            setAuthorEmail((String) additionalProperties.get(AUTHOR_EMAIL));
         }
         
-        if (additionalProperties.containsKey("gitRepoURL")) {
-            setGitRepoURL((String) additionalProperties.get("gitRepoURL"));
+        if (additionalProperties.containsKey(GIT_REPO_URL)) {
+            setGitRepoURL((String) additionalProperties.get(GIT_REPO_URL));
         }
         
-        if (additionalProperties.containsKey("license")) {
-            setLicense((String) additionalProperties.get("license"));
+        if (additionalProperties.containsKey(LICENSE)) {
+            setLicense((String) additionalProperties.get(LICENSE));
         }
 
-        additionalProperties.put("podName", podName);
-        additionalProperties.put("podVersion", podVersion);
-        additionalProperties.put("classPrefix", classPrefix);
-        additionalProperties.put("authorName", authorName);
-        additionalProperties.put("authorEmail", authorEmail);
-        additionalProperties.put("gitRepoURL", gitRepoURL);
-        additionalProperties.put("license", license);
+        additionalProperties.put(POD_NAME, podName);
+        additionalProperties.put(CodegenConstants.POD_VERSION, podVersion);
+        additionalProperties.put(CLASS_PREFIX, classPrefix);
+        additionalProperties.put(AUTHOR_NAME, authorName);
+        additionalProperties.put(AUTHOR_EMAIL, authorEmail);
+        additionalProperties.put(GIT_REPO_URL, gitRepoURL);
+        additionalProperties.put(LICENSE, license);
 
         String swaggerFolder = podName;
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PerlClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PerlClientCodegen.java
@@ -16,6 +16,8 @@ import java.util.HashSet;
 import org.apache.commons.lang.StringUtils;
 
 public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
+    public static final String MODULE_NAME = "moduleName";
+    public static final String MODULE_VERSION = "moduleVersion";
     protected String moduleName = "SwaggerClient";
     protected String moduleVersion = "1.0.0";
 
@@ -68,8 +70,8 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("object", "object");
 
         cliOptions.clear();
-        cliOptions.add(new CliOption("moduleName", "perl module name (convention: CamelCase), default: SwaggerClient"));
-        cliOptions.add(new CliOption("moduleVersion", "perl module version, default: 1.0.0"));
+        cliOptions.add(new CliOption(MODULE_NAME, "perl module name (convention: CamelCase), default: SwaggerClient"));
+        cliOptions.add(new CliOption(MODULE_VERSION, "perl module version, default: 1.0.0"));
     }
 
 
@@ -77,16 +79,16 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.containsKey("moduleVersion")) {
-            moduleVersion = (String) additionalProperties.get("moduleVersion");
+        if (additionalProperties.containsKey(MODULE_VERSION)) {
+            setModuleVersion((String) additionalProperties.get(MODULE_VERSION));
         } else {
-            additionalProperties.put("moduleVersion", moduleVersion);
+            additionalProperties.put(MODULE_VERSION, moduleVersion);
         }
 
-        if (additionalProperties.containsKey("moduleName")) {
-            moduleName = (String) additionalProperties.get("moduleName");
+        if (additionalProperties.containsKey(MODULE_NAME)) {
+            setModuleName((String) additionalProperties.get(MODULE_NAME));
         } else {
-            additionalProperties.put("moduleName", moduleName);
+            additionalProperties.put(MODULE_NAME, moduleName);
         }
 
         supportingFiles.add(new SupportingFile("ApiClient.mustache", ("lib/WWW/" + moduleName).replace('/', File.separatorChar), "ApiClient.pm"));
@@ -229,5 +231,11 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
         return underscore(operationId);
     }
 
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
 
+    public void setModuleVersion(String moduleVersion) {
+        this.moduleVersion = moduleVersion;
+    }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Iterator;
 
 public class SpringMVCServerCodegen extends JavaClientCodegen implements CodegenConfig {
+    public static final String CONFIG_PACKAGE = "configPackage";
     protected String title = "Petstore Server";
     protected String configPackage = "";
 
@@ -36,7 +37,7 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
         additionalProperties.put(CodegenConstants.ARTIFACT_VERSION, artifactVersion);
         additionalProperties.put("title", title);
         additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
-        additionalProperties.put("configPackage", configPackage);
+        additionalProperties.put(CONFIG_PACKAGE, configPackage);
 
         languageSpecificPrimitives = new HashSet<String>(
                 Arrays.asList(
@@ -49,8 +50,7 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
                         "Float")
         );
 
-        cliOptions.add(new CliOption("configPackage", "configuration package for generated code"));
-
+        cliOptions.add(new CliOption(CONFIG_PACKAGE, "configuration package for generated code"));
     }
 
     public CodegenType getTag() {
@@ -69,8 +69,8 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.containsKey("configPackage")) {
-            this.setConfigPackage((String) additionalProperties.get("configPackage"));
+        if (additionalProperties.containsKey(CONFIG_PACKAGE)) {
+            this.setConfigPackage((String) additionalProperties.get(CONFIG_PACKAGE));
         }
 
         supportingFiles.clear();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -24,13 +24,26 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
-  private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{[a-zA-Z_]+\\}");
+  public static final String PROJECT_NAME = "projectName";
+  public static final String RESPONSE_AS = "responseAs";
+  public static final String UNWRAP_REQUIRED = "unwrapRequired";
+  public static final String POD_SOURCE = "podSource";
+  public static final String POD_AUTHORS = "podAuthors";
+  public static final String POD_SOCIAL_MEDIA_URL = "podSocialMediaURL";
+  public static final String POD_DOCSET_URL = "podDocsetURL";
+  public static final String POD_LICENSE = "podLicense";
+  public static final String POD_HOMEPAGE = "podHomepage";
+  public static final String POD_SUMMARY = "podSummary";
+  public static final String POD_DESCRIPTION = "podDescription";
+  public static final String POD_SCREENSHOTS = "podScreenshots";
+  public static final String POD_DOCUMENTATION_URL = "podDocumentationURL";
   protected static final String LIBRARY_PROMISE_KIT = "PromiseKit";
   protected static final String[] RESPONSE_LIBRARIES = { LIBRARY_PROMISE_KIT };
   protected String projectName = "SwaggerClient";
   protected boolean unwrapRequired = false;
   protected String[] responseAs = new String[0];
   protected String sourceFolder = "Classes" + File.separator + "Swaggers";
+  private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{[a-zA-Z_]+\\}");
 
   public CodegenType getTag() {
     return CodegenType.CLIENT;
@@ -107,22 +120,22 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
 
     importMapping = new HashMap<String, String>();
 
-    cliOptions.add(new CliOption("projectName", "Project name in Xcode"));
-    cliOptions.add(new CliOption("responseAs", "Optionally use libraries to manage response.  Currently " +
+    cliOptions.add(new CliOption(PROJECT_NAME, "Project name in Xcode"));
+    cliOptions.add(new CliOption(RESPONSE_AS, "Optionally use libraries to manage response.  Currently " +
             StringUtils.join(RESPONSE_LIBRARIES, ", ") + " are available."));
-    cliOptions.add(new CliOption("unwrapRequired", "Treat 'required' properties in response as non-optional " +
+    cliOptions.add(new CliOption(UNWRAP_REQUIRED, "Treat 'required' properties in response as non-optional " +
             "(which would crash the app if api returns null as opposed to required option specified in json schema"));
-    cliOptions.add(new CliOption("podSource", "Source information used for Podspec"));
-    cliOptions.add(new CliOption("podVersion", "Version used for Podspec"));
-    cliOptions.add(new CliOption("podAuthors", "Authors used for Podspec"));
-    cliOptions.add(new CliOption("podSocialMediaURL", "Social Media URL used for Podspec"));
-    cliOptions.add(new CliOption("podDocsetURL", "Docset URL used for Podspec"));
-    cliOptions.add(new CliOption("podLicense", "License used for Podspec"));
-    cliOptions.add(new CliOption("podHomepage", "Homepage used for Podspec"));
-    cliOptions.add(new CliOption("podSummary", "Summary used for Podspec"));
-    cliOptions.add(new CliOption("podDescription", "Description used for Podspec"));
-    cliOptions.add(new CliOption("podScreenshots", "Screenshots used for Podspec"));
-    cliOptions.add(new CliOption("podDocumentationURL", "Documentation URL used for Podspec"));
+    cliOptions.add(new CliOption(POD_SOURCE, "Source information used for Podspec"));
+    cliOptions.add(new CliOption(CodegenConstants.POD_VERSION, "Version used for Podspec"));
+    cliOptions.add(new CliOption(POD_AUTHORS, "Authors used for Podspec"));
+    cliOptions.add(new CliOption(POD_SOCIAL_MEDIA_URL, "Social Media URL used for Podspec"));
+    cliOptions.add(new CliOption(POD_DOCSET_URL, "Docset URL used for Podspec"));
+    cliOptions.add(new CliOption(POD_LICENSE, "License used for Podspec"));
+    cliOptions.add(new CliOption(POD_HOMEPAGE, "Homepage used for Podspec"));
+    cliOptions.add(new CliOption(POD_SUMMARY, "Summary used for Podspec"));
+    cliOptions.add(new CliOption(POD_DESCRIPTION, "Description used for Podspec"));
+    cliOptions.add(new CliOption(POD_SCREENSHOTS, "Screenshots used for Podspec"));
+    cliOptions.add(new CliOption(POD_DOCUMENTATION_URL, "Documentation URL used for Podspec"));
   }
 
   @Override
@@ -130,29 +143,29 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
     super.processOpts();
 
     // Setup project name
-    if (additionalProperties.containsKey("projectName")) {
-      projectName = (String) additionalProperties.get("projectName");
+    if (additionalProperties.containsKey(PROJECT_NAME)) {
+      setProjectName((String) additionalProperties.get(PROJECT_NAME));
     } else {
-      additionalProperties.put("projectName", projectName);
+      additionalProperties.put(PROJECT_NAME, projectName);
     }
     sourceFolder = projectName + File.separator + sourceFolder;
 
     // Setup unwrapRequired option, which makes all the properties with "required" non-optional
-    if (additionalProperties.containsKey("unwrapRequired")) {
-      unwrapRequired = Boolean.parseBoolean(String.valueOf(additionalProperties.get("unwrapRequired")));
+    if (additionalProperties.containsKey(UNWRAP_REQUIRED)) {
+      setUnwrapRequired(Boolean.parseBoolean(String.valueOf(additionalProperties.get(UNWRAP_REQUIRED))));
     }
-    additionalProperties.put("unwrapRequired", unwrapRequired);
+    additionalProperties.put(UNWRAP_REQUIRED, unwrapRequired);
 
     // Setup unwrapRequired option, which makes all the properties with "required" non-optional
-    if (additionalProperties.containsKey("responseAs")) {
-      Object responseAsObject = additionalProperties.get("responseAs");
+    if (additionalProperties.containsKey(RESPONSE_AS)) {
+      Object responseAsObject = additionalProperties.get(RESPONSE_AS);
       if (responseAsObject instanceof String) {
-        responseAs = ((String)responseAsObject).split(",");
+        setResponseAs(((String)responseAsObject).split(","));
       } else {
-        responseAs = (String[]) responseAsObject;
+        setResponseAs((String[]) responseAsObject);
       }
     }
-    additionalProperties.put("responseAs", responseAs);
+    additionalProperties.put(RESPONSE_AS, responseAs);
     if (ArrayUtils.contains(responseAs, LIBRARY_PROMISE_KIT)) {
       additionalProperties.put("usePromiseKit", true);
     }
@@ -307,5 +320,17 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
     builder.append(stringAfterMatch);
 
     return builder.toString();
+  }
+
+  public void setProjectName(String projectName) {
+    this.projectName = projectName;
+  }
+
+  public void setUnwrapRequired(boolean unwrapRequired) {
+    this.unwrapRequired = unwrapRequired;
+  }
+
+  public void setResponseAs(String[] responseAs) {
+    this.responseAs = responseAs;
   }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/akkascala/AkkaScalaClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/akkascala/AkkaScalaClientOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.akkascala;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.AkkaScalaClientCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class AkkaScalaClientOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private AkkaScalaClientCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/asyncscala/AsyncScalaClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/asyncscala/AsyncScalaClientOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.asyncscala;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.AsyncScalaClientCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class AsyncScalaClientOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private AsyncScalaClientCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/inflector/JavaInflectorServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/inflector/JavaInflectorServerOptionsTest.java
@@ -1,0 +1,49 @@
+package io.swagger.codegen.inflector;
+
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.java.JavaClientOptionsTest;
+import io.swagger.codegen.languages.JavaInflectorServerCodegen;
+
+import mockit.Expectations;
+import mockit.Tested;
+
+public class JavaInflectorServerOptionsTest extends JavaClientOptionsTest {
+
+    @Tested
+    private JavaInflectorServerCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+            clientCodegen.setInvokerPackage(INVOKER_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setGroupId(GROUP_ID_VALUE);
+            times = 1;
+            clientCodegen.setArtifactId(ARTIFACT_ID_VALUE);
+            times = 1;
+            clientCodegen.setArtifactVersion(ARTIFACT_VERSION_VALUE);
+            times = 1;
+            clientCodegen.setSourceFolder(SOURCE_FOLDER_VALUE);
+            times = 1;
+            clientCodegen.setLocalVariablePrefix(LOCAL_PREFIX_VALUE);
+            times = 1;
+            clientCodegen.setSerializableModel(Boolean.valueOf(SERIALIZABLE_MODEL_VALUE));
+            times = 1;
+            clientCodegen.setLibrary(LIBRARY_VALUE);
+            times = 1;
+            clientCodegen.setFullJavaUtil(Boolean.valueOf(FULL_JAVA_UTIL_VALUE));
+            times = 1;
+        }};
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/objc/ObjcClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/objc/ObjcClientOptionsTest.java
@@ -1,0 +1,63 @@
+package io.swagger.codegen.objc;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.ObjcClientCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class ObjcClientOptionsTest extends AbstractOptionsTest {
+    private static final String CLASS_PREFIX_VALUE = "SWGObjc";
+    private static final String POD_NAME_VALUE = "SwaggerClientObjc";
+    private static final String POD_VERSION_VALUE = "1.0.0-SNAPSHOT";
+    private static final String AUTHOR_NAME_VALUE = "SwaggerObjc";
+    private static final String AUTHOR_EMAIL_VALUE = "objc@swagger.io";
+    private static final String GIT_REPO_URL_VALUE = "https://github.com/swagger-api/swagger-codegen";
+    private static final String LICENSE_VALUE = "MIT";
+
+    @Tested
+    private ObjcClientCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setClassPrefix(CLASS_PREFIX_VALUE);
+            times = 1;
+            clientCodegen.setPodName(POD_NAME_VALUE);
+            times = 1;
+            clientCodegen.setPodVersion(POD_VERSION_VALUE);
+            times = 1;
+            clientCodegen.setAuthorName(AUTHOR_NAME_VALUE);
+            times = 1;
+            clientCodegen.setAuthorEmail(AUTHOR_EMAIL_VALUE);
+            times = 1;
+            clientCodegen.setGitRepoURL(GIT_REPO_URL_VALUE);
+            times = 1;
+            clientCodegen.setLicense(LICENSE_VALUE);
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(ObjcClientCodegen.CLASS_PREFIX, CLASS_PREFIX_VALUE)
+                .put(ObjcClientCodegen.POD_NAME, POD_NAME_VALUE)
+                .put(CodegenConstants.POD_VERSION, POD_VERSION_VALUE)
+                .put(ObjcClientCodegen.AUTHOR_NAME, AUTHOR_NAME_VALUE)
+                .put(ObjcClientCodegen.AUTHOR_EMAIL, AUTHOR_EMAIL_VALUE)
+                .put(ObjcClientCodegen.GIT_REPO_URL, GIT_REPO_URL_VALUE)
+                .put(ObjcClientCodegen.LICENSE, LICENSE_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/perl/PerlClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/perl/PerlClientOptionsTest.java
@@ -1,0 +1,43 @@
+package io.swagger.codegen.perl;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.PerlClientCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class PerlClientOptionsTest extends AbstractOptionsTest {
+    private static final String MODULE_NAME_VALUE = "";
+    private static final String MODULE_VERSION_VALUE = "";
+
+    @Tested
+    private PerlClientCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModuleName(MODULE_NAME_VALUE);
+            times = 1;
+            clientCodegen.setModuleVersion(MODULE_VERSION_VALUE);
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(PerlClientCodegen.MODULE_NAME, MODULE_NAME_VALUE)
+                .put(PerlClientCodegen.MODULE_VERSION, MODULE_VERSION_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/qtfivecpp/Qt5CPPOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/qtfivecpp/Qt5CPPOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.qtfivecpp;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.Qt5CPPGenerator;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class Qt5CPPOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private Qt5CPPGenerator clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/scala/ScalaClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/scala/ScalaClientOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.scala;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.ScalaClientCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class ScalaClientOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private ScalaClientCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/scalatra/ScalatraServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/scalatra/ScalatraServerOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.scalatra;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.ScalatraServerCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class ScalatraServerOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private ScalatraServerCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/silex/SilexServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/silex/SilexServerOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.silex;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.SilexServerCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class SilexServerOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private SilexServerCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/sinatra/SinatraServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/sinatra/SinatraServerOptionsTest.java
@@ -1,0 +1,34 @@
+package io.swagger.codegen.sinatra;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.languages.SinatraServerCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class SinatraServerOptionsTest extends AbstractOptionsTest {
+
+    @Tested
+    private SinatraServerCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        //SinatraServerCodegen doesn't have its own options and base options are cleared
+        return ImmutableMap.of();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/springmvc/SpringMVCServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/springmvc/SpringMVCServerOptionsTest.java
@@ -1,0 +1,66 @@
+package io.swagger.codegen.springmvc;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.java.JavaClientOptionsTest;
+import io.swagger.codegen.languages.JavaClientCodegen;
+import io.swagger.codegen.languages.SpringMVCServerCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SpringMVCServerOptionsTest extends JavaClientOptionsTest {
+    protected static final String CONFIG_PACKAGE_VALUE = "configPackage";
+
+    @Tested
+    private SpringMVCServerCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+            clientCodegen.setInvokerPackage(INVOKER_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setGroupId(GROUP_ID_VALUE);
+            times = 1;
+            clientCodegen.setArtifactId(ARTIFACT_ID_VALUE);
+            times = 1;
+            clientCodegen.setArtifactVersion(ARTIFACT_VERSION_VALUE);
+            times = 1;
+            clientCodegen.setSourceFolder(SOURCE_FOLDER_VALUE);
+            times = 1;
+            clientCodegen.setLocalVariablePrefix(LOCAL_PREFIX_VALUE);
+            times = 1;
+            clientCodegen.setSerializableModel(Boolean.valueOf(SERIALIZABLE_MODEL_VALUE));
+            times = 1;
+            clientCodegen.setLibrary(LIBRARY_VALUE);
+            times = 1;
+            clientCodegen.setFullJavaUtil(Boolean.valueOf(FULL_JAVA_UTIL_VALUE));
+            times = 1;
+            clientCodegen.setConfigPackage(CONFIG_PACKAGE_VALUE);
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        Map<String, String> options = new HashMap<String, String>(super.getAvaliableOptions());
+        options.put(SpringMVCServerCodegen.CONFIG_PACKAGE, CONFIG_PACKAGE_VALUE);
+        return options;
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/staticDocs/StaticDocOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/staticDocs/StaticDocOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.staticDocs;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.StaticDocCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class StaticDocOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private StaticDocCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/statichtml/StaticHtmlOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/statichtml/StaticHtmlOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.statichtml;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.StaticHtmlGenerator;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class StaticHtmlOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private StaticHtmlGenerator clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swagger/SwaggerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swagger/SwaggerOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.swagger;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.SwaggerGenerator;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class SwaggerOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private SwaggerGenerator clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swaggeryaml/SwaggerYamlOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swaggeryaml/SwaggerYamlOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.swaggeryaml;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.SwaggerYamlGenerator;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class SwaggerYamlOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private SwaggerYamlGenerator clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift/SwiftOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift/SwiftOptionsTest.java
@@ -1,0 +1,82 @@
+package io.swagger.codegen.swift;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.SwiftCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class SwiftOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+    protected static final String PROJECT_NAME_VALUE = "Swagger";
+    protected static final String RESPONSE_AS_VALUE = "test";
+    protected static final String UNWRAP_REQUIRED_VALUE = "true";
+    protected static final String POD_SOURCE_VALUE = "{ :git => 'git@github.com:swagger-api/swagger-mustache.git'," +
+            " :tag => 'v1.0.0-SNAPSHOT' }";
+    protected static final String POD_VERSION_VALUE = "v1.0.0-SNAPSHOT";
+    protected static final String POD_AUTHORS_VALUE = "podAuthors";
+    protected static final String POD_SOCIAL_MEDIA_URL_VALUE = "podSocialMediaURL";
+    protected static final String POD_DOCSET_URL_VALUE = "podDocsetURL";
+    protected static final String POD_LICENSE_VALUE = "'Apache License, Version 2.0'";
+    protected static final String POD_HOMEPAGE_VALUE = "podHomepage";
+    protected static final String POD_SUMMARY_VALUE = "podSummary";
+    protected static final String POD_DESCRIPTION_VALUE = "podDescription";
+    protected static final String POD_SCREENSHOTS_VALUE = "podScreenshots";
+    protected static final String POD_DOCUMENTATION_URL_VALUE = "podDocumentationURL";
+
+    @Tested
+    private SwiftCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+            clientCodegen.setProjectName(PROJECT_NAME_VALUE);
+            times = 1;
+            clientCodegen.setResponseAs(RESPONSE_AS_VALUE.split(","));
+            times = 1;
+            clientCodegen.setUnwrapRequired(Boolean.valueOf(UNWRAP_REQUIRED_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(SwiftCodegen.PROJECT_NAME, PROJECT_NAME_VALUE)
+                .put(SwiftCodegen.RESPONSE_AS, RESPONSE_AS_VALUE)
+                .put(SwiftCodegen.UNWRAP_REQUIRED, UNWRAP_REQUIRED_VALUE)
+                .put(SwiftCodegen.POD_SOURCE, POD_SOURCE_VALUE)
+                .put(CodegenConstants.POD_VERSION, POD_VERSION_VALUE)
+                .put(SwiftCodegen.POD_AUTHORS, POD_AUTHORS_VALUE)
+                .put(SwiftCodegen.POD_SOCIAL_MEDIA_URL, POD_SOCIAL_MEDIA_URL_VALUE)
+                .put(SwiftCodegen.POD_DOCSET_URL, POD_DOCSET_URL_VALUE)
+                .put(SwiftCodegen.POD_LICENSE, POD_LICENSE_VALUE)
+                .put(SwiftCodegen.POD_HOMEPAGE, POD_HOMEPAGE_VALUE)
+                .put(SwiftCodegen.POD_SUMMARY, POD_SUMMARY_VALUE)
+                .put(SwiftCodegen.POD_DESCRIPTION, POD_DESCRIPTION_VALUE)
+                .put(SwiftCodegen.POD_SCREENSHOTS, POD_SCREENSHOTS_VALUE)
+                .put(SwiftCodegen.POD_DOCUMENTATION_URL, POD_DOCUMENTATION_URL_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/tizen/TizenClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/tizen/TizenClientOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.tizen;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.TizenClientCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class TizenClientOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private TizenClientCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescriptangular/TypeScriptAngularClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescriptangular/TypeScriptAngularClientOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.typescriptangular;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.TypeScriptAngularClientCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class TypeScriptAngularClientOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private TypeScriptAngularClientCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescriptnode/TypeScriptNodeClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescriptnode/TypeScriptNodeClientOptionsTest.java
@@ -1,0 +1,47 @@
+package io.swagger.codegen.typescriptnode;
+
+import io.swagger.codegen.AbstractOptionsTest;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.languages.TypeScriptNodeClientCodegen;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Tested;
+
+import java.util.Map;
+
+public class TypeScriptNodeClientOptionsTest extends AbstractOptionsTest {
+    protected static final String MODEL_PACKAGE_VALUE = "package";
+    protected static final String API_PACKAGE_VALUE = "apiPackage";
+    protected static final String SORT_PARAMS_VALUE = "false";
+
+    @Tested
+    private TypeScriptNodeClientCodegen clientCodegen;
+
+    @Override
+    protected CodegenConfig getCodegenConfig() {
+        return clientCodegen;
+    }
+
+    @Override
+    protected void setExpectations() {
+        new Expectations(clientCodegen) {{
+            clientCodegen.setModelPackage(MODEL_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setApiPackage(API_PACKAGE_VALUE);
+            times = 1;
+            clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(SORT_PARAMS_VALUE));
+            times = 1;
+        }};
+    }
+
+    @Override
+    protected Map<String, String> getAvaliableOptions() {
+        ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
+        return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
+                .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .build();
+    }
+}


### PR DESCRIPTION
processOptions tests have been added for Objc, perl, spring-mvc, swift, scala, async-scala, qt5cpp, html, dynamic-html, swagger, swagger-yaml, tizen, typescript-angular, typescript-node, akka-scala, inflector, scalatra, silex and sinatra