### PR TITLE
[PHP] fix __toString for nested models

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
@@ -150,7 +150,7 @@ class ApiClient
         if ($postData and in_array('Content-Type: application/x-www-form-urlencoded', $headers)) {
             $postData = http_build_query($postData);
         } elseif ((is_object($postData) or is_array($postData)) and !in_array('Content-Type: multipart/form-data', $headers)) { // json model
-            $postData = json_encode($this->serializer->sanitizeForSerialization($postData));
+            $postData = json_encode(\{{invokerPackage}}\ObjectSerializer::sanitizeForSerialization($postData));
         }
 
         $url = $this->config->getHost() . $resourcePath;

--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -46,13 +46,13 @@ class ObjectSerializer
 {
 
     /**
-     * Build a JSON POST object
+     * Serialize data
      *
      * @param mixed $data the data to serialize
      *
      * @return string serialized form of $data
      */
-    public function sanitizeForSerialization($data)
+    public static function sanitizeForSerialization($data)
     {
         if (is_scalar($data) || null === $data) {
             $sanitized = $data;
@@ -60,7 +60,7 @@ class ObjectSerializer
             $sanitized = $data->format(\DateTime::ISO8601);
         } elseif (is_array($data)) {
             foreach ($data as $property => $value) {
-                $data[$property] = $this->sanitizeForSerialization($value);
+                $data[$property] = self::sanitizeForSerialization($value);
             }
             $sanitized = $data;
         } elseif (is_object($data)) {
@@ -68,7 +68,7 @@ class ObjectSerializer
             foreach (array_keys($data::$swaggerTypes) as $property) {
                 $getter = $data::$getters[$property];
                 if ($data->$getter() !== null) {
-                    $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$getter());
+                    $values[$data::$attributeMap[$property]] = self::sanitizeForSerialization($data->$getter());
                 }
             }
             $sanitized = $values;
@@ -220,7 +220,7 @@ class ObjectSerializer
      *
      * @return object an instance of $class
      */
-    public function deserialize($data, $class, $httpHeaders=null)
+    public static function deserialize($data, $class, $httpHeaders=null)
     {
         if (null === $data) {
             $deserialized = null;
@@ -231,14 +231,14 @@ class ObjectSerializer
                 $subClass_array = explode(',', $inner, 2);
                 $subClass = $subClass_array[1];
                 foreach ($data as $key => $value) {
-                    $deserialized[$key] = $this->deserialize($value, $subClass);
+                    $deserialized[$key] = self::deserialize($value, $subClass);
                 }
             }
         } elseif (strcasecmp(substr($class, -2), '[]') == 0) {
             $subClass = substr($class, 0, -2);
             $values = array();
             foreach ($data as $key => $value) {
-                $values[] = $this->deserialize($value, $subClass);
+                $values[] = self::deserialize($value, $subClass);
             }
             $deserialized = $values;
         } elseif ($class === 'ByteArray') { // byte array
@@ -270,7 +270,7 @@ class ObjectSerializer
      
                 $propertyValue = $data->{$instance::$attributeMap[$property]};
                 if (isset($propertyValue)) {
-                    $instance->$propertySetter($this->deserialize($propertyValue, $type));
+                    $instance->$propertySetter(self::deserialize($propertyValue, $type));
                 }
             }
             $deserialized = $instance;

--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -71,7 +71,7 @@ class ObjectSerializer
                     $values[$data::$attributeMap[$property]] = self::sanitizeForSerialization($data->$getter());
                 }
             }
