### PR TITLE
Support accessing response status code and headers in Clojure client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/clojure/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/clojure/api.mustache
@@ -2,10 +2,10 @@
   (:require [<baseNamespace>.core :refer [call-api check-required-params with-collection-format]])
   (:import (java.io File)))
 <#operations><#operation>
-(defn <operationId>
+(defn <operationId>-with-http-info
   "<&summary><#notes>
   <&notes></notes>"<#hasOptionalParams>
-  ([<#allParams><#required><#isFile>^File </isFile><paramName> </required></allParams>] (<operationId><#allParams><#required> <paramName></required></allParams> nil))</hasOptionalParams>
+  ([<#allParams><#required><#isFile>^File </isFile><paramName> </required></allParams>] (<operationId>-with-http-info<#allParams><#required> <paramName></required></allParams> nil))</hasOptionalParams>
   <#hasOptionalParams>(</hasOptionalParams>[<#allParams><#required><#isFile>^File </isFile><paramName> </required></allParams><#hasOptionalParams>{:keys [<#allParams><^required><#isFile>^File </isFile><paramName> </required></allParams>]}</hasOptionalParams>]<#hasRequiredParams>
   <#hasOptionalParams> </hasOptionalParams>(check-required-params<#allParams><#required> <paramName></required></allParams>)</hasRequiredParams>
   <#hasOptionalParams> </hasOptionalParams>(call-api "<path>" :<httpMethod>
@@ -17,4 +17,11 @@
   <#hasOptionalParams> </hasOptionalParams>           :content-types [<#consumes>"<mediaType>"<#hasMore> </hasMore></consumes>]
   <#hasOptionalParams> </hasOptionalParams>           :accepts       [<#produces>"<mediaType>"<#hasMore> </hasMore></produces>]
   <#hasOptionalParams> </hasOptionalParams>           :auth-names    [<#authMethods>"<&name>"<#hasMore> </hasMore></authMethods>]})<#hasOptionalParams>)</hasOptionalParams>)
+
+(defn <operationId>
+  "<&summary><#notes>
+  <&notes></notes>"<#hasOptionalParams>
+  ([<#allParams><#required><#isFile>^File </isFile><paramName> </required></allParams>] (<operationId><#allParams><#required> <paramName></required></allParams> nil))</hasOptionalParams>
+  <#hasOptionalParams>(</hasOptionalParams>[<#allParams><#required><#isFile>^File </isFile><paramName> </required></allParams><#hasOptionalParams>optional-params</hasOptionalParams>]
+  <#hasOptionalParams> </hasOptionalParams>(:data (<operationId>-with-http-info<#allParams><#required> <paramName></required></allParams><#hasOptionalParams> optional-params</hasOptionalParams>))<#hasOptionalParams>)</hasOptionalParams>)
 </operation></operations>

--- a/modules/swagger-codegen/src/main/resources/clojure/core.mustache
+++ b/modules/swagger-codegen/src/main/resources/clojure/core.mustache
@@ -198,9 +198,10 @@
     (try
       (parse-string body true)
       (catch JsonParseException e
-        ;; return the body string directly on JSON parsing error
+        ;; Return the body string directly on JSON parsing error.
         body))
-    ;; for non-JSON response, return the body string directly
+
+    ;; For other cases, return the body string directly.
     :else body))
 
 (defn form-params->multipart
@@ -236,4 +237,4 @@
     (when debug
       (println "Response:")
       (println resp))
-    (deserialize resp)))
+    (assoc resp :data (deserialize resp))))

--- a/samples/client/petstore/clojure/src/swagger_petstore/api/pet.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/pet.clj
@@ -2,12 +2,34 @@
   (:require [swagger-petstore.core :refer [call-api check-required-params with-collection-format]])
   (:import (java.io File)))
 
+(defn update-pet-with-http-info
+  "Update an existing pet
+  "
+  ([] (update-pet-with-http-info nil))
+  ([{:keys [body ]}]
+   (call-api "/pet" :put
+             {:path-params   {}
+              :header-params {}
+              :query-params  {}
+              :form-params   {}
+              :body-param    body
+              :content-types ["application/json" "application/xml"]
+              :accepts       ["application/json" "application/xml"]
+              :auth-names    ["petstore_auth"]})))
+
 (defn update-pet
   "Update an existing pet
   "
   ([] (update-pet nil))
+  ([optional-params]
+   (:data (update-pet-with-http-info optional-params))))
+
+(defn add-pet-with-http-info
+  "Add a new pet to the store
+  "
+  ([] (add-pet-with-http-info nil))
   ([{:keys [body ]}]
-   (call-api "/pet" :put
+   (call-api "/pet" :post
              {:path-params   {}
               :header-params {}
               :query-params  {}
@@ -21,21 +43,13 @@
   "Add a new pet to the store
   "
   ([] (add-pet nil))
-  ([{:keys [body ]}]
-   (call-api "/pet" :post
-             {:path-params   {}
-              :header-params {}
-              :query-params  {}
-              :form-params   {}
-              :body-param    body
-              :content-types ["application/json" "application/xml"]
-              :accepts       ["application/json" "application/xml"]
-              :auth-names    ["petstore_auth"]})))
+  ([optional-params]
+   (:data (add-pet-with-http-info optional-params))))
 
-(defn find-pets-by-status
+(defn find-pets-by-status-with-http-info
   "Finds Pets by status
   Multiple status values can be provided with comma seperated strings"
-  ([] (find-pets-by-status nil))
+  ([] (find-pets-by-status-with-http-info nil))
   ([{:keys [status ]}]
    (call-api "/pet/findByStatus" :get
              {:path-params   {}
@@ -46,10 +60,17 @@
               :accepts       ["application/json" "application/xml"]
               :auth-names    ["petstore_auth"]})))
 
-(defn find-pets-by-tags
+(defn find-pets-by-status
+  "Finds Pets by status
+  Multiple status values can be provided with comma seperated strings"
+  ([] (find-pets-by-status nil))
+  ([optional-params]
+   (:data (find-pets-by-status-with-http-info optional-params))))
+
+(defn find-pets-by-tags-with-http-info
   "Finds Pets by tags
   Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing."
-  ([] (find-pets-by-tags nil))
+  ([] (find-pets-by-tags-with-http-info nil))
   ([{:keys [tags ]}]
    (call-api "/pet/findByTags" :get
              {:path-params   {}
@@ -60,7 +81,14 @@
               :accepts       ["application/json" "application/xml"]
               :auth-names    ["petstore_auth"]})))
 
-(defn get-pet-by-id
+(defn find-pets-by-tags
+  "Finds Pets by tags
+  Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing."
+  ([] (find-pets-by-tags nil))
+  ([optional-params]
+   (:data (find-pets-by-tags-with-http-info optional-params))))
+
+(defn get-pet-by-id-with-http-info
   "Find pet by ID
   Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
   [pet-id ]
@@ -73,10 +101,16 @@
              :accepts       ["application/json" "application/xml"]
              :auth-names    ["api_key"]}))
 
-(defn update-pet-with-form
+(defn get-pet-by-id
+  "Find pet by ID
+  Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
+  [pet-id ]
+  (:data (get-pet-by-id-with-http-info pet-id)))
+
+(defn update-pet-with-form-with-http-info
   "Updates a pet in the store with form data
   "
-  ([pet-id ] (update-pet-with-form pet-id nil))
+  ([pet-id ] (update-pet-with-form-with-http-info pet-id nil))
   ([pet-id {:keys [name status ]}]
    (call-api "/pet/{petId}" :post
              {:path-params   {"petId" pet-id }
@@ -87,10 +121,17 @@
               :accepts       ["application/json" "application/xml"]
               :auth-names    ["petstore_auth"]})))
 
-(defn delete-pet
+(defn update-pet-with-form
+  "Updates a pet in the store with form data
+  "
+  ([pet-id ] (update-pet-with-form pet-id nil))
+  ([pet-id optional-params]
+   (:data (update-pet-with-form-with-http-info pet-id optional-params))))
+
+(defn delete-pet-with-http-info
   "Deletes a pet
   "
-  ([pet-id ] (delete-pet pet-id nil))
+  ([pet-id ] (delete-pet-with-http-info pet-id nil))
   ([pet-id {:keys [api-key ]}]
    (call-api "/pet/{petId}" :delete
              {:path-params   {"petId" pet-id }
@@ -101,10 +142,17 @@
               :accepts       ["application/json" "application/xml"]
               :auth-names    ["petstore_auth"]})))
 
-(defn upload-file
+(defn delete-pet
+  "Deletes a pet
+  "
+  ([pet-id ] (delete-pet pet-id nil))
+  ([pet-id optional-params]
+   (:data (delete-pet-with-http-info pet-id optional-params))))
+
+(defn upload-file-with-http-info
   "uploads an image
   "
-  ([pet-id ] (upload-file pet-id nil))
+  ([pet-id ] (upload-file-with-http-info pet-id nil))
   ([pet-id {:keys [additional-metadata ^File file ]}]
    (call-api "/pet/{petId}/uploadImage" :post
              {:path-params   {"petId" pet-id }
@@ -114,3 +162,10 @@
               :content-types ["multipart/form-data"]
               :accepts       ["application/json" "application/xml"]
               :auth-names    ["petstore_auth"]})))
+
+(defn upload-file
+  "uploads an image
+  "
+  ([pet-id ] (upload-file pet-id nil))
+  ([pet-id optional-params]
+   (:data (upload-file-with-http-info pet-id optional-params))))

--- a/samples/client/petstore/clojure/src/swagger_petstore/api/store.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/store.clj
@@ -2,7 +2,7 @@
   (:require [swagger-petstore.core :refer [call-api check-required-params with-collection-format]])
   (:import (java.io File)))
 
-(defn get-inventory
+(defn get-inventory-with-http-info
   "Returns pet inventories by status
   Returns a map of status codes to quantities"
   []
@@ -15,10 +15,16 @@
              :accepts       ["application/json" "application/xml"]
              :auth-names    ["api_key"]}))
 
-(defn place-order
+(defn get-inventory
+  "Returns pet inventories by status
+  Returns a map of status codes to quantities"
+  []
+  (:data (get-inventory-with-http-info)))
+
+(defn place-order-with-http-info
   "Place an order for a pet
   "
-  ([] (place-order nil))
+  ([] (place-order-with-http-info nil))
   ([{:keys [body ]}]
    (call-api "/store/order" :post
              {:path-params   {}
@@ -30,7 +36,14 @@
               :accepts       ["application/json" "application/xml"]
               :auth-names    []})))
 
-(defn get-order-by-id
+(defn place-order
+  "Place an order for a pet
+  "
+  ([] (place-order nil))
+  ([optional-params]
+   (:data (place-order-with-http-info optional-params))))
+
+(defn get-order-by-id-with-http-info
   "Find purchase order by ID
   For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions"
   [order-id ]
@@ -43,7 +56,13 @@
              :accepts       ["application/json" "application/xml"]
              :auth-names    []}))
 
-(defn delete-order
+(defn get-order-by-id
+  "Find purchase order by ID
+  For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions"
+  [order-id ]
+  (:data (get-order-by-id-with-http-info order-id)))
+
+(defn delete-order-with-http-info
   "Delete purchase order by ID
   For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors"
   [order-id ]
@@ -55,3 +74,9 @@
              :content-types []
              :accepts       ["application/json" "application/xml"]
              :auth-names    []}))
+
+(defn delete-order
+  "Delete purchase order by ID
+  For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors"
+  [order-id ]
+  (:data (delete-order-with-http-info order-id)))

--- a/samples/client/petstore/clojure/src/swagger_petstore/api/user.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/user.clj
@@ -2,12 +2,34 @@
   (:require [swagger-petstore.core :refer [call-api check-required-params with-collection-format]])
   (:import (java.io File)))
 
+(defn create-user-with-http-info
+  "Create user
+  This can only be done by the logged in user."
+  ([] (create-user-with-http-info nil))
+  ([{:keys [body ]}]
+   (call-api "/user" :post
+             {:path-params   {}
+              :header-params {}
+              :query-params  {}
+              :form-params   {}
+              :body-param    body
+              :content-types []
+              :accepts       ["application/json" "application/xml"]
+              :auth-names    []})))
+
 (defn create-user
   "Create user
   This can only be done by the logged in user."
   ([] (create-user nil))
+  ([optional-params]
+   (:data (create-user-with-http-info optional-params))))
+
+(defn create-users-with-array-input-with-http-info
+  "Creates list of users with given input array
+  "
+  ([] (create-users-with-array-input-with-http-info nil))
   ([{:keys [body ]}]
-   (call-api "/user" :post
+   (call-api "/user/createWithArray" :post
              {:path-params   {}
               :header-params {}
               :query-params  {}
@@ -21,8 +43,15 @@
   "Creates list of users with given input array
   "
   ([] (create-users-with-array-input nil))
+  ([optional-params]
+   (:data (create-users-with-array-input-with-http-info optional-params))))
+
+(defn create-users-with-list-input-with-http-info
+  "Creates list of users with given input array
+  "
+  ([] (create-users-with-list-input-with-http-info nil))
   ([{:keys [body ]}]
-   (call-api "/user/createWithArray" :post
+   (call-api "/user/createWithList" :post
              {:path-params   {}
               :header-params {}
               :query-params  {}
@@ -36,21 +65,13 @@
   "Creates list of users with given input array
   "
   ([] (create-users-with-list-input nil))
-  ([{:keys [body ]}]
-   (call-api "/user/createWithList" :post
-             {:path-params   {}
-              :header-params {}
-              :query-params  {}
-              :form-params   {}
-              :body-param    body
-              :content-types []
-              :accepts       ["application/json" "application/xml"]
-              :auth-names    []})))
+  ([optional-params]
+   (:data (create-users-with-list-input-with-http-info optional-params))))
 
-(defn login-user
+(defn login-user-with-http-info
   "Logs user into the system
   "
-  ([] (login-user nil))
+  ([] (login-user-with-http-info nil))
   ([{:keys [username password ]}]
    (call-api "/user/login" :get
              {:path-params   {}
@@ -61,7 +82,14 @@
               :accepts       ["application/json" "application/xml"]
               :auth-names    []})))
 
-(defn logout-user
+(defn login-user
+  "Logs user into the system
+  "
+  ([] (login-user nil))
+  ([optional-params]
+   (:data (login-user-with-http-info optional-params))))
+
+(defn logout-user-with-http-info
   "Logs out current logged in user session
   "
   []
@@ -74,7 +102,13 @@
              :accepts       ["application/json" "application/xml"]
              :auth-names    []}))
 
-(defn get-user-by-name
+(defn logout-user
+  "Logs out current logged in user session
+  "
+  []
+  (:data (logout-user-with-http-info)))
+
+(defn get-user-by-name-with-http-info
   "Get user by user name
   "
   [username ]
@@ -87,10 +121,16 @@
              :accepts       ["application/json" "application/xml"]
              :auth-names    []}))
 
-(defn update-user
+(defn get-user-by-name
+  "Get user by user name
+  "
+  [username ]
+  (:data (get-user-by-name-with-http-info username)))
+
+(defn update-user-with-http-info
   "Updated user
   This can only be done by the logged in user."
-  ([username ] (update-user username nil))
+  ([username ] (update-user-with-http-info username nil))
   ([username {:keys [body ]}]
    (call-api "/user/{username}" :put
              {:path-params   {"username" username }
@@ -102,7 +142,14 @@
               :accepts       ["application/json" "application/xml"]
               :auth-names    []})))
 
-(defn delete-user
+(defn update-user
+  "Updated user
+  This can only be done by the logged in user."
+  ([username ] (update-user username nil))
+  ([username optional-params]
+   (:data (update-user-with-http-info username optional-params))))
+
+(defn delete-user-with-http-info
   "Delete user
   This can only be done by the logged in user."
   [username ]
@@ -114,3 +161,9 @@
              :content-types []
              :accepts       ["application/json" "application/xml"]
              :auth-names    []}))
+
+(defn delete-user
+  "Delete user
+  This can only be done by the logged in user."
+  [username ]
+  (:data (delete-user-with-http-info username)))

--- a/samples/client/petstore/clojure/src/swagger_petstore/core.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/core.clj
@@ -198,9 +198,10 @@
     (try
       (parse-string body true)
       (catch JsonParseException e
-        ;; return the body string directly on JSON parsing error
+        ;; Return the body string directly on JSON parsing error.
         body))
-    ;; for non-JSON response, return the body string directly
+
+    ;; For other cases, return the body string directly.
     :else body))
 
 (defn form-params->multipart
@@ -236,4 +237,4 @@
     (when debug
       (println "Response:")
       (println resp))
-    (deserialize resp)))
+    (assoc resp :data (deserialize resp))))

--- a/samples/client/petstore/clojure/test/swagger_petstore/api/pet_test.clj
+++ b/samples/client/petstore/clojure/test/swagger_petstore/api/pet_test.clj
@@ -30,6 +30,18 @@
     (is (= (get-in pet [:category :name]) (get-in fetched [:category :name])))
     (delete-pet id)))
 
+(deftest test-create-and-get-pet-with-http-info
+  (let [{:keys [id] :as pet} (make-random-pet)
+        _ (add-pet-with-http-info {:body pet})
+        {:keys [status headers data]} (get-pet-by-id-with-http-info id)]
+    (is (= 200 status))
+    (is (= "application/json" (:content-type headers)))
+    (is (identity data))
+    (is (= id (:id data)))
+    (is (identity (:category data)))
+    (is (= (get-in pet [:category :name]) (get-in data [:category :name])))
+    (delete-pet id)))
+
 (deftest test-find-pets-by-status
   (let [status "pending"
         {:keys [id] :as pet} (make-random-pet {:status status})


### PR DESCRIPTION
Sample code:

```clojure
(let [resp (get-pet-by-id-with-http-info 1)]
  (println "Status code:" (:status resp))
  (println "Content-Type header:" (get-in resp [:headers :content-type]))
  (println "Data: " (:data resp)))

;; The original method (without the `-with-http-info` suffix) works as before
;; which returns the data directly without HTTP response info
(println (get-pet-by-id 1))
```

Closes #1656