### PR TITLE
Updated maven-compiler-plugin to version 3.1 to address bug in older plugins …

### DIFF
--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -72,10 +72,10 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/swagger-codegen/src/main/resources/Java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pom.mustache
@@ -94,10 +94,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/swagger-codegen/src/main/resources/akka-scala/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/akka-scala/pom.mustache
@@ -104,12 +104,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>
-                    1.6</source>
-                    <target>1.6</target>
-                </configuration>
+                <version>3.1</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                    </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/modules/swagger-codegen/src/main/resources/android-java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/android-java/pom.mustache
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/swagger-codegen/src/main/resources/codegen/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/codegen/pom.mustache
@@ -78,10 +78,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/swagger-codegen/src/main/resources/scala/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/pom.mustache
@@ -103,10 +103,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -144,10 +144,10 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/client/petstore/akka-scala/pom.xml
+++ b/samples/client/petstore/akka-scala/pom.xml
@@ -104,11 +104,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>
-                    1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/client/petstore/android-java/pom.xml
+++ b/samples/client/petstore/android-java/pom.xml
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/client/petstore/java/default/pom.xml
+++ b/samples/client/petstore/java/default/pom.xml
@@ -94,10 +94,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/client/petstore/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson/pom.xml
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/client/petstore/java/retrofit/pom.xml
+++ b/samples/client/petstore/java/retrofit/pom.xml
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/client/petstore/java/retrofit2/pom.xml
+++ b/samples/client/petstore/java/retrofit2/pom.xml
@@ -98,10 +98,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/client/petstore/scala/pom.xml
+++ b/samples/client/petstore/scala/pom.xml
@@ -103,10 +103,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/client/wordnik/akka-scala/pom.xml
+++ b/samples/client/wordnik/akka-scala/pom.xml
@@ -106,12 +106,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>
-                        1.6
-                    </source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/client/wordnik/android-java/pom.xml
+++ b/samples/client/wordnik/android-java/pom.xml
@@ -98,10 +98,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/samples/client/wordnik/java/pom.xml
+++ b/samples/client/wordnik/java/pom.xml
@@ -93,10 +93,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/samples/client/wordnik/scala/pom.xml
+++ b/samples/client/wordnik/scala/pom.xml
@@ -102,10 +102,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
… where only the first line of multi-line errors generated during java jar building would displayed

When using the 
    java -jar /usr/local//Cellar/swagger-codegen/2.1.4/libexec/swagger-codegen-cli.jar \
         meta \
command to build the swagger-codegen project, errors that are generated during the 
    mvn package 
step would only show the first line.  For example:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project xyz-swagger-codegen: Compilation failure
[ERROR] /private/tmp/try3/generator/src/main/java/com/carb/codegen/XyzGenerator.java:[53,8] error: cannot find symbol
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
```

instead of

```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /private/tmp/try3/generator/src/main/java/com/carb/codegen/XyzGenerator.java:[53,9] cannot find symbol
  symbol:   variable xmodelTemplateFiles
  location: class com.carb.codegen.XyzGenerator
[INFO] 1 error
```

Updating to a more recent plugin fixes this.
