### PR TITLE
Ruby: support map/hash in model deserialization with additionalProperties

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
@@ -42,6 +42,17 @@ module {{moduleName}}
         else
           false
         end
+      when /\AArray<(?<inner_type>.+)>\z/
+        inner_type = Regexp.last_match[:inner_type]
+        value.map { |v| _deserialize(inner_type, v) }
+      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+        k_type = Regexp.last_match[:k_type]
+        v_type = Regexp.last_match[:v_type]
+        {}.tap do |hash|
+          value.each do |k, v|
+            hash[_deserialize(k_type, k)] = _deserialize(v_type, v)
+          end
+        end
       else # model
         _model = {{moduleName}}.const_get(type).new
         _model.build_from_hash(value)
@@ -63,11 +74,7 @@ module {{moduleName}}
       self.class.attribute_map.each_pair do |attr, param|
         value = self.send(attr)
         next if value.nil?
-        if value.is_a?(Array)
-          hash[param] = value.compact.map{ |v| _to_hash(v) }
-        else
-          hash[param] = _to_hash(value)
-        end
+        hash[param] = _to_hash(value)
       end
       hash
     end
@@ -75,7 +82,13 @@ module {{moduleName}}
     # Method to output non-array value in the form of hash
     # For object, use to_hash. Otherwise, just return the value
     def _to_hash(value)
-      if value.respond_to? :to_hash
+      if value.is_a?(Array)
+        value.compact.map{ |v| _to_hash(v) }
+      elsif value.is_a?(Hash)
+        {}.tap do |hash|
+          value.each { |k, v| hash[k] = _to_hash(v) }
+        end
+      elsif value.respond_to? :to_hash
         value.to_hash
       else
         value

--- a/samples/client/petstore/ruby/spec/base_object_spec.rb
+++ b/samples/client/petstore/ruby/spec/base_object_spec.rb
@@ -21,7 +21,7 @@ class ArrayMapObject < Petstore::BaseObject
       :int_map => :'Hash<String, Integer>',
       :pet_map => :'Hash<String, Pet>',
       :int_arr_map => :'Hash<String, Array<Integer>>',
-      :pet_arr_map => 'Hash<String, Array<Pet>>'
+      :pet_arr_map => :'Hash<String, Array<Pet>>'
     }
   end
 end

--- a/samples/client/petstore/ruby/spec/base_object_spec.rb
+++ b/samples/client/petstore/ruby/spec/base_object_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+class ArrayMapObject < Petstore::BaseObject
+  attr_accessor :int_arr, :pet_arr, :int_map, :pet_map, :int_arr_map, :pet_arr_map
+
+  def self.attribute_map
+    {
+      :int_arr => :int_arr,
+      :pet_arr => :pet_arr,
+      :int_map => :int_map,
+      :pet_map => :pet_map,
+      :int_arr_map => :int_arr_map,
+      :pet_arr_map => :pet_arr_map
+    }
+  end
+
+  def self.swagger_types
+    {
+      :int_arr => :'Array<Integer>',
+      :pet_arr => :'Array<Pet>',
+      :int_map => :'Hash<String, Integer>',
+      :pet_map => :'Hash<String, Pet>',
+      :int_arr_map => :'Hash<String, Array<Integer>>',
+      :pet_arr_map => 'Hash<String, Array<Pet>>'
+    }
+  end
+end
+
+
+describe Petstore::BaseObject do
+  describe 'array and map properties' do
+    let(:obj) { ArrayMapObject.new }
+
+    let(:data) do
+      {int_arr: [123, 456],
+       pet_arr: [{name: 'Kitty'}],
+       int_map: {'int' => 123},
+       pet_map: {'pet' => {name: 'Kitty'}},
+       int_arr_map: {'int_arr' => [123, 456]},
+       pet_arr_map: {'pet_arr' => [{name: 'Kitty'}]}
+      }
+    end
+
+    it 'works for #build_from_hash' do
+      obj.build_from_hash(data)
+
+      obj.int_arr.should == [123, 456]
+
+      obj.pet_arr.should be_a(Array)
+      obj.pet_arr.size.should == 1
+      pet = obj.pet_arr.first
+      pet.should be_a(Petstore::Pet)
+      pet.name.should == 'Kitty'
+
+      obj.int_map.should be_a(Hash)
+      obj.int_map.should == {'int' => 123}
+
+      obj.pet_map.should be_a(Hash)
+      pet = obj.pet_map['pet']
+      pet.should be_a(Petstore::Pet)
+      pet.name.should == 'Kitty'
+
+      obj.int_arr_map.should be_a(Hash)
+      arr = obj.int_arr_map['int_arr']
+      arr.should == [123, 456]
+
+      obj.pet_arr_map.should be_a(Hash)
+      arr = obj.pet_arr_map['pet_arr']
+      arr.should be_a(Array)
+      arr.size.should == 1
+      pet = arr.first
+      pet.should be_a(Petstore::Pet)
+      pet.name.should == 'Kitty'
+    end
+
+    it 'works for #to_hash' do
+      obj.build_from_hash(data)
+      obj.to_hash.should == data
+    end
+  end
+end


### PR DESCRIPTION
For example, the "scoreMap" and "cateMap" properties below:

```json
  "definitions": {
    "User": {
      "properties": {
        "scoreMap": {
          "type": "object",
          "additionalProperties": {
            "type": "integer",
            "format": "int32",
          }
        },
        "cateMap": {
          "type": "object",
          "additionalProperties": {
            "$ref": "#/definitions/Category"
          }
        }
      }
    }
  }
```

The integration test is good:

```
.........................

Finished in 37.14 seconds (files took 0.41683 seconds to load)
25 examples, 0 failures
```