### PR TITLE
Add support for vendor extensions to CodegenModel/Property

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -97,6 +97,8 @@ public interface CodegenConfig {
 
     String toModelFilename(String name);
 
+    String toModelFilename(String templateFilename, String name);
+
     String toModelImport(String name);
 
     String toApiImport(String name);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -5,6 +5,7 @@ import io.swagger.models.ExternalDocs;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class CodegenModel {
@@ -20,4 +21,5 @@ public class CodegenModel {
     public Set<String> imports = new HashSet<String>();
     public Boolean hasVars, emptyVars, hasMoreModels, hasEnums;
     public ExternalDocs externalDocs;
+    public Map<String, Object> vendorExtensions;
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -38,6 +38,7 @@ public class CodegenProperty {
     public List<String> _enum;
     public Map<String, Object> allowableValues;
     public CodegenProperty items;
+    public Map<String, Object> vendorExtensions;
 
     @Override
     public boolean equals(Object obj) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -289,6 +289,18 @@ public class DefaultCodegen {
     }
 
     /**
+     * Return a template-file context specific version of the model filename
+     * for scenarios where multiple files are generated per model.
+     *
+     * @param templateFilename the name of the mustache file being processed
+     * @param name the model name
+     * @return the file name of the model
+     */
+    public String toModelFilename(String templateFilename, String name) {
+        return toModelFilename(name);
+    }
+
+    /**
      * Return the operation ID (method name)
      * 
      * @param operationId operation ID
@@ -774,6 +786,8 @@ public class DefaultCodegen {
         m.classVarName = toVarName(name);
         m.modelJson = Json.pretty(model);
         m.externalDocs = model.getExternalDocs();
+        m.vendorExtensions = model.getVendorExtensions();
+
         if (model instanceof ArrayModel) {
             ArrayModel am = (ArrayModel) model;
             ArrayProperty arrayProperty = new ArrayProperty(am.getItems());
@@ -889,6 +903,7 @@ public class DefaultCodegen {
         
         property.jsonSchema = Json.pretty(p);
         property.isReadOnly = p.getReadOnly();
+        property.vendorExtensions =p.getVendorExtensions();
 
         String type = getSwaggerType(p);
         if (p instanceof AbstractNumericProperty) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -1,8 +1,19 @@
 package io.swagger.codegen;
 
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
-import io.swagger.models.*;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.Contact;
+import io.swagger.models.Info;
+import io.swagger.models.License;
+import io.swagger.models.Model;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.SecurityRequirement;
+import io.swagger.models.Swagger;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import io.swagger.models.parameters.Parameter;
@@ -12,11 +23,24 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.util.*;
-
-import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 public class DefaultGenerator extends AbstractGenerator implements Generator {
     Logger LOGGER = LoggerFactory.getLogger(DefaultGenerator.class);
@@ -193,7 +217,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
                         for (String templateName : config.modelTemplateFiles().keySet()) {
                             String suffix = config.modelTemplateFiles().get(templateName);
-                            String filename = config.modelFileFolder() + File.separator + config.toModelFilename(name) + suffix;
+                            String filename = config.modelFileFolder() + File.separator
+                                + config.toModelFilename(templateName, name) + suffix;
                             if (!config.shouldOverwrite(filename)) {
                                 continue;
                             }

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,20 @@
     <name>swagger-codegen-project</name>
     <version>2.1.5-SNAPSHOT</version>
     <url>https://github.com/swagger-api/swagger-codegen</url>
+
+      <distributionManagement>
+         <snapshotRepository>
+             <id>chop-snapshots</id>
+             <name>Chop Snapshots</name>
+             <url>${env.ARTIFACTORY_SNAPSHOTS_REPO}</url>
+         </snapshotRepository>
+         <repository>
+             <id>chop-release</id>
+             <name>Chop Release Repository</name>
+             <url>${env.ARTIFACTORY_RELEASE_REPO}</url>
+         </repository>
+      </distributionManagement>
+
     <scm>
         <connection>scm:git:git@github.com:swagger-api/swagger-codegen.git</connection>
         <developerConnection>scm:git:git@github.com:swagger-api/swagger-codegen.git</developerConnection>

--- a/settings.xml
+++ b/settings.xml
@@ -20,13 +20,13 @@
           <snapshots>
             <enabled>false</enabled>
           </snapshots>
-          <id>central</id>
+          <id>chop-release</id>
           <name>libs-release</name>
           <url>${env.ARTIFACTORY_RELEASE_REPO}</url>
         </repository>
         <repository>
           <snapshots />
-          <id>snapshots</id>
+          <id>chop-snapshots</id>
           <name>libs-snapshot</name>
           <url>${env.ARTIFACTORY_SNAPSHOTS_REPO}</url>
         </repository>

--- a/settings.xml
+++ b/settings.xml
@@ -31,6 +31,7 @@
           <url>${env.ARTIFACTORY_SNAPSHOTS_REPO}</url>
         </repository>
       </repositories>
+
       <id>artifactory</id>
     </profile>
   </profiles>

--- a/settings.xml
+++ b/settings.xml
@@ -3,12 +3,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <servers>
     <server>
-      <id>releases</id>
+      <id>chop-releases</id>
       <username>${env.ARTIFACTORY_USER}</username>
       <password>${env.ARTIFACTORY_PASSWORD}</password>
     </server>
     <server>
-      <id>snapshots</id>
+      <id>chop-snapshots</id>
       <username>${env.ARTIFACTORY_USER}</username>
       <password>${env.ARTIFACTORY_PASSWORD}</password>
     </server>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+    <server>
+      <id>releases</id>
+      <username>${env.ARTIFACTORY_USER}</username>
+      <password>${env.ARTIFACTORY_PASSWORD}</password>
+    </server>
+    <server>
+      <id>snapshots</id>
+      <username>${env.ARTIFACTORY_USER}</username>
+      <password>${env.ARTIFACTORY_PASSWORD}</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <repositories>
+        <repository>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <id>central</id>
+          <name>libs-release</name>
+          <url>${env.ARTIFACTORY_RELEASE_REPO}</url>
+        </repository>
+        <repository>
+          <snapshots />
+          <id>snapshots</id>
+          <name>libs-snapshot</name>
+          <url>${env.ARTIFACTORY_SNAPSHOTS_REPO}</url>
+        </repository>
+      </repositories>
+      <id>artifactory</id>
+    </profile>
+  </profiles>
+</settings>


### PR DESCRIPTION
Fix issue with modelFileTemplates supporting the notion of
multiple templates per model, but not providing a way to
actually output multiple files per model. Added a
toModelFilename() call which takes a template filename
argument to allow subclasses to special case the output
filename.

This is patch to support a model generator extension that
generates @AutoValue models as well as persistence entities
as separate files.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/swagger-api/swagger-codegen/1699)
<!-- Reviewable:end -->
