### PR TITLE
[C#] Fixed ArgumentOutOfRangeException. Optimized string concatenation.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -163,13 +163,14 @@ namespace {{packageName}}.Client
                 return ((DateTime)obj).ToString (Configuration.DateTimeFormat);
             else if (obj is IList)
             {
-                string flattenString = "";
-                string separator = ",";
+                var flattenedString = new StringBuilder();
                 foreach (var param in (IList)obj)
                 {
-                    flattenString += param.ToString() + separator;
+                    if (flattenedString.Length > 0)
+                        flattenedString.Append(",");
+                    flattenedString.Append(param);
                 }
-                return flattenString.Remove(flattenString.Length - 1);;
+                return flattenedString.ToString();
             }
             else
                 return Convert.ToString (obj);


### PR DESCRIPTION
If the list is empty you get the ```ArgumentOutOfRangeException``` when calling ```flattenString.Remove(flattenString.Length - 1)``` because it tries to remove a separator from the empty string.
Also using a ```StringBuilder``` is the prefered way to concatenate strings in a loop.