### PR TITLE
README.md: Validating your OpenAPI Spec should point to #validating-your-openapi-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Check out [Swagger-Spec](https://github.com/OAI/OpenAPI-Specification) for addit
     - [Where is Javascript???](#where-is-javascript)
     - [Generating a client from local files](#generating-a-client-from-local-files)
     - [Customizing the generator](#customizing-the-generator)
-    - [Validating your OpenAPI Spec](#validating-your-swagger-spec)
+    - [Validating your OpenAPI Spec](#validating-your-openapi-spec)
     - [Generating dynamic html api documentation](#generating-dynamic-html-api-documentation)
     - [Generating static html api documentation](#generating-static-html-api-documentation)
     - [To build a server stub](#to-build-a-server-stub)


### PR DESCRIPTION
Currently points to `#validating-your-swagger-spec` which leads the reader nowhere...