### PR TITLE
Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -390,8 +390,7 @@ public class CodegenConfigurator {
 
         if (isNotEmpty(configFile)) {
             try {
-                CodegenConfigurator result = Json.mapper().readValue(new File(configFile), CodegenConfigurator.class);
-                return result;
+                return Json.mapper().readValue(new File(configFile), CodegenConfigurator.class);
             } catch (IOException e) {
                 LOG.error("Unable to deserialize config file: " + configFile, e);
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -88,10 +88,9 @@ public class ExampleGenerator {
         } else if (property instanceof ArrayProperty) {
             Property innerType = ((ArrayProperty) property).getItems();
             if (innerType != null) {
-                Object[] output = new Object[]{
+                return new Object[]{
                         resolvePropertyToExample(mediaType, innerType, processedModels)
                 };
-                return output;
             }
         } else if (property instanceof DateProperty) {
             return new java.util.Date(System.currentTimeMillis());

--- a/samples/client/wordnik/android-java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/wordnik/android-java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -42,8 +42,7 @@ public class ApiInvoker {
         try {
             if ("List".equals(containerType)) {
                 JavaType typeInfo = JsonUtil.getJsonMapper().getTypeFactory().constructCollectionType(List.class, cls);
-                List response = (List<?>) JsonUtil.getJsonMapper().readValue(json, typeInfo);
-                return response;
+                return (List<?>) JsonUtil.getJsonMapper().readValue(json, typeInfo);
             } else if (String.class.equals(cls)) {
                 if (json != null && json.startsWith("\"") && json.endsWith("\"") && json.length() > 1) {
                     return json.substring(1, json.length() - 2);

--- a/samples/client/wordnik/java/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/wordnik/java/src/main/java/io/swagger/client/ApiInvoker.java
@@ -28,8 +28,7 @@ public class ApiInvoker {
         try {
             if ("List".equals(containerType)) {
                 JavaType typeInfo = JsonUtil.getJsonMapper().getTypeFactory().constructCollectionType(List.class, cls);
-                List response = (List<?>) JsonUtil.getJsonMapper().readValue(json, typeInfo);
-                return response;
+                return (List<?>) JsonUtil.getJsonMapper().readValue(json, typeInfo);
             } else if (String.class.equals(cls)) {
                 if (json != null && json.startsWith("\"") && json.endsWith("\"") && json.length() > 1) {
                     return json.substring(1, json.length() - 2);

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/configuration/SwaggerConfig.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/configuration/SwaggerConfig.java
@@ -22,7 +22,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class SwaggerConfig {
     @Bean
     ApiInfo apiInfo() {
-        ApiInfo apiInfo = new ApiInfo(
+        return new ApiInfo(
         "Swagger Petstore",
         "This is a sample server Petstore server.  You can find out more about Swagger at <a href=\"http://swagger.io\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample, you can use the api key \"special-key\" to test the authorization filters",
         "1.0.0",
@@ -30,7 +30,6 @@ public class SwaggerConfig {
         "apiteam@swagger.io",
         "Apache 2.0",
         "http://www.apache.org/licenses/LICENSE-2.0.html" );
-        return apiInfo;
     }
 
     @Bean


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488 - Local Variables should not be declared and then immediately returned or thrown
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488 - Local Variables should not be declared and then immediately returned or thrown
Please let me know if you have any questions.
Kirill Vlasov