-            $sanitized = $values;
+            $sanitized = (object)$values;
         } else {
             $sanitized = (string)$data;
         }

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -223,14 +223,14 @@ use \{{invokerPackage}}\ObjectSerializer;
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, '{{returnType}}', $httpHeader), $statusCode, $httpHeader);
+            return array(\{{invokerPackage}}\ObjectSerializer::deserialize($response, '{{returnType}}', $httpHeader), $statusCode, $httpHeader);
             {{/returnType}}{{^returnType}}
             return array(null, $statusCode, $httpHeader);
             {{/returnType}}
         } catch (ApiException $e) {
             switch ($e->getCode()) { {{#responses}}{{#dataType}}
             {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '{{dataType}}', $e->getResponseHeaders());
+                $data = \{{invokerPackage}}\ObjectSerializer::deserialize($e->getResponseBody(), '{{dataType}}', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;{{/dataType}}{{/responses}}
             }

--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -176,9 +176,9 @@ class {{classname}} implements ArrayAccess
     public function __toString()
     {
         if (defined('JSON_PRETTY_PRINT')) {
-            return json_encode(get_object_vars($this), JSON_PRETTY_PRINT);
+            return json_encode(\{{invokerPackage}}\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         } else {
-            return json_encode(get_object_vars($this));
+            return json_encode(\{{invokerPackage}}\ObjectSerializer::sanitizeForSerialization($this));
         }
     }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -341,12 +341,12 @@ class PetApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, '\Swagger\Client\Model\Pet[]', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, '\Swagger\Client\Model\Pet[]', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\Swagger\Client\Model\Pet[]', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), '\Swagger\Client\Model\Pet[]', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }
@@ -437,12 +437,12 @@ class PetApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, '\Swagger\Client\Model\Pet[]', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, '\Swagger\Client\Model\Pet[]', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\Swagger\Client\Model\Pet[]', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), '\Swagger\Client\Model\Pet[]', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }
@@ -539,12 +539,12 @@ class PetApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, '\Swagger\Client\Model\Pet', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, '\Swagger\Client\Model\Pet', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\Swagger\Client\Model\Pet', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), '\Swagger\Client\Model\Pet', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }
@@ -961,12 +961,12 @@ class PetApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, 'ByteArray', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, 'ByteArray', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), 'ByteArray', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), 'ByteArray', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -165,12 +165,12 @@ class StoreApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, 'map[string,int]', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, 'map[string,int]', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), 'map[string,int]', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), 'map[string,int]', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }
@@ -252,12 +252,12 @@ class StoreApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, '\Swagger\Client\Model\Order', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, '\Swagger\Client\Model\Order', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\Swagger\Client\Model\Order', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), '\Swagger\Client\Model\Order', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }
@@ -347,12 +347,12 @@ class StoreApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, '\Swagger\Client\Model\Order', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, '\Swagger\Client\Model\Order', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\Swagger\Client\Model\Order', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), '\Swagger\Client\Model\Order', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -407,12 +407,12 @@ class UserApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, 'string', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, 'string', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), 'string', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), 'string', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }
@@ -575,12 +575,12 @@ class UserApi
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array($this->apiClient->getSerializer()->deserialize($response, '\Swagger\Client\Model\User', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, '\Swagger\Client\Model\User', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = $this->apiClient->getSerializer()->deserialize($e->getResponseBody(), '\Swagger\Client\Model\User', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), '\Swagger\Client\Model\User', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php
@@ -150,7 +150,7 @@ class ApiClient
         if ($postData and in_array('Content-Type: application/x-www-form-urlencoded', $headers)) {
             $postData = http_build_query($postData);
         } elseif ((is_object($postData) or is_array($postData)) and !in_array('Content-Type: multipart/form-data', $headers)) { // json model
-            $postData = json_encode($this->serializer->sanitizeForSerialization($postData));
+            $postData = json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($postData));
         }
 
         $url = $this->config->getHost() . $resourcePath;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Category.php
@@ -198,9 +198,9 @@ class Category implements ArrayAccess
     public function __toString()
     {
         if (defined('JSON_PRETTY_PRINT')) {
-            return json_encode(get_object_vars($this), JSON_PRETTY_PRINT);
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         } else {
-            return json_encode(get_object_vars($this));
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this));
         }
     }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
@@ -329,9 +329,9 @@ class Order implements ArrayAccess
     public function __toString()
     {
         if (defined('JSON_PRETTY_PRINT')) {
-            return json_encode(get_object_vars($this), JSON_PRETTY_PRINT);
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         } else {
-            return json_encode(get_object_vars($this));
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this));
         }
     }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
@@ -329,9 +329,9 @@ class Pet implements ArrayAccess
     public function __toString()
     {
         if (defined('JSON_PRETTY_PRINT')) {
-            return json_encode(get_object_vars($this), JSON_PRETTY_PRINT);
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         } else {
-            return json_encode(get_object_vars($this));
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this));
         }
     }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Tag.php
@@ -198,9 +198,9 @@ class Tag implements ArrayAccess
     public function __toString()
     {
         if (defined('JSON_PRETTY_PRINT')) {
-            return json_encode(get_object_vars($this), JSON_PRETTY_PRINT);
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         } else {
-            return json_encode(get_object_vars($this));
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this));
         }
     }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/User.php
