### PR TITLE
[PHP] fix access token setter

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/configuration.mustache
@@ -211,7 +211,7 @@ class Configuration
      */
     public function setAccessToken($accessToken)
     {
-        $this->$accessToken = $accessToken;
+        $this->accessToken = $accessToken;
         return $this;
     }
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
@@ -211,7 +211,7 @@ class Configuration
      */
     public function setAccessToken($accessToken)
     {
-        $this->$accessToken = $accessToken;
+        $this->accessToken = $accessToken;
         return $this;
     }
 

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -82,6 +82,10 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
     $this->assertNotEquals($apiClient3, $apiClient4);
     // customied pet api not using the old pet api's api client
     $this->assertNotEquals($pet_api2->getApiClient(), $pet_api3->getApiClient());
+
+    // test access token
+    $api_client->getConfig()->setAccessToken("testing_only");
+    $this->assertSame('testing_only', $api_client->getConfig()->getAccessToken());
   }
 
   // test getPetById with a Pet object (id 10005)


### PR DESCRIPTION
- Fixed minor bug in PHP access token (for oauth) setter.
- Added a test case to cover the bug moving forward.

```
PHPUnit 4.7.2 by Sebastian Bergmann and contributors.

.............

Time: 26.3 seconds, Memory: 7.00Mb

OK (13 tests, 533 assertions)
```