### PR TITLE
[Java] Improve the checking of JSON MIME

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -338,6 +338,17 @@ public class ApiClient {
   }
 
   /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   */
+  public boolean isJsonMime(String mime) {
+    return mime != null && mime.matches("(?i)application\\/json(;.*)?");
+  }
+
+  /**
    * Select the Accept header's value from the given accepts array:
    *   if JSON exists in the given array, use it;
    *   otherwise use all of them (joining into a string)
@@ -347,8 +358,14 @@ public class ApiClient {
    *   null will be returned (not to set the Accept header explicitly).
    */
   public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) return null;
-    if (StringUtil.containsIgnoreCase(accepts, "application/json")) return "application/json";
+    if (accepts.length == 0) {
+      return null;
+    }
+    for (String accept : accepts) {
+      if (isJsonMime(accept)) {
+        return accept;
+      }
+    }
     return StringUtil.join(accepts, ",");
   }
 
@@ -362,8 +379,14 @@ public class ApiClient {
    *   JSON will be used.
    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) return "application/json";
-    if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
+    if (contentTypes.length == 0) {
+      return "application/json";
+    }
+    for (String contentType : contentTypes) {
+      if (isJsonMime(contentType)) {
+        return contentType;
+      }
+    }
     return contentTypes[0];
   }
 
@@ -383,7 +406,7 @@ public class ApiClient {
    * Content-Type (only JSON is supported for now).
    */
   public String serialize(Object obj, String contentType) throws ApiException {
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return json.serialize(obj);
     } else {
       throw new ApiException(400, "can not serialize object into Content-Type: " + contentType);
@@ -407,7 +430,7 @@ public class ApiClient {
     else
       body = "";
 
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return json.deserialize(body, returnType);
     } else if (returnType.getType().equals(String.class)) {
       // Expecting string, return the raw response body.

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -345,6 +345,17 @@ public class ApiClient {
   }
 
   /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   */
+  public boolean isJsonMime(String mime) {
+    return mime != null && mime.matches("(?i)application\\/json(;.*)?");
+  }
+
+  /**
    * Select the Accept header's value from the given accepts array:
    *   if JSON exists in the given array, use it;
    *   otherwise use all of them (joining into a string)
@@ -354,8 +365,14 @@ public class ApiClient {
    *   null will be returned (not to set the Accept header explicitly).
    */
   public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) return null;
-    if (StringUtil.containsIgnoreCase(accepts, "application/json")) return "application/json";
+    if (accepts.length == 0) {
+      return null;
+    }
+    for (String accept : accepts) {
+      if (isJsonMime(accept)) {
+        return accept;
+      }
+    }
     return StringUtil.join(accepts, ",");
   }
 
@@ -369,8 +386,14 @@ public class ApiClient {
    *   JSON will be used.
    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) return "application/json";
-    if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
+    if (contentTypes.length == 0) {
+      return "application/json";
+    }
+    for (String contentType : contentTypes) {
+      if (isJsonMime(contentType)) {
+        return contentType;
+      }
+    }
     return contentTypes[0];
   }
 
@@ -390,7 +413,7 @@ public class ApiClient {
    * Content-Type (only JSON is supported for now).
    */
   public Entity<String> serialize(Object obj, String contentType) throws ApiException {
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return Entity.json(json.serialize(obj));
     } else {
       throw new ApiException(400, "can not serialize object into Content-Type: " + contentType);
@@ -414,7 +437,7 @@ public class ApiClient {
     else
       body = "";
 
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return json.deserialize(body, returnType);
     } else if (returnType.getType().equals(String.class)) {
       // Expecting string, return the raw response body.

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -550,6 +550,17 @@ public class ApiClient {
   }
 
   /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   */
+  public boolean isJsonMime(String mime) {
+    return mime != null && mime.matches("(?i)application\\/json(;.*)?");
+  }
+
+  /**
    * Select the Accept header's value from the given accepts array:
    *   if JSON exists in the given array, use it;
    *   otherwise use all of them (joining into a string)
@@ -559,8 +570,14 @@ public class ApiClient {
    *   null will be returned (not to set the Accept header explicitly).
    */
   public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) return null;
-    if (StringUtil.containsIgnoreCase(accepts, "application/json")) return "application/json";
+    if (accepts.length == 0) {
+      return null;
+    }
+    for (String accept : accepts) {
+      if (isJsonMime(accept)) {
+        return accept;
+      }
+    }
     return StringUtil.join(accepts, ",");
   }
 
@@ -574,8 +591,14 @@ public class ApiClient {
    *   JSON will be used.
    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) return "application/json";
-    if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
+    if (contentTypes.length == 0) {
+      return "application/json";
+    }
+    for (String contentType : contentTypes) {
+      if (isJsonMime(contentType)) {
+        return contentType;
+      }
+    }
     return contentTypes[0];
   }
 
