### PR TITLE
Add library option in maven-plugin

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -95,6 +95,12 @@ public class CodeGenMojo extends AbstractMojo {
     private String language;
 
     /**
+     * Client language may has a library
+     */
+    @Parameter(name = "library", required = false)
+    private String library;
+
+    /**
      * Path to separate json configuration file.
      */
     @Parameter(name = "configurationFile", required = false)
@@ -151,6 +157,9 @@ public class CodeGenMojo extends AbstractMojo {
         }
         if (null != invokerPackage) {
             config.additionalProperties().put(INVOKER_PACKAGE_PARAM, invokerPackage);
+        }
+        if (null != library) {
+            config.setLibrary(library);
         }
 
         if (configOptions != null) {


### PR DESCRIPTION
Add library option to make following configuration available
```
           <configuration>
                <inputSpec>swagger.yaml</inputSpec>
                <language>java</language>
                <library>retrofit</library>
                <configOptions>
                   <sourceFolder>src/main/java</sourceFolder>
                </configOptions>
            </configuration>
```