### PR TITLE
Fixing squid:S1444 - "public static" fields should be constant

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
@@ -27,10 +27,10 @@ import java.util.Map;
 import java.util.Set;
 
 public class XmlExampleGenerator {
-    public static String NEWLINE = "\n";
-    public static String TAG_START = "<";
-    public static String CLOSE_TAG = ">";
-    public static String TAG_END = "</";
+    public static final String NEWLINE = "\n";
+    public static final String TAG_START = "<";
+    public static final String CLOSE_TAG = ">";
+    public static final String TAG_END = "</";
     private static String EMPTY = "";
     protected Map<String, Model> examples;
     protected SimpleDateFormat dtFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");

--- a/samples/client/petstore/android/default/src/main/java/io/swagger/client/JsonUtil.java
+++ b/samples/client/petstore/android/default/src/main/java/io/swagger/client/JsonUtil.java
@@ -8,7 +8,7 @@ import java.util.List;
 import io.swagger.client.model.*;
 
 public class JsonUtil {
-  public static GsonBuilder gsonBuilder;
+  public static final GsonBuilder gsonBuilder;
 
   static {
     gsonBuilder = new GsonBuilder();

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/JsonUtil.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/JsonUtil.java
@@ -8,7 +8,7 @@ import java.util.List;
 import io.swagger.client.model.*;
 
 public class JsonUtil {
-  public static GsonBuilder gsonBuilder;
+  public static final GsonBuilder gsonBuilder;
 
   static {
     gsonBuilder = new GsonBuilder();

--- a/samples/client/wordnik/android-java/src/main/java/io/swagger/client/JsonUtil.java
+++ b/samples/client/wordnik/android-java/src/main/java/io/swagger/client/JsonUtil.java
@@ -1,7 +1,7 @@
 package io.swagger.client;
 
 public class JsonUtil {
-    public static ObjectMapper mapper;
+    public static final ObjectMapper mapper;
 
     public static ObjectMapper getJsonMapper() {
         return mapper;

--- a/samples/client/wordnik/java/src/main/java/io/swagger/client/JsonUtil.java
+++ b/samples/client/wordnik/java/src/main/java/io/swagger/client/JsonUtil.java
@@ -1,7 +1,7 @@
 package io.swagger.client;
 
 public class JsonUtil {
-    public static ObjectMapper mapper;
+    public static final ObjectMapper mapper;
 
     public static ObjectMapper getJsonMapper() {
         return mapper;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1444 - ""public static"" fields should be constant
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1444
Please let me know if you have any questions.
Kirill Vlasov