### PR TITLE
Accept arrays as arguments to collection parameters in PHP client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -162,6 +162,39 @@ class ObjectSerializer
     }
 
     /**
+     * Serialize an array to a string.
+     *
+     * @param array  $collection       collection to serialize to a string
+     * @param string $collectionFormat the format use for serialization (csv,
+     * ssv, tsv, pipes, multi)
+     *
+     * @return string
+     */
+    public function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti=false)
+    {
+        if ($allowCollectionFormatMulti && ('multi' === $collectionFormat)) {
+            // http_build_query() almost does the job for us. We just
+            // need to fix the result of multidimensional arrays.
+            return preg_replace('/%5B[0-9]+%5D=/', '=', http_build_query($collection, '', '&'));
+        }
+        switch ($collectionFormat) {
+            case 'pipes':
+                return implode('|', $collection);
+
+            case 'tsv':
+                return implode("\t", $collection);
+
+            case 'ssv':
+                return implode(' ', $collection);
+
+            case 'csv':
+                // Deliberate fall through. CSV is default format.
+            default:
+                return implode(',', $collection);
+        }
+    }
+
+    /**
      * Deserialize a JSON string into an object
      *
      * @param mixed  $data       object or primitive to be deserialized

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -139,14 +139,29 @@ use \{{invokerPackage}}\ObjectSerializer;
         $headerParams['Content-Type'] = ApiClient::selectHeaderContentType(array({{#consumes}}'{{mediaType}}'{{#hasMore}},{{/hasMore}}{{/consumes}}));
   
         {{#queryParams}}// query params
+        {{#collectionFormat}}
+        if (is_array(${{paramName}})) {
+            ${{paramName}} = $this->apiClient->getSerializer()->serializeCollection(${{paramName}}, '{{collectionFormat}}', true);
+        }
+        {{/collectionFormat}}
         if (${{paramName}} !== null) {
             $queryParams['{{baseName}}'] = $this->apiClient->getSerializer()->toQueryValue(${{paramName}});
         }{{/queryParams}}
         {{#headerParams}}// header params
+        {{#collectionFormat}}
+        if (is_array(${{paramName}})) {
+            ${{paramName}} = $this->apiClient->getSerializer()->serializeCollection(${{paramName}}, '{{collectionFormat}}');
+        }
+        {{/collectionFormat}}
         if (${{paramName}} !== null) {
             $headerParams['{{baseName}}'] = $this->apiClient->getSerializer()->toHeaderValue(${{paramName}});
         }{{/headerParams}}
         {{#pathParams}}// path params
+        {{#collectionFormat}}
+        if (is_array(${{paramName}})) {
+            ${{paramName}} = $this->apiClient->getSerializer()->serializeCollection(${{paramName}}, '{{collectionFormat}}');
+        }
+        {{/collectionFormat}}
         if (${{paramName}} !== null) {
             $resourcePath = str_replace(
                 "{" . "{{baseName}}" . "}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -301,6 +301,11 @@ class PetApi
         $headerParams['Content-Type'] = ApiClient::selectHeaderContentType(array());
   
         // query params
+        
+        if (is_array($status)) {
+            $status = $this->apiClient->getSerializer()->serializeCollection($status, 'multi', true);
+        }
+        
         if ($status !== null) {
             $queryParams['status'] = $this->apiClient->getSerializer()->toQueryValue($status);
         }
@@ -391,6 +396,11 @@ class PetApi
         $headerParams['Content-Type'] = ApiClient::selectHeaderContentType(array());
   
         // query params
+        
+        if (is_array($tags)) {
+            $tags = $this->apiClient->getSerializer()->serializeCollection($tags, 'multi', true);
+        }
+        
         if ($tags !== null) {
             $queryParams['tags'] = $this->apiClient->getSerializer()->toQueryValue($tags);
         }
@@ -487,6 +497,7 @@ class PetApi
         
         
         // path params
+        
         if ($pet_id !== null) {
             $resourcePath = str_replace(
                 "{" . "petId" . "}",
@@ -591,6 +602,7 @@ class PetApi
         
         
         // path params
+        
         if ($pet_id !== null) {
             $resourcePath = str_replace(
                 "{" . "petId" . "}",
@@ -694,10 +706,12 @@ class PetApi
   
         
         // header params
+        
         if ($api_key !== null) {
             $headerParams['api_key'] = $this->apiClient->getSerializer()->toHeaderValue($api_key);
         }
         // path params
+        
         if ($pet_id !== null) {
             $resourcePath = str_replace(
                 "{" . "petId" . "}",
@@ -792,6 +806,7 @@ class PetApi
         
         
         // path params
+        
         if ($pet_id !== null) {
             $resourcePath = str_replace(
                 "{" . "petId" . "}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -314,6 +314,7 @@ class StoreApi
         
         
         // path params
+        
         if ($order_id !== null) {
             $resourcePath = str_replace(
                 "{" . "orderId" . "}",
@@ -407,6 +408,7 @@ class StoreApi
         
         
         // path params
+        
         if ($order_id !== null) {
             $resourcePath = str_replace(
                 "{" . "orderId" . "}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -371,9 +371,11 @@ class UserApi
         $headerParams['Content-Type'] = ApiClient::selectHeaderContentType(array());
   
         // query params
+        
         if ($username !== null) {
             $queryParams['username'] = $this->apiClient->getSerializer()->toQueryValue($username);
         }// query params
+        
         if ($password !== null) {
             $queryParams['password'] = $this->apiClient->getSerializer()->toQueryValue($password);
         }
@@ -537,6 +539,7 @@ class UserApi
         
         
         // path params
+        
         if ($username !== null) {
             $resourcePath = str_replace(
                 "{" . "username" . "}",
@@ -632,6 +635,7 @@ class UserApi
         
         
         // path params
+        
         if ($username !== null) {
             $resourcePath = str_replace(
                 "{" . "username" . "}",
@@ -721,6 +725,7 @@ class UserApi
         
         
         // path params
+        
         if ($username !== null) {
             $resourcePath = str_replace(
                 "{" . "username" . "}",

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
@@ -516,7 +516,7 @@ class Configuration
         $report  = "PHP SDK (Swagger\Client) Debug Report:\n";
         $report .= "    OS: ".php_uname()."\n";
         $report .= "    PHP Version: ".phpversion()."\n";
-        $report .= "    Swagger Spec Version: 1.0.0\n";
+        $report .= "    OpenAPI Spec Version: 1.0.0\n";
         $report .= "    SDK Package Version: 1.0.0\n";
         $report .= "    Temp Folder Path: ".self::getDefaultConfiguration()->getTempFolderPath()."\n";
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -162,6 +162,39 @@ class ObjectSerializer
     }
 
     /**
+     * Serialize an array to a string.
+     *
+     * @param array  $collection       collection to serialize to a string
+     * @param string $collectionFormat the format use for serialization (csv,
+     * ssv, tsv, pipes, multi)
+     *
+     * @return string
+     */
+    public function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti=false)
+    {
+        if ($allowCollectionFormatMulti && ('multi' === $collectionFormat)) {
+            // http_build_query() almost does the job for us. We just
+            // need to fix the result of multidimensional arrays.
+            return preg_replace('/%5B[0-9]+%5D=/', '=', http_build_query($collection, '', '&'));
+        }
+        switch ($collectionFormat) {
+            case 'pipes':
+                return implode('|', $collection);
+
+            case 'tsv':
+                return implode("\t", $collection);
+
+            case 'ssv':
+                return implode(' ', $collection);
+
+            case 'csv':
+                // Deliberate fall through. CSV is default format.
+            default:
+                return implode(',', $collection);
+        }
+    }
+
+    /**
      * Deserialize a JSON string into an object
      *
      * @param mixed  $data       object or primitive to be deserialized
@@ -193,7 +226,7 @@ class ObjectSerializer
             $deserialized = $values;
         } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
-        } elseif (in_array($class, array('integer', 'int', 'void', 'number', 'object', 'double', 'float', 'byte', 'DateTime', 'string', 'mixed', 'boolean', 'bool'))) {
+        } elseif (in_array($class, array('void', 'bool', 'string', 'double', 'byte', 'mixed', 'integer', 'float', 'int', 'DateTime', 'number', 'boolean', 'object'))) {
             settype($data, $class);
             $deserialized = $data;
         } elseif ($class === '\SplFileObject') {


### PR DESCRIPTION
This patch makes it possible to use arrays as arguments for parameters defined as arrays of strings -- and respects the `collectionFormat`.

Until now you had to implode the string to an array yourself before calling the API.

I've been thinking about also adding type hints to array for those parameters in method argument list. But since that would break backwards compatibility it should probably be hidden behind a command line option or something.

NB: This needs swagger-parser 1.0.12.