### PR TITLE
The swift code generator can't handle endpoints that return an array of objects

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -118,6 +118,10 @@ class Decoders {
                 fatalError("formatter failed to parse \(sourceString)")
             } {{#models}}{{#model}}
 
+			// Decoder for [{{{classname}}}]
+            Decoders.addDecoder(clazz: [{{{classname}}}].self) { (source: AnyObject) -> [{{{classname}}}] in
+                return Decoders.decode(clazz: [{{{classname}}}].self, source: source)
+            }
 			// Decoder for {{{classname}}}
             Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject) -> {{{classname}}} in
                 let sourceDictionary = source as! [NSObject:AnyObject]

--- a/samples/client/petstore/swift/Cartfile
+++ b/samples/client/petstore/swift/Cartfile
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" >= 2.0.0
+github "Alamofire/Alamofire" >= 3.0.0
 github "mxcl/PromiseKit" >=1.5.3

--- a/samples/client/petstore/swift/PetstoreClient.podspec
+++ b/samples/client/petstore/swift/PetstoreClient.podspec
@@ -7,5 +7,5 @@ Pod::Spec.new do |s|
   s.license = 'Apache License, Version 2.0'
   s.source_files = 'PetstoreClient/Classes/Swaggers/**/*.swift'
   s.dependency 'PromiseKit', '~> 2.1'
-  s.dependency 'Alamofire', '~> 2.0.0'
+  s.dependency 'Alamofire', '~> 3.0.0'
 end

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -7,8 +7,9 @@
 import Foundation
 
 public class PetstoreClientAPI {
-    static let basePath = "http://petstore.swagger.io/v2"
-    static var credential: NSURLCredential?
+    public static var basePath = "http://petstore.swagger.io/v2"
+    public static var credential: NSURLCredential?
+    public static var customHeaders: [String:String] = [:]  
     static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
 }
 
@@ -41,6 +42,14 @@ public class RequestBuilder<T> {
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody
+        
+        addHeaders(PetstoreClientAPI.customHeaders)
+    }
+    
+    public func addHeaders(aHeaders:[String:String]) {
+        for (header, value) in aHeaders {
+            headers[header] = value
+        }
     }
     
     public func execute(completion: (response: Response<T>?, erorr: ErrorType?) -> Void) { }

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -71,20 +71,20 @@ extension PetstoreClientAPI {
          - OAuth:
            - type: oauth2
            - name: petstore_auth
-         - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+         - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -93,21 +93,21 @@ extension PetstoreClientAPI {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-         - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+         - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -116,7 +116,7 @@ extension PetstoreClientAPI {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
          
          - parameter status: (query) Status values that need to be considered for filter
 
@@ -145,20 +145,20 @@ extension PetstoreClientAPI {
          - OAuth:
            - type: oauth2
            - name: petstore_auth
-         - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+         - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -167,21 +167,21 @@ extension PetstoreClientAPI {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-         - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+         - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -190,7 +190,7 @@ extension PetstoreClientAPI {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
          
          - parameter tags: (query) Tags to filter by
 
@@ -219,23 +219,20 @@ extension PetstoreClientAPI {
          - API Key:
            - type: apiKey api_key 
            - name: api_key
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+         - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -244,21 +241,21 @@ extension PetstoreClientAPI {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-         - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+         - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -267,7 +264,7 @@ extension PetstoreClientAPI {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
          
          - parameter petId: (path) ID of pet that needs to be fetched
 

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -21,12 +21,12 @@ extension PetstoreClientAPI {
          - API Key:
            - type: apiKey api_key 
            - name: api_key
-         - examples: [{example={
+         - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
-         - examples: [{example={
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
+         - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
 
          - returns: RequestBuilder<[String:Int]> 
          */
@@ -48,36 +48,36 @@ extension PetstoreClientAPI {
          
          - POST /store/order
          - 
-         - examples: [{example={
-  "id" : 123456789,
+         - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2015-10-20T06:12:32.347+0000"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2015-11-11T10:03:22.835+0000",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2015-10-19T23:12:32.350Z</shipDate>
+  <shipDate>2015-11-11T12:03:22.838Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-         - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+         - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2015-10-20T06:12:32.347+0000"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2015-11-11T10:03:22.835+0000",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2015-10-19T23:12:32.350Z</shipDate>
+  <shipDate>2015-11-11T12:03:22.838Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
          
          - parameter body: (body) order placed for purchasing the pet
 
@@ -100,36 +100,36 @@ extension PetstoreClientAPI {
          
          - GET /store/order/{orderId}
          - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-         - examples: [{example={
-  "id" : 123456789,
+         - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2015-10-20T06:12:32.351+0000"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2015-11-11T10:03:22.839+0000",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2015-10-19T23:12:32.351Z</shipDate>
+  <shipDate>2015-11-11T12:03:22.839Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-         - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+         - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2015-10-20T06:12:32.351+0000"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2015-11-11T10:03:22.839+0000",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2015-10-19T23:12:32.351Z</shipDate>
+  <shipDate>2015-11-11T12:03:22.839Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
          
          - parameter orderId: (path) ID of pet that needs to be fetched
 

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -84,8 +84,8 @@ extension PetstoreClientAPI {
          
          - GET /user/login
          - 
-         - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
-         - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
+         - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
+         - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
          
          - parameter username: (query) The user name for login
          - parameter password: (query) The password for login in clear text
@@ -134,7 +134,7 @@ extension PetstoreClientAPI {
          
          - GET /user/{username}
          - 
-         - examples: [{example={
+         - examples: [{contentType=application/json, example={
   "id" : 1,
   "username" : "johnp",
   "firstName" : "John",
@@ -143,7 +143,7 @@ extension PetstoreClientAPI {
   "password" : "-secret-",
   "phone" : "0123456789",
   "userStatus" : 0
-}, contentType=application/json}]
+}}]
          
          - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
 

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -75,29 +75,26 @@ class AlamofireRequestBuilder<T>: RequestBuilder<T> {
             request.authenticate(usingCredential: credential)
         }
 
-        request.responseJSON(options: .AllowFragments) { (req, res, result) in
+        request.responseJSON(options: .AllowFragments) { response in
             managerStore.removeValueForKey(managerId)
 
-            if result.isFailure {
-                completion(response: nil, erorr: result.error)
+            if response.result.isFailure {
+                completion(response: nil, erorr: response.result.error)
                 return
             }
 
             if () is T {
-                let response = Response(response: res!, body: () as! T)
-                completion(response: response, erorr: nil)
+                completion(response: Response(response: response.response!, body: () as! T), erorr: nil)
                 return
             }
-            if let json: AnyObject = result.value {
+            if let json: AnyObject = response.result.value {
                 let body = Decoders.decode(clazz: T.self, source: json)
-                let response = Response(response: res!, body: body)
-                completion(response: response, erorr: nil)
+                completion(response: Response(response: response.response!, body: body), erorr: nil)
                 return
             } else if "" is T {
                 // swagger-parser currently doesn't support void, which will be fixed in future swagger-parser release
                 // https://github.com/swagger-api/swagger-parser/pull/34
-                let response = Response(response: res!, body: "" as! T)
-                completion(response: response, erorr: nil)
+                completion(response: Response(response: response.response!, body: "" as! T), erorr: nil)
                 return
             }
 
@@ -113,4 +110,3 @@ class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         return httpHeaders
     }
 }
-

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -118,6 +118,10 @@ class Decoders {
                 fatalError("formatter failed to parse \(sourceString)")
             } 
 
+			// Decoder for [User]
+            Decoders.addDecoder(clazz: [User].self) { (source: AnyObject) -> [User] in
+                return Decoders.decode(clazz: [User].self, source: source)
+            }
 			// Decoder for User
             Decoders.addDecoder(clazz: User.self) { (source: AnyObject) -> User in
                 let sourceDictionary = source as! [NSObject:AnyObject]
@@ -134,6 +138,10 @@ class Decoders {
             }
 			
 
+			// Decoder for [Category]
+            Decoders.addDecoder(clazz: [Category].self) { (source: AnyObject) -> [Category] in
+                return Decoders.decode(clazz: [Category].self, source: source)
+            }
 			// Decoder for Category
             Decoders.addDecoder(clazz: Category.self) { (source: AnyObject) -> Category in
                 let sourceDictionary = source as! [NSObject:AnyObject]
@@ -144,6 +152,10 @@ class Decoders {
             }
 			
 
+			// Decoder for [Pet]
+            Decoders.addDecoder(clazz: [Pet].self) { (source: AnyObject) -> [Pet] in
+                return Decoders.decode(clazz: [Pet].self, source: source)
+            }
 			// Decoder for Pet
             Decoders.addDecoder(clazz: Pet.self) { (source: AnyObject) -> Pet in
                 let sourceDictionary = source as! [NSObject:AnyObject]
@@ -158,6 +170,10 @@ class Decoders {
             }
 			
 
+			// Decoder for [Tag]
+            Decoders.addDecoder(clazz: [Tag].self) { (source: AnyObject) -> [Tag] in
+                return Decoders.decode(clazz: [Tag].self, source: source)
+            }
 			// Decoder for Tag
             Decoders.addDecoder(clazz: Tag.self) { (source: AnyObject) -> Tag in
                 let sourceDictionary = source as! [NSObject:AnyObject]
@@ -168,6 +184,10 @@ class Decoders {
             }
 			
 
+			// Decoder for [Order]
+            Decoders.addDecoder(clazz: [Order].self) { (source: AnyObject) -> [Order] in
+                return Decoders.decode(clazz: [Order].self, source: source)
+            }
 			// Decoder for Order
             Decoders.addDecoder(clazz: Order.self) { (source: AnyObject) -> Order in
                 let sourceDictionary = source as! [NSObject:AnyObject]

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -14,6 +14,8 @@ public class Category: JSONEncodable {
     public var name: String?
     
 
+    public init() {}
+
     // MARK: JSONEncodable
     func encodeToJSON() -> AnyObject {
         var nillableDictionary = [String:AnyObject?]()

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -25,6 +25,8 @@ public class Order: JSONEncodable {
     public var complete: Bool?
     
 
+    public init() {}
+
     // MARK: JSONEncodable
     func encodeToJSON() -> AnyObject {
         var nillableDictionary = [String:AnyObject?]()

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -25,6 +25,8 @@ public class Pet: JSONEncodable {
     public var status: Status?
     
 
+    public init() {}
+
     // MARK: JSONEncodable
     func encodeToJSON() -> AnyObject {
         var nillableDictionary = [String:AnyObject?]()

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -14,6 +14,8 @@ public class Tag: JSONEncodable {
     public var name: String?
     
 
+    public init() {}
+
     // MARK: JSONEncodable
     func encodeToJSON() -> AnyObject {
         var nillableDictionary = [String:AnyObject?]()

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -21,6 +21,8 @@ public class User: JSONEncodable {
     public var userStatus: Int?
     
 
+    public init() {}
+
     // MARK: JSONEncodable
     func encodeToJSON() -> AnyObject {
         var nillableDictionary = [String:AnyObject?]()


### PR DESCRIPTION
I'm not really familiar with swift, but was using swagger to specify the API I'm working on and found it useful to generate client code based on the API specification. It seems to me that the current state of the generated swift code can't handle an array of objects at the root of the response. This patch fixes the issue, feel free to improve it.