### PR TITLE
Fixing squid:S2057 - Serializable classes should have a version id

### DIFF
--- a/modules/swagger-generator/src/main/java/io/swagger/generator/Bootstrap.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/Bootstrap.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class Bootstrap extends HttpServlet {
+    private static final long serialVersionUID = 1400930071893332856L;
+
     public void init(ServletConfig config) throws ServletException {
         ServletContext context = config.getServletContext();
 

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/exception/ApiException.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/exception/ApiException.java
@@ -17,6 +17,7 @@
 package io.swagger.generator.exception;
 
 public class ApiException extends Exception {
+    private static final long serialVersionUID = -5085112752305370687L;
     private int code;
 
     public ApiException(int code, String msg) {

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/exception/BadRequestException.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/exception/BadRequestException.java
@@ -17,6 +17,7 @@
 package io.swagger.generator.exception;
 
 public class BadRequestException extends ApiException {
+    private static final long serialVersionUID = -5540416398447252055L;
     private int code;
 
     public BadRequestException(int code, String msg) {

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/exception/NotFoundException.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/exception/NotFoundException.java
@@ -17,6 +17,7 @@
 package io.swagger.generator.exception;
 
 public class NotFoundException extends ApiException {
+    private static final long serialVersionUID = -1223255119112336573L;
     private int code;
 
     public NotFoundException(int code, String msg) {

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/util/ValidationException.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/util/ValidationException.java
@@ -3,6 +3,7 @@ package io.swagger.generator.util;
 import java.util.List;
 
 public class ValidationException extends Exception {
+    private static final long serialVersionUID = 6861195361018260380L;
     private int code;
     private String msg;
     private List<ValidationMessage> errors;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S2057 - Serializable classes should have a version id
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2057

Please let me know if you have any questions.

Kirill Vlasov