### PR TITLE
Fixing squid:S1161 - @Override annotation should be used where necessary

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Meta.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Meta.java
@@ -135,6 +135,7 @@ public class Meta implements Runnable {
      */
     private Mustache.TemplateLoader loader(final DefaultGenerator generator) {
         return new Mustache.TemplateLoader() {
+            @Override
             public Reader getTemplate(String name) {
                 return generator.getTemplateReader(TEMPLATE_DIR_CLASSPATH
                         + File.separator + name.concat(MUSTACHE_EXTENSION));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/MetaGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/MetaGenerator.java
@@ -157,6 +157,7 @@ public class MetaGenerator extends AbstractGenerator {
                     String template = readTemplate(templateDir + File.separator + support.templateFile);
                     Template tmpl = Mustache.compiler()
                             .withLoader(new Mustache.TemplateLoader() {
+                                @Override
                                 public Reader getTemplate(String name) {
                                     return getTemplateReader(templateDir + File.separator + name + ".mustache");
                                 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -60,6 +60,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 		return outputFolder + "/" + apiPackage().replace('.', File.separatorChar);
 	}
 
+	@Override
 	public String modelFileFolder() {
 		return outputFolder + "/" + modelPackage().replace('.', File.separatorChar);
 	}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AkkaScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AkkaScalaClientCodegen.java
@@ -154,14 +154,17 @@ public class AkkaScalaClientCodegen extends DefaultCodegen implements CodegenCon
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "akka-scala";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Scala client library base on Akka/Spray.";
     }
@@ -176,6 +179,7 @@ public class AkkaScalaClientCodegen extends DefaultCodegen implements CodegenCon
         return outputFolder + "/" + sourceFolder + "/" + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
     }
@@ -321,6 +325,7 @@ public class AkkaScalaClientCodegen extends DefaultCodegen implements CodegenCon
         }
     }
 
+    @Override
     public String toDefaultValue(Property p) {
         if (!p.getRequired()) {
             return "None";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
@@ -71,14 +71,17 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
                 .defaultValue("true"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "android";
     }
 
+    @Override
     public String getHelp() {
         return "Generates an Android client library.";
     }
@@ -93,6 +96,7 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
         return outputFolder + "/" + sourceFolder + "/" + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AsyncScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AsyncScalaClientCodegen.java
@@ -111,14 +111,17 @@ public class AsyncScalaClientCodegen extends DefaultCodegen implements CodegenCo
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "async-scala";
     }
 
+    @Override
     public String getHelp() {
         return "Generates an Asynchronous Scala client library.";
     }
@@ -133,6 +136,7 @@ public class AsyncScalaClientCodegen extends DefaultCodegen implements CodegenCo
         return outputFolder + "/" + sourceFolder + "/" + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
     }
@@ -182,6 +186,7 @@ public class AsyncScalaClientCodegen extends DefaultCodegen implements CodegenCo
         }
     }
 
+    @Override
     public String toDefaultValue(Property p) {
         if (p instanceof StringProperty) {
             return "null";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -135,14 +135,17 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
 
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "csharp";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a CSharp client library.";
     }
@@ -157,6 +160,7 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         return outputFolder + File.separator + sourceFolder + File.separator + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + File.separator + sourceFolder + File.separator + modelPackage().replace('.', File.separatorChar);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CsharpDotNet2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CsharpDotNet2ClientCodegen.java
@@ -135,14 +135,17 @@ public class CsharpDotNet2ClientCodegen extends DefaultCodegen implements Codege
         this.packageVersion = packageVersion;
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "CsharpDotNet2";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a C# .Net 2.0 client library.";
     }
@@ -157,6 +160,7 @@ public class CsharpDotNet2ClientCodegen extends DefaultCodegen implements Codege
         return outputFolder + File.separator + sourceFolder + File.separator + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + File.separator + sourceFolder + File.separator + modelPackage().replace('.', File.separatorChar);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/DartClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/DartClientCodegen.java
@@ -84,14 +84,17 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, "source folder for generated code"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "dart";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Dart client library.";
     }
@@ -157,6 +160,7 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         return outputFolder + "/" + sourceFolder + "/" + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlashClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlashClientCodegen.java
@@ -156,14 +156,17 @@ public class FlashClientCodegen extends DefaultCodegen implements CodegenConfig 
         return str.replaceAll("\\.", "_");
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "flash";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Flash client library.";
     }
