### PR TITLE
projectName support to fill package.json template

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Multimap;
 
 import io.swagger.codegen.*;
 import io.swagger.models.Swagger;
+import io.swagger.models.Info;
 import io.swagger.util.Yaml;
 
 import java.io.File;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -263,9 +263,9 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
         
         if (swagger.getInfo() != null) {
             Info info = swagger.getInfo();
-            if (projectName == null &&  info.getTitle() != null) {
-                // when projectName is not specified, generate it from info.title
-                //used in package.json
+            if (info.getTitle() != null) {
+                // when info.title is defined, use it for projectName
+                // used in package.json
                 projectName = dashize(info.getTitle());
                 this.additionalProperties.put("projectName", projectName);
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -259,6 +259,16 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
             }
         }
         this.additionalProperties.put("serverPort", port);
+        
+        if (swagger.getInfo() != null) {
+            Info info = swagger.getInfo();
+            if (projectName == null &&  info.getTitle() != null) {
+                // when projectName is not specified, generate it from info.title
+                //used in package.json
+                projectName = dashize(info.getTitle());
+                this.additionalProperties.put("projectName", projectName);
+            }
+        }
     }
 
         @Override


### PR DESCRIPTION
Inspired by ClojureClientCodegen.java, it is interesting to use projectName from info.title swagger spec to fill up package.json name attribute