### PR TITLE
Issue 1797 - Adding assembly info

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -24,6 +24,11 @@ import org.slf4j.LoggerFactory;
 public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(CSharpClientCodegen.class);
     protected boolean optionalMethodArgumentFlag = true;
+    protected String packageTitle = "Swagger Library";
+    protected String packageProductName = "SwaggerLibrary";
+    protected String packageDescription = "A library generated from a Swagger doc";
+    protected String packageCompany = "Swagger";
+    protected String packageCopyright = "No Copyright";
     protected String packageName = "IO.Swagger";
     protected String packageVersion = "1.0.0";
     protected String clientPackage = "IO.Swagger.Client";
@@ -117,6 +122,13 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
 
         additionalProperties.put("clientPackage", clientPackage);
 
+        // Add properties used by AssemblyInfo.mustache
+        additionalProperties.put("packageTitle", packageTitle);
+        additionalProperties.put("packageProductName", packageProductName);
+        additionalProperties.put("packageDescription", packageDescription);
+        additionalProperties.put("packageCompany", packageCompany);
+        additionalProperties.put("packageCopyright", packageCopyright);
+
         if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_METHOD_ARGUMENT)) {
             setOptionalMethodArgumentFlag(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.OPTIONAL_METHOD_ARGUMENT).toString()));
@@ -135,6 +147,7 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         supportingFiles.add(new SupportingFile("RestSharp.dll", "bin", "RestSharp.dll"));
         supportingFiles.add(new SupportingFile("compile.mustache", "", "compile.bat"));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
+        supportingFiles.add(new SupportingFile("AssemblyInfo.mustache", "src" + File.separator + "Properties", "AssemblyInfo.cs"));
 
     }
 

--- a/modules/swagger-codegen/src/main/resources/csharp/AssemblyInfo.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/AssemblyInfo.mustache
@@ -1,0 +1,33 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("{{packageTitle}}")]
+[assembly: AssemblyDescription("{{packageDescription}}")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("{{packageCompany}}")]
+[assembly: AssemblyProduct("{{packageProductName}}")]
+[assembly: AssemblyCopyright("{{packageCopyright}}")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("{{packageVersion}}")]
+[assembly: AssemblyFileVersion("{{packageVersion}}")]


### PR DESCRIPTION
Changes for issue #1797 

* New mustache template created for AssemblyInfo.cs
* Properties added to the C# codegen file to specify the assembly property values and adding AssemblyInfo.mustache to list of supporting files