### PR TITLE
Fixed bug: basePath should not be empty

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -246,9 +246,6 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
 
     @Override
     public void preprocessSwagger(Swagger swagger) {
-        if ("/".equals(swagger.getBasePath())) {
-            swagger.setBasePath("");
-        }
 
         String host = swagger.getHost();
         String port = "8080";


### PR DESCRIPTION
This last change was producing a wrong swagger spec

@see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
"The value MUST start with a leading slash (/)"