### PR TITLE
Clojure client: docstrings tweaks

### DIFF
--- a/modules/swagger-codegen/src/main/resources/clojure/core.mustache
+++ b/modules/swagger-codegen/src/main/resources/clojure/core.mustache
@@ -169,15 +169,17 @@
        (map (fn [[k v]] [k (normalize-param v)]))
        (into {})))
 
-(defn json-mime? [mime]
+(defn json-mime?
   "Check if the given MIME is a standard JSON MIME or :json."
+  [mime]
   (if mime
     (or (= :json mime)
         (re-matches #"application/json(;.*)?" (name mime)))))
 
-(defn json-preferred-mime [mimes]
+(defn json-preferred-mime
   "Choose a MIME from the given MIMEs with JSON preferred,
   i.e. return JSON if included, otherwise return the first one."
+  [mimes]
   (-> (filter json-mime? mimes)
       first
       (or (first mimes))))

--- a/samples/client/petstore/clojure/src/swagger_petstore/core.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/core.clj
@@ -169,15 +169,17 @@
        (map (fn [[k v]] [k (normalize-param v)]))
        (into {})))
 
-(defn json-mime? [mime]
+(defn json-mime?
   "Check if the given MIME is a standard JSON MIME or :json."
+  [mime]
   (if mime
     (or (= :json mime)
         (re-matches #"application/json(;.*)?" (name mime)))))
 
-(defn json-preferred-mime [mimes]
+(defn json-preferred-mime
   "Choose a MIME from the given MIMEs with JSON preferred,
   i.e. return JSON if included, otherwise return the first one."
+  [mimes]
   (-> (filter json-mime? mimes)
       first
       (or (first mimes))))


### PR DESCRIPTION
Small stylistic improvements detected with `lein check` and `lein eastwood`.

* fix some reflection warnings by specifying the return type of `make-date-format`
* put docstrings/argument lists in the right order for a couple helper functions in core.mustache