### PR TITLE
Added duplicate operation ID generation

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1792,6 +1792,20 @@ public class DefaultCodegen {
             opList = new ArrayList<CodegenOperation>();
             operations.put(tag, opList);
         }
+        // check for operationId uniqueness
+
+        String uniqueName = co.operationId;
+        int counter = 0;
+        for(CodegenOperation op : opList) {
+            if(uniqueName.equals(op.operationId)) {
+                uniqueName = co.operationId + "_" + counter;
+                counter ++;
+            }
+        }
+        if(!co.operationId.equals(uniqueName)) {
+            LOGGER.warn("generated unique operationId `" + uniqueName + "`");
+        }
+        co.operationId = uniqueName;
         opList.add(co);
         co.baseName = tag;
     }

--- a/modules/swagger-codegen/src/test/resources/2_0/duplicateOperationIds.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/duplicateOperationIds.yaml
@@ -1,0 +1,21 @@
+---
+swagger: "2.0"
+info:
+  version: "1.0.1"
+  title: "fun!"
+basePath: "/v1"
+paths:
+  /one:
+    get:
+      operationId: "duplicate"
+      parameters: []
+      responses:
+        200:
+          description: "success"
+  /two:
+    get:
+      operationId: "duplicate"
+      parameters: []
+      responses:
+        200:
+          description: "success"


### PR DESCRIPTION
If an operation ID is generated or specified, AND it is duplicated in the same operation group, there could be a build error.  The codegen will now suffix the operation_id with _%d to ensure it's unique

Fixes #1822 