### PR TITLE
[Obj-C] Fixed invalid Objective-C code generation.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class CodegenProperty {
     public String baseName, complexType, getter, setter, description, datatype, datatypeWithEnum,
-            name, min, max, defaultValue, baseType, containerType;
+            name, min, max, defaultValue, baseType, containerType, otherSettings;
 
     public String unescapedDescription;
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -27,6 +27,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     public static final String GIT_REPO_URL = "gitRepoURL";
     public static final String LICENSE = "license";
     protected Set<String> foundationClasses = new HashSet<String>();
+    protected Set<String> forbiddenBeginnings;
     protected String podName = "SwaggerClient";
     protected String podVersion = "1.0.0";
     protected String classPrefix = "SWG";
@@ -98,11 +99,13 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
                         "default", "if", "id", "static", "while",
                         "do", "int", "struct", "_Packed",
                         "double", "protocol", "interface", "implementation",
-                        "NSObject", "NSInteger", "NSNumber", "CGFloat",
+                        "new", "NSObject", "NSInteger", "NSNumber", "CGFloat",
                         "property", "nonatomic", "retain", "strong",
                         "weak", "unsafe_unretained", "readwrite", "readonly",
                         "description"
                 ));
+
+        forbiddenBeginnings = new HashSet<String>(Arrays.asList("new"));
 
         importMapping = new HashMap<String, String>();
 
@@ -206,6 +209,17 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("Configuration-header.mustache", swaggerFolder, classPrefix + "Configuration.h"));
         supportingFiles.add(new SupportingFile("podspec.mustache", "", podName + ".podspec"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
+    }
+
+    @Override
+    public CodegenProperty fromProperty(String name, Property p) {
+        CodegenProperty codegenProperty = super.fromProperty(name, p);
+        for (String forbiddenBeginning : forbiddenBeginnings) {
+            if (name.startsWith(forbiddenBeginning)) {
+                codegenProperty.otherSettings = ", getter=get" + camelize(name);
+            }
+        }
+        return codegenProperty;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/objc/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/model-header.mustache
@@ -21,7 +21,7 @@
 {{#vars}}
 {{#description}}/* {{{description}}} {{^required}}[optional]{{/required}}
  */{{/description}}
-@property(nonatomic) {{{ datatype }}} {{name}};
+@property(nonatomic{{{otherSettings}}}) {{{ datatype }}} {{name}};
 {{/vars}}
 
 @end


### PR DESCRIPTION
Hi!

I was creating the following swagger definition.
```yaml
  ChangePasswordRequest:
    type: object
    required:
      - currentPassword
      - newPassword
    properties:
      currentPassword:
        type: string
        format: password
        description: The current password in plain text.
      newPassword:
        type: string
        format: password
        description: The new password in plain text.
```

Then I tried to generate the Objective-C client from it. Unfortunately it gave me a non-compiling source code for this object.
```objc
@property(nonatomic) NSString* newPassword;
```
`SwaggerClient/SWGChangePasswordRequest.h:22:32: Property follows Cocoa naming convention for returning 'owned' objects`

[Turns out](http://stackoverflow.com/a/6327547/3503324) Objective-C doesn't like properties starting with 'new'.

One way to fix it (what this PR contains) is specify the getter's name.
```objc
@property(nonatomic , getter=getNewPassword) NSString* newPassword;
```

So I tried to extend the existing .mustache file, but I couldn't find any extensible interface for CodegenProperty, so I had to add a new field. In my opinion there should be a dynamic field/method that allows us to extend this property with any fields. What do you think?

This pull request is just an illustration, I am not proud of the coding style, just wanted to show the problem with a quick solution.