### PR TITLE
Outstanding fix for #1173: Added support for vendor extensions on model and property

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -2,10 +2,7 @@ package io.swagger.codegen;
 
 import io.swagger.models.ExternalDocs;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class CodegenModel {
     public String parent;
@@ -21,4 +18,6 @@ public class CodegenModel {
     public Set<String> imports = new HashSet<String>();
     public Boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum;
     public ExternalDocs externalDocs;
+
+    public Map<String, Object> vendorExtensions;
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -38,6 +38,7 @@ public class CodegenProperty {
     public List<String> _enum;
     public Map<String, Object> allowableValues;
     public CodegenProperty items;
+    public Map<String, Object> vendorExtensions;
 
     @Override
     public boolean equals(Object obj) {
@@ -136,6 +137,9 @@ public class CodegenProperty {
             return false;
         }
         if (this.allowableValues != other.allowableValues && (this.allowableValues == null || !this.allowableValues.equals(other.allowableValues))) {
+            return false;
+        }
+        if (this.vendorExtensions != other.vendorExtensions && (this.vendorExtensions == null || !this.vendorExtensions.equals(other.vendorExtensions))) {
             return false;
         }
         return true;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -307,7 +307,7 @@ public class DefaultCodegen {
      * Return the parameter name by removing invalid characters and proper escaping if
      * it's a reserved word.
      * 
-     * @param property Codegen property object
+     * @param name Codegen property object
      * @return the sanitized parameter name
      */
     public String toParamName(String name) {
@@ -332,8 +332,9 @@ public class DefaultCodegen {
      * Return the escaped name of the reserved word
      * 
      * @param name the name to be escaped
-     * @throws Runtime exception as reserved word is not allowed (default behavior)
      * @return the escaped reserved word
+     *
+     * throws Runtime exception as reserved word is not allowed (default behavior)
      */
     public String escapeReservedWord(String name) {
         throw new RuntimeException("reserved word " + name + " not allowed");
@@ -369,9 +370,8 @@ public class DefaultCodegen {
      * between Swagger type and the corresponding import statement for the language. This will 
      * also add some language specified CLI options, if any.
      *
-     * @param path the path of the operation
-     * @param operation Swagger operation object
-     * @return string presentation of the example path
+     *
+     * returns string presentation of the example path (it's a constructor)
      */
     public DefaultCodegen() {
         defaultIncludes = new HashSet<String>(
@@ -1430,7 +1430,7 @@ public class DefaultCodegen {
      * Convert Swagger Parameter object to Codegen Parameter object
      *
      * @param param Swagger parameter object
-     * @param a set of imports for library/package/module
+     * @param imports set of imports for library/package/module
      * @return Codegen Parameter object
      */
     public CodegenParameter fromParameter(Parameter param, Set<String> imports) {
@@ -2015,6 +2015,7 @@ public class DefaultCodegen {
     /**
      * All library templates supported.
      * (key: library name, value: library description)
+     * @return the supported libraries
      */
     public Map<String, String> supportedLibraries() {
         return supportedLibraries;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -762,6 +762,9 @@ public class DefaultCodegen {
         m.classVarName = toVarName(name);
         m.modelJson = Json.pretty(model);
         m.externalDocs = model.getExternalDocs();
+        m.vendorExtensions = model.getVendorExtensions();
+
+
         if (model instanceof ArrayModel) {
             ArrayModel am = (ArrayModel) model;
             ArrayProperty arrayProperty = new ArrayProperty(am.getItems());
@@ -880,9 +883,9 @@ public class DefaultCodegen {
         property.example = p.getExample();
         property.defaultValue = toDefaultValue(p);
         property.defaultValueWithParam = toDefaultValueWithParam(name, p);
-        
         property.jsonSchema = Json.pretty(p);
         property.isReadOnly = p.getReadOnly();
+        property.vendorExtensions = p.getVendorExtensions();
 
         String type = getSwaggerType(p);
         if (p instanceof AbstractNumericProperty) {


### PR DESCRIPTION
@fehguy added support for this in parameters; This adds vendorExtensions support for models and properties (per request from @ovidiom)

Swagger YAML
```yaml
  User:
    properties:
      accountName:
        type: "string"
        example: "JohnDoe"
        description: "User's account name."
    x-authored-json-sample: Wow we have vendor extension on a model!
```

Template (in swagger-codegen)
```mustache
Value for x-authored-json-sample: {{vendorExtensions.x-authored-json-sample}}
```

Result
```
Value for x-authored-json-sample: Wow we have vendor extension on a model!
```
