### PR TITLE
made imports more intelligent

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -15,7 +15,7 @@ public class CodegenModel {
     // list of all required parameters
     public Set<String> mandatory = new HashSet<String>();
     
-    public Set<String> imports = new HashSet<String>();
+    public Set<String> imports = new TreeSet<String>();
     public Boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum;
     public ExternalDocs externalDocs;
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -697,6 +697,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             mo.put("model", cm);
             mo.put("importPath", config.toModelImport(key));
             models.add(mo);
+
             allImports.addAll(cm.imports);
         }
         objs.put("models", models);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -147,7 +147,6 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
             this.setSourceFolder((String) additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
         }
 
-
         if (additionalProperties.containsKey(CodegenConstants.LOCAL_VARIABLE_PREFIX)) {
             this.setLocalVariablePrefix((String) additionalProperties.get(CodegenConstants.LOCAL_VARIABLE_PREFIX));
         }
@@ -199,6 +198,14 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         // optional jackson mappings for BigDecimal support
         importMapping.put("ToStringSerializer", "com.fasterxml.jackson.databind.ser.std.ToStringSerializer");
         importMapping.put("JsonSerialize", "com.fasterxml.jackson.databind.annotation.JsonSerialize");
+
+        // imports for pojos
+        importMapping.put("ApiModelProperty", "io.swagger.annotations.ApiModelProperty");
+        importMapping.put("ApiModel", "io.swagger.annotations.ApiModel");
+        importMapping.put("JsonProperty", "com.fasterxml.jackson.annotation.JsonProperty");
+        importMapping.put("JsonValue", "com.fasterxml.jackson.annotation.JsonValue");
+        importMapping.put("Objects", "java.util.Objects");
+        importMapping.put("StringUtil", invokerPackage + ".StringUtil");
 
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
         supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
@@ -469,6 +476,18 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
                 // this requires some more imports to be added for this model...
                 model.imports.add("ToStringSerializer");
                 model.imports.add("JsonSerialize");
+            }
+        }
+        if(model.isEnum == null || model.isEnum) {
+            // needed by all pojos, but not enums
+            model.imports.add("ApiModelProperty");
+            model.imports.add("ApiModel");
+            model.imports.add("JsonProperty");
+            model.imports.add("Objects");
+            model.imports.add("StringUtil");
+
+            if(model.hasEnums != null || model.hasEnums == true) {
+                model.imports.add("JsonValue");
             }
         }
         return;

--- a/modules/swagger-codegen/src/main/resources/Java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/model.mustache
@@ -6,10 +6,7 @@ import {{invokerPackage}}.StringUtil;
 
 {{#serializableModel}}
 import java.io.Serializable;{{/serializableModel}}
-import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 {{#models}}
 
 {{#model}}{{#description}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelEnumTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelEnumTest.java
@@ -10,13 +10,11 @@ import io.swagger.models.ModelImpl;
 import io.swagger.models.RefModel;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,7 +81,7 @@ public class JavaModelEnumTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.parent, "ParentModel");
-        Assert.assertEquals(cm.imports, Collections.singletonList("ParentModel"));
+        Assert.assertTrue(cm.imports.contains("ParentModel"));
 
         // Assert that only the unshared/uninherited enum remains
         Assert.assertEquals(cm.vars.size(), 1);


### PR DESCRIPTION
Using the new `postProcessModelProperty` operation, imports can be added intelligently.  This PR updates the java client with better imports and mappings.

Fixes #1764 