### PR TITLE
[Akka-Scala] Fix #1781 re specs w/o security defs

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1602,7 +1602,7 @@ public class DefaultCodegen {
      */
     public List<CodegenSecurity> fromSecurity(Map<String, SecuritySchemeDefinition> schemes) {
         if (schemes == null) {
-            return null;
+        	return Collections.emptyList();
         }
 
         List<CodegenSecurity> secs = new ArrayList<CodegenSecurity>(schemes.size());


### PR DESCRIPTION
Per issue recommendation, fix is to DefaultCodegen#fromSecurity, which
now returns an empty list rather than null if no securityDefinitions
property is present in the swagger spec