### PR TITLE
Minimal update for Ruby testing on El Capitan

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest', '~> 4.4', '>= 4.4.6'
   s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
   s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'
-  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.10'
+  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.11'
 
   s.files         = `find *`.split("\n").uniq.sort.select{|f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")

--- a/samples/client/petstore/ruby/Gemfile.lock
+++ b/samples/client/petstore/ruby/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     addressable (2.3.8)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
-    autotest-fsevent (0.2.10)
+    autotest-fsevent (0.2.11)
       sys-uname
     autotest-growl (0.2.16)
     autotest-rails-pure (4.1.2)
@@ -51,7 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   autotest (~> 4.4, >= 4.4.6)
-  autotest-fsevent (~> 0.2, >= 0.2.10)
+  autotest-fsevent (~> 0.2, >= 0.2.11)
   autotest-growl (~> 0.2, >= 0.2.16)
   autotest-rails-pure (~> 4.1, >= 4.1.2)
   petstore!

--- a/samples/client/petstore/ruby/petstore.gemspec
+++ b/samples/client/petstore/ruby/petstore.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest', '~> 4.4', '>= 4.4.6'
   s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
   s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'
-  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.10'
+  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.11'
 
   s.files         = `find *`.split("\n").uniq.sort.select{|f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")


### PR DESCRIPTION
This PR addresses running the Ruby integration tests on El Capitan

One of the development dependencies of the generated Ruby client is [autotest-fsevent](https://github.com/svoop/autotest-fsevent/). It's used to detect file system changes and re-run the tests automatically. Building the clients works fine, but when attempting to run the integration tests for Ruby with the latest OS X (El Capitan) it errors out with this message:

```
Installing autotest-fsevent 0.2.10 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/var/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/autotest-fsevent-0.2.10/ext/fsevent
/usr/local/var/rbenv/versions/2.3.0/bin/ruby -r ./siteconf20160107-72766-a9grd3.rb extconf.rb
extconf.rb:24:in `<main>': Darwin 15 is not (yet) supported (RuntimeError)

extconf failed, exit code 1

Gem files will remain installed in /usr/local/var/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/autotest-fsevent-0.2.10 for inspection.
Results logged to /usr/local/var/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/extensions/x86_64-darwin-15/2.3.0-static/autotest-fsevent-0.2.10/gem_make.out
Using typhoeus 0.7.1
Using webmock 1.21.0
Using rspec 3.2.0
An error occurred while installing autotest-fsevent (0.2.10), and Bundler cannot
continue.
Make sure that `gem install autotest-fsevent -v '0.2.10'` succeeds before
```

The issue is fixed in the latest version of autotest-fsevent, v0.2.11, see [CHANGELOG](https://github.com/svoop/autotest-fsevent/blob/master/CHANGELOG.txt).

We could fix this in two ways:

1. Adjust the version locked in `samples/client/petstore/ruby/Gemfile.lock`. Typically `Gemfile.lock` files are not actually checked in on Ruby gems, so either updating the version to `0.2.11` or removing the file entirely would be workable.
2. Adjust the development dependency to include latest version.

I opted for 2 because it seemed like a much simpler change and more in-line with how the project was being managed. I'm happy to do the work to handle 1 if you prefer.