### PR TITLE
Added with-http-info API methods to Ruby client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -17,7 +17,7 @@ module {{moduleName}}
 {{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}
 {{/required}}{{/allParams}}    # @return [{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}]
     def {{operationId}}({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
-      {{#returnType}}status_code, headers, data = {{/returnType}}{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts)
+      {{#returnType}}data, status_code, headers = {{/returnType}}{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts)
       {{#returnType}}return data{{/returnType}}{{^returnType}}return nil{{/returnType}}
     end
 
@@ -26,7 +26,7 @@ module {{moduleName}}
 {{#allParams}}{{#required}}    # @param {{paramName}} {{description}}
 {{/required}}{{/allParams}}    # @param [Hash] opts the optional parameters
 {{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}
-{{/required}}{{/allParams}}    # @return [Array<Fixnum, Hash, {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}>] response status code, response headers and {{#returnType}}{{{returnType}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}
+{{/required}}{{/allParams}}    # @return [Array<({{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}, Fixnum, Hash)>] {{#returnType}}{{{returnType}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
     def {{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: {{classname}}#{{operationId}} ..."
@@ -74,7 +74,7 @@ module {{moduleName}}
       {{/bodyParam}}
 
       auth_names = [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
-      status_code, headers, data = @api_client.call_api(:{{httpMethod}}, path,
+      data, status_code, headers = @api_client.call_api(:{{httpMethod}}, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -82,9 +82,9 @@ module {{moduleName}}
         :auth_names => auth_names{{#returnType}},
         :return_type => '{{{returnType}}}'{{/returnType}})
       if Configuration.debugging
-        Configuration.logger.debug "API called: {{classname}}#{{operationId}}\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: {{classname}}#{{operationId}}\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 {{/operation}}
   end

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -17,6 +17,17 @@ module {{moduleName}}
 {{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}
 {{/required}}{{/allParams}}    # @return [{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}]
     def {{operationId}}({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
+      {{#returnType}}status_code, headers, data = {{/returnType}}{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts)
+      {{#returnType}}return data{{/returnType}}{{^returnType}}return nil{{/returnType}}
+    end
+
+    # {{summary}}
+    # {{notes}}
+{{#allParams}}{{#required}}    # @param {{paramName}} {{description}}
+{{/required}}{{/allParams}}    # @param [Hash] opts the optional parameters
+{{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}
+{{/required}}{{/allParams}}    # @return [Array<Fixnum, Hash, {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}>] response status code, response headers and {{#returnType}}{{{returnType}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}
+    def {{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: {{classname}}#{{operationId}} ..."
       end
@@ -63,26 +74,17 @@ module {{moduleName}}
       {{/bodyParam}}
 
       auth_names = [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
-      {{#returnType}}result = @api_client.call_api(:{{httpMethod}}, path,
+      status_code, headers, data = @api_client.call_api(:{{httpMethod}}, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names,
-        :return_type => '{{{returnType}}}')
+        :auth_names => auth_names{{#returnType}},
+        :return_type => '{{{returnType}}}'{{/returnType}})
       if Configuration.debugging
-        Configuration.logger.debug "API called: {{classname}}#{{operationId}}. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: {{classname}}#{{operationId}}\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result{{/returnType}}{{^returnType}}@api_client.call_api(:{{httpMethod}}, path,
-        :header_params => header_params,
-        :query_params => query_params,
-        :form_params => form_params,
-        :body => post_body,
-        :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: {{classname}}#{{operationId}}"
-      end
-      return nil{{/returnType}}
+      return status_code, headers, data
     end
 {{/operation}}
   end

--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -25,8 +25,10 @@ module {{moduleName}}
       }
     end
 
-    # Call an API with given options and an array of 3 elements:
-    # response status code, response headers and the data deserialized from response body (could be nil).
+    # Call an API with given options.
+    #
+    # @return [Array<(Object, Fixnum, Hash)>] an array of 3 elements:
+    #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
       response = request.run
@@ -47,7 +49,7 @@ module {{moduleName}}
       else
         data = nil
       end
-      return response.code, response.headers, data
+      return data, response.code, response.headers
     end
 
     def build_request(http_method, path, opts = {})

--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -15,9 +15,6 @@ module {{moduleName}}
     # @return [Hash]
     attr_accessor :default_headers
 
-    # Stores the HTTP response from the last API call using this API client.
-    attr_accessor :last_response
-
     def initialize(host = nil)
       @host = host || Configuration.base_url
       @format = 'json'
@@ -28,12 +25,11 @@ module {{moduleName}}
       }
     end
 
+    # Call an API with given options and an array of 3 elements:
+    # response status code, response headers and the data deserialized from response body (could be nil).
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
       response = request.run
-
-      # record as last response
-      @last_response = response
 
       if Configuration.debugging
         Configuration.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
@@ -47,10 +43,11 @@ module {{moduleName}}
       end
 
       if opts[:return_type]
-        deserialize(response, opts[:return_type])
+        data = deserialize(response, opts[:return_type])
       else
-        nil
+        data = nil
       end
+      return response.code, response.headers, data
     end
 
     def build_request(http_method, path, opts = {})

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -22,7 +22,7 @@ module Petstore
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [Pet] :body Pet object that needs to be added to the store
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_pet_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#update_pet ..."
@@ -53,16 +53,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      status_code, headers, data = @api_client.call_api(:PUT, path,
+      data, status_code, headers = @api_client.call_api(:PUT, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#update_pet\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: PetApi#update_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Add a new pet to the store
@@ -79,7 +79,7 @@ module Petstore
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [Pet] :body Pet object that needs to be added to the store
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def add_pet_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#add_pet ..."
@@ -110,16 +110,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      status_code, headers, data = @api_client.call_api(:POST, path,
+      data, status_code, headers = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#add_pet\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: PetApi#add_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Finds Pets by status
@@ -128,7 +128,7 @@ module Petstore
     # @option opts [Array<String>] :status Status values that need to be considered for filter
     # @return [Array<Pet>]
     def find_pets_by_status(opts = {})
-      status_code, headers, data = find_pets_by_status_with_http_info(opts)
+      data, status_code, headers = find_pets_by_status_with_http_info(opts)
       return data
     end
 
@@ -136,7 +136,7 @@ module Petstore
     # Multiple status values can be provided with comma seperated strings
     # @param [Hash] opts the optional parameters
     # @option opts [Array<String>] :status Status values that need to be considered for filter
-    # @return [Array<Fixnum, Hash, Array<Pet>>] response status code, response headers and Array<Pet> data
+    # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_status_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#find_pets_by_status ..."
@@ -168,7 +168,7 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      status_code, headers, data = @api_client.call_api(:GET, path,
+      data, status_code, headers = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -176,9 +176,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Array<Pet>')
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#find_pets_by_status\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: PetApi#find_pets_by_status\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Finds Pets by tags
@@ -187,7 +187,7 @@ module Petstore
     # @option opts [Array<String>] :tags Tags to filter by
     # @return [Array<Pet>]
     def find_pets_by_tags(opts = {})
-      status_code, headers, data = find_pets_by_tags_with_http_info(opts)
+      data, status_code, headers = find_pets_by_tags_with_http_info(opts)
       return data
     end
 
@@ -195,7 +195,7 @@ module Petstore
     # Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
     # @param [Hash] opts the optional parameters
     # @option opts [Array<String>] :tags Tags to filter by
-    # @return [Array<Fixnum, Hash, Array<Pet>>] response status code, response headers and Array<Pet> data
+    # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_tags_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#find_pets_by_tags ..."
@@ -227,7 +227,7 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      status_code, headers, data = @api_client.call_api(:GET, path,
+      data, status_code, headers = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -235,9 +235,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Array<Pet>')
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#find_pets_by_tags\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: PetApi#find_pets_by_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Find pet by ID
@@ -246,7 +246,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Pet]
     def get_pet_by_id(pet_id, opts = {})
-      status_code, headers, data = get_pet_by_id_with_http_info(pet_id, opts)
+      data, status_code, headers = get_pet_by_id_with_http_info(pet_id, opts)
       return data
     end
 
@@ -254,7 +254,7 @@ module Petstore
     # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
     # @param pet_id ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
-    # @return [Array<Fixnum, Hash, Pet>] response status code, response headers and Pet data
+    # @return [Array<(Pet, Fixnum, Hash)>] Pet data, response status code and response headers
     def get_pet_by_id_with_http_info(pet_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#get_pet_by_id ..."
@@ -288,7 +288,7 @@ module Petstore
       
 
       auth_names = ['api_key']
-      status_code, headers, data = @api_client.call_api(:GET, path,
+      data, status_code, headers = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -296,9 +296,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Pet')
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#get_pet_by_id\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: PetApi#get_pet_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Updates a pet in the store with form data
@@ -319,7 +319,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @option opts [String] :name Updated name of the pet
     # @option opts [String] :status Updated status of the pet
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_pet_with_form_with_http_info(pet_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#update_pet_with_form ..."
@@ -355,16 +355,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      status_code, headers, data = @api_client.call_api(:POST, path,
+      data, status_code, headers = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#update_pet_with_form\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: PetApi#update_pet_with_form\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Deletes a pet
@@ -383,7 +383,7 @@ module Petstore
     # @param pet_id Pet id to delete
     # @param [Hash] opts the optional parameters
     # @option opts [String] :api_key 
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_pet_with_http_info(pet_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#delete_pet ..."
@@ -418,16 +418,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      status_code, headers, data = @api_client.call_api(:DELETE, path,
+      data, status_code, headers = @api_client.call_api(:DELETE, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#delete_pet\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: PetApi#delete_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # uploads an image
@@ -448,7 +448,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @option opts [File] :file file to upload
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def upload_file_with_http_info(pet_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#upload_file ..."
@@ -484,16 +484,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      status_code, headers, data = @api_client.call_api(:POST, path,
+      data, status_code, headers = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#upload_file\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: PetApi#upload_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
   end
 end

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -14,6 +14,16 @@ module Petstore
     # @option opts [Pet] :body Pet object that needs to be added to the store
     # @return [nil]
     def update_pet(opts = {})
+      update_pet_with_http_info(opts)
+      return nil
+    end
+
+    # Update an existing pet
+    # 
+    # @param [Hash] opts the optional parameters
+    # @option opts [Pet] :body Pet object that needs to be added to the store
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def update_pet_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#update_pet ..."
       end
@@ -43,16 +53,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      @api_client.call_api(:PUT, path,
+      status_code, headers, data = @api_client.call_api(:PUT, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#update_pet"
+        Configuration.logger.debug "API called: PetApi#update_pet\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # Add a new pet to the store
@@ -61,6 +71,16 @@ module Petstore
     # @option opts [Pet] :body Pet object that needs to be added to the store
     # @return [nil]
     def add_pet(opts = {})
+      add_pet_with_http_info(opts)
+      return nil
+    end
+
+    # Add a new pet to the store
+    # 
+    # @param [Hash] opts the optional parameters
+    # @option opts [Pet] :body Pet object that needs to be added to the store
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def add_pet_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#add_pet ..."
       end
@@ -90,16 +110,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      @api_client.call_api(:POST, path,
+      status_code, headers, data = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#add_pet"
+        Configuration.logger.debug "API called: PetApi#add_pet\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # Finds Pets by status
@@ -108,6 +128,16 @@ module Petstore
     # @option opts [Array<String>] :status Status values that need to be considered for filter
     # @return [Array<Pet>]
     def find_pets_by_status(opts = {})
+      status_code, headers, data = find_pets_by_status_with_http_info(opts)
+      return data
+    end
+
+    # Finds Pets by status
+    # Multiple status values can be provided with comma seperated strings
+    # @param [Hash] opts the optional parameters
+    # @option opts [Array<String>] :status Status values that need to be considered for filter
+    # @return [Array<Fixnum, Hash, Array<Pet>>] response status code, response headers and Array<Pet> data
+    def find_pets_by_status_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#find_pets_by_status ..."
       end
@@ -138,7 +168,7 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      result = @api_client.call_api(:GET, path,
+      status_code, headers, data = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -146,9 +176,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Array<Pet>')
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#find_pets_by_status. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: PetApi#find_pets_by_status\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result
+      return status_code, headers, data
     end
 
     # Finds Pets by tags
@@ -157,6 +187,16 @@ module Petstore
     # @option opts [Array<String>] :tags Tags to filter by
     # @return [Array<Pet>]
     def find_pets_by_tags(opts = {})
+      status_code, headers, data = find_pets_by_tags_with_http_info(opts)
+      return data
+    end
+
+    # Finds Pets by tags
+    # Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
+    # @param [Hash] opts the optional parameters
+    # @option opts [Array<String>] :tags Tags to filter by
+    # @return [Array<Fixnum, Hash, Array<Pet>>] response status code, response headers and Array<Pet> data
+    def find_pets_by_tags_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#find_pets_by_tags ..."
       end
@@ -187,7 +227,7 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      result = @api_client.call_api(:GET, path,
+      status_code, headers, data = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -195,9 +235,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Array<Pet>')
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#find_pets_by_tags. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: PetApi#find_pets_by_tags\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result
+      return status_code, headers, data
     end
 
     # Find pet by ID
@@ -206,6 +246,16 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Pet]
     def get_pet_by_id(pet_id, opts = {})
+      status_code, headers, data = get_pet_by_id_with_http_info(pet_id, opts)
+      return data
+    end
+
+    # Find pet by ID
+    # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
+    # @param pet_id ID of pet that needs to be fetched
+    # @param [Hash] opts the optional parameters
+    # @return [Array<Fixnum, Hash, Pet>] response status code, response headers and Pet data
+    def get_pet_by_id_with_http_info(pet_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#get_pet_by_id ..."
       end
@@ -238,7 +288,7 @@ module Petstore
       
 
       auth_names = ['api_key']
-      result = @api_client.call_api(:GET, path,
+      status_code, headers, data = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -246,9 +296,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Pet')
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#get_pet_by_id. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: PetApi#get_pet_by_id\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result
+      return status_code, headers, data
     end
 
     # Updates a pet in the store with form data
@@ -259,6 +309,18 @@ module Petstore
     # @option opts [String] :status Updated status of the pet
     # @return [nil]
     def update_pet_with_form(pet_id, opts = {})
+      update_pet_with_form_with_http_info(pet_id, opts)
+      return nil
+    end
+
+    # Updates a pet in the store with form data
+    # 
+    # @param pet_id ID of pet that needs to be updated
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :name Updated name of the pet
+    # @option opts [String] :status Updated status of the pet
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def update_pet_with_form_with_http_info(pet_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#update_pet_with_form ..."
       end
@@ -293,16 +355,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      @api_client.call_api(:POST, path,
+      status_code, headers, data = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#update_pet_with_form"
+        Configuration.logger.debug "API called: PetApi#update_pet_with_form\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # Deletes a pet
@@ -312,6 +374,17 @@ module Petstore
     # @option opts [String] :api_key 
     # @return [nil]
     def delete_pet(pet_id, opts = {})
+      delete_pet_with_http_info(pet_id, opts)
+      return nil
+    end
+
+    # Deletes a pet
+    # 
+    # @param pet_id Pet id to delete
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :api_key 
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def delete_pet_with_http_info(pet_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#delete_pet ..."
       end
@@ -345,16 +418,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      @api_client.call_api(:DELETE, path,
+      status_code, headers, data = @api_client.call_api(:DELETE, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#delete_pet"
+        Configuration.logger.debug "API called: PetApi#delete_pet\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # uploads an image
@@ -365,6 +438,18 @@ module Petstore
     # @option opts [File] :file file to upload
     # @return [nil]
     def upload_file(pet_id, opts = {})
+      upload_file_with_http_info(pet_id, opts)
+      return nil
+    end
+
+    # uploads an image
+    # 
+    # @param pet_id ID of pet to update
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :additional_metadata Additional data to pass to server
+    # @option opts [File] :file file to upload
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def upload_file_with_http_info(pet_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: PetApi#upload_file ..."
       end
@@ -399,16 +484,16 @@ module Petstore
       
 
       auth_names = ['petstore_auth']
-      @api_client.call_api(:POST, path,
+      status_code, headers, data = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#upload_file"
+        Configuration.logger.debug "API called: PetApi#upload_file\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
   end
 end

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -13,14 +13,14 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Hash<String, Integer>]
     def get_inventory(opts = {})
-      status_code, headers, data = get_inventory_with_http_info(opts)
+      data, status_code, headers = get_inventory_with_http_info(opts)
       return data
     end
 
     # Returns pet inventories by status
     # Returns a map of status codes to quantities
     # @param [Hash] opts the optional parameters
-    # @return [Array<Fixnum, Hash, Hash<String, Integer>>] response status code, response headers and Hash<String, Integer> data
+    # @return [Array<(Hash<String, Integer>, Fixnum, Hash)>] Hash<String, Integer> data, response status code and response headers
     def get_inventory_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: StoreApi#get_inventory ..."
@@ -51,7 +51,7 @@ module Petstore
       
 
       auth_names = ['api_key']
-      status_code, headers, data = @api_client.call_api(:GET, path,
+      data, status_code, headers = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -59,9 +59,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Hash<String, Integer>')
       if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#get_inventory\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: StoreApi#get_inventory\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Place an order for a pet
@@ -70,7 +70,7 @@ module Petstore
     # @option opts [Order] :body order placed for purchasing the pet
     # @return [Order]
     def place_order(opts = {})
-      status_code, headers, data = place_order_with_http_info(opts)
+      data, status_code, headers = place_order_with_http_info(opts)
       return data
     end
 
@@ -78,7 +78,7 @@ module Petstore
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [Order] :body order placed for purchasing the pet
-    # @return [Array<Fixnum, Hash, Order>] response status code, response headers and Order data
+    # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
     def place_order_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: StoreApi#place_order ..."
@@ -109,7 +109,7 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:POST, path,
+      data, status_code, headers = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -117,9 +117,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Order')
       if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#place_order\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: StoreApi#place_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Find purchase order by ID
@@ -128,7 +128,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Order]
     def get_order_by_id(order_id, opts = {})
-      status_code, headers, data = get_order_by_id_with_http_info(order_id, opts)
+      data, status_code, headers = get_order_by_id_with_http_info(order_id, opts)
       return data
     end
 
@@ -136,7 +136,7 @@ module Petstore
     # For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
     # @param order_id ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
-    # @return [Array<Fixnum, Hash, Order>] response status code, response headers and Order data
+    # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
     def get_order_by_id_with_http_info(order_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: StoreApi#get_order_by_id ..."
@@ -170,7 +170,7 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:GET, path,
+      data, status_code, headers = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -178,9 +178,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Order')
       if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#get_order_by_id\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: StoreApi#get_order_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Delete purchase order by ID
@@ -197,7 +197,7 @@ module Petstore
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     # @param order_id ID of the order that needs to be deleted
     # @param [Hash] opts the optional parameters
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_order_with_http_info(order_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: StoreApi#delete_order ..."
@@ -231,16 +231,16 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:DELETE, path,
+      data, status_code, headers = @api_client.call_api(:DELETE, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#delete_order\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: StoreApi#delete_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
   end
 end

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -13,6 +13,15 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Hash<String, Integer>]
     def get_inventory(opts = {})
+      status_code, headers, data = get_inventory_with_http_info(opts)
+      return data
+    end
+
+    # Returns pet inventories by status
+    # Returns a map of status codes to quantities
+    # @param [Hash] opts the optional parameters
+    # @return [Array<Fixnum, Hash, Hash<String, Integer>>] response status code, response headers and Hash<String, Integer> data
+    def get_inventory_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: StoreApi#get_inventory ..."
       end
@@ -42,7 +51,7 @@ module Petstore
       
 
       auth_names = ['api_key']
-      result = @api_client.call_api(:GET, path,
+      status_code, headers, data = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -50,9 +59,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Hash<String, Integer>')
       if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#get_inventory. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: StoreApi#get_inventory\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result
+      return status_code, headers, data
     end
 
     # Place an order for a pet
@@ -61,6 +70,16 @@ module Petstore
     # @option opts [Order] :body order placed for purchasing the pet
     # @return [Order]
     def place_order(opts = {})
+      status_code, headers, data = place_order_with_http_info(opts)
+      return data
+    end
+
+    # Place an order for a pet
+    # 
+    # @param [Hash] opts the optional parameters
+    # @option opts [Order] :body order placed for purchasing the pet
+    # @return [Array<Fixnum, Hash, Order>] response status code, response headers and Order data
+    def place_order_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: StoreApi#place_order ..."
       end
@@ -90,7 +109,7 @@ module Petstore
       
 
       auth_names = []
-      result = @api_client.call_api(:POST, path,
+      status_code, headers, data = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -98,9 +117,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Order')
       if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#place_order. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: StoreApi#place_order\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result
+      return status_code, headers, data
     end
 
     # Find purchase order by ID
@@ -109,6 +128,16 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Order]
     def get_order_by_id(order_id, opts = {})
+      status_code, headers, data = get_order_by_id_with_http_info(order_id, opts)
+      return data
+    end
+
+    # Find purchase order by ID
+    # For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
+    # @param order_id ID of pet that needs to be fetched
+    # @param [Hash] opts the optional parameters
+    # @return [Array<Fixnum, Hash, Order>] response status code, response headers and Order data
+    def get_order_by_id_with_http_info(order_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: StoreApi#get_order_by_id ..."
       end
@@ -141,7 +170,7 @@ module Petstore
       
 
       auth_names = []
-      result = @api_client.call_api(:GET, path,
+      status_code, headers, data = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -149,9 +178,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Order')
       if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#get_order_by_id. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: StoreApi#get_order_by_id\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result
+      return status_code, headers, data
     end
 
     # Delete purchase order by ID
@@ -160,6 +189,16 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def delete_order(order_id, opts = {})
+      delete_order_with_http_info(order_id, opts)
+      return nil
+    end
+
+    # Delete purchase order by ID
+    # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+    # @param order_id ID of the order that needs to be deleted
+    # @param [Hash] opts the optional parameters
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def delete_order_with_http_info(order_id, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: StoreApi#delete_order ..."
       end
@@ -192,16 +231,16 @@ module Petstore
       
 
       auth_names = []
-      @api_client.call_api(:DELETE, path,
+      status_code, headers, data = @api_client.call_api(:DELETE, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#delete_order"
+        Configuration.logger.debug "API called: StoreApi#delete_order\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
   end
 end

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -22,7 +22,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param [Hash] opts the optional parameters
     # @option opts [User] :body Created user object
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_user_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#create_user ..."
@@ -53,16 +53,16 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:POST, path,
+      data, status_code, headers = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: UserApi#create_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Creates list of users with given input array
@@ -79,7 +79,7 @@ module Petstore
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [Array<User>] :body List of user object
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_users_with_array_input_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#create_users_with_array_input ..."
@@ -110,16 +110,16 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:POST, path,
+      data, status_code, headers = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_users_with_array_input\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: UserApi#create_users_with_array_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Creates list of users with given input array
@@ -136,7 +136,7 @@ module Petstore
     # 
     # @param [Hash] opts the optional parameters
     # @option opts [Array<User>] :body List of user object
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_users_with_list_input_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#create_users_with_list_input ..."
@@ -167,16 +167,16 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:POST, path,
+      data, status_code, headers = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_users_with_list_input\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: UserApi#create_users_with_list_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Logs user into the system
@@ -186,7 +186,7 @@ module Petstore
     # @option opts [String] :password The password for login in clear text
     # @return [String]
     def login_user(opts = {})
-      status_code, headers, data = login_user_with_http_info(opts)
+      data, status_code, headers = login_user_with_http_info(opts)
       return data
     end
 
@@ -195,7 +195,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @option opts [String] :username The user name for login
     # @option opts [String] :password The password for login in clear text
-    # @return [Array<Fixnum, Hash, String>] response status code, response headers and String data
+    # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def login_user_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#login_user ..."
@@ -228,7 +228,7 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:GET, path,
+      data, status_code, headers = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -236,9 +236,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'String')
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#login_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: UserApi#login_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Logs out current logged in user session
@@ -253,7 +253,7 @@ module Petstore
     # Logs out current logged in user session
     # 
     # @param [Hash] opts the optional parameters
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def logout_user_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#logout_user ..."
@@ -284,16 +284,16 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:GET, path,
+      data, status_code, headers = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#logout_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: UserApi#logout_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Get user by user name
@@ -302,7 +302,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [User]
     def get_user_by_name(username, opts = {})
-      status_code, headers, data = get_user_by_name_with_http_info(username, opts)
+      data, status_code, headers = get_user_by_name_with_http_info(username, opts)
       return data
     end
 
@@ -310,7 +310,7 @@ module Petstore
     # 
     # @param username The name that needs to be fetched. Use user1 for testing.
     # @param [Hash] opts the optional parameters
-    # @return [Array<Fixnum, Hash, User>] response status code, response headers and User data
+    # @return [Array<(User, Fixnum, Hash)>] User data, response status code and response headers
     def get_user_by_name_with_http_info(username, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#get_user_by_name ..."
@@ -344,7 +344,7 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:GET, path,
+      data, status_code, headers = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -352,9 +352,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'User')
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#get_user_by_name\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: UserApi#get_user_by_name\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Updated user
@@ -373,7 +373,7 @@ module Petstore
     # @param username name that need to be deleted
     # @param [Hash] opts the optional parameters
     # @option opts [User] :body Updated user object
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_user_with_http_info(username, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#update_user ..."
@@ -407,16 +407,16 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:PUT, path,
+      data, status_code, headers = @api_client.call_api(:PUT, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#update_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: UserApi#update_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
 
     # Delete user
@@ -433,7 +433,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param username The name that needs to be deleted
     # @param [Hash] opts the optional parameters
-    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_user_with_http_info(username, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#delete_user ..."
@@ -467,16 +467,16 @@ module Petstore
       
 
       auth_names = []
-      status_code, headers, data = @api_client.call_api(:DELETE, path,
+      data, status_code, headers = @api_client.call_api(:DELETE, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#delete_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
+        Configuration.logger.debug "API called: UserApi#delete_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
-      return status_code, headers, data
+      return data, status_code, headers
     end
   end
 end

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -14,6 +14,16 @@ module Petstore
     # @option opts [User] :body Created user object
     # @return [nil]
     def create_user(opts = {})
+      create_user_with_http_info(opts)
+      return nil
+    end
+
+    # Create user
+    # This can only be done by the logged in user.
+    # @param [Hash] opts the optional parameters
+    # @option opts [User] :body Created user object
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def create_user_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#create_user ..."
       end
@@ -43,16 +53,16 @@ module Petstore
       
 
       auth_names = []
-      @api_client.call_api(:POST, path,
+      status_code, headers, data = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_user"
+        Configuration.logger.debug "API called: UserApi#create_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # Creates list of users with given input array
@@ -61,6 +71,16 @@ module Petstore
     # @option opts [Array<User>] :body List of user object
     # @return [nil]
     def create_users_with_array_input(opts = {})
+      create_users_with_array_input_with_http_info(opts)
+      return nil
+    end
+
+    # Creates list of users with given input array
+    # 
+    # @param [Hash] opts the optional parameters
+    # @option opts [Array<User>] :body List of user object
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def create_users_with_array_input_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#create_users_with_array_input ..."
       end
@@ -90,16 +110,16 @@ module Petstore
       
 
       auth_names = []
-      @api_client.call_api(:POST, path,
+      status_code, headers, data = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_users_with_array_input"
+        Configuration.logger.debug "API called: UserApi#create_users_with_array_input\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # Creates list of users with given input array
@@ -108,6 +128,16 @@ module Petstore
     # @option opts [Array<User>] :body List of user object
     # @return [nil]
     def create_users_with_list_input(opts = {})
+      create_users_with_list_input_with_http_info(opts)
+      return nil
+    end
+
+    # Creates list of users with given input array
+    # 
+    # @param [Hash] opts the optional parameters
+    # @option opts [Array<User>] :body List of user object
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def create_users_with_list_input_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#create_users_with_list_input ..."
       end
@@ -137,16 +167,16 @@ module Petstore
       
 
       auth_names = []
-      @api_client.call_api(:POST, path,
+      status_code, headers, data = @api_client.call_api(:POST, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_users_with_list_input"
+        Configuration.logger.debug "API called: UserApi#create_users_with_list_input\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # Logs user into the system
@@ -156,6 +186,17 @@ module Petstore
     # @option opts [String] :password The password for login in clear text
     # @return [String]
     def login_user(opts = {})
+      status_code, headers, data = login_user_with_http_info(opts)
+      return data
+    end
+
+    # Logs user into the system
+    # 
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :username The user name for login
+    # @option opts [String] :password The password for login in clear text
+    # @return [Array<Fixnum, Hash, String>] response status code, response headers and String data
+    def login_user_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#login_user ..."
       end
@@ -187,7 +228,7 @@ module Petstore
       
 
       auth_names = []
-      result = @api_client.call_api(:GET, path,
+      status_code, headers, data = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -195,9 +236,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'String')
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#login_user. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: UserApi#login_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result
+      return status_code, headers, data
     end
 
     # Logs out current logged in user session
@@ -205,6 +246,15 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def logout_user(opts = {})
+      logout_user_with_http_info(opts)
+      return nil
+    end
+
+    # Logs out current logged in user session
+    # 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def logout_user_with_http_info(opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#logout_user ..."
       end
@@ -234,16 +284,16 @@ module Petstore
       
 
       auth_names = []
-      @api_client.call_api(:GET, path,
+      status_code, headers, data = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#logout_user"
+        Configuration.logger.debug "API called: UserApi#logout_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # Get user by user name
@@ -252,6 +302,16 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [User]
     def get_user_by_name(username, opts = {})
+      status_code, headers, data = get_user_by_name_with_http_info(username, opts)
+      return data
+    end
+
+    # Get user by user name
+    # 
+    # @param username The name that needs to be fetched. Use user1 for testing.
+    # @param [Hash] opts the optional parameters
+    # @return [Array<Fixnum, Hash, User>] response status code, response headers and User data
+    def get_user_by_name_with_http_info(username, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#get_user_by_name ..."
       end
@@ -284,7 +344,7 @@ module Petstore
       
 
       auth_names = []
-      result = @api_client.call_api(:GET, path,
+      status_code, headers, data = @api_client.call_api(:GET, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -292,9 +352,9 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'User')
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#get_user_by_name. Result: #{result.inspect}"
+        Configuration.logger.debug "API called: UserApi#get_user_by_name\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return result
+      return status_code, headers, data
     end
 
     # Updated user
@@ -304,6 +364,17 @@ module Petstore
     # @option opts [User] :body Updated user object
     # @return [nil]
     def update_user(username, opts = {})
+      update_user_with_http_info(username, opts)
+      return nil
+    end
+
+    # Updated user
+    # This can only be done by the logged in user.
+    # @param username name that need to be deleted
+    # @param [Hash] opts the optional parameters
+    # @option opts [User] :body Updated user object
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def update_user_with_http_info(username, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#update_user ..."
       end
@@ -336,16 +407,16 @@ module Petstore
       
 
       auth_names = []
-      @api_client.call_api(:PUT, path,
+      status_code, headers, data = @api_client.call_api(:PUT, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#update_user"
+        Configuration.logger.debug "API called: UserApi#update_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
 
     # Delete user
@@ -354,6 +425,16 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def delete_user(username, opts = {})
+      delete_user_with_http_info(username, opts)
+      return nil
+    end
+
+    # Delete user
+    # This can only be done by the logged in user.
+    # @param username The name that needs to be deleted
+    # @param [Hash] opts the optional parameters
+    # @return [Array<Fixnum, Hash, nil>] response status code, response headers and nil
+    def delete_user_with_http_info(username, opts = {})
       if Configuration.debugging
         Configuration.logger.debug "Calling API: UserApi#delete_user ..."
       end
@@ -386,16 +467,16 @@ module Petstore
       
 
       auth_names = []
-      @api_client.call_api(:DELETE, path,
+      status_code, headers, data = @api_client.call_api(:DELETE, path,
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
       if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#delete_user"
+        Configuration.logger.debug "API called: UserApi#delete_user\nStatus code: #{status_code}\nHeaders: #{headers}\nData: #{data.inspect}"
       end
-      return nil
+      return status_code, headers, data
     end
   end
 end

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -25,8 +25,10 @@ module Petstore
       }
     end
 
-    # Call an API with given options and an array of 3 elements:
-    # response status code, response headers and the data deserialized from response body (could be nil).
+    # Call an API with given options.
+    #
+    # @return [Array<(Object, Fixnum, Hash)>] an array of 3 elements:
+    #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
       response = request.run
@@ -47,7 +49,7 @@ module Petstore
       else
         data = nil
       end
-      return response.code, response.headers, data
+      return data, response.code, response.headers
     end
 
     def build_request(http_method, path, opts = {})

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -15,9 +15,6 @@ module Petstore
     # @return [Hash]
     attr_accessor :default_headers
 
-    # Stores the HTTP response from the last API call using this API client.
-    attr_accessor :last_response
-
     def initialize(host = nil)
       @host = host || Configuration.base_url
       @format = 'json'
@@ -28,12 +25,11 @@ module Petstore
       }
     end
 
+    # Call an API with given options and an array of 3 elements:
+    # response status code, response headers and the data deserialized from response body (could be nil).
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)
       response = request.run
-
-      # record as last response
-      @last_response = response
 
       if Configuration.debugging
         Configuration.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
@@ -47,10 +43,11 @@ module Petstore
       end
 
       if opts[:return_type]
-        deserialize(response, opts[:return_type])
+        data = deserialize(response, opts[:return_type])
       else
-        nil
+        data = nil
       end
+      return response.code, response.headers, data
     end
 
     def build_request(http_method, path, opts = {})

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -50,6 +50,17 @@ describe "Pet" do
       pet.category.name.should == "category test"
     end
 
+    it "should fetch a pet object with http info" do
+      status_code, headers, pet = @pet_api.get_pet_by_id_with_http_info(10002)
+      status_code.should == 200
+      headers['Content-Type'].should == 'application/json'
+      pet.should be_a(Petstore::Pet)
+      pet.id.should == 10002
+      pet.name.should == "RUBY UNIT TESTING"
+      pet.tags[0].name.should == "tag test"
+      pet.category.name.should == "category test"
+    end
+
     it "should not find a pet that does not exist" do
       begin
         @pet_api.get_pet_by_id(-10002)

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -51,7 +51,7 @@ describe "Pet" do
     end
 
     it "should fetch a pet object with http info" do
-      status_code, headers, pet = @pet_api.get_pet_by_id_with_http_info(10002)
+      pet, status_code, headers = @pet_api.get_pet_by_id_with_http_info(10002)
       status_code.should == 200
       headers['Content-Type'].should == 'application/json'
       pet.should be_a(Petstore::Pet)


### PR DESCRIPTION
Added with-http-info API methods to Ruby client to allow accessing response status code and headers, and removed the methods of recording last response info from ApiClient.

Sample code:

```ruby
pet, status_code, headers = @pet_api.get_pet_by_id_with_http_info(1)
puts headers['Content-Type']
```