### PR TITLE
[C#] fix filename and Content-Disposition parsing on FileStream

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -232,7 +232,7 @@ namespace {{packageName}}.Client
                     var filePath = String.IsNullOrEmpty(Configuration.TempFolderPath)
                         ? Path.GetTempPath()
                         : Configuration.TempFolderPath;
-                    var regex = new Regex(@"Content-Disposition:.*filename=['""]?([^'""\s]+)['""]?$");
+                    var regex = new Regex(@"Content-Disposition=.*filename=['""]?([^'""\s]+)['""]?$");
                     foreach (var header in headers)
                     {
                         var match = regex.Match(header.ToString());

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -233,12 +233,15 @@ namespace {{packageName}}.Client
                         ? Path.GetTempPath()
                         : Configuration.TempFolderPath;
                     var regex = new Regex(@"Content-Disposition:.*filename=['""]?([^'""\s]+)['""]?$");
-                    var match = regex.Match(headers.ToString());
-                    if (match.Success)
+                    foreach (var header in headers)
                     {
-                        string fileName = filePath + match.Value.Replace("\"", "").Replace("'", "");
-                        File.WriteAllBytes(fileName, data);
-                        return new FileStream(fileName, FileMode.Open);
+                        var match = regex.Match(header.ToString());
+                        if (match.Success)
+                        {
+                            string fileName = filePath + match.Groups[1].Value.Replace("\"", "").Replace("'", "");
+                            File.WriteAllBytes(fileName, data);
+                            return new FileStream(fileName, FileMode.Open);
+                        }
                     }
                 }
                 var stream = new MemoryStream(data);

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -402,6 +402,23 @@
         ]
       }
     },
+    "/pet/{petId}/downloadImage" : {
+      "get" : {
+        "tags" : [ "pet" ],
+        "summary" : "downloads an image",
+        "description" : "",
+        "operationId" : "downloadFile",
+        "produces" : [ "application/octet-stream" ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/File"
+            }
+          }
+        }
+      }
+    },
     "/store/inventory": {
       "get": {
         "tags": [
@@ -971,6 +988,65 @@
       },
       "xml": {
         "name": "Order"
+      }
+    },
+    "definitions" : {
+      "File": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "canonicalPath": {
+            "type": "string"
+          },
+          "parent": {
+            "type": "string"
+          },
+          "absolute": {
+            "type": "boolean",
+            "default": false
+          },
+          "absoluteFile": {
+            "$ref": "#/definitions/File"
+          },
+          "absolutePath": {
+            "type": "string"
+          },
+          "canonicalFile": {
+            "$ref": "#/definitions/File"
+          },
+          "freeSpace": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "parentFile": {
+            "$ref": "#/definitions/File"
+          },
+          "totalSpace": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "usableSpace": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "directory": {
+            "type": "boolean",
+            "default": false
+          },
+          "file": {
+            "type": "boolean",
+            "default": false
+          },
+          "hidden": {
+            "type": "boolean",
+            "default": false
+          }
+        }
       }
     }
   }

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/PetApi.cs
@@ -6,6 +6,7 @@ using RestSharp;
 using IO.Swagger.Client;
 using IO.Swagger.Model;
 
