### PR TITLE
File downloading improvements for Ruby and Java

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -724,8 +724,9 @@ public class ApiClient {
       // Get filename from the Content-Disposition header.
       Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
       Matcher matcher = pattern.matcher(contentDisposition);
-      if (matcher.find())
-        filename = matcher.group(1);
+      if (matcher.find()) {
+        filename = matcher.group(1).replaceAll(".*[/\\\\]", "");
+      }
     }
 
     String prefix = null;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -568,6 +568,17 @@ public class ApiClient {
   }
 
   /**
+   * Sanitize filename by removing path.
+   * e.g. ../../sun.gif becomes sun.gif
+   *
+   * @param filename The filename to be sanitized
+   * @return The sanitized filename
+   */
+  public String sanitizeFilename(String filename) {
+    return filename.replaceAll(".*[/\\\\]", "");
+  }
+
+  /**
    * Check if the given MIME is a JSON MIME.
    * JSON MIME examples:
    *   application/json
@@ -725,7 +736,7 @@ public class ApiClient {
       Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
       Matcher matcher = pattern.matcher(contentDisposition);
       if (matcher.find()) {
-        filename = matcher.group(1).replaceAll(".*[/\\\\]", "");
+        filename = sanitizeFilename(matcher.group(1));
       }
     }
 

--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -170,23 +170,28 @@ module {{moduleName}}
     # from the "Content-Disposition" header if provided, otherwise a random filename.
     #
     # @see Configuration#temp_folder_path
-    # @return [File] the file downloaded
+    # @return [Tempfile] the file downloaded
     def download_file(response)
-      tmp_file = Tempfile.new '', @config.temp_folder_path
       content_disposition = response.headers['Content-Disposition']
       if content_disposition
         filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
-        path = File.join File.dirname(tmp_file), filename
+        prefix = File.basename(filename)
       else
-        path = tmp_file.path
+        prefix = 'download-'
       end
-      # close and delete temp file
-      tmp_file.close!
+      prefix = prefix + '-' unless prefix.end_with?('-')
 
-      File.open(path, 'w') { |file| file.write(response.body) }
-      @config.logger.info "File written to #{path}. Please move the file to a proper folder "\
-                          "for further processing and delete the temp afterwards"
-      File.new(path)
+      tempfile = nil
+      encoding = response.body.encoding
+      Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding) do |file|
+        file.write(response.body)
+        tempfile = file
+      end
+      @config.logger.info "Temp file written to #{tempfile.path}, please copy the file to a proper folder "\
+                          "with e.g. `FileUtils.cp(tempfile.path, '/new/file/path')` otherwise the temp file "\
+                          "will be deleted automatically with GC. It's also recommended to delete the temp file "\
+                          "explicitly with `tempfile.delete`"
+      tempfile
     end
 
     def build_request_url(path)

--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -175,7 +175,7 @@ module {{moduleName}}
       content_disposition = response.headers['Content-Disposition']
       if content_disposition
         filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
-        prefix = File.basename(filename)
+        prefix = sanitize_filename(filename)
       else
         prefix = 'download-'
       end
@@ -192,6 +192,15 @@ module {{moduleName}}
                           "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                           "explicitly with `tempfile.delete`"
       tempfile
+    end
+
+    # Sanitize filename by removing path.
+    # e.g. ../../sun.gif becomes sun.gif
+    #
+    # @param [String] filename the filename to be sanitized
+    # @return [String] the sanitized filename
+    def sanitize_filename(filename)
+      filename.gsub /.*[\/\\]/, ''
     end
 
     def build_request_url(path)

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -567,6 +567,17 @@ public class ApiClient {
   }
 
   /**
+   * Sanitize filename by removing path.
+   * e.g. ../../sun.gif becomes sun.gif
+   *
+   * @param filename The filename to be sanitized
+   * @return The sanitized filename
+   */
+  public String sanitizeFilename(String filename) {
+    return filename.replaceAll(".*[/\\\\]", "");
+  }
+
+  /**
    * Check if the given MIME is a JSON MIME.
    * JSON MIME examples:
    *   application/json
@@ -724,7 +735,7 @@ public class ApiClient {
       Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
       Matcher matcher = pattern.matcher(contentDisposition);
       if (matcher.find()) {
-        filename = matcher.group(1).replaceAll(".*[/\\\\]", "");
+        filename = sanitizeFilename(matcher.group(1));
       }
     }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -141,8 +141,8 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     authentications.put("petstore_auth", new OAuth());
+    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }
@@ -723,8 +723,9 @@ public class ApiClient {
       // Get filename from the Content-Disposition header.
       Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
       Matcher matcher = pattern.matcher(contentDisposition);
-      if (matcher.find())
-        filename = matcher.group(1);
+      if (matcher.find()) {
+        filename = matcher.group(1).replaceAll(".*[/\\\\]", "");
+      }
     }
 
     String prefix = null;

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ApiClientTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ApiClientTest.java
@@ -276,4 +276,17 @@ public class ApiClientTest {
             assertEquals(values.size(), pairValueSplit.length);
         }
     }
+
+    @Test
+    public void testSanitizeFilename() {
+        assertEquals("sun", apiClient.sanitizeFilename("sun"));
+        assertEquals("sun.gif", apiClient.sanitizeFilename("sun.gif"));
+        assertEquals("sun.gif", apiClient.sanitizeFilename("../sun.gif"));
+        assertEquals("sun.gif", apiClient.sanitizeFilename("/var/tmp/sun.gif"));
+        assertEquals("sun.gif", apiClient.sanitizeFilename("./sun.gif"));
+        assertEquals("sun.gif", apiClient.sanitizeFilename("..\\sun.gif"));
+        assertEquals("sun.gif", apiClient.sanitizeFilename("\\var\\tmp\\sun.gif"));
+        assertEquals("sun.gif", apiClient.sanitizeFilename("c:\\var\\tmp\\sun.gif"));
+        assertEquals("sun.gif", apiClient.sanitizeFilename(".\\sun.gif"));
+    }
 }

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -175,7 +175,7 @@ module Petstore
       content_disposition = response.headers['Content-Disposition']
       if content_disposition
         filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
-        prefix = File.basename(filename)
+        prefix = sanitize_filename(filename)
       else
         prefix = 'download-'
       end
@@ -192,6 +192,15 @@ module Petstore
                           "will be deleted automatically with GC. It's also recommended to delete the temp file "\
                           "explicitly with `tempfile.delete`"
       tempfile
+    end
+
+    # Sanitize filename by removing path.
+    # e.g. ../../sun.gif becomes sun.gif
+    #
+    # @param [String] filename the filename to be sanitized
+    # @return [String] the sanitized filename
+    def sanitize_filename(filename)
+      filename.gsub /.*[\/\\]/, ''
     end
 
     def build_request_url(path)

--- a/samples/client/petstore/ruby/petstore.gemspec
+++ b/samples/client/petstore/ruby/petstore.gemspec
@@ -6,12 +6,13 @@ Gem::Specification.new do |s|
   s.name        = "petstore"
   s.version     = Petstore::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Zeke Sikelianos", "Tony Tam"]
-  s.email       = ["zeke@wordnik.com", "fehguy@gmail.com"]
-  s.homepage    = "http://swagger.io"
-  s.summary     = %q{A ruby wrapper for the swagger APIs}
-  s.description = %q{This gem maps to a swagger API}
-  s.license     = "Apache-2.0"
+  s.authors     = [""]
+  s.email       = [""]
+  s.homepage    = ""
+  s.summary     = ""
+  s.description = ""
+  s.license     = ""
+
 
   s.add_runtime_dependency 'typhoeus', '~> 0.2', '>= 0.2.1'
   s.add_runtime_dependency 'json', '~> 1.4', '>= 1.4.6'

--- a/samples/client/petstore/ruby/spec/api_client_spec.rb
+++ b/samples/client/petstore/ruby/spec/api_client_spec.rb
@@ -258,4 +258,20 @@ describe Petstore::ApiClient do
     end
   end
 
+  describe "#sanitize_filename" do
+    let(:api_client) { Petstore::ApiClient.new }
+
+    it "works" do
+      api_client.sanitize_filename('sun').should == 'sun'
+      api_client.sanitize_filename('sun.gif').should == 'sun.gif'
+      api_client.sanitize_filename('../sun.gif').should == 'sun.gif'
+      api_client.sanitize_filename('/var/tmp/sun.gif').should == 'sun.gif'
+      api_client.sanitize_filename('./sun.gif').should == 'sun.gif'
+      api_client.sanitize_filename('..\sun.gif').should == 'sun.gif'
+      api_client.sanitize_filename('\var\tmp\sun.gif').should == 'sun.gif'
+      api_client.sanitize_filename('c:\var\tmp\sun.gif').should == 'sun.gif'
+      api_client.sanitize_filename('.\sun.gif').should == 'sun.gif'
+    end
+  end
+
 end


### PR DESCRIPTION
- Java okhttp-gson: sanitize the filename got from response header by removing path delimiters from downloading filename
- Ruby: IO improvements on file downloading
  - Use `File.basename` to sanitize the filename got from response header
  - Write to the `Tempfile` directly and return it to use less IO
  - Set file encoding according to the response body's encoding

See #1848