@@ -179,6 +182,7 @@ public class FlashClientCodegen extends DefaultCodegen implements CodegenConfig 
                 + apiPackage().replace('.', File.separatorChar)).replace('/', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return (outputFolder + File.separatorChar + sourceFolder + File.separatorChar
                 + modelPackage().replace('.', File.separatorChar)).replace('/', File.separatorChar);
@@ -214,6 +218,7 @@ public class FlashClientCodegen extends DefaultCodegen implements CodegenConfig 
         return type;
     }
 
+    @Override
     public String toDefaultValue(Property p) {
         if (p instanceof StringProperty) {
             return "null";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -132,6 +132,7 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
         }
     }
 
+    @Override
     public String apiPackage() {
         return controllerPackage;
     }
@@ -142,6 +143,7 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
      * @return the CodegenType for this generator
      * @see io.swagger.codegen.CodegenType
      */
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
@@ -152,6 +154,7 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
      *
      * @return the friendly name for the generator
      */
+    @Override
     public String getName() {
         return "python-flask";
     }
@@ -162,6 +165,7 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
      *
      * @return A string value for the help message
      */
+    @Override
     public String getHelp() {
         return "Generates a python server library using the connexion project.  By default, " +
                 "it will also generate service classes--which you can disable with the `-Dnoservice` environment variable.";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JMeterCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JMeterCodegen.java
@@ -22,6 +22,7 @@ public class JMeterCodegen extends DefaultCodegen implements CodegenConfig {
    * @return  the CodegenType for this generator
    * @see     io.swagger.codegen.CodegenType
    */
+  @Override
   public CodegenType getTag() {
     return CodegenType.CLIENT;
   }
@@ -32,6 +33,7 @@ public class JMeterCodegen extends DefaultCodegen implements CodegenConfig {
    * 
    * @return the friendly name for the generator
    */
+  @Override
   public String getName() {
     return "jmeter";
   }
@@ -42,6 +44,7 @@ public class JMeterCodegen extends DefaultCodegen implements CodegenConfig {
    * 
    * @return A string value for the help message
    */
+  @Override
   public String getHelp() {
     return "Generates a JMeter .jmx file.";
   }
@@ -97,6 +100,7 @@ public class JMeterCodegen extends DefaultCodegen implements CodegenConfig {
 //    supportingFiles.add(new SupportingFile("testdata-localhost.mustache", "input", "testdata-localhost.csv"));
   }
 
+  @Override
   public void preprocessSwagger(Swagger swagger) {
     if (swagger != null && swagger.getPaths() != null) {
       for (String pathname : swagger.getPaths().keySet()) {
@@ -126,6 +130,7 @@ public class JMeterCodegen extends DefaultCodegen implements CodegenConfig {
    * Location to write model files.  You can use the modelPackage() as defined when the class is
    * instantiated
    */
+  @Override
   public String modelFileFolder() {
     return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
   }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -530,6 +530,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         return objs;
     }
 
+    @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
         if("retrofit".equals(getLibrary()) || "retrofit2".equals(getLibrary())) {
             Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
@@ -555,6 +556,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         return objs;
     }
 
+    @Override
     public void preprocessSwagger(Swagger swagger) {
         if (swagger != null && swagger.getPaths() != null) {
             for (String pathname : swagger.getPaths().keySet()) {
@@ -606,6 +608,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         return accepts;
     }
 
+    @Override
     protected boolean needToImport(String type) {
         return super.needToImport(type) && type.indexOf(".") < 0;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
@@ -45,14 +45,17 @@ public class JavaInflectorServerCodegen extends JavaClientCodegen implements Cod
         );
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
 
+    @Override
     public String getName() {
         return "inflector";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Java Inflector Server application.";
     }
@@ -131,6 +134,7 @@ public class JavaInflectorServerCodegen extends JavaClientCodegen implements Cod
         return objs;
     }
 
+    @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         if (operations != null) {
@@ -188,6 +192,7 @@ public class JavaInflectorServerCodegen extends JavaClientCodegen implements Cod
         return camelize(name)+ "Controller";
     }
 
+    @Override
     public boolean shouldOverwrite(String filename) {
         return super.shouldOverwrite(filename);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -373,6 +373,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         return objs;
     }
 
+    @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
         if("retrofit".equals(getLibrary())) {
             Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
@@ -396,6 +397,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         return objs;
     }
 
+    @Override
     protected boolean needToImport(String type) {
         return super.needToImport(type) && type.indexOf(".") < 0;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JaxRSServerCodegen.java
@@ -35,14 +35,17 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
         additionalProperties.put("title", title);
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
 
+    @Override
     public String getName() {
         return "jaxrs";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Java JAXRS Server application.";
     }
@@ -144,6 +147,7 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
         return objs;
     }
 
+    @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         if (operations != null) {
@@ -229,6 +233,7 @@ public class JaxRSServerCodegen extends JavaClientCodegen implements CodegenConf
         return outputFolder + "/" + output + "/" + apiPackage().replace('.', '/');
     }
 
+    @Override
     public boolean shouldOverwrite(String filename) {
         return super.shouldOverwrite(filename) && !filename.endsWith("ServiceImpl.java") && !filename.endsWith("ServiceFactory.java");
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -97,6 +97,7 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
         }
     }
 
+    @Override
     public String apiPackage() {
         return "controllers";
     }
@@ -107,6 +108,7 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
      * @return the CodegenType for this generator
      * @see io.swagger.codegen.CodegenType
      */
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
@@ -117,6 +119,7 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
      *
      * @return the friendly name for the generator
      */
+    @Override
     public String getName() {
         return "nodejs";
     }
@@ -127,6 +130,7 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
      *
      * @return A string value for the help message
      */
+    @Override
     public String getHelp() {
         return "Generates a nodejs server library using the swagger-tools project.  By default, " +
                 "it will also generate service classes--which you can disable with the `-Dnoservice` environment variable.";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -133,14 +133,17 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(LICENSE, "License to use in the podspec file.").defaultValue("MIT"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "objc";
     }
 
+    @Override
     public String getHelp() {
         return "Generates an Objective-C client library.";
     }
@@ -356,6 +359,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         return classPrefix + camelize(name) + "Api";
     }
 
+    @Override
     public String toApiFilename(String name) {
         return classPrefix + camelize(name) + "Api";
     }
@@ -395,6 +399,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         return toVarName(name);
     }
 
+    @Override
     public String escapeReservedWord(String name) {
         return "_" + name;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PerlClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PerlClientCodegen.java
@@ -104,14 +104,17 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("autodoc.script.mustache", ("bin/").replace('/', File.separatorChar), "autodoc"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "perl";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Perl client library.";
     }
@@ -126,6 +129,7 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
         return (outputFolder + "/lib/WWW/" + moduleName + apiPackage()).replace('/', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return (outputFolder + "/lib/WWW/" + moduleName + modelPackage()).replace('/', File.separatorChar);
     }
@@ -162,6 +166,7 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
         return type;
     }
 
+    @Override
     public String toDefaultValue(Property p) {
         return "null";
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -139,14 +139,17 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
                     .replaceAll(regLastPathSeparator+ "$", "");
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "php";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a PHP client library.";
     }
@@ -223,6 +226,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         return (outputFolder + "/" + toPackagePath(apiPackage, srcBasePath));
     }
 
+    @Override
     public String modelFileFolder() {
         return (outputFolder + "/" + toPackagePath(modelPackage, srcBasePath));
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -108,14 +108,17 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         return str.replaceAll("\\.", "_");
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "python";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Python client library.";
     }
@@ -130,6 +133,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         return outputFolder + File.separatorChar + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + File.separatorChar + modelPackage().replace('.', File.separatorChar);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -140,6 +140,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
      * @return the CodegenType for this generator
      * @see io.swagger.codegen.CodegenType
      */
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
@@ -150,6 +151,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
      *
      * @return the friendly name for the generator
      */
+    @Override
     public String getName() {
         return "qt5cpp";
     }
@@ -160,6 +162,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
      *
      * @return A string value for the help message
      */
+    @Override
     public String getHelp() {
         return "Generates a qt5 C++ client library.";
     }
@@ -189,6 +192,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
      * Location to write model files.  You can use the modelPackage() as defined when the class is
      * instantiated
      */
+    @Override
     public String modelFileFolder() {
         return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -130,14 +130,17 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("base_object.mustache", modelFolder, "base_object.rb"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "ruby";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Ruby client library.";
     }
@@ -166,6 +169,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
         return outputFolder + File.separator + libFolder + File.separator + gemName + File.separator + apiPackage.replace("/", File.separator);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + File.separator + libFolder + File.separator + gemName + File.separator + modelPackage.replace("/", File.separator);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
@@ -112,14 +112,17 @@ public class ScalaClientCodegen extends DefaultCodegen implements CodegenConfig 
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "scala";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Scala client library.";
     }
@@ -134,6 +137,7 @@ public class ScalaClientCodegen extends DefaultCodegen implements CodegenConfig 
         return outputFolder + "/" + sourceFolder + "/" + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
     }
@@ -183,6 +187,7 @@ public class ScalaClientCodegen extends DefaultCodegen implements CodegenConfig 
         }
     }
 
+    @Override
     public String toDefaultValue(Property p) {
         if (p instanceof StringProperty) {
             return "null";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalatraServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalatraServerCodegen.java
@@ -123,14 +123,17 @@ public class ScalatraServerCodegen extends DefaultCodegen implements CodegenConf
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
 
+    @Override
     public String getName() {
         return "scalatra";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Scala server application with Scalatra.";
     }
@@ -145,6 +148,7 @@ public class ScalatraServerCodegen extends DefaultCodegen implements CodegenConf
         return outputFolder + "/" + sourceFolder + "/" + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SilexServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SilexServerCodegen.java
@@ -88,14 +88,17 @@ public class SilexServerCodegen extends DefaultCodegen implements CodegenConfig 
         supportingFiles.add(new SupportingFile(".htaccess", packagePath.replace('/', File.separatorChar), ".htaccess"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
 
+    @Override
     public String getName() {
         return "silex-PHP";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Silex server library.";
     }
@@ -110,6 +113,7 @@ public class SilexServerCodegen extends DefaultCodegen implements CodegenConfig 
         return (outputFolder + "/" + apiPackage()).replace('/', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return (outputFolder + "/" + modelPackage()).replace('/', File.separatorChar);
     }
@@ -148,6 +152,7 @@ public class SilexServerCodegen extends DefaultCodegen implements CodegenConfig 
         return toModelName(type);
     }
 
+    @Override
     public String toDefaultValue(Property p) {
         return "null";
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SinatraServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SinatraServerCodegen.java
@@ -81,14 +81,17 @@ public class SinatraServerCodegen extends DefaultCodegen implements CodegenConfi
         supportingFiles.add(new SupportingFile("swagger.mustache","","swagger.yaml"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
 
+    @Override
     public String getName() {
         return "sinatra";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Sinatra server library.";
     }
@@ -135,6 +138,7 @@ public class SinatraServerCodegen extends DefaultCodegen implements CodegenConfi
         return type;
     }
 
+    @Override
     public String toDefaultValue(Property p) {
         return "null";
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SlimFrameworkServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SlimFrameworkServerCodegen.java
@@ -90,14 +90,17 @@ public class SlimFrameworkServerCodegen extends DefaultCodegen implements Codege
         supportingFiles.add(new SupportingFile(".htaccess", packagePath.replace('/', File.separatorChar), ".htaccess"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
 
+    @Override
     public String getName() {
         return "slim";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Slim Framework server library.";
     }
@@ -112,6 +115,7 @@ public class SlimFrameworkServerCodegen extends DefaultCodegen implements Codege
         return (outputFolder + "/" + apiPackage()).replace('/', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return (outputFolder + "/" + modelPackage()).replace('/', File.separatorChar);
     }
@@ -162,6 +166,7 @@ public class SlimFrameworkServerCodegen extends DefaultCodegen implements Codege
         return super.getTypeDeclaration(name);
     }
 
+    @Override
     public String toDefaultValue(Property p) {
         return "null";
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringMVCServerCodegen.java
@@ -53,14 +53,17 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
         cliOptions.add(new CliOption(CONFIG_PACKAGE, "configuration package for generated code"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
 
+    @Override
     public String getName() {
         return "spring-mvc";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Java Spring-MVC Server application using the SpringFox integration.";
     }
@@ -126,6 +129,7 @@ public class SpringMVCServerCodegen extends JavaClientCodegen implements Codegen
         co.baseName = basePath;
     }
 
+    @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         if (operations != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticDocCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticDocCodegen.java
@@ -50,14 +50,17 @@ public class StaticDocCodegen extends DefaultCodegen implements CodegenConfig {
         instantiationTypes.put("map", "HashMap");
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.DOCUMENTATION;
     }
 
+    @Override
     public String getName() {
         return "dynamic-html";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a dynamic HTML site.";
     }
@@ -72,6 +75,7 @@ public class StaticDocCodegen extends DefaultCodegen implements CodegenConfig {
         return outputFolder + File.separator + sourceFolder + File.separator + "operations";
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + File.separator + sourceFolder + File.separator + "models";
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtmlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtmlGenerator.java
@@ -50,14 +50,17 @@ public class StaticHtmlGenerator extends DefaultCodegen implements CodegenConfig
         importMapping = new HashMap<String, String>();
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.DOCUMENTATION;
     }
 
+    @Override
     public String getName() {
         return "html";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a static HTML file.";
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerGenerator.java
@@ -19,14 +19,17 @@ public class SwaggerGenerator extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.DOCUMENTATION;
     }
 
+    @Override
     public String getName() {
         return "swagger";
     }
 
+    @Override
     public String getHelp() {
         return "Creates a static swagger.json file.";
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwaggerYamlGenerator.java
@@ -19,14 +19,17 @@ public class SwaggerYamlGenerator extends DefaultCodegen implements CodegenConfi
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.DOCUMENTATION;
     }
 
+    @Override
     public String getName() {
         return "swagger-yaml";
     }
 
+    @Override
     public String getHelp() {
         return "Creates a static swagger.yaml file.";
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -45,14 +45,17 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
   protected String sourceFolder = "Classes" + File.separator + "Swaggers";
   private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{[a-zA-Z_]+\\}");
 
+  @Override
   public CodegenType getTag() {
     return CodegenType.CLIENT;
   }
 
+  @Override
   public String getName() {
     return "swift";
   }
 
+  @Override
   public String getHelp() {
     return "Generates a swift client library.";
   }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TizenClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TizenClientCodegen.java
@@ -110,14 +110,17 @@ public class TizenClientCodegen extends DefaultCodegen implements CodegenConfig 
         supportingFiles.add(new SupportingFile("error-body.mustache", sourceFolder, PREFIX + "Error.cpp"));
     }
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
 
+    @Override
     public String getName() {
         return "tizen";
     }
 
+    @Override
     public String getHelp() {
         return "Generates a Samsung Tizen C++ client library.";
     }
@@ -250,6 +253,7 @@ public class TizenClientCodegen extends DefaultCodegen implements CodegenConfig 
         return PREFIX + initialCaps(name) + "Api";
     }
 
+    @Override
     public String toApiFilename(String name) {
         return PREFIX + initialCaps(name) + "Api";
     }
@@ -261,6 +265,7 @@ public class TizenClientCodegen extends DefaultCodegen implements CodegenConfig 
         return "p" + paramName;
     }
 
+    @Override
     public String escapeReservedWord(String name) {
         return "_" + name;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -10,6 +10,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 		return "typescript-angular";
 	}
 
+	@Override
 	public String getHelp() {
 		return "Generates a TypeScript AngularJS client library.";
 	}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/AbstractOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/AbstractOptionsTest.java
@@ -51,6 +51,7 @@ public abstract class AbstractOptionsTest {
 
     private Function<CliOption, String> getCliOptionTransformer() {
         return new Function<CliOption, String>() {
+            @Override
             public String apply(CliOption option) {
                 return option.getOpt();
             }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -86,6 +86,7 @@ public class CodegenTest {
         final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/requiredTest.json");
 
         final DefaultCodegen codegen = new DefaultCodegen() {
+            @Override
             public String getSwaggerType(Property p) {
                 if (p != null && !p.getRequired()) {
                     return "Optional<" + super.getSwaggerType(p) + ">";

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/Bootstrap.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/Bootstrap.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class Bootstrap extends HttpServlet {
+    @Override
     public void init(ServletConfig config) throws ServletException {
         ServletContext context = config.getServletContext();
 

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/resource/ExceptionWriter.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/resource/ExceptionWriter.java
@@ -13,6 +13,7 @@ import javax.ws.rs.ext.Provider;
 
 @Provider
 public class ExceptionWriter implements ExceptionMapper<Exception> {
+    @Override
     public Response toResponse(Exception exception) {
         if (exception instanceof javax.ws.rs.WebApplicationException) {
             javax.ws.rs.WebApplicationException e = (javax.ws.rs.WebApplicationException) exception;

--- a/modules/swagger-generator/src/main/java/io/swagger/generator/util/ValidationException.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/util/ValidationException.java
@@ -19,6 +19,7 @@ public class ValidationException extends Exception {
         this.code = code;
     }
 
+    @Override
     public String getMessage() {
         return msg;
     }

--- a/modules/swagger-generator/src/test/java/io/swagger/generator/online/OnlineGeneratorOptionsTest.java
+++ b/modules/swagger-generator/src/test/java/io/swagger/generator/online/OnlineGeneratorOptionsTest.java
@@ -94,6 +94,7 @@ public class OnlineGeneratorOptionsTest {
 
         final Maps.EntryTransformer<String, InvocationCounter, String> transformer =
                 new Maps.EntryTransformer<String, InvocationCounter, String>() {
+                    @Override
                     public String transformEntry(String key, InvocationCounter value) {
                         return value.getValue();
                     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S1161 - @Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1161

Please let me know if you have any questions.

Kirill Vlasov