### PR TITLE
[Clojure] Integration tests and config options

### DIFF
--- a/modules/swagger-codegen/src/main/resources/clojure/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/clojure/api.mustache
@@ -1,5 +1,5 @@
 {{=< >=}}(ns <package>.<classname>
-  (:require [<projectName>.core :refer [call-api check-required-params]])
+  (:require [<baseNamespace>.core :refer [call-api check-required-params]])
   (:import (java.io File)))
 <#operations><#operation>
 (defn <nickname>

--- a/modules/swagger-codegen/src/main/resources/clojure/project.mustache
+++ b/modules/swagger-codegen/src/main/resources/clojure/project.mustache
@@ -1,8 +1,8 @@
 {{=< >=}}(defproject <&projectName> "<&projectVersion>"
   :description "<&projectDescription>"<#projectUrl>
-  :url "<&projectUrl>"</projectUrl><#licenseName>
-  :license {:name "<&licenseName>"<#licenseUrl>
-            :url "<&licenseUrl>"</licenseUrl>}</licenseName>
+  :url "<&projectUrl>"</projectUrl><#projectLicenseName>
+  :license {:name "<&projectLicenseName>"<#projectLicenseUrl>
+            :url "<&projectLicenseUrl>"</projectLicenseUrl>}</projectLicenseName>
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [clj-http "2.0.0"]
                  [cheshire "5.5.0"]])

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,18 @@
             </modules>
         </profile>
         <profile>
+            <id>clojure-client</id>
+            <activation>
+                <property>
+                    <name>env</name>
+                    <value>clojure</value>
+                </property>
+            </activation>
+            <modules>
+                <module>samples/client/petstore/clojure</module>
+            </modules>
+        </profile>
+        <profile>
             <id>java-client</id>
             <activation>
                 <property>
@@ -435,6 +447,7 @@
             </activation>
             <modules>
                 <module>samples/client/petstore/android-java</module>
+                <module>samples/client/petstore/clojure</module>
                 <module>samples/client/petstore/java/default</module>
                 <module>samples/client/petstore/java/jersey2</module>
                 <module>samples/client/petstore/java/okhttp-gson</module>

--- a/samples/client/petstore/clojure/.gitignore
+++ b/samples/client/petstore/clojure/.gitignore
@@ -1,7 +1,6 @@
 /target
 /classes
 /checkouts
-pom.xml
 pom.xml.asc
 *.jar
 *.class

--- a/samples/client/petstore/clojure/pom.xml
+++ b/samples/client/petstore/clojure/pom.xml
@@ -1,0 +1,32 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.swagger</groupId>
+    <artifactId>swagger-petstore-clojure</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Swagger Petstore - Clojure Client</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>lein-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>lein</executable>
+                            <arguments>
+                                <argument>test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Improvements to Clojure client codegen (see #1585):

* Include the petstore clojure client into integration tests
* Add support of config options to Clojure client

Below is all config options supported in Clojure client for now:

```
$ java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar config-help -l clojure
CONFIG OPTIONS
	sortParamsByRequiredFlag
	    Sort method arguments to place required parameters before optional parameters. (Default: true)

	ensureUniqueParams
	    Whether to ensure parameter names are unique in an operation (rename parameters that are not). Default: true

	projectName
	    name of the project (Default: generated from info.title or "swagger-clj-client")

	projectDescription
	    description of the project (Default: using info.description or "Client library of <projectNname>")

	projectVersion
	    version of the project (Default: using info.version or "1.0.0")

	projectUrl
	    URL of the project (Default: using info.contact.url or not included in project.clj)

	projectLicenseName
	    name of the license the project uses (Default: using info.license.name or not included in project.clj)

	projectLicenseUrl
	    URL of the license the project uses (Default: using info.license.url or not included in project.clj)

	baseNamespace
	    the base/top namespace (Default: generated from projectName)
```