### PR TITLE
Add oauth support for Java client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -167,6 +167,19 @@ public class ApiClient {
   }
 
   /**
+   * Helper method to set access token for the first OAuth2 authentication.
+   */
+  public void setAccessToken(String accessToken) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setAccessToken(accessToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Set the User-Agent header's value (by adding to the default header map).
    */
   public ApiClient setUserAgent(String userAgent) {

--- a/modules/swagger-codegen/src/main/resources/Java/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/auth/OAuth.mustache
@@ -7,8 +7,20 @@ import java.util.List;
 
 {{>generatedAnnotation}}
 public class OAuth implements Authentication {
+  private String accessToken;
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
   @Override
   public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {
-    // TODO: support oauth
+    if (accessToken != null) {
+      headerParams.put("Authorization", "Bearer " + accessToken);
+    }
   }
 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -174,6 +174,19 @@ public class ApiClient {
   }
 
   /**
+   * Helper method to set access token for the first OAuth2 authentication.
+   */
+  public void setAccessToken(String accessToken) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setAccessToken(accessToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Set the User-Agent header's value (by adding to the default header map).
    */
   public ApiClient setUserAgent(String userAgent) {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -370,6 +370,19 @@ public class ApiClient {
   }
 
   /**
+   * Helper method to set access token for the first OAuth2 authentication.
+   */
+  public void setAccessToken(String accessToken) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setAccessToken(accessToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  /**
    * Set the User-Agent header's value (by adding to the default header map).
    */
   public ApiClient setUserAgent(String userAgent) {

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
@@ -39,7 +39,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-10-20T10:56:59.550-07:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-02T21:16:46.418+08:00")
 public class ApiClient {
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -67,8 +67,8 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     authentications.put("petstore_auth", new OAuth());
+    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }
@@ -163,6 +163,19 @@ public class ApiClient {
       }
     }
     throw new RuntimeException("No API key authentication configured!");
+  }
+
+  /**
+   * Helper method to set access token for the first OAuth2 authentication.
+   */
+  public void setAccessToken(String accessToken) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setAccessToken(accessToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
   }
 
   /**

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,10 +5,22 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-10-20T10:56:59.550-07:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-02T21:16:46.418+08:00")
 public class OAuth implements Authentication {
+  private String accessToken;
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
   @Override
   public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {
-    // TODO: support oauth
+    if (accessToken != null) {
+      headerParams.put("Authorization", "Bearer " + accessToken);
+    }
   }
 }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
@@ -43,7 +43,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-10-29T09:31:27.804+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-02T22:10:35.641+08:00")
 public class ApiClient {
   private Client client;
   private Map<String, Client> hostMap = new HashMap<String, Client>();
@@ -170,6 +170,19 @@ public class ApiClient {
       }
     }
     throw new RuntimeException("No API key authentication configured!");
+  }
+
+  /**
+   * Helper method to set access token for the first OAuth2 authentication.
+   */
+  public void setAccessToken(String accessToken) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setAccessToken(accessToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
   }
 
   /**

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,10 +5,22 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-10-20T11:29:47.599-07:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-02T22:10:35.641+08:00")
 public class OAuth implements Authentication {
+  private String accessToken;
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
   @Override
   public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {
-    // TODO: support oauth
+    if (accessToken != null) {
+      headerParams.put("Authorization", "Bearer " + accessToken);
+    }
   }
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -105,8 +105,8 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     authentications.put("petstore_auth", new OAuth());
+    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }
@@ -366,6 +366,19 @@ public class ApiClient {
       }
     }
     throw new RuntimeException("No API key authentication configured!");
+  }
+
+  /**
+   * Helper method to set access token for the first OAuth2 authentication.
+   */
+  public void setAccessToken(String accessToken) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setAccessToken(accessToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
   }
 
   /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,10 +5,22 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-10-20T11:42:25.339-07:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-02T22:14:00.422+08:00")
 public class OAuth implements Authentication {
+  private String accessToken;
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
   @Override
   public void applyToParams(List<Pair> queryParams, Map<String, String> headerParams) {
-    // TODO: support oauth
+    if (accessToken != null) {
+      headerParams.put("Authorization", "Bearer " + accessToken);
+    }
   }
 }


### PR DESCRIPTION
ref: #1441
credit: @mach-kernel

see also #1446, #1485

The integration test is good for Java clients (default, jersey2 and okhttp-json):

```
Tests run: 33, Failures: 0, Errors: 0, Skipped: 0
```