### PR TITLE
Make parameters unique in generated code

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -40,6 +40,9 @@ public class CodegenConstants {
     public static final String SORT_PARAMS_BY_REQUIRED_FLAG = "sortParamsByRequiredFlag";
     public static final String SORT_PARAMS_BY_REQUIRED_FLAG_DESC = "Sort method arguments to place required parameters before optional parameters. Default: true";
 
+    public static final String ENSURE_UNIQUE_PARAMS = "ensureUniqueParams";
+    public static final String ENSURE_UNIQUE_PARAMS_DESC = "Whether to ensure parameter names are unique in an operation (rename parameters that are not). Default: false";
+
     public static final String PACKAGE_NAME = "packageName";
     public static final String PACKAGE_VERSION = "packageVersion";
     public static final String POD_VERSION = "podVersion";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -41,7 +41,7 @@ public class CodegenConstants {
     public static final String SORT_PARAMS_BY_REQUIRED_FLAG_DESC = "Sort method arguments to place required parameters before optional parameters. Default: true";
 
     public static final String ENSURE_UNIQUE_PARAMS = "ensureUniqueParams";
-    public static final String ENSURE_UNIQUE_PARAMS_DESC = "Whether to ensure parameter names are unique in an operation (rename parameters that are not). Default: false";
+    public static final String ENSURE_UNIQUE_PARAMS_DESC = "Whether to ensure parameter names are unique in an operation (rename parameters that are not). Default: true";
 
     public static final String PACKAGE_NAME = "packageName";
     public static final String PACKAGE_VERSION = "packageVersion";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -87,7 +87,7 @@ public class DefaultCodegen {
     protected Map<String, String> supportedLibraries = new LinkedHashMap<String, String>();
     protected String library = null;
     protected Boolean sortParamsByRequiredFlag = true;
-    protected Boolean ensureUniqueParams = false;
+    protected Boolean ensureUniqueParams = true;
 
     public List<CliOption> cliOptions() {
         return cliOptions;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1738,10 +1738,16 @@ public class DefaultCodegen {
         return word;
     }
 
-    // Generate the next name for the given name, e.g.
-    //   status    => status2
-    //   status2   => status3
-    //   myName100 => myName101
+    /**
+     * Generate the next name for the given name, i.e. append "2" to the base name if not ending with a number,
+     * otherwise increase the number by 1. For example:
+     *   status    => status2
+     *   status2   => status3
+     *   myName100 => myName101
+     *
+     * @param name The base name
+     * @return The next name for the base name
+     */
     private String generateNextName(String name) {
         Pattern pattern = Pattern.compile("\\d+\\z");
         Matcher matcher = pattern.matcher(name);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -87,6 +87,7 @@ public class DefaultCodegen {
     protected Map<String, String> supportedLibraries = new LinkedHashMap<String, String>();
     protected String library = null;
     protected Boolean sortParamsByRequiredFlag = true;
+    protected Boolean ensureUniqueParams = false;
 
     public List<CliOption> cliOptions() {
         return cliOptions;
@@ -108,6 +109,11 @@ public class DefaultCodegen {
         if (additionalProperties.containsKey(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG)) {
             this.setSortParamsByRequiredFlag(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.ENSURE_UNIQUE_PARAMS)) {
+            this.setEnsureUniqueParams(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.ENSURE_UNIQUE_PARAMS).toString()));
         }
     }
 
@@ -243,6 +249,10 @@ public class DefaultCodegen {
 
     public void setSortParamsByRequiredFlag(Boolean sortParamsByRequiredFlag) {
         this.sortParamsByRequiredFlag = sortParamsByRequiredFlag;
+    }
+
+    public void setEnsureUniqueParams(Boolean ensureUniqueParams) {
+        this.ensureUniqueParams = ensureUniqueParams;
     }
 
     /**
@@ -436,6 +446,7 @@ public class DefaultCodegen {
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
         cliOptions.add(new CliOption(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.ENSURE_UNIQUE_PARAMS, CodegenConstants.ENSURE_UNIQUE_PARAMS_DESC));
     }
 
     /**
@@ -1245,6 +1256,23 @@ public class DefaultCodegen {
         if (parameters != null) {
             for (Parameter param : parameters) {
                 CodegenParameter p = fromParameter(param, imports);
+                // rename parameters to make sure all of them have unique names
+                if (ensureUniqueParams) {
+                    while (true) {
+                        boolean exists = false;
+                        for (CodegenParameter cp : allParams) {
+                            if (p.paramName.equals(cp.paramName)) {
+                                exists = true;
+                                break;
+                            }
+                        }
+                        if (exists) {
+                            p.paramName = generateNextName(p.paramName);
+                        } else {
+                            break;
+                        }
+                    }
+                }
                 allParams.add(p);
                 if (param instanceof QueryParameter) {
                     p.isQueryParam = new Boolean(true);
@@ -1283,7 +1311,7 @@ public class DefaultCodegen {
         op.httpMethod = httpMethod.toUpperCase();
 
         // move "required" parameters in front of "optional" parameters
-        if(sortParamsByRequiredFlag) {
+        if (sortParamsByRequiredFlag) {
           Collections.sort(allParams, new Comparator<CodegenParameter>() {
               @Override
               public int compare(CodegenParameter one, CodegenParameter another) {
@@ -1708,6 +1736,22 @@ public class DefaultCodegen {
         word = word.replace('-', '_');
         word = word.toLowerCase();
         return word;
+    }
+
+    // Generate the next name for the given name, e.g.
+    //   status    => status2
+    //   status2   => status3
+    //   myName100 => myName101
+    private String generateNextName(String name) {
+        Pattern pattern = Pattern.compile("\\d+\\z");
+        Matcher matcher = pattern.matcher(name);
+        if (matcher.find()) {
+            String numStr = matcher.group();
+            int num = Integer.parseInt(numStr) + 1;
+            return name.substring(0, name.length() - numStr.length()) + num;
+        } else {
+            return name + "2";
+        }
     }
 
     private void addImport(CodegenModel m, String type) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -56,6 +56,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         embeddedTemplateDir = templateDir = "Java";
         apiPackage = "io.swagger.client.api";
         modelPackage = "io.swagger.client.model";
+        ensureUniqueParams = true;
 
         reservedWords = new HashSet<String>(
                 Arrays.asList(

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -56,7 +56,6 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         embeddedTemplateDir = templateDir = "Java";
         apiPackage = "io.swagger.client.api";
         modelPackage = "io.swagger.client.model";
-        ensureUniqueParams = true;
 
         reservedWords = new HashSet<String>(
                 Arrays.asList(

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -2,6 +2,7 @@ package io.swagger.codegen.languages;
 
 import io.swagger.codegen.CliOption;
 import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.DefaultCodegen;
 import io.swagger.codegen.SupportingFile;
@@ -12,6 +13,7 @@ import io.swagger.models.properties.Property;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -32,6 +34,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
         modelTemplateFiles.put("model.mustache", ".rb");
         apiTemplateFiles.put("api.mustache", ".rb");
         embeddedTemplateDir = templateDir = "ruby";
+        ensureUniqueParams = true;
 
         typeMapping.clear();
         languageSpecificPrimitives.clear();
@@ -70,7 +73,14 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("file", "File");
 
         // remove modelPackage and apiPackage added by default
-        cliOptions.clear();
+        Iterator<CliOption> itr = cliOptions.iterator();
+        while (itr.hasNext()) {
+            CliOption opt = itr.next();
+            if (CodegenConstants.MODEL_PACKAGE.equals(opt.getOpt()) ||
+                    CodegenConstants.API_PACKAGE.equals(opt.getOpt())) {
+                itr.remove();
+            }
+        }
         cliOptions.add(new CliOption(GEM_NAME, "gem name (convention: underscore_case), default: swagger_client"));
         cliOptions.add(new CliOption(MODULE_NAME, "top module name (convention: CamelCase, usually corresponding to gem name), default: SwaggerClient"));
         cliOptions.add(new CliOption(GEM_VERSION, "gem version, default: 1.0.0"));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -34,7 +34,6 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
         modelTemplateFiles.put("model.mustache", ".rb");
         apiTemplateFiles.put("api.mustache", ".rb");
         embeddedTemplateDir = templateDir = "ruby";
-        ensureUniqueParams = true;
 
         typeMapping.clear();
         languageSpecificPrimitives.clear();

--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -64,7 +64,7 @@ public class {{classname}} {
     {{/queryParams}}
 
     {{#headerParams}}if ({{paramName}} != null)
-    {{localVariablePrefix}}headerParams.put("{{baseName}}", {{localVariablePrefix}}apiClient.parameterToString({{paramName}}));
+      {{localVariablePrefix}}headerParams.put("{{baseName}}", {{localVariablePrefix}}apiClient.parameterToString({{paramName}}));
     {{/headerParams}}
 
     {{#formParams}}if ({{paramName}} != null)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AkkaScalaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AkkaScalaClientOptionsProvider.java
@@ -10,6 +10,7 @@ public class AkkaScalaClientOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class AkkaScalaClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AndroidClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AndroidClientOptionsProvider.java
@@ -13,6 +13,7 @@ public class AndroidClientOptionsProvider implements OptionsProvider {
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String INVOKER_PACKAGE_VALUE = "io.swagger.client.test";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String GROUP_ID_VALUE = "io.swagger.test";
     public static final String ARTIFACT_VERSION_VALUE = "1.0.0-SNAPSHOT";
     public static final String SOURCE_FOLDER_VALUE = "src/main/java/test";
@@ -29,6 +30,7 @@ public class AndroidClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.INVOKER_PACKAGE, INVOKER_PACKAGE_VALUE)
                 .put(CodegenConstants.GROUP_ID, GROUP_ID_VALUE)
                 .put(CodegenConstants.ARTIFACT_ID, ARTIFACT_ID_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AsyncScalaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AsyncScalaClientOptionsProvider.java
@@ -10,6 +10,7 @@ public class AsyncScalaClientOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class AsyncScalaClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/DartClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/DartClientOptionsProvider.java
@@ -11,6 +11,7 @@ public class DartClientOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "packagedart";
     public static final String API_PACKAGE_VALUE = "apiPackageDart";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String BROWSER_CLIENT_VALUE = "true";
     public static final String PUB_NAME_VALUE = "swagger";
     public static final String PUB_VERSION_VALUE = "1.0.0-SNAPSHOT";
@@ -28,6 +29,7 @@ public class DartClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(DartClientCodegen.BROWSER_CLIENT, BROWSER_CLIENT_VALUE)
                 .put(DartClientCodegen.PUB_NAME, PUB_NAME_VALUE)
                 .put(DartClientCodegen.PUB_VERSION, PUB_VERSION_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
@@ -20,6 +20,7 @@ public class JavaOptionsProvider implements OptionsProvider {
     public static final String LIBRARY_VALUE = "jersey2";
     public static final String SERIALIZABLE_MODEL_VALUE = "false";
     public static final String FULL_JAVA_UTIL_VALUE = "true";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public Map<String, String> createOptions() {
@@ -27,6 +28,7 @@ public class JavaOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.INVOKER_PACKAGE, INVOKER_PACKAGE_VALUE)
                 .put(CodegenConstants.GROUP_ID, GROUP_ID_VALUE)
                 .put(CodegenConstants.ARTIFACT_ID, ARTIFACT_ID_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/NodeJSServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/NodeJSServerOptionsProvider.java
@@ -10,6 +10,7 @@ public class NodeJSServerOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class NodeJSServerOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/PhpClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/PhpClientOptionsProvider.java
@@ -11,6 +11,7 @@ public class PhpClientOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String VARIABLE_NAMING_CONVENTION_VALUE = "snake_case";
     public static final String INVOKER_PACKAGE_VALUE = "Swagger\\Client\\Php";
     public static final String PACKAGE_PATH_VALUE = "SwaggerClient-php";
@@ -30,6 +31,7 @@ public class PhpClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(PhpClientCodegen.VARIABLE_NAMING_CONVENTION, VARIABLE_NAMING_CONVENTION_VALUE)
                 .put(CodegenConstants.INVOKER_PACKAGE, INVOKER_PACKAGE_VALUE)
                 .put(PhpClientCodegen.PACKAGE_PATH, PACKAGE_PATH_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Qt5CPPOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Qt5CPPOptionsProvider.java
@@ -10,6 +10,7 @@ public class Qt5CPPOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class Qt5CPPOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/RubyClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/RubyClientOptionsProvider.java
@@ -1,5 +1,6 @@
 package io.swagger.codegen.options;
 
+import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.languages.RubyClientCodegen;
 
 import com.google.common.collect.ImmutableMap;
@@ -10,6 +11,8 @@ public class RubyClientOptionsProvider implements OptionsProvider {
     public static final String GEM_NAME_VALUE = "swagger_client_ruby";
     public static final String MODULE_NAME_VALUE = "SwaggerClientRuby";
     public static final String GEM_VERSION_VALUE = "1.0.0-SNAPSHOT";
+    public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +25,8 @@ public class RubyClientOptionsProvider implements OptionsProvider {
         return builder.put(RubyClientCodegen.GEM_NAME, GEM_NAME_VALUE)
                 .put(RubyClientCodegen.MODULE_NAME, MODULE_NAME_VALUE)
                 .put(RubyClientCodegen.GEM_VERSION, GEM_VERSION_VALUE)
+                .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/ScalaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/ScalaClientOptionsProvider.java
@@ -10,6 +10,7 @@ public class ScalaClientOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class ScalaClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/ScalatraServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/ScalatraServerOptionsProvider.java
@@ -10,6 +10,7 @@ public class ScalatraServerOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class ScalatraServerOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SilexServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SilexServerOptionsProvider.java
@@ -10,6 +10,7 @@ public class SilexServerOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class SilexServerOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/StaticDocOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/StaticDocOptionsProvider.java
@@ -10,6 +10,7 @@ public class StaticDocOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class StaticDocOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/StaticHtmlOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/StaticHtmlOptionsProvider.java
@@ -10,6 +10,7 @@ public class StaticHtmlOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class StaticHtmlOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerOptionsProvider.java
@@ -10,6 +10,7 @@ public class SwaggerOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class SwaggerOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerYamlOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwaggerYamlOptionsProvider.java
@@ -10,6 +10,7 @@ public class SwaggerYamlOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class SwaggerYamlOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwiftOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwiftOptionsProvider.java
@@ -11,6 +11,7 @@ public class SwiftOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String PROJECT_NAME_VALUE = "Swagger";
     public static final String RESPONSE_AS_VALUE = "test";
     public static final String UNWRAP_REQUIRED_VALUE = "true";
@@ -38,6 +39,7 @@ public class SwiftOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(SwiftCodegen.PROJECT_NAME, PROJECT_NAME_VALUE)
                 .put(SwiftCodegen.RESPONSE_AS, RESPONSE_AS_VALUE)
                 .put(SwiftCodegen.UNWRAP_REQUIRED, UNWRAP_REQUIRED_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TizenClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TizenClientOptionsProvider.java
@@ -10,6 +10,7 @@ public class TizenClientOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class TizenClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAngularClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAngularClientOptionsProvider.java
@@ -10,6 +10,7 @@ public class TypeScriptAngularClientOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class TypeScriptAngularClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptNodeClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptNodeClientOptionsProvider.java
@@ -10,6 +10,7 @@ public class TypeScriptNodeClientOptionsProvider implements OptionsProvider {
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
+    public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
 
     @Override
     public String getLanguage() {
@@ -22,6 +23,7 @@ public class TypeScriptNodeClientOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.MODEL_PACKAGE, MODEL_PACKAGE_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
+                .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .build();
     }
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
@@ -11,7 +11,7 @@ import java.io.File;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-10-30T16:36:47.681+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-04T19:58:40.953+08:00")
 public class PetApi {
   private ApiClient apiClient;
 
@@ -367,7 +367,7 @@ public class PetApi {
     
 
     if (apiKey != null)
-    headerParams.put("api_key", apiClient.parameterToString(apiKey));
+      headerParams.put("api_key", apiClient.parameterToString(apiKey));
     
 
     


### PR DESCRIPTION
Make parameters unique in generated code through a config option, "ensureUniqueParams", which is true by default and can be set to false to turn it off.

See #1422