### PR TITLE
Modified dateformat to parse UTC ISO 8601 dates correctly.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/apiInvoker.mustache
@@ -69,7 +69,7 @@ public class ApiInvoker {
    * ISO 8601 date time format.
    * @see https://en.wikipedia.org/wiki/ISO_8601
    */
-  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
   /**
    * ISO 8601 date format.

--- a/modules/swagger-codegen/src/main/resources/android-java/jsonUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/jsonUtil.mustache
@@ -13,7 +13,7 @@ public class JsonUtil {
   static {
     gsonBuilder = new GsonBuilder();
     gsonBuilder.serializeNulls();
-    gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
   }
 
   public static Gson getGson() {

--- a/samples/client/petstore/android-java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android-java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -69,7 +69,7 @@ public class ApiInvoker {
    * ISO 8601 date time format.
    * @see https://en.wikipedia.org/wiki/ISO_8601
    */
-  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+  public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
   /**
    * ISO 8601 date format.

--- a/samples/client/petstore/android-java/src/main/java/io/swagger/client/JsonUtil.java
+++ b/samples/client/petstore/android-java/src/main/java/io/swagger/client/JsonUtil.java
@@ -13,7 +13,7 @@ public class JsonUtil {
   static {
     gsonBuilder = new GsonBuilder();
     gsonBuilder.serializeNulls();
-    gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
   }
 
   public static Gson getGson() {

--- a/samples/client/petstore/android-java/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/android-java/src/main/java/io/swagger/client/model/Pet.java
@@ -1,8 +1,8 @@
 package io.swagger.client.model;
 
 import io.swagger.client.model.Category;
-import io.swagger.client.model.Tag;
 import java.util.*;
+import io.swagger.client.model.Tag;
 
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;


### PR DESCRIPTION
This enables the android client to parse dates in ISO 8601 format correctly. This fixes #1134 