### PR TITLE
Fix default needToImport

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1714,8 +1714,7 @@ public class DefaultCodegen {
      */
     protected boolean needToImport(String type) {
         return !defaultIncludes.contains(type)
-            && !languageSpecificPrimitives.contains(type)
-            && type.indexOf(".") < 0;
+            && !languageSpecificPrimitives.contains(type);
     }
 
     protected List<Map<String, Object>> toExamples(Map<String, Object> examples) {

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
@@ -41,7 +41,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-09T22:51:50.471-05:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class ApiClient {
   private Map<String, Client> hostMap = new HashMap<String, Client>();
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -79,8 +79,8 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("petstore_auth", new OAuth());
     authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
+    authentications.put("petstore_auth", new OAuth());
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiException.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiException.java
@@ -3,7 +3,7 @@ package io.swagger.client;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class ApiException extends Exception {
   private int code = 0;
   private Map<String, List<String>> responseHeaders = null;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/Configuration.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/Configuration.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class Configuration {
   private static ApiClient defaultApiClient = new ApiClient();
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/Pair.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/Pair.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/StringUtil.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/StringUtil.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
@@ -12,7 +12,7 @@ import java.io.File;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-09T22:51:50.471-05:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class PetApi {
   private ApiClient apiClient;
 
@@ -344,6 +344,46 @@ public class PetApi {
 
     
     apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
+    
+  }
+  
+  /**
+   * downloads an image
+   * 
+   * @return File
+   */
+  public File downloadFile() throws ApiException {
+    Object postBody = null;
+    
+    // create path and map variables
+    String path = "/pet/{petId}/downloadImage".replaceAll("\\{format\\}","json");
+
+    // query params
+    List<Pair> queryParams = new ArrayList<Pair>();
+    Map<String, String> headerParams = new HashMap<String, String>();
+    Map<String, Object> formParams = new HashMap<String, Object>();
+
+    
+
+    
+
+    
+
+    final String[] accepts = {
+      "application/octet-stream"
+    };
+    final String accept = apiClient.selectHeaderAccept(accepts);
+
+    final String[] contentTypes = {
+      
+    };
+    final String contentType = apiClient.selectHeaderContentType(contentTypes);
+
+    String[] authNames = new String[] {  };
+
+    
+    GenericType<File> returnType = new GenericType<File>() {};
+    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
   }
   

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/StoreApi.java
@@ -12,7 +12,7 @@ import io.swagger.client.model.Order;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-09T22:51:50.471-05:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class StoreApi {
   private ApiClient apiClient;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/UserApi.java
@@ -12,7 +12,7 @@ import java.util.*;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-09T22:51:50.471-05:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class UserApi {
   private ApiClient apiClient;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/Authentication.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/Authentication.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public interface Authentication {
   /** Apply authentication settings to header and query params. */
   void applyToParams(List<Pair> queryParams, Map<String, String> headerParams);

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/HttpBasicAuth.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import java.io.UnsupportedEncodingException;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class OAuth implements Authentication {
   private String accessToken;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
@@ -9,8 +9,9 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 
+
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class Category   {
   
   private Long id = null;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
@@ -10,8 +10,9 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 
+
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class Order   {
   
   private Long id = null;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
@@ -12,8 +12,9 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 
+
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class Pet   {
   
   private Long id = null;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
@@ -9,8 +9,9 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 
+
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class Tag   {
   
   private Long id = null;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
@@ -9,8 +9,9 @@ import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 
+
 @ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-11-29T00:18:25.953+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
 public class User   {
   
   private Long id = null;


### PR DESCRIPTION
The default `needToImport` was accidentally updated with `type.indexOf(".") < 0` in the following commit:

https://github.com/swagger-api/swagger-codegen/commit/edf2642e739f75debcc40bf454c8ee9513215f80

The correct approach is to override `needToImport` in language specified generator.