### PR TITLE
[Feign]Fix wrong query param key name in feign client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
@@ -19,7 +19,7 @@ public interface {{classname}} extends ApiClient.Api {
 {{#allParams}}   * @param {{paramName}} {{description}}
 {{/allParams}}   * @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
    */
-  @RequestLine("{{httpMethod}} {{{path}}}{{#hasQueryParams}}?{{/hasQueryParams}}{{#queryParams}}{{paramName}}={{=<% %>=}}{<%paramName%>}<%={{ }}=%>{{#hasMore}}&{{/hasMore}}{{/queryParams}}")
+  @RequestLine("{{httpMethod}} {{{path}}}{{#hasQueryParams}}?{{/hasQueryParams}}{{#queryParams}}{{baseName}}={{=<% %>=}}{<%paramName%>}<%={{ }}=%>{{#hasMore}}&{{/hasMore}}{{/queryParams}}")
   @Headers({
     "Content-type: {{vendorExtensions.x-contentType}}",
     "Accepts: {{vendorExtensions.x-accepts}}",{{#headerParams}}


### PR DESCRIPTION
Query params get generated as
```java
@RequestLine("GET /myendpoint?myId={myId}")
```
instead of
```java
@RequestLine("GET /myendpoint?my_id={myId}")
```
when the query param name is "my_id"