+
 namespace IO.Swagger.Api
 {
     
@@ -306,6 +307,42 @@ namespace IO.Swagger.Api
         /// <param name="apiKey"></param>
         /// <returns>Task of ApiResponse</returns>
         System.Threading.Tasks.Task<ApiResponse<Object>> DeletePetAsyncWithHttpInfo (long? petId, string apiKey = null);
+        
+        /// <summary>
+        /// downloads an image
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <returns>Stream</returns>
+        Stream DownloadFile ();
+  
+        /// <summary>
+        /// downloads an image
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <returns>ApiResponse of Stream</returns>
+        ApiResponse<Stream> DownloadFileWithHttpInfo ();
+
+        /// <summary>
+        /// downloads an image
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <returns>Task of Stream</returns>
+        System.Threading.Tasks.Task<Stream> DownloadFileAsync ();
+
+        /// <summary>
+        /// downloads an image
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <returns>Task of ApiResponse (Stream)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Stream>> DownloadFileAsyncWithHttpInfo ();
         
         /// <summary>
         /// uploads an image
@@ -1485,6 +1522,131 @@ namespace IO.Swagger.Api
             return new ApiResponse<Object>(statusCode,
                 response.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 null);
+        }
+        
+        /// <summary>
+        /// downloads an image 
+        /// </summary>
+        /// <returns>Stream</returns>
+        public Stream DownloadFile ()
+        {
+             ApiResponse<Stream> response = DownloadFileWithHttpInfo();
+             return response.Data;
+        }
+
+        /// <summary>
+        /// downloads an image 
+        /// </summary>
+        /// <returns>ApiResponse of Stream</returns>
+        public ApiResponse< Stream > DownloadFileWithHttpInfo ()
+        {
+            
+    
+            var path_ = "/pet/{petId}/downloadImage";
+    
+            var pathParams = new Dictionary<String, String>();
+            var queryParams = new Dictionary<String, String>();
+            var headerParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var formParams = new Dictionary<String, String>();
+            var fileParams = new Dictionary<String, FileParameter>();
+            String postBody = null;
+
+            // to determine the Accept header
+            String[] http_header_accepts = new String[] {
+                "application/octet-stream"
+            };
+            String http_header_accept = Configuration.ApiClient.SelectHeaderAccept(http_header_accepts);
+            if (http_header_accept != null)
+                headerParams.Add("Accept", Configuration.ApiClient.SelectHeaderAccept(http_header_accepts));
+
+            // set "format" to json by default
+            // e.g. /pet/{petId}.{format} becomes /pet/{petId}.json
+            pathParams.Add("format", "json");
+            
+            
+            
+            
+            
+
+            
+    
+            // make the HTTP request
+            IRestResponse response = (IRestResponse) Configuration.ApiClient.CallApi(path_, Method.GET, queryParams, postBody, headerParams, formParams, fileParams, pathParams);
+
+            int statusCode = (int) response.StatusCode;
+    
+            if (statusCode >= 400)
+                throw new ApiException (statusCode, "Error calling DownloadFile: " + response.Content, response.Content);
+            else if (statusCode == 0)
+                throw new ApiException (statusCode, "Error calling DownloadFile: " + response.ErrorMessage, response.ErrorMessage);
+    
+            return new ApiResponse<Stream>(statusCode,
+                response.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
+                (Stream) Configuration.ApiClient.Deserialize(response, typeof(Stream)));
+            
+        }
+    
+        /// <summary>
+        /// downloads an image 
+        /// </summary>
+        /// <returns>Task of Stream</returns>
+        public async System.Threading.Tasks.Task<Stream> DownloadFileAsync ()
+        {
+             ApiResponse<Stream> response = await DownloadFileAsyncWithHttpInfo();
+             return response.Data;
+
+        }
+
+        /// <summary>
+        /// downloads an image 
+        /// </summary>
+        /// <returns>Task of ApiResponse (Stream)</returns>
+        public async System.Threading.Tasks.Task<ApiResponse<Stream>> DownloadFileAsyncWithHttpInfo ()
+        {
+            
+    
+            var path_ = "/pet/{petId}/downloadImage";
+    
+            var pathParams = new Dictionary<String, String>();
+            var queryParams = new Dictionary<String, String>();
+            var headerParams = new Dictionary<String, String>();
+            var formParams = new Dictionary<String, String>();
+            var fileParams = new Dictionary<String, FileParameter>();
+            String postBody = null;
+
+            // to determine the Accept header
+            String[] http_header_accepts = new String[] {
+                "application/octet-stream"
+            };
+            String http_header_accept = Configuration.ApiClient.SelectHeaderAccept(http_header_accepts);
+            if (http_header_accept != null)
+                headerParams.Add("Accept", Configuration.ApiClient.SelectHeaderAccept(http_header_accepts));
+
+            // set "format" to json by default
+            // e.g. /pet/{petId}.{format} becomes /pet/{petId}.json
+            pathParams.Add("format", "json");
+            
+            
+            
+            
+            
+
+            
+
+            // make the HTTP request
+            IRestResponse response = (IRestResponse) await Configuration.ApiClient.CallApiAsync(path_, Method.GET, queryParams, postBody, headerParams, formParams, fileParams, pathParams);
+
+            int statusCode = (int) response.StatusCode;
+ 
+            if (statusCode >= 400)
+                throw new ApiException (statusCode, "Error calling DownloadFile: " + response.Content, response.Content);
+            else if (statusCode == 0)
+                throw new ApiException (statusCode, "Error calling DownloadFile: " + response.ErrorMessage, response.ErrorMessage);
+
+            return new ApiResponse<Stream>(statusCode,
+                response.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
+                (Stream) Configuration.ApiClient.Deserialize(response, typeof(Stream)));
+            
         }
         
         /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/StoreApi.cs