@@ -626,7 +649,7 @@ public class ApiClient {
       // ensuring a default content type
       contentType = "application/json";
     }
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return json.deserialize(respBody, returnType);
     } else if (returnType.equals(String.class)) {
       // Expecting string, return the raw response body.
@@ -650,7 +673,7 @@ public class ApiClient {
    * @throws ApiException If fail to serialize the given object
    */
   public String serialize(Object obj, String contentType) throws ApiException {
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       if (obj != null)
         return json.serialize(obj);
       else
@@ -822,7 +845,9 @@ public class ApiClient {
 
     String contentType = (String) headerParams.get("Content-Type");
     // ensuring a default content type
-    if (contentType == null) contentType = "application/json";
+    if (contentType == null) {
+      contentType = "application/json";
+    }
 
     RequestBody reqBody;
     if (!HttpMethod.permitsRequestBody(method)) {

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
@@ -39,7 +39,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-02T18:29:05.463+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-09T16:17:57.986+08:00")
 public class ApiClient {
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -337,6 +337,17 @@ public class ApiClient {
   }
 
   /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   */
+  public boolean isJsonMime(String mime) {
+    return mime != null && mime.matches("(?i)application\\/json(;.*)?");
+  }
+
+  /**
    * Select the Accept header's value from the given accepts array:
    *   if JSON exists in the given array, use it;
    *   otherwise use all of them (joining into a string)
@@ -346,8 +357,14 @@ public class ApiClient {
    *   null will be returned (not to set the Accept header explicitly).
    */
   public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) return null;
-    if (StringUtil.containsIgnoreCase(accepts, "application/json")) return "application/json";
+    if (accepts.length == 0) {
+      return null;
+    }
+    for (String accept : accepts) {
+      if (isJsonMime(accept)) {
+        return accept;
+      }
+    }
     return StringUtil.join(accepts, ",");
   }
 
@@ -361,8 +378,14 @@ public class ApiClient {
    *   JSON will be used.
    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) return "application/json";
-    if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
+    if (contentTypes.length == 0) {
+      return "application/json";
+    }
+    for (String contentType : contentTypes) {
+      if (isJsonMime(contentType)) {
+        return contentType;
+      }
+    }
     return contentTypes[0];
   }
 
@@ -382,7 +405,7 @@ public class ApiClient {
    * Content-Type (only JSON is supported for now).
    */
   public String serialize(Object obj, String contentType) throws ApiException {
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return json.serialize(obj);
     } else {
       throw new ApiException(400, "can not serialize object into Content-Type: " + contentType);
@@ -406,7 +429,7 @@ public class ApiClient {
     else
       body = "";
 
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return json.deserialize(body, returnType);
     } else if (returnType.getType().equals(String.class)) {
       // Expecting string, return the raw response body.

--- a/samples/client/petstore/java/default/src/test/java/io/swagger/client/ApiClientTest.java
+++ b/samples/client/petstore/java/default/src/test/java/io/swagger/client/ApiClientTest.java
@@ -39,15 +39,28 @@ public class ApiClientTest {
     }
 
     @Test
+    public void testIsJsonMime() {
+      assertFalse(apiClient.isJsonMime(null));
+      assertFalse(apiClient.isJsonMime(""));
+      assertFalse(apiClient.isJsonMime("text/plain"));
+      assertFalse(apiClient.isJsonMime("application/xml"));
+      assertFalse(apiClient.isJsonMime("application/jsonp"));
+
+      assertTrue(apiClient.isJsonMime("application/json"));
+      assertTrue(apiClient.isJsonMime("application/json; charset=UTF8"));
+      assertTrue(apiClient.isJsonMime("APPLICATION/JSON"));
+    }
+
+    @Test
     public void testSelectHeaderAccept() {
-        String[] accepts = {"APPLICATION/JSON", "APPLICATION/XML"};
+        String[] accepts = {"application/json", "application/xml"};
         assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
 
-        accepts = new String[]{"application/json", "application/xml"};
-        assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
+        accepts = new String[]{"APPLICATION/XML", "APPLICATION/JSON"};
+        assertEquals("APPLICATION/JSON", apiClient.selectHeaderAccept(accepts));
 
-        accepts = new String[]{"application/xml", "application/json"};
-        assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
+        accepts = new String[]{"application/xml", "application/json; charset=UTF8"};
+        assertEquals("application/json; charset=UTF8", apiClient.selectHeaderAccept(accepts));
 
         accepts = new String[]{"text/plain", "application/xml"};
         assertEquals("text/plain,application/xml", apiClient.selectHeaderAccept(accepts));
@@ -58,14 +71,14 @@ public class ApiClientTest {
 
     @Test
     public void testSelectHeaderContentType() {
-        String[] contentTypes = {"APPLICATION/JSON", "APPLICATION/XML"};
+        String[] contentTypes = {"application/json", "application/xml"};
         assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
 
-        contentTypes = new String[]{"application/json", "application/xml"};
-        assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
+        contentTypes = new String[]{"APPLICATION/JSON", "APPLICATION/XML"};
+        assertEquals("APPLICATION/JSON", apiClient.selectHeaderContentType(contentTypes));
 
-        contentTypes = new String[]{"application/xml", "application/json"};
-        assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
+        contentTypes = new String[]{"application/xml", "application/json; charset=UTF8"};
+        assertEquals("application/json; charset=UTF8", apiClient.selectHeaderContentType(contentTypes));
 
         contentTypes = new String[]{"text/plain", "application/xml"};
         assertEquals("text/plain", apiClient.selectHeaderContentType(contentTypes));

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
@@ -42,7 +42,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-02T18:29:08.393+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-09T16:27:55.818+08:00")
 public class ApiClient {
   private Client client;
   private Map<String, Client> hostMap = new HashMap<String, Client>();
@@ -344,6 +344,17 @@ public class ApiClient {
   }
 
   /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   */
+  public boolean isJsonMime(String mime) {
+    return mime != null && mime.matches("(?i)application\\/json(;.*)?");
+  }
+
+  /**
    * Select the Accept header's value from the given accepts array:
    *   if JSON exists in the given array, use it;
    *   otherwise use all of them (joining into a string)
@@ -353,8 +364,14 @@ public class ApiClient {
    *   null will be returned (not to set the Accept header explicitly).
    */
   public String selectHeaderAccept(String[] accepts) {
-    if (accepts.length == 0) return null;
-    if (StringUtil.containsIgnoreCase(accepts, "application/json")) return "application/json";
+    if (accepts.length == 0) {
+      return null;
+    }
+    for (String accept : accepts) {
+      if (isJsonMime(accept)) {
+        return accept;
+      }
+    }
     return StringUtil.join(accepts, ",");
   }
 
@@ -368,8 +385,14 @@ public class ApiClient {
    *   JSON will be used.
    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) return "application/json";
-    if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
+    if (contentTypes.length == 0) {
+      return "application/json";
+    }
+    for (String contentType : contentTypes) {
+      if (isJsonMime(contentType)) {
+        return contentType;
+      }
+    }
     return contentTypes[0];
   }
 
@@ -389,7 +412,7 @@ public class ApiClient {
    * Content-Type (only JSON is supported for now).
    */
   public Entity<String> serialize(Object obj, String contentType) throws ApiException {
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return Entity.json(json.serialize(obj));
     } else {
       throw new ApiException(400, "can not serialize object into Content-Type: " + contentType);
@@ -413,7 +436,7 @@ public class ApiClient {
     else
       body = "";
 
-    if (contentType.startsWith("application/json")) {
+    if (isJsonMime(contentType)) {
       return json.deserialize(body, returnType);
     } else if (returnType.getType().equals(String.class)) {
       // Expecting string, return the raw response body.

--- a/samples/client/petstore/java/jersey2/src/test/java/io/swagger/client/ApiClientTest.java
+++ b/samples/client/petstore/java/jersey2/src/test/java/io/swagger/client/ApiClientTest.java
@@ -39,15 +39,28 @@ public class ApiClientTest {
     }
 
     @Test
+    public void testIsJsonMime() {
+      assertFalse(apiClient.isJsonMime(null));
+      assertFalse(apiClient.isJsonMime(""));
+      assertFalse(apiClient.isJsonMime("text/plain"));
+      assertFalse(apiClient.isJsonMime("application/xml"));
+      assertFalse(apiClient.isJsonMime("application/jsonp"));
+
+      assertTrue(apiClient.isJsonMime("application/json"));
+      assertTrue(apiClient.isJsonMime("application/json; charset=UTF8"));
+      assertTrue(apiClient.isJsonMime("APPLICATION/JSON"));
+    }
+
+    @Test
     public void testSelectHeaderAccept() {
-        String[] accepts = {"APPLICATION/JSON", "APPLICATION/XML"};
+        String[] accepts = {"application/json", "application/xml"};
         assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
 
-        accepts = new String[]{"application/json", "application/xml"};
-        assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
+        accepts = new String[]{"APPLICATION/XML", "APPLICATION/JSON"};
+        assertEquals("APPLICATION/JSON", apiClient.selectHeaderAccept(accepts));
 
-        accepts = new String[]{"application/xml", "application/json"};
-        assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
+        accepts = new String[]{"application/xml", "application/json; charset=UTF8"};
+        assertEquals("application/json; charset=UTF8", apiClient.selectHeaderAccept(accepts));
 
         accepts = new String[]{"text/plain", "application/xml"};
         assertEquals("text/plain,application/xml", apiClient.selectHeaderAccept(accepts));
@@ -58,14 +71,14 @@ public class ApiClientTest {
 
     @Test
     public void testSelectHeaderContentType() {
-        String[] contentTypes = {"APPLICATION/JSON", "APPLICATION/XML"};
+        String[] contentTypes = {"application/json", "application/xml"};
         assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
 
-        contentTypes = new String[]{"application/json", "application/xml"};
-        assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
+        contentTypes = new String[]{"APPLICATION/JSON", "APPLICATION/XML"};
+        assertEquals("APPLICATION/JSON", apiClient.selectHeaderContentType(contentTypes));
 
-        contentTypes = new String[]{"application/xml", "application/json"};
-        assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
+        contentTypes = new String[]{"application/xml", "application/json; charset=UTF8"};
+        assertEquals("application/json; charset=UTF8", apiClient.selectHeaderContentType(contentTypes));
 
         contentTypes = new String[]{"text/plain", "application/xml"};
         assertEquals("text/plain", apiClient.selectHeaderContentType(contentTypes));

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ApiClientTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ApiClientTest.java
@@ -78,15 +78,28 @@ public class ApiClientTest {
     }
 
     @Test
+    public void testIsJsonMime() {
+      assertFalse(apiClient.isJsonMime(null));
+      assertFalse(apiClient.isJsonMime(""));
+      assertFalse(apiClient.isJsonMime("text/plain"));
+      assertFalse(apiClient.isJsonMime("application/xml"));
+      assertFalse(apiClient.isJsonMime("application/jsonp"));
+
+      assertTrue(apiClient.isJsonMime("application/json"));
+      assertTrue(apiClient.isJsonMime("application/json; charset=UTF8"));
+      assertTrue(apiClient.isJsonMime("APPLICATION/JSON"));
+    }
+
+    @Test
     public void testSelectHeaderAccept() {
-        String[] accepts = {"APPLICATION/JSON", "APPLICATION/XML"};
+        String[] accepts = {"application/json", "application/xml"};
         assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
 
-        accepts = new String[]{"application/json", "application/xml"};
-        assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
+        accepts = new String[]{"APPLICATION/XML", "APPLICATION/JSON"};
+        assertEquals("APPLICATION/JSON", apiClient.selectHeaderAccept(accepts));
 
-        accepts = new String[]{"application/xml", "application/json"};
-        assertEquals("application/json", apiClient.selectHeaderAccept(accepts));
+        accepts = new String[]{"application/xml", "application/json; charset=UTF8"};
+        assertEquals("application/json; charset=UTF8", apiClient.selectHeaderAccept(accepts));
 
         accepts = new String[]{"text/plain", "application/xml"};
         assertEquals("text/plain,application/xml", apiClient.selectHeaderAccept(accepts));
@@ -97,14 +110,14 @@ public class ApiClientTest {
 
     @Test
     public void testSelectHeaderContentType() {
-        String[] contentTypes = {"APPLICATION/JSON", "APPLICATION/XML"};
+        String[] contentTypes = {"application/json", "application/xml"};
         assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
 
-        contentTypes = new String[]{"application/json", "application/xml"};
-        assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
+        contentTypes = new String[]{"APPLICATION/JSON", "APPLICATION/XML"};
+        assertEquals("APPLICATION/JSON", apiClient.selectHeaderContentType(contentTypes));
 
-        contentTypes = new String[]{"application/xml", "application/json"};
-        assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
+        contentTypes = new String[]{"application/xml", "application/json; charset=UTF8"};
+        assertEquals("application/json; charset=UTF8", apiClient.selectHeaderContentType(contentTypes));
 
         contentTypes = new String[]{"text/plain", "application/xml"};
         assertEquals("text/plain", apiClient.selectHeaderContentType(contentTypes));


### PR DESCRIPTION
Improve the checking of JSON MIME in Java clients to support suffix like charset in `application/json; charset=UTF8`.

The Petstore sample is updated and [the integration test is OK](https://travis-ci.org/xhh/swagger-codegen/builds/95753065).