### PR TITLE
[PHP] add default value to PHP model

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -6,10 +6,7 @@ import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.DefaultCodegen;
 import io.swagger.codegen.SupportingFile;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.MapProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.*;
 
 import java.io.File;
 import java.util.Arrays;
@@ -276,10 +273,6 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         return toModelName(type);
     }
 
-    public String toDefaultValue(Property p) {
-        return "null";
-    }
-
     public void setInvokerPackage(String invokerPackage) {
         this.invokerPackage = invokerPackage;
     }
@@ -375,6 +368,53 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
 
         return camelize(sanitizeName(operationId), true);
+    }
+
+    /**
+     * Return the default value of the property
+     *
+     * @param p Swagger property object
+     * @return string presentation of the default value of the property
+     */
+    @Override
+    public String toDefaultValue(Property p) {
+        if (p instanceof StringProperty) {
+            StringProperty dp = (StringProperty) p;
+            if (dp.getDefault() != null) {
+                return "'" + dp.getDefault().toString() + "'";
+            }
+        } else if (p instanceof BooleanProperty) {
+            BooleanProperty dp = (BooleanProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        } else if (p instanceof DateProperty) {
+            // TODO
+        } else if (p instanceof DateTimeProperty) {
+            // TODO
+        } else if (p instanceof DoubleProperty) {
+            DoubleProperty dp = (DoubleProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        } else if (p instanceof FloatProperty) {
+            FloatProperty dp = (FloatProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        } else if (p instanceof IntegerProperty) {
+            IntegerProperty dp = (IntegerProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        } else if (p instanceof LongProperty) {
+            LongProperty dp = (LongProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        }
+
+        return null;
     }
 
 }

--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -89,7 +89,7 @@ class {{classname}} implements ArrayAccess
       * ${{name}} {{#description}}{{{description}}}{{/description}}
       * @var {{datatype}}
       */
-    protected ${{name}};
+    protected ${{name}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}};
     {{/vars}}
 
     /**

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
@@ -42,7 +42,7 @@ public class PhpModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "int");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, null);
         Assert.assertEquals(property1.baseType, "int");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -53,7 +53,7 @@ public class PhpModelTest {
         Assert.assertEquals(property2.baseName, "name");
         Assert.assertEquals(property2.datatype, "string");
         Assert.assertEquals(property2.name, "name");
-        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertEquals(property2.defaultValue, null);
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
@@ -65,7 +65,7 @@ public class PhpModelTest {
         Assert.assertEquals(property3.complexType, "\\DateTime");
         Assert.assertEquals(property3.datatype, "\\DateTime");
         Assert.assertEquals(property3.name, "created_at");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, null);
         Assert.assertEquals(property3.baseType, "\\DateTime");
         Assert.assertNull(property3.hasMore);
         Assert.assertNull(property3.required);
@@ -92,7 +92,7 @@ public class PhpModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.datatype, "int");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, null);
         Assert.assertEquals(property1.baseType, "int");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);


### PR DESCRIPTION
Add default value to PHP model's properties.

Tested with Petstore (manually added default value to Order's properties).

```
[INFO] --- exec-maven-plugin:1.2.1:exec (bundle-test) @ PhpPetstoreClientTests ---




PHPUnit 4.7.2 by Sebastian Bergmann and contributors.

.............

Time: 7.44 seconds, Memory: 18.00Mb

OK (13 tests, 3113 assertions)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 9.746 s
[INFO] Finished at: 2015-12-08T16:01:10+08:00
[INFO] Final Memory: 11M/245M
[INFO] ------------------------------------------------------------------------
```