### PR TITLE
add parentModel to CodegenModel

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -9,6 +9,7 @@ public class CodegenModel {
     public String name, classname, description, classVarName, modelJson, dataType;
     public String unescapedDescription;
     public String defaultValue;
+    public CodegenModel parentModel;
     public List<CodegenProperty> vars = new ArrayList<CodegenProperty>();
     public List<String> allowableValues;
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -790,17 +790,23 @@ public class DefaultCodegen {
             if (parent != null) {
                 final String parentRef = parent.getSimpleRef();
                 m.parentSchema = parentRef;
-                m.parent = toModelName(parent.getSimpleRef());
+                m.parent = toModelName(parentRef);
+                
                 addImport(m, m.parent);
-                if (!supportsInheritance && allDefinitions != null) {
+                if (allDefinitions != null) {
                     final Model parentModel = allDefinitions.get(m.parentSchema);
                     if (parentModel instanceof ModelImpl) {
                         final ModelImpl _parent = (ModelImpl) parentModel;
-                        if (_parent.getProperties() != null) {
-                            properties.putAll(_parent.getProperties());
+                        if (supportsInheritance) {
+                            m.parentModel = fromModel(parentRef, parentModel, allDefinitions);
                         }
-                        if (_parent.getRequired() != null) {
-                            required.addAll(_parent.getRequired());
+                        else {
+                            if (_parent.getProperties() != null) {
+                                properties.putAll(_parent.getProperties());
+                            }
+                            if (_parent.getRequired() != null) {
+                                required.addAll(_parent.getRequired());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This fixes #1568, allowing you to access a parent's model, including it's properties