### PR TITLE
Add WithHttpInfo API methods to Java okhttp-gson client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -232,6 +232,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         if ("okhttp-gson".equals(getLibrary())) {
             // the "okhttp-gson" library template requires "ApiCallback.mustache" for async call
             supportingFiles.add(new SupportingFile("ApiCallback.mustache", invokerFolder, "ApiCallback.java"));
+            supportingFiles.add(new SupportingFile("ApiResponse.mustache", invokerFolder, "ApiResponse.java"));
             supportingFiles.add(new SupportingFile("ProgressRequestBody.mustache", invokerFolder, "ProgressRequestBody.java"));
             supportingFiles.add(new SupportingFile("ProgressResponseBody.mustache", invokerFolder, "ProgressResponseBody.java"));
             // "build.sbt" is for development with SBT

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -104,9 +104,6 @@ public class ApiClient {
 
   private Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
-
   private DateFormat dateFormat;
   private DateFormat datetimeFormat;
   private boolean lenientDatetimeFormat;
@@ -175,24 +172,6 @@ public class ApiClient {
   public ApiClient setJSON(JSON json) {
     this.json = json;
     return this;
-  }
-
-  /**
-   * Gets the status code of the previous request.
-   * NOTE: Status code of last async response is not recorded here, it is
-   * passed to the callback methods instead.
-   */
-  public int getStatusCode() {
-    return statusCode;
-  }
-
-  /**
-   * Gets the response headers of the previous request.
-   * NOTE: Headers of last async response is not recorded here, it is passed
-   * to callback methods instead.
-   */
-  public Map<String, List<String>> getResponseHeaders() {
-    return responseHeaders;
   }
 
   public boolean isVerifyingSsl() {
@@ -731,7 +710,7 @@ public class ApiClient {
   /**
    * @see #execute(Call, Type)
    */
-  public <T> T execute(Call call) throws ApiException {
+  public <T> ApiResponse<T> execute(Call call) throws ApiException {
     return execute(call, null);
   }
 
@@ -740,14 +719,15 @@ public class ApiClient {
    *
    * @param returnType The return type used to deserialize HTTP response body
    * @param <T> The return type corresponding to (same with) returnType
-   * @return The Java object deserialized from response body. Returns null if returnType is null.
+   * @return <code>ApiResponse</code> object containing response status, headers and
+   *   data, which is a Java object deserialized from response body and would be null
+   *   when returnType is null.
    */
-  public <T> T execute(Call call, Type returnType) throws ApiException {
+  public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
     try {
       Response response = call.execute();
-      this.statusCode = response.code();
-      this.responseHeaders = response.headers().toMultimap();
-      return handleResponse(response, returnType);
+      T data = handleResponse(response, returnType);
+      return new ApiResponse<T>(response.code(), response.headers().toMultimap(), data);
     } catch (IOException e) {
       throw new ApiException(e);
     }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -597,6 +597,8 @@ public class ApiClient {
    * @param response HTTP response
    * @param returnType The type of the Java object
    * @return The deserialized Java object
+   * @throws ApiException If fail to deserialize response body, i.e. cannot read response body
+   *   or the Content-Type of the response is not supported.
    */
   public <T> T deserialize(Response response, Type returnType) throws ApiException {
     if (response == null || returnType == null)
@@ -645,6 +647,7 @@ public class ApiClient {
    * @param obj The Java object
    * @param contentType The request Content-Type
    * @return The serialized string
+   * @throws ApiException If fail to serialize the given object
    */
   public String serialize(Object obj, String contentType) throws ApiException {
     if (contentType.startsWith("application/json")) {
@@ -659,6 +662,7 @@ public class ApiClient {
 
   /**
    * Download file from the given response.
+   * @throws ApiException If fail to read file content from response and write to disk
    */
   public File downloadFileFromResponse(Response response) throws ApiException {
     try {
@@ -722,6 +726,7 @@ public class ApiClient {
    * @return <code>ApiResponse</code> object containing response status, headers and
    *   data, which is a Java object deserialized from response body and would be null
    *   when returnType is null.
+   * @throws ApiException If fail to execute the call
    */
   public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
     try {
@@ -736,7 +741,7 @@ public class ApiClient {
   /**
    * #see executeAsync(Call, Type, ApiCallback)
    */
-  public <T> void executeAsync(Call call, ApiCallback<T> callback) throws ApiException {
+  public <T> void executeAsync(Call call, ApiCallback<T> callback) {
     executeAsync(call, null, callback);
   }
 
@@ -767,6 +772,12 @@ public class ApiClient {
     });
   }
 
+  /**
+   * Handle the given response, return the deserialized object when the response is successful.
+   *
+   * @throws ApiException If the response has a unsuccessful status code or
+   *   fail to deserialize the response body
+   */
   public <T> T handleResponse(Response response, Type returnType) throws ApiException {
     if (response.isSuccessful()) {
       if (returnType == null || response.code() == 204) {
@@ -800,6 +811,7 @@ public class ApiClient {
    * @param formParams The form parameters
    * @param authNames The authentications to apply
    * @return The HTTP call
+   * @throws ApiException If fail to serialize the request body object
    */
   public Call buildCall(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     updateParamsForAuth(authNames, queryParams, headerParams);

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiResponse.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiResponse.mustache
@@ -3,15 +3,29 @@ package {{invokerPackage}};
 import java.util.List;
 import java.util.Map;
 
+/**
+ * API response returned by API call.
+ *
+ * @param T The type of data that is deserialized from response body
+ */
 public class ApiResponse<T> {
   final private int statusCode;
   final private Map<String, List<String>> headers;
   final private T data;
 
+  /**
+   * @param statusCode The status code of HTTP response
+   * @param headers The headers of HTTP response
+   */
   public ApiResponse(int statusCode, Map<String, List<String>> headers) {
     this(statusCode, headers, null);
   }
 
+  /**
+   * @param statusCode The status code of HTTP response
+   * @param headers The headers of HTTP response
+   * @param data The object deserialized from response bod
+   */
   public ApiResponse(int statusCode, Map<String, List<String>> headers, T data) {
     this.statusCode = statusCode;
     this.headers = headers;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiResponse.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiResponse.mustache
@@ -1,0 +1,32 @@
+package {{invokerPackage}};
+
+import java.util.List;
+import java.util.Map;
+
+public class ApiResponse<T> {
+  final private int statusCode;
+  final private Map<String, List<String>> headers;
+  final private T data;
+
+  public ApiResponse(int statusCode, Map<String, List<String>> headers) {
+    this(statusCode, headers, null);
+  }
+
+  public ApiResponse(int statusCode, Map<String, List<String>> headers, T data) {
+    this.statusCode = statusCode;
+    this.headers = headers;
+    this.data = data;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  public Map<String, List<String>> getHeaders() {
+    return headers;
+  }
+
+  public T getData() {
+    return data;
+  }
+}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -3,6 +3,7 @@ package {{package}};
 import {{invokerPackage}}.ApiCallback;
 import {{invokerPackage}}.ApiClient;
 import {{invokerPackage}}.ApiException;
+import {{invokerPackage}}.ApiResponse;
 import {{invokerPackage}}.Configuration;
 import {{invokerPackage}}.Pair;
 import {{invokerPackage}}.ProgressRequestBody;
@@ -106,9 +107,20 @@ public class {{classname}} {
    * @return {{{returnType}}}{{/returnType}}
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
+    {{#returnType}}ApiResponse<{{{returnType}}}> {{localVariablePrefix}}resp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
+    return {{localVariablePrefix}}resp.getData();{{/returnType}}
+  }
+
+  /**
+   * {{summary}}
+   * {{notes}}{{#allParams}}
+   * @param {{paramName}} {{description}}{{/allParams}}
+   * @return ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
+   */
+  public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
     Call {{localVariablePrefix}}call = {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}null, null);
     {{#returnType}}Type {{localVariablePrefix}}returnType = new TypeToken<{{{returnType}}}>(){}.getType();
-    return {{localVariablePrefix}}apiClient.execute({{localVariablePrefix}}call, {{localVariablePrefix}}returnType);{{/returnType}}{{^returnType}}{{localVariablePrefix}}apiClient.execute({{localVariablePrefix}}call);{{/returnType}}
+    return {{localVariablePrefix}}apiClient.execute({{localVariablePrefix}}call, {{localVariablePrefix}}returnType);{{/returnType}}{{^returnType}}return {{localVariablePrefix}}apiClient.execute({{localVariablePrefix}}call);{{/returnType}}
   }
 
   /**

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -105,6 +105,7 @@ public class {{classname}} {
    * {{notes}}{{#allParams}}
    * @param {{paramName}} {{description}}{{/allParams}}{{#returnType}}
    * @return {{{returnType}}}{{/returnType}}
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
     {{#returnType}}ApiResponse<{{{returnType}}}> {{localVariablePrefix}}resp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
@@ -116,6 +117,7 @@ public class {{classname}} {
    * {{notes}}{{#allParams}}
    * @param {{paramName}} {{description}}{{/allParams}}
    * @return ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
     Call {{localVariablePrefix}}call = {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}null, null);
@@ -129,6 +131,7 @@ public class {{classname}} {
    * @param {{paramName}} {{description}}{{/allParams}}
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{localVariablePrefix}}callback) throws ApiException {
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -596,6 +596,8 @@ public class ApiClient {
    * @param response HTTP response
    * @param returnType The type of the Java object
    * @return The deserialized Java object
+   * @throws ApiException If fail to deserialize response body, i.e. cannot read response body
+   *   or the Content-Type of the response is not supported.
    */
   public <T> T deserialize(Response response, Type returnType) throws ApiException {
     if (response == null || returnType == null)
@@ -644,6 +646,7 @@ public class ApiClient {
    * @param obj The Java object
    * @param contentType The request Content-Type
    * @return The serialized string
+   * @throws ApiException If fail to serialize the given object
    */
   public String serialize(Object obj, String contentType) throws ApiException {
     if (contentType.startsWith("application/json")) {
@@ -658,6 +661,7 @@ public class ApiClient {
 
   /**
    * Download file from the given response.
+   * @throws ApiException If fail to read file content from response and write to disk
    */
   public File downloadFileFromResponse(Response response) throws ApiException {
     try {
@@ -721,6 +725,7 @@ public class ApiClient {
    * @return <code>ApiResponse</code> object containing response status, headers and
    *   data, which is a Java object deserialized from response body and would be null
    *   when returnType is null.
+   * @throws ApiException If fail to execute the call
    */
   public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
     try {
@@ -735,7 +740,7 @@ public class ApiClient {
   /**
    * #see executeAsync(Call, Type, ApiCallback)
    */
-  public <T> void executeAsync(Call call, ApiCallback<T> callback) throws ApiException {
+  public <T> void executeAsync(Call call, ApiCallback<T> callback) {
     executeAsync(call, null, callback);
   }
 
@@ -766,6 +771,12 @@ public class ApiClient {
     });
   }
 
+  /**
+   * Handle the given response, return the deserialized object when the response is successful.
+   *
+   * @throws ApiException If the response has a unsuccessful status code or
+   *   fail to deserialize the response body
+   */
   public <T> T handleResponse(Response response, Type returnType) throws ApiException {
     if (response.isSuccessful()) {
       if (returnType == null || response.code() == 204) {
@@ -799,6 +810,7 @@ public class ApiClient {
    * @param formParams The form parameters
    * @param authNames The authentications to apply
    * @return The HTTP call
+   * @throws ApiException If fail to serialize the request body object
    */
   public Call buildCall(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, Object> formParams, String[] authNames, ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     updateParamsForAuth(authNames, queryParams, headerParams);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiException.java
@@ -3,7 +3,7 @@ package io.swagger.client;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:08.052+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-07T12:21:33.403+08:00")
 public class ApiException extends Exception {
   private int code = 0;
   private Map<String, List<String>> responseHeaders = null;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiResponse.java
@@ -3,15 +3,29 @@ package io.swagger.client;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * API response returned by API call.
+ *
+ * @param T The type of data that is deserialized from response body
+ */
 public class ApiResponse<T> {
   final private int statusCode;
   final private Map<String, List<String>> headers;
   final private T data;
 
+  /**
+   * @param statusCode The status code of HTTP response
+   * @param headers The headers of HTTP response
+   */
   public ApiResponse(int statusCode, Map<String, List<String>> headers) {
     this(statusCode, headers, null);
   }
 
+  /**
+   * @param statusCode The status code of HTTP response
+   * @param headers The headers of HTTP response
+   * @param data The object deserialized from response bod
+   */
   public ApiResponse(int statusCode, Map<String, List<String>> headers, T data) {
     this.statusCode = statusCode;
     this.headers = headers;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiResponse.java
@@ -1,0 +1,32 @@
+package io.swagger.client;
+
+import java.util.List;
+import java.util.Map;
+
+public class ApiResponse<T> {
+  final private int statusCode;
+  final private Map<String, List<String>> headers;
+  final private T data;
+
+  public ApiResponse(int statusCode, Map<String, List<String>> headers) {
+    this(statusCode, headers, null);
+  }
+
+  public ApiResponse(int statusCode, Map<String, List<String>> headers, T data) {
+    this.statusCode = statusCode;
+    this.headers = headers;
+    this.data = data;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  public Map<String, List<String>> getHeaders() {
+    return headers;
+  }
+
+  public T getData() {
+    return data;
+  }
+}

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/Configuration.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/Configuration.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:08.052+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-07T12:21:33.403+08:00")
 public class Configuration {
   private static ApiClient defaultApiClient = new ApiClient();
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/Pair.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/Pair.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:08.052+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-07T12:21:33.403+08:00")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/StringUtil.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/StringUtil.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:08.052+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-07T12:21:33.403+08:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
@@ -89,6 +89,7 @@ public class PetApi {
    * Update an existing pet
    * 
    * @param body Pet object that needs to be added to the store
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void updatePet(Pet body) throws ApiException {
     updatePetWithHttpInfo(body);
@@ -99,6 +100,7 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
     Call call = updatePetCall(body, null, null);
@@ -111,6 +113,7 @@ public class PetApi {
    * @param body Pet object that needs to be added to the store
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call updatePetAsync(Pet body, final ApiCallback<Void> callback) throws ApiException {
 
@@ -184,6 +187,7 @@ public class PetApi {
    * Add a new pet to the store
    * 
    * @param body Pet object that needs to be added to the store
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void addPet(Pet body) throws ApiException {
     addPetWithHttpInfo(body);
@@ -194,6 +198,7 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
     Call call = addPetCall(body, null, null);
@@ -206,6 +211,7 @@ public class PetApi {
    * @param body Pet object that needs to be added to the store
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call addPetAsync(Pet body, final ApiCallback<Void> callback) throws ApiException {
 
@@ -282,6 +288,7 @@ public class PetApi {
    * Multiple status values can be provided with comma seperated strings
    * @param status Status values that need to be considered for filter
    * @return List<Pet>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public List<Pet> findPetsByStatus(List<String> status) throws ApiException {
     ApiResponse<List<Pet>> resp = findPetsByStatusWithHttpInfo(status);
@@ -293,6 +300,7 @@ public class PetApi {
    * Multiple status values can be provided with comma seperated strings
    * @param status Status values that need to be considered for filter
    * @return ApiResponse<List<Pet>>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
     Call call = findPetsByStatusCall(status, null, null);
@@ -306,6 +314,7 @@ public class PetApi {
    * @param status Status values that need to be considered for filter
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call findPetsByStatusAsync(List<String> status, final ApiCallback<List<Pet>> callback) throws ApiException {
 
@@ -383,6 +392,7 @@ public class PetApi {
    * Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
    * @param tags Tags to filter by
    * @return List<Pet>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
     ApiResponse<List<Pet>> resp = findPetsByTagsWithHttpInfo(tags);
@@ -394,6 +404,7 @@ public class PetApi {
    * Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
    * @param tags Tags to filter by
    * @return ApiResponse<List<Pet>>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
     Call call = findPetsByTagsCall(tags, null, null);
@@ -407,6 +418,7 @@ public class PetApi {
    * @param tags Tags to filter by
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call findPetsByTagsAsync(List<String> tags, final ApiCallback<List<Pet>> callback) throws ApiException {
 
@@ -488,6 +500,7 @@ public class PetApi {
    * Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
    * @param petId ID of pet that needs to be fetched
    * @return Pet
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public Pet getPetById(Long petId) throws ApiException {
     ApiResponse<Pet> resp = getPetByIdWithHttpInfo(petId);
@@ -499,6 +512,7 @@ public class PetApi {
    * Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
    * @param petId ID of pet that needs to be fetched
    * @return ApiResponse<Pet>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
     Call call = getPetByIdCall(petId, null, null);
@@ -512,6 +526,7 @@ public class PetApi {
    * @param petId ID of pet that needs to be fetched
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call getPetByIdAsync(Long petId, final ApiCallback<Pet> callback) throws ApiException {
 
@@ -598,6 +613,7 @@ public class PetApi {
    * @param petId ID of pet that needs to be updated
    * @param name Updated name of the pet
    * @param status Updated status of the pet
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void updatePetWithForm(String petId, String name, String status) throws ApiException {
     updatePetWithFormWithHttpInfo(petId, name, status);
@@ -610,6 +626,7 @@ public class PetApi {
    * @param name Updated name of the pet
    * @param status Updated status of the pet
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(String petId, String name, String status) throws ApiException {
     Call call = updatePetWithFormCall(petId, name, status, null, null);
@@ -624,6 +641,7 @@ public class PetApi {
    * @param status Updated status of the pet
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call updatePetWithFormAsync(String petId, String name, String status, final ApiCallback<Void> callback) throws ApiException {
 
@@ -706,6 +724,7 @@ public class PetApi {
    * 
    * @param petId Pet id to delete
    * @param apiKey 
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void deletePet(Long petId, String apiKey) throws ApiException {
     deletePetWithHttpInfo(petId, apiKey);
@@ -717,6 +736,7 @@ public class PetApi {
    * @param petId Pet id to delete
    * @param apiKey 
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
     Call call = deletePetCall(petId, apiKey, null, null);
@@ -730,6 +750,7 @@ public class PetApi {
    * @param apiKey 
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call deletePetAsync(Long petId, String apiKey, final ApiCallback<Void> callback) throws ApiException {
 
@@ -815,6 +836,7 @@ public class PetApi {
    * @param petId ID of pet to update
    * @param additionalMetadata Additional data to pass to server
    * @param file file to upload
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void uploadFile(Long petId, String additionalMetadata, File file) throws ApiException {
     uploadFileWithHttpInfo(petId, additionalMetadata, file);
@@ -827,6 +849,7 @@ public class PetApi {
    * @param additionalMetadata Additional data to pass to server
    * @param file file to upload
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
     Call call = uploadFileCall(petId, additionalMetadata, file, null, null);
@@ -841,6 +864,7 @@ public class PetApi {
    * @param file file to upload
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call uploadFileAsync(Long petId, String additionalMetadata, File file, final ApiCallback<Void> callback) throws ApiException {
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.ApiCallback;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
+import io.swagger.client.ApiResponse;
 import io.swagger.client.Configuration;
 import io.swagger.client.Pair;
 import io.swagger.client.ProgressRequestBody;
@@ -90,8 +91,18 @@ public class PetApi {
    * @param body Pet object that needs to be added to the store
    */
   public void updatePet(Pet body) throws ApiException {
+    updatePetWithHttpInfo(body);
+  }
+
+  /**
+   * Update an existing pet
+   * 
+   * @param body Pet object that needs to be added to the store
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
     Call call = updatePetCall(body, null, null);
-    apiClient.execute(call);
+    return apiClient.execute(call);
   }
 
   /**
@@ -106,7 +117,7 @@ public class PetApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -175,8 +186,18 @@ public class PetApi {
    * @param body Pet object that needs to be added to the store
    */
   public void addPet(Pet body) throws ApiException {
+    addPetWithHttpInfo(body);
+  }
+
+  /**
+   * Add a new pet to the store
+   * 
+   * @param body Pet object that needs to be added to the store
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
     Call call = addPetCall(body, null, null);
-    apiClient.execute(call);
+    return apiClient.execute(call);
   }
 
   /**
@@ -191,7 +212,7 @@ public class PetApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -263,6 +284,17 @@ public class PetApi {
    * @return List<Pet>
    */
   public List<Pet> findPetsByStatus(List<String> status) throws ApiException {
+    ApiResponse<List<Pet>> resp = findPetsByStatusWithHttpInfo(status);
+    return resp.getData();
+  }
+
+  /**
+   * Finds Pets by status
+   * Multiple status values can be provided with comma seperated strings
+   * @param status Status values that need to be considered for filter
+   * @return ApiResponse<List<Pet>>
+   */
+  public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
     Call call = findPetsByStatusCall(status, null, null);
     Type returnType = new TypeToken<List<Pet>>(){}.getType();
     return apiClient.execute(call, returnType);
@@ -280,7 +312,7 @@ public class PetApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -353,6 +385,17 @@ public class PetApi {
    * @return List<Pet>
    */
   public List<Pet> findPetsByTags(List<String> tags) throws ApiException {
+    ApiResponse<List<Pet>> resp = findPetsByTagsWithHttpInfo(tags);
+    return resp.getData();
+  }
+
+  /**
+   * Finds Pets by tags
+   * Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
+   * @param tags Tags to filter by
+   * @return ApiResponse<List<Pet>>
+   */
+  public ApiResponse<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws ApiException {
     Call call = findPetsByTagsCall(tags, null, null);
     Type returnType = new TypeToken<List<Pet>>(){}.getType();
     return apiClient.execute(call, returnType);
@@ -370,7 +413,7 @@ public class PetApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -447,6 +490,17 @@ public class PetApi {
    * @return Pet
    */
   public Pet getPetById(Long petId) throws ApiException {
+    ApiResponse<Pet> resp = getPetByIdWithHttpInfo(petId);
+    return resp.getData();
+  }
+
+  /**
+   * Find pet by ID
+   * Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
+   * @param petId ID of pet that needs to be fetched
+   * @return ApiResponse<Pet>
+   */
+  public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
     Call call = getPetByIdCall(petId, null, null);
     Type returnType = new TypeToken<Pet>(){}.getType();
     return apiClient.execute(call, returnType);
@@ -464,7 +518,7 @@ public class PetApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -487,7 +541,7 @@ public class PetApi {
   }
   
   /* Build call for updatePetWithForm */
-  private Call updatePetWithFormCall(String petId,String name,String status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+  private Call updatePetWithFormCall(String petId, String name, String status, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     Object postBody = null;
     
     // verify the required parameter 'petId' is set
@@ -546,8 +600,20 @@ public class PetApi {
    * @param status Updated status of the pet
    */
   public void updatePetWithForm(String petId, String name, String status) throws ApiException {
-    Call call = updatePetWithFormCall(petId,name,status, null, null);
-    apiClient.execute(call);
+    updatePetWithFormWithHttpInfo(petId, name, status);
+  }
+
+  /**
+   * Updates a pet in the store with form data
+   * 
+   * @param petId ID of pet that needs to be updated
+   * @param name Updated name of the pet
+   * @param status Updated status of the pet
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> updatePetWithFormWithHttpInfo(String petId, String name, String status) throws ApiException {
+    Call call = updatePetWithFormCall(petId, name, status, null, null);
+    return apiClient.execute(call);
   }
 
   /**
@@ -564,7 +630,7 @@ public class PetApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -580,13 +646,13 @@ public class PetApi {
       };
     }
 
-    Call call = updatePetWithFormCall(petId,name,status, progressListener, progressRequestListener);
+    Call call = updatePetWithFormCall(petId, name, status, progressListener, progressRequestListener);
     apiClient.executeAsync(call, callback);
     return call;
   }
   
   /* Build call for deletePet */
-  private Call deletePetCall(Long petId,String apiKey, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+  private Call deletePetCall(Long petId, String apiKey, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     Object postBody = null;
     
     // verify the required parameter 'petId' is set
@@ -642,8 +708,19 @@ public class PetApi {
    * @param apiKey 
    */
   public void deletePet(Long petId, String apiKey) throws ApiException {
-    Call call = deletePetCall(petId,apiKey, null, null);
-    apiClient.execute(call);
+    deletePetWithHttpInfo(petId, apiKey);
+  }
+
+  /**
+   * Deletes a pet
+   * 
+   * @param petId Pet id to delete
+   * @param apiKey 
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
+    Call call = deletePetCall(petId, apiKey, null, null);
+    return apiClient.execute(call);
   }
 
   /**
@@ -659,7 +736,7 @@ public class PetApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -675,13 +752,13 @@ public class PetApi {
       };
     }
 
-    Call call = deletePetCall(petId,apiKey, progressListener, progressRequestListener);
+    Call call = deletePetCall(petId, apiKey, progressListener, progressRequestListener);
     apiClient.executeAsync(call, callback);
     return call;
   }
   
   /* Build call for uploadFile */
-  private Call uploadFileCall(Long petId,String additionalMetadata,File file, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+  private Call uploadFileCall(Long petId, String additionalMetadata, File file, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     Object postBody = null;
     
     // verify the required parameter 'petId' is set
@@ -740,8 +817,20 @@ public class PetApi {
    * @param file file to upload
    */
   public void uploadFile(Long petId, String additionalMetadata, File file) throws ApiException {
-    Call call = uploadFileCall(petId,additionalMetadata,file, null, null);
-    apiClient.execute(call);
+    uploadFileWithHttpInfo(petId, additionalMetadata, file);
+  }
+
+  /**
+   * uploads an image
+   * 
+   * @param petId ID of pet to update
+   * @param additionalMetadata Additional data to pass to server
+   * @param file file to upload
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
+    Call call = uploadFileCall(petId, additionalMetadata, file, null, null);
+    return apiClient.execute(call);
   }
 
   /**
@@ -758,7 +847,7 @@ public class PetApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -774,7 +863,7 @@ public class PetApi {
       };
     }
 
-    Call call = uploadFileCall(petId,additionalMetadata,file, progressListener, progressRequestListener);
+    Call call = uploadFileCall(petId, additionalMetadata, file, progressListener, progressRequestListener);
     apiClient.executeAsync(call, callback);
     return call;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
@@ -89,6 +89,7 @@ public class StoreApi {
    * Returns pet inventories by status
    * Returns a map of status codes to quantities
    * @return Map<String, Integer>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public Map<String, Integer> getInventory() throws ApiException {
     ApiResponse<Map<String, Integer>> resp = getInventoryWithHttpInfo();
@@ -99,6 +100,7 @@ public class StoreApi {
    * Returns pet inventories by status
    * Returns a map of status codes to quantities
    * @return ApiResponse<Map<String, Integer>>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
     Call call = getInventoryCall(null, null);
@@ -111,6 +113,7 @@ public class StoreApi {
    * Returns a map of status codes to quantities
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call getInventoryAsync(final ApiCallback<Map<String, Integer>> callback) throws ApiException {
 
@@ -186,6 +189,7 @@ public class StoreApi {
    * 
    * @param body order placed for purchasing the pet
    * @return Order
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public Order placeOrder(Order body) throws ApiException {
     ApiResponse<Order> resp = placeOrderWithHttpInfo(body);
@@ -197,6 +201,7 @@ public class StoreApi {
    * 
    * @param body order placed for purchasing the pet
    * @return ApiResponse<Order>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
     Call call = placeOrderCall(body, null, null);
@@ -210,6 +215,7 @@ public class StoreApi {
    * @param body order placed for purchasing the pet
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call placeOrderAsync(Order body, final ApiCallback<Order> callback) throws ApiException {
 
@@ -291,6 +297,7 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
    * @param orderId ID of pet that needs to be fetched
    * @return Order
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public Order getOrderById(String orderId) throws ApiException {
     ApiResponse<Order> resp = getOrderByIdWithHttpInfo(orderId);
@@ -302,6 +309,7 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
    * @param orderId ID of pet that needs to be fetched
    * @return ApiResponse<Order>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(String orderId) throws ApiException {
     Call call = getOrderByIdCall(orderId, null, null);
@@ -315,6 +323,7 @@ public class StoreApi {
    * @param orderId ID of pet that needs to be fetched
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call getOrderByIdAsync(String orderId, final ApiCallback<Order> callback) throws ApiException {
 
@@ -395,6 +404,7 @@ public class StoreApi {
    * Delete purchase order by ID
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
    * @param orderId ID of the order that needs to be deleted
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void deleteOrder(String orderId) throws ApiException {
     deleteOrderWithHttpInfo(orderId);
@@ -405,6 +415,7 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
    * @param orderId ID of the order that needs to be deleted
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
     Call call = deleteOrderCall(orderId, null, null);
@@ -417,6 +428,7 @@ public class StoreApi {
    * @param orderId ID of the order that needs to be deleted
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call deleteOrderAsync(String orderId, final ApiCallback<Void> callback) throws ApiException {
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.ApiCallback;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
+import io.swagger.client.ApiResponse;
 import io.swagger.client.Configuration;
 import io.swagger.client.Pair;
 import io.swagger.client.ProgressRequestBody;
@@ -43,7 +44,7 @@ public class StoreApi {
 
   
   /* Build call for getInventory */
-  private Call getInventoryCall( final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+  private Call getInventoryCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     Object postBody = null;
     
 
@@ -90,7 +91,17 @@ public class StoreApi {
    * @return Map<String, Integer>
    */
   public Map<String, Integer> getInventory() throws ApiException {
-    Call call = getInventoryCall( null, null);
+    ApiResponse<Map<String, Integer>> resp = getInventoryWithHttpInfo();
+    return resp.getData();
+  }
+
+  /**
+   * Returns pet inventories by status
+   * Returns a map of status codes to quantities
+   * @return ApiResponse<Map<String, Integer>>
+   */
+  public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
+    Call call = getInventoryCall(null, null);
     Type returnType = new TypeToken<Map<String, Integer>>(){}.getType();
     return apiClient.execute(call, returnType);
   }
@@ -106,7 +117,7 @@ public class StoreApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -122,7 +133,7 @@ public class StoreApi {
       };
     }
 
-    Call call = getInventoryCall( progressListener, progressRequestListener);
+    Call call = getInventoryCall(progressListener, progressRequestListener);
     Type returnType = new TypeToken<Map<String, Integer>>(){}.getType();
     apiClient.executeAsync(call, returnType, callback);
     return call;
@@ -177,6 +188,17 @@ public class StoreApi {
    * @return Order
    */
   public Order placeOrder(Order body) throws ApiException {
+    ApiResponse<Order> resp = placeOrderWithHttpInfo(body);
+    return resp.getData();
+  }
+
+  /**
+   * Place an order for a pet
+   * 
+   * @param body order placed for purchasing the pet
+   * @return ApiResponse<Order>
+   */
+  public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
     Call call = placeOrderCall(body, null, null);
     Type returnType = new TypeToken<Order>(){}.getType();
     return apiClient.execute(call, returnType);
@@ -194,7 +216,7 @@ public class StoreApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -271,6 +293,17 @@ public class StoreApi {
    * @return Order
    */
   public Order getOrderById(String orderId) throws ApiException {
+    ApiResponse<Order> resp = getOrderByIdWithHttpInfo(orderId);
+    return resp.getData();
+  }
+
+  /**
+   * Find purchase order by ID
+   * For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
+   * @param orderId ID of pet that needs to be fetched
+   * @return ApiResponse<Order>
+   */
+  public ApiResponse<Order> getOrderByIdWithHttpInfo(String orderId) throws ApiException {
     Call call = getOrderByIdCall(orderId, null, null);
     Type returnType = new TypeToken<Order>(){}.getType();
     return apiClient.execute(call, returnType);
@@ -288,7 +321,7 @@ public class StoreApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -364,8 +397,18 @@ public class StoreApi {
    * @param orderId ID of the order that needs to be deleted
    */
   public void deleteOrder(String orderId) throws ApiException {
+    deleteOrderWithHttpInfo(orderId);
+  }
+
+  /**
+   * Delete purchase order by ID
+   * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+   * @param orderId ID of the order that needs to be deleted
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
     Call call = deleteOrderCall(orderId, null, null);
-    apiClient.execute(call);
+    return apiClient.execute(call);
   }
 
   /**
@@ -380,7 +423,7 @@ public class StoreApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
@@ -89,6 +89,7 @@ public class UserApi {
    * Create user
    * This can only be done by the logged in user.
    * @param body Created user object
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void createUser(User body) throws ApiException {
     createUserWithHttpInfo(body);
@@ -99,6 +100,7 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param body Created user object
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
     Call call = createUserCall(body, null, null);
@@ -111,6 +113,7 @@ public class UserApi {
    * @param body Created user object
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call createUserAsync(User body, final ApiCallback<Void> callback) throws ApiException {
 
@@ -184,6 +187,7 @@ public class UserApi {
    * Creates list of users with given input array
    * 
    * @param body List of user object
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void createUsersWithArrayInput(List<User> body) throws ApiException {
     createUsersWithArrayInputWithHttpInfo(body);
@@ -194,6 +198,7 @@ public class UserApi {
    * 
    * @param body List of user object
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
     Call call = createUsersWithArrayInputCall(body, null, null);
@@ -206,6 +211,7 @@ public class UserApi {
    * @param body List of user object
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call createUsersWithArrayInputAsync(List<User> body, final ApiCallback<Void> callback) throws ApiException {
 
@@ -279,6 +285,7 @@ public class UserApi {
    * Creates list of users with given input array
    * 
    * @param body List of user object
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void createUsersWithListInput(List<User> body) throws ApiException {
     createUsersWithListInputWithHttpInfo(body);
@@ -289,6 +296,7 @@ public class UserApi {
    * 
    * @param body List of user object
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
     Call call = createUsersWithListInputCall(body, null, null);
@@ -301,6 +309,7 @@ public class UserApi {
    * @param body List of user object
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call createUsersWithListInputAsync(List<User> body, final ApiCallback<Void> callback) throws ApiException {
 
@@ -380,6 +389,7 @@ public class UserApi {
    * @param username The user name for login
    * @param password The password for login in clear text
    * @return String
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public String loginUser(String username, String password) throws ApiException {
     ApiResponse<String> resp = loginUserWithHttpInfo(username, password);
@@ -392,6 +402,7 @@ public class UserApi {
    * @param username The user name for login
    * @param password The password for login in clear text
    * @return ApiResponse<String>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
     Call call = loginUserCall(username, password, null, null);
@@ -406,6 +417,7 @@ public class UserApi {
    * @param password The password for login in clear text
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call loginUserAsync(String username, String password, final ApiCallback<String> callback) throws ApiException {
 
@@ -479,6 +491,7 @@ public class UserApi {
   /**
    * Logs out current logged in user session
    * 
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void logoutUser() throws ApiException {
     logoutUserWithHttpInfo();
@@ -488,6 +501,7 @@ public class UserApi {
    * Logs out current logged in user session
    * 
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
     Call call = logoutUserCall(null, null);
@@ -499,6 +513,7 @@ public class UserApi {
    * 
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call logoutUserAsync(final ApiCallback<Void> callback) throws ApiException {
 
@@ -579,6 +594,7 @@ public class UserApi {
    * 
    * @param username The name that needs to be fetched. Use user1 for testing.
    * @return User
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public User getUserByName(String username) throws ApiException {
     ApiResponse<User> resp = getUserByNameWithHttpInfo(username);
@@ -590,6 +606,7 @@ public class UserApi {
    * 
    * @param username The name that needs to be fetched. Use user1 for testing.
    * @return ApiResponse<User>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
     Call call = getUserByNameCall(username, null, null);
@@ -603,6 +620,7 @@ public class UserApi {
    * @param username The name that needs to be fetched. Use user1 for testing.
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call getUserByNameAsync(String username, final ApiCallback<User> callback) throws ApiException {
 
@@ -684,6 +702,7 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param username name that need to be deleted
    * @param body Updated user object
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void updateUser(String username, User body) throws ApiException {
     updateUserWithHttpInfo(username, body);
@@ -695,6 +714,7 @@ public class UserApi {
    * @param username name that need to be deleted
    * @param body Updated user object
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
     Call call = updateUserCall(username, body, null, null);
@@ -708,6 +728,7 @@ public class UserApi {
    * @param body Updated user object
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call updateUserAsync(String username, User body, final ApiCallback<Void> callback) throws ApiException {
 
@@ -787,6 +808,7 @@ public class UserApi {
    * Delete user
    * This can only be done by the logged in user.
    * @param username The name that needs to be deleted
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public void deleteUser(String username) throws ApiException {
     deleteUserWithHttpInfo(username);
@@ -797,6 +819,7 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param username The name that needs to be deleted
    * @return ApiResponse<Void>
+   * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
     Call call = deleteUserCall(username, null, null);
@@ -809,6 +832,7 @@ public class UserApi {
    * @param username The name that needs to be deleted
    * @param callback The callback to be executed when the API call finishes
    * @return The request call
+   * @throws ApiException If fail to process the API call, e.g. serializing the request body object
    */
   public Call deleteUserAsync(String username, final ApiCallback<Void> callback) throws ApiException {
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.ApiCallback;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
+import io.swagger.client.ApiResponse;
 import io.swagger.client.Configuration;
 import io.swagger.client.Pair;
 import io.swagger.client.ProgressRequestBody;
@@ -90,8 +91,18 @@ public class UserApi {
    * @param body Created user object
    */
   public void createUser(User body) throws ApiException {
+    createUserWithHttpInfo(body);
+  }
+
+  /**
+   * Create user
+   * This can only be done by the logged in user.
+   * @param body Created user object
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
     Call call = createUserCall(body, null, null);
-    apiClient.execute(call);
+    return apiClient.execute(call);
   }
 
   /**
@@ -106,7 +117,7 @@ public class UserApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -175,8 +186,18 @@ public class UserApi {
    * @param body List of user object
    */
   public void createUsersWithArrayInput(List<User> body) throws ApiException {
+    createUsersWithArrayInputWithHttpInfo(body);
+  }
+
+  /**
+   * Creates list of users with given input array
+   * 
+   * @param body List of user object
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
     Call call = createUsersWithArrayInputCall(body, null, null);
-    apiClient.execute(call);
+    return apiClient.execute(call);
   }
 
   /**
@@ -191,7 +212,7 @@ public class UserApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -260,8 +281,18 @@ public class UserApi {
    * @param body List of user object
    */
   public void createUsersWithListInput(List<User> body) throws ApiException {
+    createUsersWithListInputWithHttpInfo(body);
+  }
+
+  /**
+   * Creates list of users with given input array
+   * 
+   * @param body List of user object
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
     Call call = createUsersWithListInputCall(body, null, null);
-    apiClient.execute(call);
+    return apiClient.execute(call);
   }
 
   /**
@@ -276,7 +307,7 @@ public class UserApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -298,7 +329,7 @@ public class UserApi {
   }
   
   /* Build call for loginUser */
-  private Call loginUserCall(String username,String password, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+  private Call loginUserCall(String username, String password, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     Object postBody = null;
     
 
@@ -351,7 +382,19 @@ public class UserApi {
    * @return String
    */
   public String loginUser(String username, String password) throws ApiException {
-    Call call = loginUserCall(username,password, null, null);
+    ApiResponse<String> resp = loginUserWithHttpInfo(username, password);
+    return resp.getData();
+  }
+
+  /**
+   * Logs user into the system
+   * 
+   * @param username The user name for login
+   * @param password The password for login in clear text
+   * @return ApiResponse<String>
+   */
+  public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
+    Call call = loginUserCall(username, password, null, null);
     Type returnType = new TypeToken<String>(){}.getType();
     return apiClient.execute(call, returnType);
   }
@@ -369,7 +412,7 @@ public class UserApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -385,14 +428,14 @@ public class UserApi {
       };
     }
 
-    Call call = loginUserCall(username,password, progressListener, progressRequestListener);
+    Call call = loginUserCall(username, password, progressListener, progressRequestListener);
     Type returnType = new TypeToken<String>(){}.getType();
     apiClient.executeAsync(call, returnType, callback);
     return call;
   }
   
   /* Build call for logoutUser */
-  private Call logoutUserCall( final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+  private Call logoutUserCall(final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     Object postBody = null;
     
 
@@ -438,8 +481,17 @@ public class UserApi {
    * 
    */
   public void logoutUser() throws ApiException {
-    Call call = logoutUserCall( null, null);
-    apiClient.execute(call);
+    logoutUserWithHttpInfo();
+  }
+
+  /**
+   * Logs out current logged in user session
+   * 
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
+    Call call = logoutUserCall(null, null);
+    return apiClient.execute(call);
   }
 
   /**
@@ -453,7 +505,7 @@ public class UserApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -469,7 +521,7 @@ public class UserApi {
       };
     }
 
-    Call call = logoutUserCall( progressListener, progressRequestListener);
+    Call call = logoutUserCall(progressListener, progressRequestListener);
     apiClient.executeAsync(call, callback);
     return call;
   }
@@ -529,6 +581,17 @@ public class UserApi {
    * @return User
    */
   public User getUserByName(String username) throws ApiException {
+    ApiResponse<User> resp = getUserByNameWithHttpInfo(username);
+    return resp.getData();
+  }
+
+  /**
+   * Get user by user name
+   * 
+   * @param username The name that needs to be fetched. Use user1 for testing.
+   * @return ApiResponse<User>
+   */
+  public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
     Call call = getUserByNameCall(username, null, null);
     Type returnType = new TypeToken<User>(){}.getType();
     return apiClient.execute(call, returnType);
@@ -546,7 +609,7 @@ public class UserApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -569,7 +632,7 @@ public class UserApi {
   }
   
   /* Build call for updateUser */
-  private Call updateUserCall(String username,User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+  private Call updateUserCall(String username, User body, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
     Object postBody = body;
     
     // verify the required parameter 'username' is set
@@ -623,8 +686,19 @@ public class UserApi {
    * @param body Updated user object
    */
   public void updateUser(String username, User body) throws ApiException {
-    Call call = updateUserCall(username,body, null, null);
-    apiClient.execute(call);
+    updateUserWithHttpInfo(username, body);
+  }
+
+  /**
+   * Updated user
+   * This can only be done by the logged in user.
+   * @param username name that need to be deleted
+   * @param body Updated user object
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
+    Call call = updateUserCall(username, body, null, null);
+    return apiClient.execute(call);
   }
 
   /**
@@ -640,7 +714,7 @@ public class UserApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {
@@ -656,7 +730,7 @@ public class UserApi {
       };
     }
 
-    Call call = updateUserCall(username,body, progressListener, progressRequestListener);
+    Call call = updateUserCall(username, body, progressListener, progressRequestListener);
     apiClient.executeAsync(call, callback);
     return call;
   }
@@ -715,8 +789,18 @@ public class UserApi {
    * @param username The name that needs to be deleted
    */
   public void deleteUser(String username) throws ApiException {
+    deleteUserWithHttpInfo(username);
+  }
+
+  /**
+   * Delete user
+   * This can only be done by the logged in user.
+   * @param username The name that needs to be deleted
+   * @return ApiResponse<Void>
+   */
+  public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
     Call call = deleteUserCall(username, null, null);
-    apiClient.execute(call);
+    return apiClient.execute(call);
   }
 
   /**
@@ -731,7 +815,7 @@ public class UserApi {
     ProgressResponseBody.ProgressListener progressListener = null;
     ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
 
-    if(callback != null) {
+    if (callback != null) {
       progressListener = new ProgressResponseBody.ProgressListener() {
         @Override
         public void update(long bytesRead, long contentLength, boolean done) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:08.052+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-07T12:21:33.403+08:00")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/Authentication.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/Authentication.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:08.052+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-07T12:21:33.403+08:00")
 public interface Authentication {
   /** Apply authentication settings to header and query params. */
   void applyToParams(List<Pair> queryParams, Map<String, String> headerParams);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:08.052+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-07T12:21:33.403+08:00")
 public class OAuth implements Authentication {
   private String accessToken;
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Pet.java
@@ -2,8 +2,8 @@ package io.swagger.client.model;
 
 import io.swagger.client.StringUtil;
 import io.swagger.client.model.Category;
-import io.swagger.client.model.Tag;
 import java.util.*;
+import io.swagger.client.model.Tag;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/petstore/test/PetApiTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/petstore/test/PetApiTest.java
@@ -1,10 +1,6 @@
 package io.swagger.petstore.test;
 
-import io.swagger.client.ApiClient;
-import io.swagger.client.ApiException;
-import io.swagger.client.Configuration;
-
-import io.swagger.client.ApiCallback;
+import io.swagger.client.*;
 import io.swagger.client.api.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
@@ -65,6 +61,21 @@ public class PetApiTest {
         api.addPet(pet);
 
         Pet fetched = api.getPetById(pet.getId());
+        assertNotNull(fetched);
+        assertEquals(pet.getId(), fetched.getId());
+        assertNotNull(fetched.getCategory());
+        assertEquals(fetched.getCategory().getName(), pet.getCategory().getName());
+    }
+
+    @Test
+    public void testCreateAndGetPetWithHttpInfo() throws Exception {
+        Pet pet = createRandomPet();
+        api.addPetWithHttpInfo(pet);
+
+        ApiResponse<Pet> resp = api.getPetByIdWithHttpInfo(pet.getId());
+        assertEquals(200, resp.getStatusCode());
+        assertEquals("application/json", resp.getHeaders().get("Content-Type").get(0));
+        Pet fetched = resp.getData();
         assertNotNull(fetched);
         assertEquals(pet.getId(), fetched.getId());
         assertNotNull(fetched.getCategory());


### PR DESCRIPTION
Added WithHttpInfo API methods to Java okhttp-gson client to allow accessing response status code and headers, and removed the methods of recording last response info from ApiClient.

Sample code:

```java
PetApi api = new PetApi();
ApiResponse<Pet> resp = api.getPetByIdWithHttpInfo(1L);
System.out.println(resp.getStatusCode()); // 200
System.out.println(resp.getHeaders().get("Content-Type").get(0)); // "application/json"
Pet pet = resp.getData();
```