@@ -6,6 +6,7 @@ using RestSharp;
 using IO.Swagger.Client;
 using IO.Swagger.Model;
 
+
 namespace IO.Swagger.Api
 {
     

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/UserApi.cs
@@ -6,6 +6,7 @@ using RestSharp;
 using IO.Swagger.Client;
 using IO.Swagger.Model;
 
+
 namespace IO.Swagger.Api
 {
     

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/Configuration.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/Configuration.cs
@@ -24,15 +24,15 @@ namespace IO.Swagger.Client
         /// <param name="apiKeyPrefix">Dictionary of API key prefix</param>
         /// <param name="tempFolderPath">Temp folder path</param>
         /// <param name="dateTimeFormat">DateTime format string</param>
-        public Configuration(ApiClient apiClient = null,
-                             Dictionary<String, String> defaultHeader = null,
-                             string username = null,
-                             string password = null,
-                             string accessToken = null,
-                             Dictionary<String, String> apiKey = null,
-                             Dictionary<String, String> apiKeyPrefix = null,
-                             string tempFolderPath = null,
-                             string dateTimeFormat = null
+        public Configuration(ApiClient apiClient,
+                             Dictionary<String, String> defaultHeader,
+                             string username,
+                             string password,
+                             string accessToken,
+                             Dictionary<String, String> apiKey,
+                             Dictionary<String, String> apiKeyPrefix,
+                             string tempFolderPath,
+                             string dateTimeFormat
                             )
         {
             if (apiClient == null)
@@ -43,11 +43,8 @@ namespace IO.Swagger.Client
             Username = username;
             Password = password;
             AccessToken = accessToken;
-
-			if (apiKey != null)
-                ApiKey = apiKey;
-			if (apiKeyPrefix != null)
-			    ApiKeyPrefix = apiKeyPrefix;
+            ApiKey = apiKey;
+            ApiKeyPrefix = apiKeyPrefix;
 
             TempFolderPath = tempFolderPath;
             DateTimeFormat = dateTimeFormat;
@@ -58,7 +55,7 @@ namespace IO.Swagger.Client
         /// Initializes a new instance of the Configuration class.
         /// </summary>
         /// <param name="apiClient">Api client.</param>
-        public Configuration(ApiClient apiClient)
+        public Configuration(ApiClient apiClient=null)
         {
             if (apiClient == null)
                 ApiClient = ApiClient.Default;

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Category.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Category.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
+
+
 namespace IO.Swagger.Model
 {
 
@@ -122,4 +124,6 @@ namespace IO.Swagger.Model
         }
 
     }
+
+
 }

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Order.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Order.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
+
+
 namespace IO.Swagger.Model
 {
 
@@ -187,4 +189,6 @@ namespace IO.Swagger.Model
         }
 
     }
+
+
 }

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Pet.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Pet.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
+
+
 namespace IO.Swagger.Model
 {
 
@@ -187,4 +189,6 @@ namespace IO.Swagger.Model
         }
 
     }
+
+
 }

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Tag.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Tag.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
+
+
 namespace IO.Swagger.Model
 {
 
@@ -122,4 +124,6 @@ namespace IO.Swagger.Model
         }
 
     }
+
+
 }

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/User.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/User.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
+
+
 namespace IO.Swagger.Model
 {
 
@@ -219,4 +221,6 @@ namespace IO.Swagger.Model
         }
 
     }
+
+
 }


### PR DESCRIPTION
Having a service which returns a FileStream:
@ApiOperation(value = "file", response = java.io.File.class)

the generated ApiClient.cs includes handling FileStreams:
var regex = new Regex(@"Content-Disposition:.*filename=['""]?([^'""\s]+)['""]?$");

but should be Content-Diosposition=...

Additionally the regex is applied onto: headers.ToString()
which has the value: "System.Collections.Generic.List`1[RestSharp.Parameter]"

Therefor, a filename will never be correctly parsed.