### PR TITLE
[Qt5] improve Qt5 test cases

### DIFF
--- a/samples/client/petstore/qt5cpp/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/qt5cpp/PetStore/PetApiTests.cpp
@@ -35,34 +35,12 @@ void PetApiTests::runTests() {
     delete tests;
 }
 
-void PetApiTests::getPetByIdTest() {
-    SWGPetApi* api = getApi();
-
-    static QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
-
-    auto validator = [](SWGPet* pet) {
-        QVERIFY(pet->getId() == 3);
-        loop.quit();
-    };
-
-    connect(api, &SWGPetApi::getPetByIdSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
-    api->getPetById(3);
-    timer.start();
-    loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    delete api;
-}
-
 void PetApiTests::findPetsByStatusTest() {
     SWGPetApi* api = getApi();
 
     static QEventLoop loop;
     QTimer timer;
-    timer.setInterval(1000);
+    timer.setInterval(4000);
     timer.setSingleShot(true);
 
     auto validator = [](QList<SWGPet*>* pets) {

--- a/samples/client/petstore/qt5cpp/PetStore/PetApiTests.h
+++ b/samples/client/petstore/qt5cpp/PetStore/PetApiTests.h
@@ -25,7 +25,6 @@ signals:
     bool success();
 
 private slots:
-    void getPetByIdTest();
     void findPetsByStatusTest();
     void createAndGetPetTest();
     void updatePetTest();

--- a/samples/client/petstore/qt5cpp/PetStore/PetStore.pro.user
+++ b/samples/client/petstore/qt5cpp/PetStore/PetStore.pro.user
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 3.3.2, 2015-05-15T11:02:11. -->
+<!-- Written by QtCreator 3.5.1, 2015-12-08T17:23:46. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
-  <value type="QByteArray">{e1009bf2-3b8d-440a-a972-23a1fd0a9453}</value>
+  <value type="QByteArray">{20946a4e-8558-4260-a72e-14a8108ad944}</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
@@ -58,14 +58,14 @@
  <data>
   <variable>ProjectExplorer.Project.Target.0</variable>
   <valuemap type="QVariantMap">
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.4.1 clang 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.4.1 clang 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.54.clang_64_kit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.5.1 clang 64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.5.1 clang 64bit</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.55.clang_64_kit</value>
    <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/tony/dev/projects/swagger-api/swagger-codegen/samples/client/petstore/qt5cpp/build-PetStore-Desktop_Qt_5_4_1_clang_64bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/williamcheng/Code/wing328/swagger-codegen/samples/client/petstore/qt5cpp/build-PetStore-Desktop_Qt_5_5_1_clang_64bit-Debug</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -76,6 +76,7 @@
       <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibraryAuto">true</value>
       <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">false</value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">false</value>
      </valuemap>
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
@@ -125,7 +126,7 @@
     <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/tony/dev/projects/swagger-api/swagger-codegen/samples/client/petstore/qt5cpp/build-PetStore-Desktop_Qt_5_4_1_clang_64bit-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/williamcheng/Code/wing328/swagger-codegen/samples/client/petstore/qt5cpp/build-PetStore-Desktop_Qt_5_5_1_clang_64bit-Release</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -136,6 +137,7 @@
       <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibraryAuto">true</value>
       <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">false</value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">false</value>
      </valuemap>
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
@@ -216,12 +218,10 @@
     <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
     <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
     <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
-    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">/usr/local/bin/valgrind</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
     <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
-     <value type="int">11</value>
-     <value type="int">14</value>
-     <value type="int">12</value>
-     <value type="int">13</value>
+     <value type="int">0</value>
+     <value type="int">1</value>
      <value type="int">2</value>
      <value type="int">3</value>
      <value type="int">4</value>
@@ -231,14 +231,16 @@
      <value type="int">8</value>
      <value type="int">9</value>
      <value type="int">10</value>
-     <value type="int">0</value>
-     <value type="int">1</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
     </valuelist>
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">PetStore</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/tony/dev/projects/swagger-api/swagger-codegen/samples/client/petstore/qt5cpp/PetStore/PetStore.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/williamcheng/Code/wing328/swagger-codegen/samples/client/petstore/qt5cpp/PetStore/PetStore.pro</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.CommandLineArguments"></value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">PetStore.pro</value>
     <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>


### PR DESCRIPTION
- removed getPetbyId test as the endpoint is tested in `createAndGetPetTest()`
- changed internal timeout value from 1000 to 4000 to avoid timing out

Test result looks good:
```
QDEBUG : PetApiTests::updatePetTest() got a request body
QDEBUG : PetApiTests::updatePetTest() got a request body
PASS   : PetApiTests::updatePetTest()
QDEBUG : PetApiTests::updatePetWithFormTest() got a request body
PASS   : PetApiTests::updatePetWithFormTest()
PASS   : PetApiTests::cleanupTestCase()
Totals: 6 passed, 0 failed, 0 skipped, 0 blacklisted
********* Finished testing of PetApiTests *********
```