### PR TITLE
#1858: The Java equals/hashcode methods ignores state from superclasses

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -34,15 +34,16 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
-        {{/hasMore}}{{^hasMore}};{{/hasMore}}{{/vars}}{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+
+    return true {{#hasVars}}&& {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+        {{/hasMore}}{{/vars}}{{/hasVars}}
+    {{#parent}}&& super.equals(o){{/parent}};
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}});
+    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}},{{/hasVars}} super.hashCode(){{/parent}});
   }
 
   @Override


### PR DESCRIPTION
This fixes equals/hashCode for derived classes.

Example of the generated equals/hashCode on a POJO that extends another class:

```java
  @Override
  public boolean equals(java.lang.Object o) {
    if (this == o) {
      return true;
    }
    if (o == null || getClass() != o.getClass()) {
      return false;
    }
    Account account = (Account) o;

    return true && Objects.equals(website, account.website) &&
        Objects.equals(createdOn, account.createdOn) &&
        Objects.equals(links, account.links) &&
        Objects.equals(displayName, account.displayName) &&
        Objects.equals(uuid, account.uuid) &&
        Objects.equals(username, account.username)
    && super.equals(o);
  }

  @Override
  public int hashCode() {
    return Objects.hash(website, createdOn, links, displayName, uuid, username, super.hashCode());
  }
```

And one that does not have a parent:

```java
  @Override
  public boolean equals(java.lang.Object o) {
    if (this == o) {
      return true;
    }
    if (o == null || getClass() != o.getClass()) {
      return false;
    }
    Object object = (Object) o;

    return true && Objects.equals(type, object.type)
    ;
  }

  @Override
  public int hashCode() {
    return Objects.hash(type);
  }
```