### PR TITLE
added BigDecimal java serialization options

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -109,6 +109,10 @@ public interface CodegenConfig {
 
     Map<String, Object> postProcessSupportingFileData(Map<String, Object> objs);
 
+    void postProcessModelProperty(CodegenModel model, CodegenProperty property);
+
+    void postProcessParameter(CodegenParameter parameter);
+
     String apiFilename(String templateName, String tag);
 
     boolean shouldOverwrite(String filename);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -34,6 +34,9 @@ public class CodegenConstants {
     public static final String SERIALIZABLE_MODEL = "serializableModel";
     public static final String SERIALIZABLE_MODEL_DESC = "boolean - toggle \"implements Serializable\" for generated models";
 
+    public static final String SERIALIZE_BIG_DECIMAL_AS_STRING = "bigDecimalAsString";
+    public static final String SERIALIZE_BIG_DECIMAL_AS_STRING_DESC = "boolean - treat BigDecimal values as Strings to avoid precision loss.  Default: false";
+
     public static final String LIBRARY = "library";
     public static final String LIBRARY_DESC = "library template (sub-template)";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -120,6 +120,12 @@ public class DefaultCodegen {
         return objs;
     }
 
+    // override to post-process any model properties
+    public void postProcessModelProperty(CodegenModel model, CodegenProperty property){}
+
+    // override to post-process any parameters
+    public void postProcessParameter(CodegenParameter parameter){}
+
     //override with any special handling of the entire swagger spec
     public void preprocessSwagger(Swagger swagger) {
     }
@@ -620,7 +626,9 @@ public class DefaultCodegen {
      **/
     public String getSwaggerType(Property p) {
         String datatype = null;
-        if (p instanceof StringProperty) {
+        if (p instanceof StringProperty && "number".equals(p.getFormat())) {
+            datatype = "BigDecimal";
+        } else if (p instanceof StringProperty) {
             datatype = "string";
         } else if (p instanceof ByteArrayProperty) {
             datatype = "ByteArray";
@@ -842,6 +850,12 @@ public class DefaultCodegen {
                 addParentContainer(m, name, mapProperty);
             }
             addVars(m, impl.getProperties(), impl.getRequired());
+        }
+
+        if(m.vars != null) {
+            for(CodegenProperty prop : m.vars) {
+                postProcessModelProperty(m, prop);
+            }
         }
         return m;
     }
@@ -1595,6 +1609,8 @@ public class DefaultCodegen {
             }
             p.paramName = toParamName(bp.getName());
         }
+
+        postProcessParameter(p);
         return p;
     }
 

--- a/modules/swagger-codegen/src/main/resources/Java/enumClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/enumClass.mustache
@@ -1,17 +1,17 @@
 
-public enum {{{datatypeWithEnum}}} {
-  {{#allowableValues}}{{#enumVars}}{{{name}}}("{{{value}}}"){{^-last}},
-  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+  public enum {{{datatypeWithEnum}}} {
+    {{#allowableValues}}{{#enumVars}}{{{name}}}("{{{value}}}"){{^-last}},
+    {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
 
-  private String value;
+    private String value;
 
-  {{{datatypeWithEnum}}}(String value) {
-    this.value = value;
+    {{{datatypeWithEnum}}}(String value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return value;
+    }
   }
-
-  @Override
-  @JsonValue
-  public String toString() {
-    return value;
-  }
-}

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -14,6 +14,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}
    * maximum: {{maximum}}{{/maximum}}
    **/
+  {{#vendorExtensions.extraAnnotation}}{{vendorExtensions.extraAnnotation}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
   public {{{datatypeWithEnum}}} {{getter}}() {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/inflector/JavaInflectorServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/inflector/JavaInflectorServerOptionsTest.java
@@ -4,8 +4,6 @@ import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.java.JavaClientOptionsTest;
 import io.swagger.codegen.languages.JavaInflectorServerCodegen;
 import io.swagger.codegen.options.JavaInflectorServerOptionsProvider;
-import io.swagger.codegen.options.JavaOptionsProvider;
-
 import mockit.Expectations;
 import mockit.Tested;
 
@@ -49,6 +47,8 @@ public class JavaInflectorServerOptionsTest extends JavaClientOptionsTest {
             clientCodegen.setLibrary(JavaInflectorServerOptionsProvider.LIBRARY_VALUE);
             times = 1;
             clientCodegen.setFullJavaUtil(Boolean.valueOf(JavaInflectorServerOptionsProvider.FULL_JAVA_UTIL_VALUE));
+            times = 1;
+            clientCodegen.setSerializeBigDecimalAsString(true);
             times = 1;
         }};
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
@@ -38,6 +38,7 @@ public class JavaOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SERIALIZABLE_MODEL, SERIALIZABLE_MODEL_VALUE)
                 .put(JavaClientCodegen.FULL_JAVA_UTIL, FULL_JAVA_UTIL_VALUE)
                 .put(CodegenConstants.LIBRARY, LIBRARY_VALUE)
+                .put(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING, "true")
                 .build();
     }
 


### PR DESCRIPTION
This commit adds an option to java clients to serialize BigDecimal values as strings.  It also gives the option to post-process models, for injecting other vendor extensions, imports, etc.