### PR TITLE
[Javascript] Fix syntax issue when generating Javascript client operation without parameters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
@@ -20,7 +20,7 @@ var {{classname}} = function {{classname}}() {
 {{/allParams}}   * @param {function} callback the callback function
    * @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
    */
-  self.{{nickname}} = function({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}, callback) {
+  self.{{nickname}} = function({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}callback) {
     
     var {{localVariablePrefix}}postBody = {{#bodyParam}}{{^isBinary}}JSON.stringify({{paramName}}){{/isBinary}}{{#isBinary}}null{{/isBinary}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
     var {{localVariablePrefix}}postBinaryBody = {{#bodyParam}}{{#isBinary}}{{paramName}}{{/isBinary}}{{^isBinary}}null{{/isBinary}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};

--- a/samples/client/petstore/javascript/src/scripts/rest/api/PetApi.js
+++ b/samples/client/petstore/javascript/src/scripts/rest/api/PetApi.js
@@ -1,5 +1,5 @@
 /*
- * @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavascriptClientCodegen", date = "2015-12-07T10:51:19.835+08:00")
+ * @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavascriptClientCodegen", date = "2015-12-09T16:07:21.000+07:00")
  */
 
 //export module

--- a/samples/client/petstore/javascript/src/scripts/rest/api/StoreApi.js
+++ b/samples/client/petstore/javascript/src/scripts/rest/api/StoreApi.js
@@ -1,5 +1,5 @@
 /*
- * @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavascriptClientCodegen", date = "2015-12-07T10:51:19.835+08:00")
+ * @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavascriptClientCodegen", date = "2015-12-09T16:07:21.000+07:00")
  */
 
 //export module
@@ -18,7 +18,7 @@ var StoreApi = function StoreApi() {
    * @param {function} callback the callback function
    * @return Map<String, Integer>
    */
-  self.getInventory = function(, callback) {
+  self.getInventory = function(callback) {
     
     var postBody = null;
     var postBinaryBody = null;

--- a/samples/client/petstore/javascript/src/scripts/rest/api/UserApi.js
+++ b/samples/client/petstore/javascript/src/scripts/rest/api/UserApi.js
@@ -1,5 +1,5 @@
 /*
- * @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavascriptClientCodegen", date = "2015-12-07T10:51:19.835+08:00")
+ * @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavascriptClientCodegen", date = "2015-12-09T16:07:21.000+07:00")
  */
 
 //export module
@@ -230,7 +230,7 @@ var UserApi = function UserApi() {
    * @param {function} callback the callback function
    * @return void
    */
-  self.logoutUser = function(, callback) {
+  self.logoutUser = function(callback) {
     
     var postBody = null;
     var postBinaryBody = null;

--- a/samples/client/petstore/javascript/src/scripts/rest/model/Pet.js
+++ b/samples/client/petstore/javascript/src/scripts/rest/model/Pet.js
@@ -38,7 +38,7 @@ if ( typeof define === "function" && define.amd ) {
 }
 
 
-var Pet = function Pet(name, photoUrls) { 
+var Pet = function Pet(photoUrls, name) { 
   	var self = this;
   	
   	/**


### PR DESCRIPTION
When generating Client JS for an operation without parameters, an unnecessary comma is added before the callback parameter:
```
self.logoutUser = function(, callback) {
```
You can see the error directly on the generating UserApi.js:
https://github.com/swagger-api/swagger-codegen/blob/master/samples/client/petstore/javascript/src/scripts/rest/api/UserApi.js#L233

My PR add a hasParams check before adding the comma and the PetStore example generating with the fix.