### PR TITLE
skip trailing comma for enums in TypeScript angular

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Angular/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Angular/model.mustache
@@ -28,7 +28,7 @@ namespace {{package}} {
 {{#isEnum}}
 
         export enum {{datatypeWithEnum}} { {{#allowableValues}}{{#values}}
-            {{.}} = <any> '{{.}}',{{/values}}{{/allowableValues}}
+            {{.}} = <any> '{{.}}'{{^-last}},{{/-last}}{{/values}}{{/allowableValues}}
         }
 {{/isEnum}}
 {{/vars}}

--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -31,7 +31,7 @@ export namespace {{classname}} {
 {{#vars}}
 {{#isEnum}}
     export enum {{datatypeWithEnum}} { {{#allowableValues}}{{#values}}
-        {{.}} = <any> '{{.}}',{{/values}}{{/allowableValues}}
+        {{.}} = <any> '{{.}}'{{^-last}},{{/-last}}{{/values}}{{/allowableValues}}
     }
 {{/isEnum}}
 {{/vars}}

--- a/samples/client/petstore/typescript-angular/API/Client/Order.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/Order.ts
@@ -26,7 +26,7 @@ namespace API.Client {
         export enum StatusEnum { 
             placed = <any> 'placed',
             approved = <any> 'approved',
-            delivered = <any> 'delivered',
+            delivered = <any> 'delivered'
         }
     }
 }

--- a/samples/client/petstore/typescript-angular/API/Client/Pet.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/Pet.ts
@@ -26,7 +26,7 @@ namespace API.Client {
         export enum StatusEnum { 
             available = <any> 'available',
             pending = <any> 'pending',
-            sold = <any> 'sold',
+            sold = <any> 'sold'
         }
     }
 }

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -43,7 +43,7 @@ export namespace Pet {
     export enum StatusEnum { 
         available = <any> 'available',
         pending = <any> 'pending',
-        sold = <any> 'sold',
+        sold = <any> 'sold'
     }
 }
 export class Tag {
@@ -67,7 +67,7 @@ export namespace Order {
     export enum StatusEnum { 
         placed = <any> 'placed',
         approved = <any> 'approved',
-        delivered = <any> 'delivered',
+        delivered = <any> 'delivered'
     }
 }
 


### PR DESCRIPTION
This change skips the trailing comma for enums in angular TypeScript models.