@@ -390,9 +390,9 @@ class User implements ArrayAccess
     public function __toString()
     {
         if (defined('JSON_PRETTY_PRINT')) {
-            return json_encode(get_object_vars($this), JSON_PRETTY_PRINT);
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         } else {
-            return json_encode(get_object_vars($this));
+            return json_encode(\Swagger\Client\ObjectSerializer::sanitizeForSerialization($this));
         }
     }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -46,13 +46,13 @@ class ObjectSerializer
 {
 
     /**
-     * Build a JSON POST object
+     * Serialize data
      *
      * @param mixed $data the data to serialize
      *
      * @return string serialized form of $data
      */
-    public function sanitizeForSerialization($data)
+    public static function sanitizeForSerialization($data)
     {
         if (is_scalar($data) || null === $data) {
             $sanitized = $data;
@@ -60,7 +60,7 @@ class ObjectSerializer
             $sanitized = $data->format(\DateTime::ISO8601);
         } elseif (is_array($data)) {
             foreach ($data as $property => $value) {
-                $data[$property] = $this->sanitizeForSerialization($value);
+                $data[$property] = self::sanitizeForSerialization($value);
             }
             $sanitized = $data;
         } elseif (is_object($data)) {
@@ -68,7 +68,7 @@ class ObjectSerializer
             foreach (array_keys($data::$swaggerTypes) as $property) {
                 $getter = $data::$getters[$property];
                 if ($data->$getter() !== null) {
-                    $values[$data::$attributeMap[$property]] = $this->sanitizeForSerialization($data->$getter());
+                    $values[$data::$attributeMap[$property]] = self::sanitizeForSerialization($data->$getter());
                 }
             }
             $sanitized = $values;
@@ -220,7 +220,7 @@ class ObjectSerializer
      *
      * @return object an instance of $class
      */
-    public function deserialize($data, $class, $httpHeaders=null)
+    public static function deserialize($data, $class, $httpHeaders=null)
     {
         if (null === $data) {
             $deserialized = null;
@@ -231,14 +231,14 @@ class ObjectSerializer
                 $subClass_array = explode(',', $inner, 2);
                 $subClass = $subClass_array[1];
                 foreach ($data as $key => $value) {
-                    $deserialized[$key] = $this->deserialize($value, $subClass);
+                    $deserialized[$key] = self::deserialize($value, $subClass);
                 }
             }
         } elseif (strcasecmp(substr($class, -2), '[]') == 0) {
             $subClass = substr($class, 0, -2);
             $values = array();
             foreach ($data as $key => $value) {
-                $values[] = $this->deserialize($value, $subClass);
+                $values[] = self::deserialize($value, $subClass);
             }
             $deserialized = $values;
         } elseif ($class === 'ByteArray') { // byte array
@@ -270,7 +270,7 @@ class ObjectSerializer
      
                 $propertyValue = $data->{$instance::$attributeMap[$property]};
                 if (isset($propertyValue)) {
-                    $instance->$propertySetter($this->deserialize($propertyValue, $type));
+                    $instance->$propertySetter(self::deserialize($propertyValue, $type));
                 }
             }
             $deserialized = $instance;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -71,7 +71,7 @@ class ObjectSerializer
                     $values[$data::$attributeMap[$property]] = self::sanitizeForSerialization($data->$getter());
                 }
             }
-            $sanitized = $values;
+            $sanitized = (object)$values;
         } else {
             $sanitized = (string)$data;
         }

--- a/samples/client/petstore/php/SwaggerClient-php/tests/OrderApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/OrderApiTest.php
@@ -45,8 +45,7 @@ class OrderApiTest extends \PHPUnit_Framework_TestCase
   "complete": false
 }
 ORDER;
-        $serializer = new Swagger\Client\ObjectSerializer;
-        $order = $serializer->deserialize(json_decode($order_json), 'Swagger\Client\Model\Order');
+        $order = \Swagger\Client\ObjectSerializer::deserialize(json_decode($order_json), 'Swagger\Client\Model\Order');
         
         $this->assertInstanceOf('Swagger\Client\Model\Order', $order);
         $this->assertSame(10, $order->getId());
@@ -70,8 +69,7 @@ ORDER;
   "complete": false
 }]]
 ORDER;
-        $serializer = new Swagger\Client\ObjectSerializer;
-        $order = $serializer->deserialize(json_decode($order_json), 'Swagger\Client\Model\Order[][]');
+        $order = \Swagger\Client\ObjectSerializer::deserialize(json_decode($order_json), 'Swagger\Client\Model\Order[][]');
 
         $this->assertArrayHasKey(0, $order); 
         $this->assertArrayHasKey(0, $order[0]);
@@ -102,8 +100,7 @@ ORDER;
   }
 }
 ORDER;
-        $serializer = new Swagger\Client\ObjectSerializer;
-        $order = $serializer->deserialize(json_decode($order_json), 'map[string,map[string,\Swagger\Client\Model\Order]]');
+        $order = \Swagger\Client\ObjectSerializer::deserialize(json_decode($order_json), 'map[string,map[string,\Swagger\Client\Model\Order]]');
 
         $this->assertArrayHasKey('test', $order); 
         $this->assertArrayHasKey('test2', $order['test']);

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -316,6 +316,16 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($json['tags'][0]['id'], $pet_id);
         $this->assertSame($json['tags'][0]['name'], 'test php tag');
     }
+
+    // test empty object serialization
+    public function testEmptyPetSerialization()
+    {
+        $new_pet = new Swagger\Client\Model\Pet;
+        // the empty object should be serialised to {}
+        $this->assertSame("{}", "$new_pet");
+
+    }
+
 }
 
 ?>


### PR DESCRIPTION
To fix #1914 

```
{
    "id": 10005,
    "category": {
        "id": 10005,
        "name": "test php category"
    },
    "name": "PHP Unit Test",
    "tags": [
        {
            "id": 10005,
            "name": "test php tag"
        }
    ]
}
```