### PR TITLE
Document Java 8 as requirement.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 language: java
 jdk:
   - oraclejdk7
+  - oraclejdk8
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -78,16 +78,16 @@ brew install swagger-codegen
 
 To build from source, you need the following installed and available in your $PATH:
 
-* [Java 7](http://java.oracle.com)
+* [Java 7 or 8](http://java.oracle.com)
 
 * [Apache maven 3.0.3 or greater](http://maven.apache.org/)
 
 #### OS X Users
-Don't forget to install Java 7. You probably have 1.6 or 1.8.
+Don't forget to install Java 7 or 8. You probably have 1.6.
 
 Export JAVA_HOME in order to use the supported Java version:
 ```
-export JAVA_HOME=`/usr/libexec/java_home -v 1.7`
+export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
 export PATH=${JAVA_HOME}/bin:$PATH
 ```
 

--- a/modules/swagger-codegen/src/main/resources/perl/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/README.mustache
@@ -162,7 +162,7 @@ you could also call them on class names.
 
 See the homepage `https://github.com/swagger-api/swagger-codegen` for full details. 
 But briefly, clone the git repository, build the codegen codebase, set up your build 
-config file, then run the API build script. You will need git, Java 7 and Apache 
+config file, then run the API build script. You will need git, Java 7 or 8 and Apache
 maven 3.0.3 or better already installed.
 
 The config file should specify the project name for the generated library: 

--- a/modules/swagger-codegen/src/main/resources/perl/Role.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/Role.mustache
@@ -264,7 +264,7 @@ you could also call them on class names.
 
 See the homepage C<https://github.com/swagger-api/swagger-codegen> for full details. 
 But briefly, clone the git repository, build the codegen codebase, set up your build 
-config file, then run the API build script. You will need git, Java 7 and Apache 
+config file, then run the API build script. You will need git, Java 7 or 8 and Apache
 maven 3.0.3 or better already installed.
 
 The config file should specify the project name for the generated library: 


### PR DESCRIPTION
According to #205 it should be fine to build swagger-codegen with Java 8.

The documentation still mentions Java 7 as the only working Java version (http://swagger.io/swagger-codegen/ also mentions Java 7).
