### PR TITLE
[Java okhttp-gson] Implement the "debugging" option of ApiClient

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -11,6 +11,8 @@ import com.squareup.okhttp.MultipartBuilder;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.internal.http.HttpMethod;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor.Level;
 
 import java.lang.reflect.Type;
 
@@ -115,6 +117,8 @@ public class ApiClient {
 
   private OkHttpClient httpClient;
   private JSON json;
+
+  private HttpLoggingInterceptor loggingInterceptor;
 
   public ApiClient() {
     httpClient = new OkHttpClient();
@@ -452,6 +456,16 @@ public class ApiClient {
    * @param debugging To enable (true) or disable (false) debugging
    */
   public ApiClient setDebugging(boolean debugging) {
+    if (debugging != this.debugging) {
+      if (debugging) {
+        loggingInterceptor = new HttpLoggingInterceptor();
+        loggingInterceptor.setLevel(Level.BODY);
+        httpClient.interceptors().add(loggingInterceptor);
+      } else {
+        httpClient.interceptors().remove(loggingInterceptor);
+        loggingInterceptor = null;
+      }
+    }
     this.debugging = debugging;
     return this;
   }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -118,6 +118,11 @@
       <version>${okhttp-version}</version>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <version>${okhttp-version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson-version}</version>
@@ -133,7 +138,7 @@
   </dependencies>
   <properties>
     <swagger-annotations-version>1.5.0</swagger-annotations-version>
-    <okhttp-version>2.4.0</okhttp-version>
+    <okhttp-version>2.7.2</okhttp-version>
     <gson-version>2.3.1</gson-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <junit-version>4.8.1</junit-version>

--- a/samples/client/petstore/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson/pom.xml
@@ -118,6 +118,11 @@
       <version>${okhttp-version}</version>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <version>${okhttp-version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${gson-version}</version>
@@ -133,7 +138,7 @@
   </dependencies>
   <properties>
     <swagger-annotations-version>1.5.0</swagger-annotations-version>
-    <okhttp-version>2.4.0</okhttp-version>
+    <okhttp-version>2.7.2</okhttp-version>
     <gson-version>2.3.1</gson-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <junit-version>4.8.1</junit-version>

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -11,6 +11,8 @@ import com.squareup.okhttp.MultipartBuilder;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.internal.http.HttpMethod;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor.Level;
 
 import java.lang.reflect.Type;
 
@@ -116,6 +118,8 @@ public class ApiClient {
   private OkHttpClient httpClient;
   private JSON json;
 
+  private HttpLoggingInterceptor loggingInterceptor;
+
   public ApiClient() {
     httpClient = new OkHttpClient();
 
@@ -141,8 +145,8 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     authentications.put("petstore_auth", new OAuth());
+    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }
@@ -451,6 +455,16 @@ public class ApiClient {
    * @param debugging To enable (true) or disable (false) debugging
    */
   public ApiClient setDebugging(boolean debugging) {
+    if (debugging != this.debugging) {
+      if (debugging) {
+        loggingInterceptor = new HttpLoggingInterceptor();
+        loggingInterceptor.setLevel(Level.BODY);
+        httpClient.interceptors().add(loggingInterceptor);
+      } else {
+        httpClient.interceptors().remove(loggingInterceptor);
+        loggingInterceptor = null;
+      }
+    }
     this.debugging = debugging;
     return this;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ApiClientTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ApiClientTest.java
@@ -186,14 +186,15 @@ public class ApiClientTest {
 
     @Test
     public void testGetAndSetConnectTimeout() {
-        assertEquals(0, apiClient.getConnectTimeout());
-        assertEquals(0, apiClient.getHttpClient().getConnectTimeout());
-
-        apiClient.setConnectTimeout(10000);
+        // connect timeout defaults to 10 seconds
         assertEquals(10000, apiClient.getConnectTimeout());
         assertEquals(10000, apiClient.getHttpClient().getConnectTimeout());
 
         apiClient.setConnectTimeout(0);
+        assertEquals(0, apiClient.getConnectTimeout());
+        assertEquals(0, apiClient.getHttpClient().getConnectTimeout());
+
+        apiClient.setConnectTimeout(10000);
     }
 
     @Test


### PR DESCRIPTION
Support `debugging` for ApiClient by utilizing the `HttpLoggingInterceptor` class introduced in [OkHttp 2.6.0](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-260), and upgrade OkHttp to the latest version in the meantime.