### PR TITLE
[C#] Fix comments and add compile-mono.sh

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -185,6 +185,8 @@ public class CSharpClientCodegen extends DefaultCodegen implements CodegenConfig
         supportingFiles.add(new SupportingFile("Newtonsoft.Json.dll", "bin", "Newtonsoft.Json.dll"));
         supportingFiles.add(new SupportingFile("RestSharp.dll", "bin", "RestSharp.dll"));
         supportingFiles.add(new SupportingFile("compile.mustache", "", "compile.bat"));
+        supportingFiles.add(new SupportingFile("compile-mono.sh.mustache", "", "compile-mono.sh"));
+        supportingFiles.add(new SupportingFile("packages.config.mustache", "vendor" + java.io.File.separator, "packages.config"));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
 
         if (optionalAssemblyInfoFlag) {

--- a/modules/swagger-codegen/src/main/resources/CsharpDotNet2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/CsharpDotNet2/ApiClient.mustache
@@ -159,6 +159,7 @@ namespace {{packageName}}.Client
         /// </summary>
         /// <param name="content">HTTP body (e.g. string, JSON).</param>
         /// <param name="type">Object type.</param>
+        /// <param name="headers">HTTP headers.</param>
         /// <returns>Object representation of the JSON string.</returns>
         public object Deserialize(string content, Type type, IList<Parameter> headers=null)
         {

--- a/modules/swagger-codegen/src/main/resources/CsharpDotNet2/ApiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/CsharpDotNet2/ApiException.mustache
@@ -20,7 +20,6 @@ namespace {{packageName}}.Client {
       /// <summary>
       /// Initializes a new instance of the <see cref="ApiException"/> class.
       /// </summary>
-      /// <param name="basePath">The base path.</param>
       public ApiException() {}
 
       /// <summary>

--- a/modules/swagger-codegen/src/main/resources/CsharpDotNet2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/CsharpDotNet2/api.mustache
@@ -9,6 +9,9 @@ using {{packageName}}.Client;
 namespace {{packageName}}.Api
 {
     {{#operations}}
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints
+    /// </summary>
     public interface I{{classname}}
     {
         {{#operation}}
@@ -16,7 +19,7 @@ namespace {{packageName}}.Api
         /// {{summary}} {{notes}}
         /// </summary>
         {{#allParams}}/// <param name="{{paramName}}">{{description}}</param>
-        {{/allParams}}/// <returns>{{#returnType}}{{{returnType}}}{{/returnType}}</returns>
+        {{/allParams}}/// <returns>{{#returnType}}{{returnType}}{{/returnType}}</returns>
         {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
         {{/operation}}
     }
@@ -71,7 +74,7 @@ namespace {{packageName}}.Api
         /// <summary>
         /// Gets or sets the API client.
         /// </summary>
-        /// <value>An instance of the ApiClient</param>
+        /// <value>An instance of the ApiClient</value>
         public ApiClient ApiClient {get; set;}
     
         {{#operation}}
@@ -79,7 +82,7 @@ namespace {{packageName}}.Api
         /// {{summary}} {{notes}}
         /// </summary>
         {{#allParams}}/// <param name="{{paramName}}">{{description}}</param> 
-        {{/allParams}}/// <returns>{{#returnType}}{{{returnType}}}{{/returnType}}</returns>            
+        {{/allParams}}/// <returns>{{#returnType}}{{returnType}}{{/returnType}}</returns>            
         public {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{nickname}} ({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
         {
             {{#allParams}}{{#required}}

--- a/modules/swagger-codegen/src/main/resources/CsharpDotNet2/compile-mono.sh.mustache
+++ b/modules/swagger-codegen/src/main/resources/CsharpDotNet2/compile-mono.sh.mustache
@@ -7,6 +7,6 @@ vendor/RestSharp.Net2.1.1.11/lib/net20/RestSharp.Net2.dll,\
 System.Runtime.Serialization.dll \
 -target:library \
 -out:bin/{{packageName}}.dll \
--recurse:src/*.cs \
+-recurse:'src/*.cs' \
 -doc:bin/{{packageName}}.xml \
 -platform:anycpu

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiResponse.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiResponse.mustache
@@ -27,10 +27,10 @@ namespace {{packageName}}.Client
         public T Data { get; private set; }
   
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiResponse"/> class.
+        /// Initializes a new instance of the <see cref="ApiResponse&lt;T&gt;" /> class.
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
-        /// <param name="message">Error message.</param>
+        /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
         public ApiResponse(int statusCode, IDictionary<string, string> headers, T data)
         {

--- a/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
@@ -24,6 +24,7 @@ namespace {{packageName}}.Client
         /// <param name="apiKeyPrefix">Dictionary of API key prefix</param>
         /// <param name="tempFolderPath">Temp folder path</param>
         /// <param name="dateTimeFormat">DateTime format string</param>
+        /// <param name="timeout">HTTP connection timeout (in milliseconds)</param>
         public Configuration(ApiClient apiClient = null,
                              Dictionary<String, String> defaultHeader = null,
                              string username = null,

--- a/modules/swagger-codegen/src/main/resources/csharp/compile-mono.sh.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/compile-mono.sh.mustache
@@ -1,0 +1,12 @@
+wget -nc https://nuget.org/nuget.exe;
+mozroots --import --sync
+mono nuget.exe install vendor/packages.config -o vendor;
+mkdir -p bin;
+mcs -sdk:45 -r:vendor/Newtonsoft.Json.8.0.2/lib/net45/Newtonsoft.Json.dll,\
+vendor/RestSharp.105.2.3/lib/net45/RestSharp.dll,\
+System.Runtime.Serialization.dll \
+-target:library \
+-out:bin/{{packageName}}.dll \
+-recurse:'src/*.cs' \
+-doc:bin/{{packageName}}.xml \
+-platform:anycpu

--- a/modules/swagger-codegen/src/main/resources/csharp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model.mustache
@@ -74,7 +74,7 @@ namespace {{packageName}}.Model
         /// <summary>
         /// Returns true if {{classname}} instances are equal
         /// </summary>
-        /// <param name="obj">Instance of {{classname}} to be compared</param>
+        /// <param name="other">Instance of {{classname}} to be compared</param>
         /// <returns>Boolean</returns>
         public bool Equals({{classname}} other)
         {

--- a/modules/swagger-codegen/src/main/resources/csharp/packages.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/packages.config.mustache
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/compile-mono.sh
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/compile-mono.sh
@@ -7,6 +7,6 @@ vendor/RestSharp.Net2.1.1.11/lib/net20/RestSharp.Net2.dll,\
 System.Runtime.Serialization.dll \
 -target:library \
 -out:bin/IO.Swagger.dll \
--recurse:src/*.cs \
+-recurse:'src/*.cs' \
 -doc:bin/IO.Swagger.xml \
 -platform:anycpu

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Api/PetApi.cs
@@ -8,6 +8,9 @@ using IO.Swagger.Model;
 namespace IO.Swagger.Api
 {
     
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints
+    /// </summary>
     public interface IPetApi
     {
         
@@ -29,14 +32,14 @@ namespace IO.Swagger.Api
         /// Finds Pets by status Multiple status values can be provided with comma seperated strings
         /// </summary>
         /// <param name="status">Status values that need to be considered for filter</param>
-        /// <returns>List<Pet></returns>
+        /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus (List<string> status);
         
         /// <summary>
         /// Finds Pets by tags Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <param name="tags">Tags to filter by</param>
-        /// <returns>List<Pet></returns>
+        /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByTags (List<string> tags);
         
         /// <summary>
@@ -124,7 +127,7 @@ namespace IO.Swagger.Api
         /// <summary>
         /// Gets or sets the API client.
         /// </summary>
-        /// <value>An instance of the ApiClient</param>
+        /// <value>An instance of the ApiClient</value>
         public ApiClient ApiClient {get; set;}
     
         
@@ -212,7 +215,7 @@ namespace IO.Swagger.Api
         /// Finds Pets by status Multiple status values can be provided with comma seperated strings
         /// </summary>
         /// <param name="status">Status values that need to be considered for filter</param> 
-        /// <returns>List<Pet></returns>            
+        /// <returns>List&lt;Pet&gt;</returns>            
         public List<Pet> FindPetsByStatus (List<string> status)
         {
             
@@ -252,7 +255,7 @@ namespace IO.Swagger.Api
         /// Finds Pets by tags Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <param name="tags">Tags to filter by</param> 
-        /// <returns>List<Pet></returns>            
+        /// <returns>List&lt;Pet&gt;</returns>            
         public List<Pet> FindPetsByTags (List<string> tags)
         {
             

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Api/StoreApi.cs
@@ -8,13 +8,16 @@ using IO.Swagger.Model;
 namespace IO.Swagger.Api
 {
     
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints
+    /// </summary>
     public interface IStoreApi
     {
         
         /// <summary>
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
-        /// <returns>Dictionary<String, int?></returns>
+        /// <returns>Dictionary&lt;String, int?&gt;</returns>
         Dictionary<String, int?> GetInventory ();
         
         /// <summary>
@@ -90,14 +93,14 @@ namespace IO.Swagger.Api
         /// <summary>
         /// Gets or sets the API client.
         /// </summary>
-        /// <value>An instance of the ApiClient</param>
+        /// <value>An instance of the ApiClient</value>
         public ApiClient ApiClient {get; set;}
     
         
         /// <summary>
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
-        /// <returns>Dictionary<String, int?></returns>            
+        /// <returns>Dictionary&lt;String, int?&gt;</returns>            
         public Dictionary<String, int?> GetInventory ()
         {
             

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Api/UserApi.cs
@@ -8,6 +8,9 @@ using IO.Swagger.Model;
 namespace IO.Swagger.Api
 {
     
+    /// <summary>
+    /// Represents a collection of functions to interact with the API endpoints
+    /// </summary>
     public interface IUserApi
     {
         
@@ -120,7 +123,7 @@ namespace IO.Swagger.Api
         /// <summary>
         /// Gets or sets the API client.
         /// </summary>
-        /// <value>An instance of the ApiClient</param>
+        /// <value>An instance of the ApiClient</value>
         public ApiClient ApiClient {get; set;}
     
         

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Client/ApiClient.cs
@@ -159,6 +159,7 @@ namespace IO.Swagger.Client
         /// </summary>
         /// <param name="content">HTTP body (e.g. string, JSON).</param>
         /// <param name="type">Object type.</param>
+        /// <param name="headers">HTTP headers.</param>
         /// <returns>Object representation of the JSON string.</returns>
         public object Deserialize(string content, Type type, IList<Parameter> headers=null)
         {

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Client/ApiException.cs
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Client/ApiException.cs
@@ -20,7 +20,6 @@ namespace IO.Swagger.Client {
       /// <summary>
       /// Initializes a new instance of the <see cref="ApiException"/> class.
       /// </summary>
-      /// <param name="basePath">The base path.</param>
       public ApiException() {}
 
       /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/ApiClient.cs
@@ -194,6 +194,12 @@ namespace IO.Swagger.Client
                 // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8
                 // For example: 2009-06-15T13:45:30.0000000
                 return ((DateTime)obj).ToString (Configuration.DateTimeFormat);
+            else if (obj is DateTimeOffset)
+                // Return a formatted date string - Can be customized with Configuration.DateTimeFormat
+                // Defaults to an ISO 8601, using the known as a Round-trip date/time pattern ("o")
+                // https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8
+                // For example: 2009-06-15T13:45:30.0000000
+                return ((DateTimeOffset)obj).ToString (Configuration.DateTimeFormat);   
             else if (obj is IList)
             {
                 var flattenedString = new StringBuilder();

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/ApiResponse.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/ApiResponse.cs
@@ -27,10 +27,10 @@ namespace IO.Swagger.Client
         public T Data { get; private set; }
   
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiResponse"/> class.
+        /// Initializes a new instance of the <see cref="ApiResponse&lt;T&gt;" /> class.
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
-        /// <param name="message">Error message.</param>
+        /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
         public ApiResponse(int statusCode, IDictionary<string, string> headers, T data)
         {

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/Configuration.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/Configuration.cs
@@ -24,6 +24,7 @@ namespace IO.Swagger.Client
         /// <param name="apiKeyPrefix">Dictionary of API key prefix</param>
         /// <param name="tempFolderPath">Temp folder path</param>
         /// <param name="dateTimeFormat">DateTime format string</param>
+        /// <param name="timeout">HTTP connection timeout (in milliseconds)</param>
         public Configuration(ApiClient apiClient = null,
                              Dictionary<String, String> defaultHeader = null,
                              string username = null,

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Category.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Category.cs
@@ -78,7 +78,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// Returns true if Category instances are equal
         /// </summary>
-        /// <param name="obj">Instance of Category to be compared</param>
+        /// <param name="other">Instance of Category to be compared</param>
         /// <returns>Boolean</returns>
         public bool Equals(Category other)
         {

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Order.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Order.cs
@@ -111,7 +111,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// Returns true if Order instances are equal
         /// </summary>
-        /// <param name="obj">Instance of Order to be compared</param>
+        /// <param name="other">Instance of Order to be compared</param>
         /// <returns>Boolean</returns>
         public bool Equals(Order other)
         {

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Pet.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Pet.cs
@@ -111,7 +111,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// Returns true if Pet instances are equal
         /// </summary>
-        /// <param name="obj">Instance of Pet to be compared</param>
+        /// <param name="other">Instance of Pet to be compared</param>
         /// <returns>Boolean</returns>
         public bool Equals(Pet other)
         {

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Tag.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/Tag.cs
@@ -78,7 +78,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// Returns true if Tag instances are equal
         /// </summary>
-        /// <param name="obj">Instance of Tag to be compared</param>
+        /// <param name="other">Instance of Tag to be compared</param>
         /// <returns>Boolean</returns>
         public bool Equals(Tag other)
         {

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/User.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/User.cs
@@ -127,7 +127,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// Returns true if User instances are equal
         /// </summary>
-        /// <param name="obj">Instance of User to be compared</param>
+        /// <param name="other">Instance of User to be compared</param>
         /// <returns>Boolean</returns>
         public bool Equals(User other)
         {


### PR DESCRIPTION
- fixed comments to avoid warning when building dll (C#, C# .net 2.0)
- added compile-mono.sh (copied from C# .net 2.0)