### PR TITLE
Custom headers in Swift; base URL is now modifyable

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
@@ -7,8 +7,9 @@
 import Foundation
 
 public class {{projectName}}API {
-    static let basePath = "{{basePath}}"
-    static var credential: NSURLCredential?
+    public static var basePath = "{{basePath}}"
+    public static var credential: NSURLCredential?
+    public static var customHeaders: [String:String] = [:]  
     static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
 }
 
@@ -41,6 +42,14 @@ public class RequestBuilder<T> {
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody
+        
+        addHeaders({{projectName}}API.customHeaders)
+    }
+    
+    public func addHeaders(aHeaders:[String:String]) {
+        for (header, value) in aHeaders {
+            headers[header] = value
+        }
     }
     
     public func execute(completion: (response: Response<T>?, erorr: ErrorType?) -> Void) { }


### PR DESCRIPTION
Adds much desired ability to add custom HTTP headers as reported in #1345.
Base URL is now modifyable for clients running on different environments (e.g. testing/production)