### PR TITLE
adds a parentSchema name, escapes reserved words in java client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -5,7 +5,7 @@ import io.swagger.models.ExternalDocs;
 import java.util.*;
 
 public class CodegenModel {
-    public String parent;
+    public String parent, parentSchema;
     public String name, classname, description, classVarName, modelJson, dataType;
     public String unescapedDescription;
     public String defaultValue;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -789,10 +789,11 @@ public class DefaultCodegen {
             final RefModel parent = (RefModel) composed.getParent();
             if (parent != null) {
                 final String parentRef = parent.getSimpleRef();
-                m.parent = parentRef;
-                addImport(m, toModelName(parent.getSimpleRef()));
+                m.parentSchema = parentRef;
+                m.parent = toModelName(parent.getSimpleRef());
+                addImport(m, m.parent);
                 if (!supportsInheritance && allDefinitions != null) {
-                    final Model parentModel = allDefinitions.get(parentRef);
+                    final Model parentModel = allDefinitions.get(m.parentSchema);
                     if (parentModel instanceof ModelImpl) {
                         final ModelImpl _parent = (ModelImpl) parentModel;
                         if (_parent.getProperties() != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -44,6 +44,11 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
 
         reservedWords = new HashSet<String>(
                 Arrays.asList(
+                        // used as internal variables, can collide with parameter names
+                        "path", "queryParams", "headerParams", "formParams", "postBody", "accepts", "accept", "contentTypes",
+                        "contentType", "authNames",
+
+                        // language reserved words
                         "abstract", "continue", "for", "new", "switch", "assert",
                         "default", "if", "package", "synchronized", "boolean", "do", "goto", "private",
                         "this", "break", "double", "implements", "protected", "throw", "byte", "else",

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -455,8 +455,8 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
     public CodegenModel fromModel(String name, Model model, Map<String, Model> allDefinitions) {
         CodegenModel codegenModel = super.fromModel(name, model, allDefinitions);
 
-        if (allDefinitions != null && codegenModel != null && codegenModel.parent != null && codegenModel.hasEnums) {
-            final Model parentModel = allDefinitions.get(codegenModel.parent);
+        if (allDefinitions != null && codegenModel != null && codegenModel.parentSchema != null && codegenModel.hasEnums) {
+            final Model parentModel = allDefinitions.get(codegenModel.parentSchema);
             final CodegenModel parentCodegenModel = super.fromModel(codegenModel.parent, parentModel);
             codegenModel = this.reconcileInlineEnums(codegenModel, parentCodegenModel);
         }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelEnumTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelEnumTest.java
@@ -80,7 +80,7 @@ public class JavaModelEnumTest {
 
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.parent, "parentModel");
+        Assert.assertEquals(cm.parent, "ParentModel");
         Assert.assertTrue(cm.imports.contains("ParentModel"));
 
         // Assert that only the unshared/uninherited enum remains

--- a/modules/swagger-generator/Dockerfile
+++ b/modules/swagger-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM java:8-jdk
 
 WORKDIR /generator
 COPY target/lib/jetty-runner* /generator/jetty-runner.jar


### PR DESCRIPTION
Fixes #1819, #1820 (java only)