### PR TITLE
Ruby client: allow setting Configuration in ApiClient

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -5,8 +5,8 @@ module {{moduleName}}
   class {{classname}}
     attr_accessor :api_client
 
-    def initialize(api_client = nil)
-      @api_client = api_client || Configuration.api_client
+    def initialize(api_client = ApiClient.default)
+      @api_client = api_client
     end
 {{#operation}}
 {{newline}}
@@ -28,8 +28,8 @@ module {{moduleName}}
 {{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}
 {{/required}}{{/allParams}}    # @return [Array<({{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}, Fixnum, Hash)>] {{#returnType}}{{{returnType}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
     def {{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: {{classname}}#{{operationId}} ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: {{classname}}#{{operationId}} ..."
       end
       {{#allParams}}{{#required}}
       # verify the required parameter '{{paramName}}' is set
@@ -81,8 +81,8 @@ module {{moduleName}}
         :body => post_body,
         :auth_names => auth_names{{#returnType}},
         :return_type => '{{{returnType}}}'{{/returnType}})
-      if Configuration.debugging
-        Configuration.logger.debug "API called: {{classname}}#{{operationId}}\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: {{classname}}#{{operationId}}\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end

--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -7,22 +7,25 @@ require 'uri'
 
 module {{moduleName}}
   class ApiClient
-
-    attr_accessor :host
+    # The Configuration object holding settings to be used in the API client.
+    attr_accessor :config
 
     # Defines the headers to be used in HTTP requests of all API calls by default.
     #
     # @return [Hash]
     attr_accessor :default_headers
 
-    def initialize(host = nil)
-      @host = host || Configuration.base_url
-      @format = 'json'
+    def initialize(config = Configuration.default)
+      @config = config
       @user_agent = "ruby-swagger-#{VERSION}"
       @default_headers = {
-        'Content-Type' => "application/#{@format.downcase}",
+        'Content-Type' => "application/json",
         'User-Agent' => @user_agent
       }
+    end
+
+    def self.default
+      @@default ||= ApiClient.new
     end
 
     # Call an API with given options.
@@ -33,8 +36,8 @@ module {{moduleName}}
       request = build_request(http_method, path, opts)
       response = request.run
 
-      if Configuration.debugging
-        Configuration.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
+      if @config.debugging
+        @config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
       end
 
       unless response.success?
@@ -68,18 +71,18 @@ module {{moduleName}}
         :method => http_method,
         :headers => header_params,
         :params => query_params,
-        :ssl_verifypeer => Configuration.verify_ssl,
-        :sslcert => Configuration.cert_file,
-        :sslkey => Configuration.key_file,
-        :cainfo => Configuration.ssl_ca_cert,
-        :verbose => Configuration.debugging
+        :ssl_verifypeer => @config.verify_ssl,
+        :sslcert => @config.cert_file,
+        :sslkey => @config.key_file,
+        :cainfo => @config.ssl_ca_cert,
+        :verbose => @config.debugging
       }
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])
         req_opts.update :body => req_body
-        if Configuration.debugging
-          Configuration.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
+        if @config.debugging
+          @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
       end
 
@@ -168,7 +171,7 @@ module {{moduleName}}
     # @see Configuration#temp_folder_path
     # @return [File] the file downloaded
     def download_file(response)
-      tmp_file = Tempfile.new '', Configuration.temp_folder_path
+      tmp_file = Tempfile.new '', @config.temp_folder_path
       content_disposition = response.headers['Content-Disposition']
       if content_disposition
         filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
@@ -180,15 +183,15 @@ module {{moduleName}}
       tmp_file.close!
 
       File.open(path, 'w') { |file| file.write(response.body) }
-      Configuration.logger.info "File written to #{path}. Please move the file to a proper "\
-                                "folder for further processing and delete the temp afterwards"
+      @config.logger.info "File written to #{path}. Please move the file to a proper folder "\
+                          "for further processing and delete the temp afterwards"
       File.new(path)
     end
 
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(host + path)
+      URI.encode(@config.base_url + path)
     end
 
     def build_request_body(header_params, form_params, body)
@@ -216,7 +219,7 @@ module {{moduleName}}
     # Update hearder and query params based on authentication settings.
     def update_params_for_auth!(header_params, query_params, auth_names)
       Array(auth_names).each do |auth_name|
-        auth_setting = Configuration.auth_settings[auth_name]
+        auth_setting = @config.auth_settings[auth_name]
         next unless auth_setting
         case auth_setting[:in]
         when 'header' then header_params[auth_setting[:key]] = auth_setting[:value]

--- a/modules/swagger-codegen/src/main/resources/ruby/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/configuration.mustache
@@ -1,14 +1,7 @@
 require 'uri'
-require 'singleton'
 
 module {{moduleName}}
   class Configuration
-
-    include Singleton
-
-    # Default api client
-    attr_accessor :api_client
-
     # Defines url scheme
     attr_accessor :scheme
 
@@ -94,17 +87,6 @@ module {{moduleName}}
 
     attr_accessor :force_ending_format
 
-    class << self
-      def method_missing(method_name, *args, &block)
-        config = Configuration.instance
-        if config.respond_to?(method_name)
-          config.send(method_name, *args, &block)
-        else
-          super
-        end
-      end
-    end
-
     def initialize
       @scheme = '{{scheme}}'
       @host = '{{host}}'
@@ -118,10 +100,17 @@ module {{moduleName}}
       @inject_format = false
       @force_ending_format = false
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
+
+      yield(self) if block_given?
     end
 
-    def api_client
-      @api_client ||= ApiClient.new
+    # The default Configuration object.
+    def self.default
+      @@default ||= Configuration.new
+    end
+
+    def configure
+      yield(self) if block_given?
     end
 
     def scheme=(scheme)

--- a/modules/swagger-codegen/src/main/resources/ruby/gem.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/gem.mustache
@@ -19,17 +19,17 @@ require '{{importPath}}'
 
 module {{moduleName}}
   class << self
-    # Configure sdk using block.
-    # {{moduleName}}.configure do |config|
-    #   config.username = "xxx"
-    #   config.password = "xxx"
-    # end
-    # If no block given, return the configuration singleton instance.
+    # Customize default settings for the SDK using block.
+    #   {{moduleName}}.configure do |config|
+    #     config.username = "xxx"
+    #     config.password = "xxx"
+    #   end
+    # If no block given, return the default Configuration object.
     def configure
       if block_given?
-        yield Configuration.instance
+        yield(Configuration.default)
       else
-        Configuration.instance
+        Configuration.default
       end
     end
   end

--- a/samples/client/petstore/ruby/lib/petstore.rb
+++ b/samples/client/petstore/ruby/lib/petstore.rb
@@ -19,17 +19,17 @@ require 'petstore/api/pet_api'
 
 module Petstore
   class << self
-    # Configure sdk using block.
-    # Petstore.configure do |config|
-    #   config.username = "xxx"
-    #   config.password = "xxx"
-    # end
-    # If no block given, return the configuration singleton instance.
+    # Customize default settings for the SDK using block.
+    #   Petstore.configure do |config|
+    #     config.username = "xxx"
+    #     config.password = "xxx"
+    #   end
+    # If no block given, return the default Configuration object.
     def configure
       if block_given?
-        yield Configuration.instance
+        yield(Configuration.default)
       else
-        Configuration.instance
+        Configuration.default
       end
     end
   end

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -4,8 +4,8 @@ module Petstore
   class PetApi
     attr_accessor :api_client
 
-    def initialize(api_client = nil)
-      @api_client = api_client || Configuration.api_client
+    def initialize(api_client = ApiClient.default)
+      @api_client = api_client
     end
 
     # Update an existing pet
@@ -24,8 +24,8 @@ module Petstore
     # @option opts [Pet] :body Pet object that needs to be added to the store
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_pet_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: PetApi#update_pet ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: PetApi#update_pet ..."
       end
       
       # resource path
@@ -59,8 +59,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#update_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: PetApi#update_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -81,8 +81,8 @@ module Petstore
     # @option opts [Pet] :body Pet object that needs to be added to the store
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def add_pet_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: PetApi#add_pet ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: PetApi#add_pet ..."
       end
       
       # resource path
@@ -116,8 +116,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#add_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: PetApi#add_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -138,8 +138,8 @@ module Petstore
     # @option opts [Array<String>] :status Status values that need to be considered for filter
     # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_status_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: PetApi#find_pets_by_status ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: PetApi#find_pets_by_status ..."
       end
       
       # resource path
@@ -175,8 +175,8 @@ module Petstore
         :body => post_body,
         :auth_names => auth_names,
         :return_type => 'Array<Pet>')
-      if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#find_pets_by_status\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: PetApi#find_pets_by_status\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -197,8 +197,8 @@ module Petstore
     # @option opts [Array<String>] :tags Tags to filter by
     # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_tags_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: PetApi#find_pets_by_tags ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: PetApi#find_pets_by_tags ..."
       end
       
       # resource path
@@ -234,8 +234,8 @@ module Petstore
         :body => post_body,
         :auth_names => auth_names,
         :return_type => 'Array<Pet>')
-      if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#find_pets_by_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: PetApi#find_pets_by_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -256,8 +256,8 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Array<(Pet, Fixnum, Hash)>] Pet data, response status code and response headers
     def get_pet_by_id_with_http_info(pet_id, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: PetApi#get_pet_by_id ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: PetApi#get_pet_by_id ..."
       end
       
       # verify the required parameter 'pet_id' is set
@@ -295,8 +295,8 @@ module Petstore
         :body => post_body,
         :auth_names => auth_names,
         :return_type => 'Pet')
-      if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#get_pet_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: PetApi#get_pet_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -321,8 +321,8 @@ module Petstore
     # @option opts [String] :status Updated status of the pet
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_pet_with_form_with_http_info(pet_id, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: PetApi#update_pet_with_form ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: PetApi#update_pet_with_form ..."
       end
       
       # verify the required parameter 'pet_id' is set
@@ -361,8 +361,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#update_pet_with_form\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: PetApi#update_pet_with_form\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -385,8 +385,8 @@ module Petstore
     # @option opts [String] :api_key 
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_pet_with_http_info(pet_id, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: PetApi#delete_pet ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: PetApi#delete_pet ..."
       end
       
       # verify the required parameter 'pet_id' is set
@@ -424,8 +424,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#delete_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: PetApi#delete_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -450,8 +450,8 @@ module Petstore
     # @option opts [File] :file file to upload
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def upload_file_with_http_info(pet_id, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: PetApi#upload_file ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: PetApi#upload_file ..."
       end
       
       # verify the required parameter 'pet_id' is set
@@ -490,8 +490,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: PetApi#upload_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: PetApi#upload_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -4,8 +4,8 @@ module Petstore
   class StoreApi
     attr_accessor :api_client
 
-    def initialize(api_client = nil)
-      @api_client = api_client || Configuration.api_client
+    def initialize(api_client = ApiClient.default)
+      @api_client = api_client
     end
 
     # Returns pet inventories by status
@@ -22,8 +22,8 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Array<(Hash<String, Integer>, Fixnum, Hash)>] Hash<String, Integer> data, response status code and response headers
     def get_inventory_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: StoreApi#get_inventory ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: StoreApi#get_inventory ..."
       end
       
       # resource path
@@ -58,8 +58,8 @@ module Petstore
         :body => post_body,
         :auth_names => auth_names,
         :return_type => 'Hash<String, Integer>')
-      if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#get_inventory\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: StoreApi#get_inventory\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -80,8 +80,8 @@ module Petstore
     # @option opts [Order] :body order placed for purchasing the pet
     # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
     def place_order_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: StoreApi#place_order ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: StoreApi#place_order ..."
       end
       
       # resource path
@@ -116,8 +116,8 @@ module Petstore
         :body => post_body,
         :auth_names => auth_names,
         :return_type => 'Order')
-      if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#place_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: StoreApi#place_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -138,8 +138,8 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
     def get_order_by_id_with_http_info(order_id, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: StoreApi#get_order_by_id ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: StoreApi#get_order_by_id ..."
       end
       
       # verify the required parameter 'order_id' is set
@@ -177,8 +177,8 @@ module Petstore
         :body => post_body,
         :auth_names => auth_names,
         :return_type => 'Order')
-      if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#get_order_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: StoreApi#get_order_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -199,8 +199,8 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_order_with_http_info(order_id, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: StoreApi#delete_order ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: StoreApi#delete_order ..."
       end
       
       # verify the required parameter 'order_id' is set
@@ -237,8 +237,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: StoreApi#delete_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: StoreApi#delete_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -4,8 +4,8 @@ module Petstore
   class UserApi
     attr_accessor :api_client
 
-    def initialize(api_client = nil)
-      @api_client = api_client || Configuration.api_client
+    def initialize(api_client = ApiClient.default)
+      @api_client = api_client
     end
 
     # Create user
@@ -24,8 +24,8 @@ module Petstore
     # @option opts [User] :body Created user object
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_user_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: UserApi#create_user ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: UserApi#create_user ..."
       end
       
       # resource path
@@ -59,8 +59,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: UserApi#create_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -81,8 +81,8 @@ module Petstore
     # @option opts [Array<User>] :body List of user object
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_users_with_array_input_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: UserApi#create_users_with_array_input ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: UserApi#create_users_with_array_input ..."
       end
       
       # resource path
@@ -116,8 +116,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_users_with_array_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: UserApi#create_users_with_array_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -138,8 +138,8 @@ module Petstore
     # @option opts [Array<User>] :body List of user object
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_users_with_list_input_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: UserApi#create_users_with_list_input ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: UserApi#create_users_with_list_input ..."
       end
       
       # resource path
@@ -173,8 +173,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#create_users_with_list_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: UserApi#create_users_with_list_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -197,8 +197,8 @@ module Petstore
     # @option opts [String] :password The password for login in clear text
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def login_user_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: UserApi#login_user ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: UserApi#login_user ..."
       end
       
       # resource path
@@ -235,8 +235,8 @@ module Petstore
         :body => post_body,
         :auth_names => auth_names,
         :return_type => 'String')
-      if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#login_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: UserApi#login_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -255,8 +255,8 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def logout_user_with_http_info(opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: UserApi#logout_user ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: UserApi#logout_user ..."
       end
       
       # resource path
@@ -290,8 +290,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#logout_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: UserApi#logout_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -312,8 +312,8 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Array<(User, Fixnum, Hash)>] User data, response status code and response headers
     def get_user_by_name_with_http_info(username, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: UserApi#get_user_by_name ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: UserApi#get_user_by_name ..."
       end
       
       # verify the required parameter 'username' is set
@@ -351,8 +351,8 @@ module Petstore
         :body => post_body,
         :auth_names => auth_names,
         :return_type => 'User')
-      if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#get_user_by_name\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: UserApi#get_user_by_name\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -375,8 +375,8 @@ module Petstore
     # @option opts [User] :body Updated user object
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_user_with_http_info(username, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: UserApi#update_user ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: UserApi#update_user ..."
       end
       
       # verify the required parameter 'username' is set
@@ -413,8 +413,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#update_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: UserApi#update_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end
@@ -435,8 +435,8 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_user_with_http_info(username, opts = {})
-      if Configuration.debugging
-        Configuration.logger.debug "Calling API: UserApi#delete_user ..."
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "Calling API: UserApi#delete_user ..."
       end
       
       # verify the required parameter 'username' is set
@@ -473,8 +473,8 @@ module Petstore
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names)
-      if Configuration.debugging
-        Configuration.logger.debug "API called: UserApi#delete_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: UserApi#delete_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -1,14 +1,7 @@
 require 'uri'
-require 'singleton'
 
 module Petstore
   class Configuration
-
-    include Singleton
-
-    # Default api client
-    attr_accessor :api_client
-
     # Defines url scheme
     attr_accessor :scheme
 
@@ -94,17 +87,6 @@ module Petstore
 
     attr_accessor :force_ending_format
 
-    class << self
-      def method_missing(method_name, *args, &block)
-        config = Configuration.instance
-        if config.respond_to?(method_name)
-          config.send(method_name, *args, &block)
-        else
-          super
-        end
-      end
-    end
-
     def initialize
       @scheme = 'http'
       @host = 'petstore.swagger.io'
@@ -118,10 +100,17 @@ module Petstore
       @inject_format = false
       @force_ending_format = false
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
+
+      yield(self) if block_given?
     end
 
-    def api_client
-      @api_client ||= ApiClient.new
+    # The default Configuration object.
+    def self.default
+      @@default ||= Configuration.new
+    end
+
+    def configure
+      yield(self) if block_given?
     end
 
     def scheme=(scheme)

--- a/samples/client/petstore/ruby/spec/api_client_spec.rb
+++ b/samples/client/petstore/ruby/spec/api_client_spec.rb
@@ -10,34 +10,34 @@ describe Petstore::ApiClient do
       context 'host' do
         it 'removes http from host' do
           Petstore.configure { |c| c.host = 'http://example.com' }
-          Petstore.configure.host.should == 'example.com'
+          Petstore::Configuration.default.host.should == 'example.com'
         end
 
         it 'removes https from host' do
           Petstore.configure { |c| c.host = 'https://wookiee.com' }
-          Petstore.configure.host.should == 'wookiee.com'
+          Petstore::ApiClient.default.config.host.should == 'wookiee.com'
         end
 
         it 'removes trailing path from host' do
           Petstore.configure { |c| c.host = 'hobo.com/v4' }
-          Petstore.configure.host.should == 'hobo.com'
+          Petstore::Configuration.default.host.should == 'hobo.com'
         end
       end
 
       context 'base_path' do
         it "prepends a slash to base_path" do
           Petstore.configure { |c| c.base_path = 'v4/dog' }
-          Petstore.configure.base_path.should == '/v4/dog'
+          Petstore::Configuration.default.base_path.should == '/v4/dog'
         end
 
         it "doesn't prepend a slash if one is already there" do
           Petstore.configure { |c| c.base_path = '/v4/dog' }
-          Petstore.configure.base_path.should == '/v4/dog'
+          Petstore::Configuration.default.base_path.should == '/v4/dog'
         end
 
         it "ends up as a blank string if nil" do
           Petstore.configure { |c| c.base_path = nil }
-          Petstore.configure.base_path.should == ''
+          Petstore::Configuration.default.base_path.should == ''
         end
       end
 
@@ -53,12 +53,25 @@ describe Petstore::ApiClient do
       end
 
       api_client = Petstore::ApiClient.new
+
+      config2 = Petstore::Configuration.new do |c|
+        c.api_key_prefix['api_key'] = 'PREFIX2'
+        c.api_key['api_key'] = 'special-key2'
+      end
+      api_client2 = Petstore::ApiClient.new(config2)
       
+      auth_names = ['api_key', 'unknown']
+
       header_params = {}
       query_params = {}
-      auth_names = ['api_key', 'unknown']
       api_client.update_params_for_auth! header_params, query_params, auth_names
       header_params.should == {'api_key' => 'PREFIX special-key'}
+      query_params.should == {}
+
+      header_params = {}
+      query_params = {}
+      api_client2.update_params_for_auth! header_params, query_params, auth_names
+      header_params.should == {'api_key' => 'PREFIX2 special-key2'}
       query_params.should == {}
     end
 

--- a/samples/client/petstore/ruby/spec/configuration_spec.rb
+++ b/samples/client/petstore/ruby/spec/configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Petstore::Configuration do
-  let(:config) { Petstore::Configuration.instance }
+  let(:config) { Petstore::Configuration.default }
 
   before(:each) do
     Petstore.configure do |c|

--- a/samples/client/petstore/ruby/spec/spec_helper.rb
+++ b/samples/client/petstore/ruby/spec/spec_helper.rb
@@ -36,7 +36,7 @@ end
 #  help
 #end
 
-API_CLIENT = Petstore::ApiClient.new
+API_CLIENT = Petstore::ApiClient.new(Petstore::Configuration.new)
 
 # always delete and then re-create the pet object with 10002
 def prepare_pet(pet_api)


### PR DESCRIPTION
Removed the singleton design from the Configuration class.
Added a `config` field to ApiClient to hold the settings the ApiClient uses.