### PR TITLE
spring-mvc-j8: Uses Java 8 interface default and provide async callback

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
@@ -18,12 +18,13 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
     public static final String CONFIG_PACKAGE = "configPackage";
     protected String title = "Petstore Server";
     protected String configPackage = "";
+    protected String templateFileName = "api.mustache";
 
     public SpringMVCServerCodegen() {
         super();
         outputFolder = "generated-code/javaSpringMVC";
         modelTemplateFiles.put("model.mustache", ".java");
-        apiTemplateFiles.put("api.mustache", ".java");
+        apiTemplateFiles.put(getTemplateFileName(), ".java");
         embeddedTemplateDir = templateDir = "JavaSpringMVC";
         apiPackage = "io.swagger.api";
         modelPackage = "io.swagger.model";
@@ -51,6 +52,10 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
         );
 
         cliOptions.add(new CliOption(CONFIG_PACKAGE, "configuration package for generated code"));
+    }
+
+    protected String getTemplateFileName() {
+        return templateFileName;
     }
 
     public CodegenType getTag() {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerJava8Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerJava8Codegen.java
@@ -1,0 +1,29 @@
+package io.swagger.codegen.languages;
+
+import io.swagger.codegen.CodegenConfig;
+
+/**
+ * Extends spring-mvc code-gen, uses Java 8 default interface default and provide async callback.
+ *
+ * This is mainly for Maven code-gen plugin use-case. When Swagger spec on existing project changed
+ * there is no need to manually copy/paste the new functions from the generated client. This will
+ * provide a default (empty) implementation to existing impl and user just need to override it.
+ *
+ * Because it is an interface, an actual impl will be needed to actuate a service endpoint.
+ */
+public class SpringMVCServerJava8Codegen extends SpringMVCServerCodegen implements CodegenConfig {
+
+    public SpringMVCServerJava8Codegen() {
+        super();
+    }
+
+    @Override
+    protected String getTemplateFileName() {
+        return "api-j8.mustache";
+    }
+
+    @Override
+    public String getName() {
+        return "spring-mvc-j8";
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/JavaSpringMVC/api-j8.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpringMVC/api-j8.mustache
@@ -1,0 +1,64 @@
+package {{apiPackage}};
+
+import {{modelPackage}}.*;
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import java.util.concurrent.Callable;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static org.springframework.http.MediaType.*;
+
+@Controller
+@RequestMapping(value = "/{{baseName}}", produces = {APPLICATION_JSON_VALUE})
+@Api(value = "/{{baseName}}", description = "the {{baseName}} API")
+{{>generatedAnnotation}}
+{{#operations}}
+public interface {{classname}} {
+  {{#operation}}
+
+  @ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
+    {{#authMethods}}@Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
+      {{#scopes}}@AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
+      {{/hasMore}}{{/scopes}}
+      }{{/isOAuth}}){{#hasMore}},
+    {{/hasMore}}{{/authMethods}}
+  }{{/hasAuthMethods}})
+  @ApiResponses(value = { {{#responses}}
+    @ApiResponse(code = {{{code}}}, message = "{{{message}}}"){{#hasMore}},{{/hasMore}}{{/responses}} })
+  @RequestMapping(value = "{{path}}", 
+    {{#hasProduces}}produces = { {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }, {{/hasProduces}}
+    {{#hasConsumes}}consumes = { {{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} },{{/hasConsumes}}
+    method = RequestMethod.{{httpMethod}})
+  default Callable<ResponseEntity<{{>returnTypes}}>> {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},
+    {{/hasMore}}{{/allParams}})
+      throws NotFoundException {
+      // do some magic!
+      return () -> new ResponseEntity<{{>returnTypes}}>(HttpStatus.OK);
+  }
+
+  {{/operation}}
+}
+{{/operations}}

--- a/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -22,6 +22,7 @@ io.swagger.codegen.languages.SilexServerCodegen
 io.swagger.codegen.languages.SinatraServerCodegen
 io.swagger.codegen.languages.SlimFrameworkServerCodegen
 io.swagger.codegen.languages.SpringMVCServerCodegen
+io.swagger.codegen.languages.SpringMVCServerJava8Codegen
 io.swagger.codegen.languages.StaticDocCodegen
 io.swagger.codegen.languages.StaticHtmlGenerator
 io.swagger.codegen.languages.SwaggerGenerator


### PR DESCRIPTION
 This template is mainly for Maven code-gen plugin use-case. When Swagger
spec on **existing** project changed there is no need to manually copy/paste
the new functions from the generated client. This will provide a default
(empty) implementation to existing impl and user just need to override
it.

Because it is an interface, an actual implementation will be needed to
actuate a service end-point (don't forget the @Controller tag on the impl class!).