### PR TITLE
[C#] add cli option to optionally generate Assemblyinfo.cs

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -54,4 +54,9 @@ public class CodegenConstants {
     public static final String POD_VERSION = "podVersion";
 
     public static final String OPTIONAL_METHOD_ARGUMENT = "optionalMethodArgument";
+    public static final String OPTIONAL_METHOD_ARGUMENT_DESC = "Optional method argument, e.g. void square(int x=10) (.net 4.0+ only).";
+
+    public static final String OPTIONAL_ASSEMBLY_INFO = "optionalAssemblyInfo";
+    public static final String OPTIONAL_ASSEMBLY_INFO_DESC = "Generate AssemblyInfo.cs (Default: true).";
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(CSharpClientCodegen.class);
+    protected boolean optionalAssemblyInfoFlag = true;
     protected boolean optionalMethodArgumentFlag = true;
     protected String packageTitle = "Swagger Library";
     protected String packageProductName = "SwaggerLibrary";
@@ -111,6 +112,8 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
                 CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG_DESC).defaultValue(Boolean.TRUE.toString()));
         cliOptions.add(CliOption.newBoolean(CodegenConstants.OPTIONAL_METHOD_ARGUMENT, "C# Optional method argument, " +
                 "e.g. void square(int x=10) (.net 4.0+ only)."));
+        cliOptions.add(CliOption.newBoolean(CodegenConstants.OPTIONAL_ASSEMBLY_INFO,
+                CodegenConstants.OPTIONAL_ASSEMBLY_INFO_DESC).defaultValue(Boolean.TRUE.toString()));
     }
 
     @Override
@@ -147,6 +150,11 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         }
         additionalProperties.put("optionalMethodArgument", optionalMethodArgumentFlag);
         
+        if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_ASSEMBLY_INFO)) {
+            setOptionalAssemblyInfoFlag(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.OPTIONAL_ASSEMBLY_INFO).toString()));
+        }
+
         supportingFiles.add(new SupportingFile("Configuration.mustache",
                 sourceFolder + File.separator + clientPackage.replace(".", java.io.File.separator), "Configuration.cs"));
         supportingFiles.add(new SupportingFile("ApiClient.mustache",
@@ -159,7 +167,10 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         supportingFiles.add(new SupportingFile("RestSharp.dll", "bin", "RestSharp.dll"));
         supportingFiles.add(new SupportingFile("compile.mustache", "", "compile.bat"));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
-        supportingFiles.add(new SupportingFile("AssemblyInfo.mustache", "src" + File.separator + "Properties", "AssemblyInfo.cs"));
+
+        if (optionalAssemblyInfoFlag) {
+            supportingFiles.add(new SupportingFile("AssemblyInfo.mustache", "src" + File.separator + "Properties", "AssemblyInfo.cs"));
+        }
 
     }
 
@@ -299,6 +310,10 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         }
 
         return camelize(sanitizeName(operationId));
+    }
+
+    public void setOptionalAssemblyInfoFlag(boolean flag) {
+        this.optionalAssemblyInfoFlag = flag;
     }
 
     public void setOptionalMethodArgumentFlag(boolean flag) {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpClientOptionsTest.java
@@ -31,6 +31,9 @@ public class CSharpClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setPackageVersion(CSharpClientOptionsProvider.PACKAGE_VERSION_VALUE);
             times = 1;
+            clientCodegen.setOptionalAssemblyInfoFlag(true);
+            times = 1;
+
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/CSharpClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/CSharpClientOptionsProvider.java
@@ -22,6 +22,7 @@ public class CSharpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PACKAGE_VERSION, PACKAGE_VERSION_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, "true")
                 .put(CodegenConstants.OPTIONAL_METHOD_ARGUMENT, "true")
+                .put(CodegenConstants.OPTIONAL_ASSEMBLY_INFO, "true")
                 .build();
     }
 

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/Properties/AssemblyInfo.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Swagger Library")]
+[assembly: AssemblyDescription("A library generated from a Swagger doc")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Swagger")]
+[assembly: AssemblyProduct("SwaggerLibrary")]
+[assembly: AssemblyCopyright("No Copyright")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyFileVersion("1.0.0")]

--- a/samples/client/petstore/csharp/SwaggerClientTest/SwaggerClientTest.userprefs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/SwaggerClientTest.userprefs
@@ -1,11 +1,18 @@
 ﻿<Properties StartupItem="SwaggerClientTest.csproj">
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/PetApi.cs">
+  <MonoDevelop.Ide.Workbench ActiveDocument="TestPet.cs">
     <Files>
-      <File FileName="TestConfiguration.cs" Line="1" Column="1" />
-      <File FileName="TestPet.cs" Line="1" Column="1" />
-      <File FileName="Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/PetApi.cs" Line="15" Column="29" />
+      <File FileName="TestPet.cs" Line="182" Column="4" />
     </Files>
+    <Pads>
+      <Pad Id="MonoDevelop.NUnit.TestPad">
+        <State name="__root__">
+          <Node name="SwaggerClientTest" expanded="True">
+            <Node name="SwaggerClientTest" selected="True" />
+          </Node>
+        </State>
+      </Pad>
+    </Pads>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
     <BreakpointStore />


### PR DESCRIPTION
When including the entire folder into a C# project, AssemblyInfo.cs conflicts with the existing one in the project so making it optional as it's only required when building the dll. Default is to generate AssemblyInfo.cs.