### PR TITLE
[Java] Update imports in models of Java clients

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -482,12 +482,15 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
             // needed by all pojos, but not enums
             model.imports.add("ApiModelProperty");
             model.imports.add("ApiModel");
-            model.imports.add("JsonProperty");
             model.imports.add("Objects");
-            model.imports.add("StringUtil");
 
-            if(model.hasEnums != null || model.hasEnums == true) {
-                model.imports.add("JsonValue");
+            final String lib = getLibrary();
+            if(StringUtils.isEmpty(lib) || "feign".equals(lib) || "jersey2".equals(lib)) {
+                model.imports.add("JsonProperty");
+
+                if(model.hasEnums != null || model.hasEnums == true) {
+                  model.imports.add("JsonValue");
+                }
             }
         }
         return;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/model.mustache
@@ -1,17 +1,11 @@
 package {{package}};
 
-import {{invokerPackage}}.StringUtil;
 {{#imports}}import {{import}};
 {{/imports}}
 
 import com.google.gson.annotations.SerializedName;
 
-{{#serializableModel}}
-import java.io.Serializable;{{/serializableModel}}
-import java.util.Objects;
-
-import io.swagger.annotations.*;
-
+{{#serializableModel}}import java.io.Serializable;{{/serializableModel}}
 {{#models}}
 
 {{#model}}{{#description}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/model.mustache
@@ -1,17 +1,11 @@
 package {{package}};
 
-import {{invokerPackage}}.StringUtil;
 {{#imports}}import {{import}};
 {{/imports}}
 
 import com.google.gson.annotations.SerializedName;
 
-{{#serializableModel}}
-import java.io.Serializable;{{/serializableModel}}
-import java.util.Objects;
-
-import io.swagger.annotations.*;
-
+{{#serializableModel}}import java.io.Serializable;{{/serializableModel}}
 {{#models}}
 
 {{#model}}{{#description}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/model.mustache
@@ -1,17 +1,11 @@
 package {{package}};
 
-import {{invokerPackage}}.StringUtil;
 {{#imports}}import {{import}};
 {{/imports}}
 
 import com.google.gson.annotations.SerializedName;
 
-{{#serializableModel}}
-import java.io.Serializable;{{/serializableModel}}
-import java.util.Objects;
-
-import io.swagger.annotations.*;
-
+{{#serializableModel}}import java.io.Serializable;{{/serializableModel}}
 {{#models}}
 
 {{#model}}{{#description}}

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
@@ -12,7 +12,7 @@ import java.io.File;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-21T14:12:11.520+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:26:41.149+08:00")
 public class PetApi {
   private ApiClient apiClient;
 
@@ -344,46 +344,6 @@ public class PetApi {
 
     
     apiClient.invokeAPI(path, "DELETE", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, null);
-    
-  }
-  
-  /**
-   * downloads an image
-   * 
-   * @return File
-   */
-  public File downloadFile() throws ApiException {
-    Object postBody = null;
-    
-    // create path and map variables
-    String path = "/pet/{petId}/downloadImage".replaceAll("\\{format\\}","json");
-
-    // query params
-    List<Pair> queryParams = new ArrayList<Pair>();
-    Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, Object> formParams = new HashMap<String, Object>();
-
-    
-
-    
-
-    
-
-    final String[] accepts = {
-      "application/octet-stream"
-    };
-    final String accept = apiClient.selectHeaderAccept(accepts);
-
-    final String[] contentTypes = {
-      
-    };
-    final String contentType = apiClient.selectHeaderContentType(contentTypes);
-
-    String[] authNames = new String[] {  };
-
-    
-    GenericType<File> returnType = new GenericType<File>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     
   }
   

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:32:50.163+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:17:07.711+08:00")
 public class Category   {
   
   private Long id = null;
@@ -20,6 +19,7 @@ public class Category   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -32,6 +32,7 @@ public class Category   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
@@ -1,18 +1,17 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Date;
-
-
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:32:50.163+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:17:07.711+08:00")
 public class Order   {
   
   private Long id = null;
@@ -21,23 +20,23 @@ public class Order   {
   private Date shipDate = null;
 
 
-public enum StatusEnum {
-  PLACED("placed"),
-  APPROVED("approved"),
-  DELIVERED("delivered");
+  public enum StatusEnum {
+    PLACED("placed"),
+    APPROVED("approved"),
+    DELIVERED("delivered");
 
-  private String value;
+    private String value;
 
-  StatusEnum(String value) {
-    this.value = value;
+    StatusEnum(String value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return value;
+    }
   }
-
-  @Override
-  @JsonValue
-  public String toString() {
-    return value;
-  }
-}
 
   private StatusEnum status = null;
   private Boolean complete = null;
@@ -45,6 +44,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -57,6 +57,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("petId")
   public Long getPetId() {
@@ -69,6 +70,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("quantity")
   public Integer getQuantity() {
@@ -81,6 +83,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
   public Date getShipDate() {
@@ -94,6 +97,7 @@ public enum StatusEnum {
   /**
    * Order Status
    **/
+  
   @ApiModelProperty(value = "Order Status")
   @JsonProperty("status")
   public StatusEnum getStatus() {
@@ -106,6 +110,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
   public Boolean getComplete() {

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
@@ -1,20 +1,19 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Category;
-import java.util.*;
 import io.swagger.client.model.Tag;
-
-
+import java.util.*;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:32:50.163+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:17:07.711+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -24,29 +23,30 @@ public class Pet   {
   private List<Tag> tags = new ArrayList<Tag>();
 
 
-public enum StatusEnum {
-  AVAILABLE("available"),
-  PENDING("pending"),
-  SOLD("sold");
+  public enum StatusEnum {
+    AVAILABLE("available"),
+    PENDING("pending"),
+    SOLD("sold");
 
-  private String value;
+    private String value;
 
-  StatusEnum(String value) {
-    this.value = value;
+    StatusEnum(String value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return value;
+    }
   }
-
-  @Override
-  @JsonValue
-  public String toString() {
-    return value;
-  }
-}
 
   private StatusEnum status = null;
 
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -59,6 +59,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("category")
   public Category getCategory() {
@@ -71,6 +72,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
   public String getName() {
@@ -83,6 +85,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
   public List<String> getPhotoUrls() {
@@ -95,6 +98,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
   public List<Tag> getTags() {
@@ -108,6 +112,7 @@ public enum StatusEnum {
   /**
    * pet status in the store
    **/
+  
   @ApiModelProperty(value = "pet status in the store")
   @JsonProperty("status")
   public StatusEnum getStatus() {

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:32:50.163+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:17:07.711+08:00")
 public class Tag   {
   
   private Long id = null;
@@ -20,6 +19,7 @@ public class Tag   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -32,6 +32,7 @@ public class Tag   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:32:50.163+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:17:07.711+08:00")
 public class User   {
   
   private Long id = null;
@@ -26,6 +25,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -38,6 +38,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("username")
   public String getUsername() {
@@ -50,6 +51,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("firstName")
   public String getFirstName() {
@@ -62,6 +64,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("lastName")
   public String getLastName() {
@@ -74,6 +77,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("email")
   public String getEmail() {
@@ -86,6 +90,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("password")
   public String getPassword() {
@@ -98,6 +103,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("phone")
   public String getPhone() {
@@ -111,6 +117,7 @@ public class User   {
   /**
    * User Status
    **/
+  
   @ApiModelProperty(value = "User Status")
   @JsonProperty("userStatus")
   public Integer getUserStatus() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Category.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:53:36.016+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:27:43.581+08:00")
 public class Category   {
   
   private Long id = null;
@@ -20,6 +19,7 @@ public class Category   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -32,6 +32,7 @@ public class Category   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
@@ -1,18 +1,17 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Date;
-
-
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:53:36.016+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:27:43.581+08:00")
 public class Order   {
   
   private Long id = null;
@@ -21,23 +20,23 @@ public class Order   {
   private Date shipDate = null;
 
 
-public enum StatusEnum {
-  PLACED("placed"),
-  APPROVED("approved"),
-  DELIVERED("delivered");
+  public enum StatusEnum {
+    PLACED("placed"),
+    APPROVED("approved"),
+    DELIVERED("delivered");
 
-  private String value;
+    private String value;
 
-  StatusEnum(String value) {
-    this.value = value;
+    StatusEnum(String value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return value;
+    }
   }
-
-  @Override
-  @JsonValue
-  public String toString() {
-    return value;
-  }
-}
 
   private StatusEnum status = null;
   private Boolean complete = null;
@@ -45,6 +44,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -57,6 +57,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("petId")
   public Long getPetId() {
@@ -69,6 +70,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("quantity")
   public Integer getQuantity() {
@@ -81,6 +83,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
   public Date getShipDate() {
@@ -94,6 +97,7 @@ public enum StatusEnum {
   /**
    * Order Status
    **/
+  
   @ApiModelProperty(value = "Order Status")
   @JsonProperty("status")
   public StatusEnum getStatus() {
@@ -106,6 +110,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
   public Boolean getComplete() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
@@ -1,20 +1,19 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Category;
-import java.util.*;
 import io.swagger.client.model.Tag;
-
-
+import java.util.*;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:53:36.016+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:27:43.581+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -24,29 +23,30 @@ public class Pet   {
   private List<Tag> tags = new ArrayList<Tag>();
 
 
-public enum StatusEnum {
-  AVAILABLE("available"),
-  PENDING("pending"),
-  SOLD("sold");
+  public enum StatusEnum {
+    AVAILABLE("available"),
+    PENDING("pending"),
+    SOLD("sold");
 
-  private String value;
+    private String value;
 
-  StatusEnum(String value) {
-    this.value = value;
+    StatusEnum(String value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return value;
+    }
   }
-
-  @Override
-  @JsonValue
-  public String toString() {
-    return value;
-  }
-}
 
   private StatusEnum status = null;
 
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -59,6 +59,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("category")
   public Category getCategory() {
@@ -71,6 +72,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
   public String getName() {
@@ -83,6 +85,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
   public List<String> getPhotoUrls() {
@@ -95,6 +98,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
   public List<Tag> getTags() {
@@ -108,6 +112,7 @@ public enum StatusEnum {
   /**
    * pet status in the store
    **/
+  
   @ApiModelProperty(value = "pet status in the store")
   @JsonProperty("status")
   public StatusEnum getStatus() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Tag.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:53:36.016+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:27:43.581+08:00")
 public class Tag   {
   
   private Long id = null;
@@ -20,6 +19,7 @@ public class Tag   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -32,6 +32,7 @@ public class Tag   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/User.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:53:36.016+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:27:43.581+08:00")
 public class User   {
   
   private Long id = null;
@@ -26,6 +25,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -38,6 +38,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("username")
   public String getUsername() {
@@ -50,6 +51,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("firstName")
   public String getFirstName() {
@@ -62,6 +64,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("lastName")
   public String getLastName() {
@@ -74,6 +77,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("email")
   public String getEmail() {
@@ -86,6 +90,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("password")
   public String getPassword() {
@@ -98,6 +103,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("phone")
   public String getPhone() {
@@ -111,6 +117,7 @@ public class User   {
   /**
    * User Status
    **/
+  
   @ApiModelProperty(value = "User Status")
   @JsonProperty("userStatus")
   public Integer getUserStatus() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Category.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:35:06.891+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:19:27.559+08:00")
 public class Category   {
   
   private Long id = null;
@@ -20,6 +19,7 @@ public class Category   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -32,6 +32,7 @@ public class Category   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
@@ -1,18 +1,17 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Date;
-
-
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:35:06.891+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:19:27.559+08:00")
 public class Order   {
   
   private Long id = null;
@@ -21,23 +20,23 @@ public class Order   {
   private Date shipDate = null;
 
 
-public enum StatusEnum {
-  PLACED("placed"),
-  APPROVED("approved"),
-  DELIVERED("delivered");
+  public enum StatusEnum {
+    PLACED("placed"),
+    APPROVED("approved"),
+    DELIVERED("delivered");
 
-  private String value;
+    private String value;
 
-  StatusEnum(String value) {
-    this.value = value;
+    StatusEnum(String value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return value;
+    }
   }
-
-  @Override
-  @JsonValue
-  public String toString() {
-    return value;
-  }
-}
 
   private StatusEnum status = null;
   private Boolean complete = null;
@@ -45,6 +44,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -57,6 +57,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("petId")
   public Long getPetId() {
@@ -69,6 +70,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("quantity")
   public Integer getQuantity() {
@@ -81,6 +83,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
   public Date getShipDate() {
@@ -94,6 +97,7 @@ public enum StatusEnum {
   /**
    * Order Status
    **/
+  
   @ApiModelProperty(value = "Order Status")
   @JsonProperty("status")
   public StatusEnum getStatus() {
@@ -106,6 +110,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
   public Boolean getComplete() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
@@ -1,20 +1,19 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Category;
-import java.util.*;
 import io.swagger.client.model.Tag;
-
-
+import java.util.*;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:35:06.891+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:19:27.559+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -24,29 +23,30 @@ public class Pet   {
   private List<Tag> tags = new ArrayList<Tag>();
 
 
-public enum StatusEnum {
-  AVAILABLE("available"),
-  PENDING("pending"),
-  SOLD("sold");
+  public enum StatusEnum {
+    AVAILABLE("available"),
+    PENDING("pending"),
+    SOLD("sold");
 
-  private String value;
+    private String value;
 
-  StatusEnum(String value) {
-    this.value = value;
+    StatusEnum(String value) {
+      this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return value;
+    }
   }
-
-  @Override
-  @JsonValue
-  public String toString() {
-    return value;
-  }
-}
 
   private StatusEnum status = null;
 
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -59,6 +59,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("category")
   public Category getCategory() {
@@ -71,6 +72,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
   public String getName() {
@@ -83,6 +85,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
   public List<String> getPhotoUrls() {
@@ -95,6 +98,7 @@ public enum StatusEnum {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
   public List<Tag> getTags() {
@@ -108,6 +112,7 @@ public enum StatusEnum {
   /**
    * pet status in the store
    **/
+  
   @ApiModelProperty(value = "pet status in the store")
   @JsonProperty("status")
   public StatusEnum getStatus() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Tag.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:35:06.891+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:19:27.559+08:00")
 public class Tag   {
   
   private Long id = null;
@@ -20,6 +19,7 @@ public class Tag   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -32,6 +32,7 @@ public class Tag   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/User.java
@@ -1,17 +1,16 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
-
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Objects;
 
-import io.swagger.annotations.*;
-import com.fasterxml.jackson.annotation.*;
 
 
 
-@ApiModel(description = "")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-29T11:35:06.891+08:00")
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2015-12-31T12:19:27.559+08:00")
 public class User   {
   
   private Long id = null;
@@ -26,6 +25,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
@@ -38,6 +38,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("username")
   public String getUsername() {
@@ -50,6 +51,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("firstName")
   public String getFirstName() {
@@ -62,6 +64,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("lastName")
   public String getLastName() {
@@ -74,6 +77,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("email")
   public String getEmail() {
@@ -86,6 +90,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("password")
   public String getPassword() {
@@ -98,6 +103,7 @@ public class User   {
   
   /**
    **/
+  
   @ApiModelProperty(value = "")
   @JsonProperty("phone")
   public String getPhone() {
@@ -111,6 +117,7 @@ public class User   {
   /**
    * User Status
    **/
+  
   @ApiModelProperty(value = "User Status")
   @JsonProperty("userStatus")
   public Integer getUserStatus() {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Category.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Order.java
@@ -1,14 +1,12 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Date;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Pet.java
@@ -1,16 +1,14 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Category;
-import java.util.*;
 import io.swagger.client.model.Tag;
+import java.util.*;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Tag.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/User.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Category.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Order.java
@@ -1,14 +1,12 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Date;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Pet.java
@@ -1,16 +1,14 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Category;
-import java.util.*;
 import io.swagger.client.model.Tag;
+import java.util.*;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Tag.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/User.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Category.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Order.java
@@ -1,14 +1,12 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.Date;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Pet.java
@@ -1,16 +1,14 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Category;
-import java.util.*;
 import io.swagger.client.model.Tag;
+import java.util.*;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Tag.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/User.java
@@ -1,13 +1,11 @@
 package io.swagger.client.model;
 
-import io.swagger.client.StringUtil;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import com.google.gson.annotations.SerializedName;
 
-
-import java.util.Objects;
-
-import io.swagger.annotations.*;
 
 
 


### PR DESCRIPTION
- Remove the StringUtil import which is no longer needed
- Remove duplicated imports of Objects and io.swagger.annotations.*
- Only include jackson related imports in the Java clients needing it
  (i.e. the default, jersey2 and feign Java clients)

See discussion on #1777 