### PR TITLE
Support java code generation for UUIDProperty

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -651,6 +651,8 @@ public class DefaultCodegen {
             datatype = "map";
         } else if (p instanceof DecimalProperty) {
             datatype = "number";
+        } else if ( p instanceof UUIDProperty) {
+            datatype = "UUID";
         } else if (p instanceof RefProperty) {
             try {
                 RefProperty r = (RefProperty) p;


### PR DESCRIPTION
A property defined as "type: string & format: uuid" is now generated in
Java using "java.util.UUID" class instead of a classical String. In the
Java, the UUID class do not provide a constructor. You may use the
method UUID.fromString(<uuid_string>) to construct your UUID object.