### PR TITLE
Fixed configuration of host in api_client so that it gets done at run-time not load-time

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -66,8 +66,7 @@ class ApiClient(object):
     :param header_name: a header to pass when making calls to the API.
     :param header_value: a header value to pass when making calls to the API.
     """
-    def __init__(self, host=Configuration().host,
-                 header_name=None, header_value=None, cookie=None):
+    def __init__(self, host=None, header_name=None, header_value=None, cookie=None):
 
         """
         Constructor of the class.
@@ -76,7 +75,10 @@ class ApiClient(object):
         self.default_headers = {}
         if header_name is not None:
             self.default_headers[header_name] = header_value
-        self.host = host
+        if host is None:
+            self.host = Configuration().host
+        else:
+            self.host = host
         self.cookie = cookie
         # Set default User-Agent.
         self.user_agent = 'Python-Swagger/{{packageVersion}}'


### PR DESCRIPTION
in Python, a method used as the default value of a formal parameter defines the value when the function is defined (normally at `import` time), not when the method is invoked

So if someone tried 

````
Configuration().host = mySpecialHost
api = MySpecialApi()
````

it would not work because the Configuration().host in api_client was invoked when the module was loaded, not when the constructor is run.

Note: I tested this by editing the generated python code, not the .mustache file
