### PR TITLE
Do not resolve non-model body parameter as inline model

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -45,13 +45,15 @@ public class InlineModelResolver {
                                 if (bp.getSchema() != null) {
                                     Model model = bp.getSchema();
                                     if(model instanceof ModelImpl) {
-                                        String modelName = uniqueName(bp.getName());
                                         ModelImpl obj = (ModelImpl) model;
-                                        flattenProperties(obj.getProperties(), pathname);
+                                        if (obj.getType() == null || "object".equals(obj.getType())) {
+                                            String modelName = uniqueName(bp.getName());
+                                            flattenProperties(obj.getProperties(), pathname);
 
-                                        bp.setSchema(new RefModel(modelName));
-                                        addGenerated(modelName, model);
-                                        swagger.addDefinition(modelName, model);
+                                            bp.setSchema(new RefModel(modelName));
+                                            addGenerated(modelName, model);
+                                            swagger.addDefinition(modelName, model);
+                                        }
                                     }
                                     else if (model instanceof ArrayModel) {
                                         ArrayModel am = (ArrayModel) model;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -14,7 +14,7 @@ public class CodegenTest {
 
     @Test(description = "read a file upload param from a 2.0 spec")
     public void fileUploadParamTest() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/petstore.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/petstore.json");
         final DefaultCodegen codegen = new DefaultCodegen();
         final String path = "/pet/{petId}/uploadImage";
         final Operation p = model.getPaths().get(path).getPost();
@@ -39,7 +39,7 @@ public class CodegenTest {
 
     @Test(description = "read formParam values from a 2.0 spec")
     public void formParamTest() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/petstore.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/petstore.json");
         final DefaultCodegen codegen = new DefaultCodegen();
         final String path = "/pet/{petId}";
         final Operation p = model.getPaths().get(path).getPost();
@@ -83,7 +83,7 @@ public class CodegenTest {
 
     @Test(description = "handle required parameters from a 2.0 spec as required when figuring out Swagger types")
     public void requiredParametersTest() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/requiredTest.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/requiredTest.json");
 
         final DefaultCodegen codegen = new DefaultCodegen() {
             public String getSwaggerType(Property p) {
@@ -106,7 +106,7 @@ public class CodegenTest {
 
     @Test(description = "select main response from a 2.0 spec using the lowest 2XX code")
     public void responseSelectionTest1() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/responseSelectionTest.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/responseSelectionTest.json");
         final DefaultCodegen codegen = new DefaultCodegen();
         final String path = "/tests/withTwoHundredAndDefault";
         final Operation p = model.getPaths().get(path).getGet();
@@ -117,7 +117,7 @@ public class CodegenTest {
 
     @Test(description = "select main response from a 2.0 spec using the default keyword when no 2XX code")
     public void responseSelectionTest2() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/responseSelectionTest.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/responseSelectionTest.json");
         final DefaultCodegen codegen = new DefaultCodegen();
         final String path = "/tests/withoutTwoHundredButDefault";
         final Operation p = model.getPaths().get(path).getGet();
@@ -128,7 +128,7 @@ public class CodegenTest {
 
     @Test(description = "return byte array when response format is byte")
     public void binaryDataTest() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/binaryDataTest.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/binaryDataTest.json");
         final DefaultCodegen codegen = new DefaultCodegen();
         final String path = "/tests/binaryResponse";
         final Operation p = model.getPaths().get(path).getPost();
@@ -142,7 +142,7 @@ public class CodegenTest {
     
     @Test(description = "use operation consumes and produces")
     public void localConsumesAndProducesTest() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/globalConsumesAndProduces.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/globalConsumesAndProduces.json");
         final DefaultCodegen codegen = new DefaultCodegen();
         final String path = "/tests/localConsumesAndProduces";
         final Operation p = model.getPaths().get(path).getGet();
@@ -158,7 +158,7 @@ public class CodegenTest {
     
     @Test(description = "use spec consumes and produces")
     public void globalConsumesAndProducesTest() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/globalConsumesAndProduces.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/globalConsumesAndProduces.json");
         final DefaultCodegen codegen = new DefaultCodegen();
         final String path = "/tests/globalConsumesAndProduces";
         final Operation p = model.getPaths().get(path).getGet();
@@ -174,7 +174,7 @@ public class CodegenTest {
  
     @Test(description = "use operation consumes and produces (reset in operation with empty array)")
     public void localResetConsumesAndProducesTest() {
-        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/globalConsumesAndProduces.json");
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/globalConsumesAndProduces.json");
         final DefaultCodegen codegen = new DefaultCodegen();
         final String path = "/tests/localResetConsumesAndProduces";
         final Operation p = model.getPaths().get(path).getGet();
@@ -186,5 +186,12 @@ public class CodegenTest {
         Assert.assertFalse(op.hasProduces);
         Assert.assertNull(op.produces);
 
+    }
+
+    private Swagger parseAndPrepareSwagger(String path) {
+        Swagger swagger = new SwaggerParser().read(path);
+        // resolve inline models
+        new InlineModelResolver().flatten(swagger);
+        return swagger;
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/InlineModelResolverTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/InlineModelResolverTest.java
@@ -128,6 +128,28 @@ public class InlineModelResolverTest {
     }
 
     @Test
+    public void notResolveNonModelBodyParameter() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ModelImpl()
+                                        .type("string")
+                                        .format("binary")))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Operation operation = swagger.getPaths().get("/hello").getGet();
+        BodyParameter bp = (BodyParameter)operation.getParameters().get(0);
+        assertTrue(bp.getSchema() instanceof ModelImpl);
+        ModelImpl m = (ModelImpl) bp.getSchema();
+        assertEquals("string", m.getType());
+        assertEquals("binary", m.getFormat());
+    }
+
+    @Test
     public void resolveInlineArrayBodyParameter() throws Exception {
         Swagger swagger = new Swagger();
 


### PR DESCRIPTION
This PR fixes the issue of treating non-model body parameter as inline model, for example:

```json
 {
    "name": "InputBinaryData",
    "in": "body",
    "required": true,
    "schema": {
        "type": "string",
        "format": "binary"
    }
}
```