### PR TITLE
Issue 1797 - Adding assembly info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ samples/client/petstore/python/.venv/
 *.pm~
 *.xml~
 *.t~
+
+#purecloud build paths
+dists/

--- a/bin/purecloud-csharp.sh
+++ b/bin/purecloud-csharp.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+SCRIPT="$0"
+
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+
+if [ ! -d "${APP_DIR}" ]; then
+  APP_DIR=`dirname "$SCRIPT"`/..
+  APP_DIR=`cd "${APP_DIR}"; pwd`
+fi
+
+executable="./modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"
+
+if [ ! -f "$executable" ]
+then
+  mvn clean package
+fi
+
+# if you've executed sbt assembly previously it will use that instead.
+export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+ags="$@ generate -i https://public-api.us-east-1.inindca.com/api/v1/docs/swagger -l purecloudcsharp -o dists/purecloud/csharp"
+
+java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -90,6 +90,8 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         typeMapping.put("map", "Dictionary");
         typeMapping.put("object", "Object");
 
+        importMapping.remove("LocalDateTime");
+
         cliOptions.clear();
         cliOptions.add(new CliOption(CodegenConstants.PACKAGE_NAME, "C# package name (convention: Camel.Case).")
                 .defaultValue("IO.Swagger"));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -24,6 +24,11 @@ import org.slf4j.LoggerFactory;
 public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(CSharpClientCodegen.class);
     protected boolean optionalMethodArgumentFlag = true;
+    protected String packageTitle = "Swagger Library";
+    protected String packageProductName = "SwaggerLibrary";
+    protected String packageDescription = "A library generated from a Swagger doc";
+    protected String packageCompany = "Swagger";
+    protected String packageCopyright = "No Copyright";
     protected String packageName = "IO.Swagger";
     protected String packageVersion = "1.0.0";
     protected String clientPackage = "IO.Swagger.Client";
@@ -117,6 +122,13 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
 
         additionalProperties.put("clientPackage", clientPackage);
 
+        // Add properties used by AssemblyInfo.mustache
+        additionalProperties.put("packageTitle", packageTitle);
+        additionalProperties.put("packageProductName", packageProductName);
+        additionalProperties.put("packageDescription", packageDescription);
+        additionalProperties.put("packageCompany", packageCompany);
+        additionalProperties.put("packageCopyright", packageCopyright);
+
         if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_METHOD_ARGUMENT)) {
             setOptionalMethodArgumentFlag(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.OPTIONAL_METHOD_ARGUMENT).toString()));
@@ -135,6 +147,7 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         supportingFiles.add(new SupportingFile("RestSharp.dll", "bin", "RestSharp.dll"));
         supportingFiles.add(new SupportingFile("compile.mustache", "", "compile.bat"));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
+        supportingFiles.add(new SupportingFile("AssemblyInfo.mustache", "src" + File.separator + "Properties", "AssemblyInfo.cs"));
 
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PureCloudCSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PureCloudCSharpClientCodegen.java
@@ -1,0 +1,31 @@
+package io.swagger.codegen.languages;
+
+public class PureCloudCSharpClientCodegen extends CSharpClientCodegen {
+
+    public PureCloudCSharpClientCodegen() {
+        super();
+
+        // Override some variables
+        packageTitle = "PureCloud Public API Library";
+        packageProductName = "PureCloudPublicAPILibrary";
+        packageDescription = "A .NET library to interface with the PureCloud Public API";
+        packageCompany = "Interactive Intelligence, Inc.";
+        packageCopyright = "Copyright © Interactive Intelligence, Inc. 2015";
+        packageName = "ININ.PureCloud.PublicAPI";
+        apiPackage = packageName + ".Api";
+        modelPackage = packageName + ".Model";
+        clientPackage = packageName + ".Client";
+        //TODO: determine this programatically somehow
+        packageVersion = "0.0.0.1";
+
+        /* There is a type named "PureCloud" that must be fully qualified since the compiler assumes that "PureCloud"
+         * means the namespace "ININ.PureCloud"
+         */
+        typeMapping.put("PureCloud", "ININ.PureCloud.PublicAPI.Model.PureCloud");
+    }
+
+    @Override
+    public String getName() {
+        return "purecloudcsharp";
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -33,3 +33,4 @@ io.swagger.codegen.languages.TypeScriptNodeClientCodegen
 io.swagger.codegen.languages.AkkaScalaClientCodegen
 io.swagger.codegen.languages.CsharpDotNet2ClientCodegen
 io.swagger.codegen.languages.ClojureClientCodegen
+io.swagger.codegen.languages.PureCloudCSharpClientCodegen

--- a/modules/swagger-codegen/src/main/resources/csharp/AssemblyInfo.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/AssemblyInfo.mustache
@@ -1,0 +1,33 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("{{packageTitle}}")]
+[assembly: AssemblyDescription("{{packageDescription}}")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("{{packageCompany}}")]
+[assembly: AssemblyProduct("{{packageProductName}}")]
+[assembly: AssemblyCopyright("{{packageCopyright}}")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("{{packageVersion}}")]
+[assembly: AssemblyFileVersion("{{packageVersion}}")]

--- a/modules/swagger-codegen/src/main/resources/csharp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model.mustache
@@ -16,7 +16,7 @@ namespace {{packageName}}.Model
     /// {{description}}
     /// </summary>
     [DataContract]
-    public class {{classname}} : IEquatable<{{classname}}>{{#parent}}, {{{parent}}}{{/parent}}
+    public class {{classname}} : {{#parent}}{{{parent}}}, {{/parent}} IEquatable<{{classname}}>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class.


### PR DESCRIPTION
Changes for #1797:

* New mustache template created for AssemblyInfo.cs
* Properties added to the C# codegen file to specify the assembly property values and adding AssemblyInfo.mustache to list of supporting files