### PR TITLE
[TypeScript] double quote model property name

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Angular/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Angular/model.mustache
@@ -18,7 +18,7 @@ namespace {{package}} {
          * {{{description}}}
          */
 {{/description}}
-        {{name}}{{^required}}?{{/required}}: {{#isEnum}}{{classname}}.{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
+        "{{name}}"{{^required}}?{{/required}}: {{#isEnum}}{{classname}}.{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
 {{/vars}}
     }
 

--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -22,7 +22,7 @@ export class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
     * {{{description}}}
     */
 {{/description}}
-    {{name}}: {{#isEnum}}{{classname}}.{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
+    "{{name}}": {{#isEnum}}{{classname}}.{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
 {{/vars}}
 }
 

--- a/samples/client/petstore/typescript-angular/API/Client/Category.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/Category.ts
@@ -5,9 +5,9 @@ namespace API.Client {
 
     export interface Category {
 
-        id?: number;
+        "id"?: number;
 
-        name?: string;
+        "name"?: string;
     }
 
 }

--- a/samples/client/petstore/typescript-angular/API/Client/Order.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/Order.ts
@@ -5,20 +5,20 @@ namespace API.Client {
 
     export interface Order {
 
-        id?: number;
+        "id"?: number;
 
-        petId?: number;
+        "petId"?: number;
 
-        quantity?: number;
+        "quantity"?: number;
 
-        shipDate?: Date;
+        "shipDate"?: Date;
 
         /**
          * Order Status
          */
-        status?: Order.StatusEnum;
+        "status"?: Order.StatusEnum;
 
-        complete?: boolean;
+        "complete"?: boolean;
     }
 
     export namespace Order {

--- a/samples/client/petstore/typescript-angular/API/Client/Pet.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/Pet.ts
@@ -5,20 +5,20 @@ namespace API.Client {
 
     export interface Pet {
 
-        id?: number;
+        "id"?: number;
 
-        category?: Category;
+        "category"?: Category;
 
-        name: string;
+        "name": string;
 
-        photoUrls: Array<string>;
+        "photoUrls": Array<string>;
 
-        tags?: Array<Tag>;
+        "tags"?: Array<Tag>;
 
         /**
          * pet status in the store
          */
-        status?: Pet.StatusEnum;
+        "status"?: Pet.StatusEnum;
     }
 
     export namespace Pet {

--- a/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
@@ -289,5 +289,63 @@ namespace API.Client {
 
             return this.$http(httpRequestParams);
         }
+        /**
+         * Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
+         * Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
+         * @param petId ID of pet that needs to be fetched
+         */
+        public getPetByIdWithByteArray (petId: number, extraHttpRequestParams?: any ) : ng.IHttpPromise<string> {
+            const path = this.basePath + '/pet/{petId}?testing_byte_array=true'
+                .replace('{' + 'petId' + '}', String(petId));
+
+            let queryParameters: any = {};
+            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            // verify required parameter 'petId' is set
+            if (!petId) {
+                throw new Error('Missing required parameter petId when calling getPetByIdWithByteArray');
+            }
+            let httpRequestParams: any = {
+                method: 'GET',
+                url: path,
+                json: true,
+                
+                
+                params: queryParameters,
+                headers: headerParams
+            };
+
+            if (extraHttpRequestParams) {
+                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+            }
+
+            return this.$http(httpRequestParams);
+        }
+        /**
+         * Fake endpoint to test byte array in body parameter for adding a new pet to the store
+         * 
+         * @param body Pet object in the form of byte array
+         */
+        public addPetUsingByteArray (body?: string, extraHttpRequestParams?: any ) : ng.IHttpPromise<{}> {
+            const path = this.basePath + '/pet?testing_byte_array=true';
+
+            let queryParameters: any = {};
+            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let httpRequestParams: any = {
+                method: 'POST',
+                url: path,
+                json: true,
+                data: body,
+                
+                
+                params: queryParameters,
+                headers: headerParams
+            };
+
+            if (extraHttpRequestParams) {
+                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+            }
+
+            return this.$http(httpRequestParams);
+        }
     }
 }

--- a/samples/client/petstore/typescript-angular/API/Client/Tag.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/Tag.ts
@@ -5,9 +5,9 @@ namespace API.Client {
 
     export interface Tag {
 
-        id?: number;
+        "id"?: number;
 
-        name?: string;
+        "name"?: string;
     }
 
 }

--- a/samples/client/petstore/typescript-angular/API/Client/User.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/User.ts
@@ -5,24 +5,24 @@ namespace API.Client {
 
     export interface User {
 
-        id?: number;
+        "id"?: number;
 
-        username?: string;
+        "username"?: string;
 
-        firstName?: string;
+        "firstName"?: string;
 
-        lastName?: string;
+        "lastName"?: string;
 
-        email?: string;
+        "email"?: string;
 
-        password?: string;
+        "password"?: string;
 
-        phone?: string;
+        "phone"?: string;
 
         /**
          * User Status
          */
-        userStatus?: number;
+        "userStatus"?: number;
     }
 
 }

--- a/samples/client/petstore/typescript-angular/README.md
+++ b/samples/client/petstore/typescript-angular/README.md
@@ -16,4 +16,4 @@ npm run clean
 
 ## Author
 
-mads@maetzke-tandrup.dk
+mads@maetzke-tandrup.dk, Swagger-Codegen community

--- a/samples/client/petstore/typescript-node/README.md
+++ b/samples/client/petstore/typescript-node/README.md
@@ -19,4 +19,4 @@ npm run clean
 
 ## Author
 
-mads@maetzke-tandrup.dk
+mads@maetzke-tandrup.dk, Swagger-Codegen community

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -9,34 +9,34 @@ import http = require('http');
 /* tslint:disable:no-unused-variable */
 
 export class User {
-    id: number;
-    username: string;
-    firstName: string;
-    lastName: string;
-    email: string;
-    password: string;
-    phone: string;
+    "id": number;
+    "username": string;
+    "firstName": string;
+    "lastName": string;
+    "email": string;
+    "password": string;
+    "phone": string;
     /**
     * User Status
     */
-    userStatus: number;
+    "userStatus": number;
 }
 
 export class Category {
-    id: number;
-    name: string;
+    "id": number;
+    "name": string;
 }
 
 export class Pet {
-    id: number;
-    category: Category;
-    name: string;
-    photoUrls: Array<string>;
-    tags: Array<Tag>;
+    "id": number;
+    "category": Category;
+    "name": string;
+    "photoUrls": Array<string>;
+    "tags": Array<Tag>;
     /**
     * pet status in the store
     */
-    status: Pet.StatusEnum;
+    "status": Pet.StatusEnum;
 }
 
 export namespace Pet {
@@ -47,20 +47,20 @@ export namespace Pet {
     }
 }
 export class Tag {
-    id: number;
-    name: string;
+    "id": number;
+    "name": string;
 }
 
 export class Order {
-    id: number;
-    petId: number;
-    quantity: number;
-    shipDate: Date;
+    "id": number;
+    "petId": number;
+    "quantity": number;
+    "shipDate": Date;
     /**
     * Order Status
     */
-    status: Order.StatusEnum;
-    complete: boolean;
+    "status": Order.StatusEnum;
+    "complete": boolean;
 }
 
 export namespace Order {
@@ -1045,6 +1045,113 @@ export class PetApi {
             headers: headerParams,
             uri: path,
             json: true,
+        }
+
+        this.authentications.petstore_auth.applyToRequest(requestOptions);
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+
+        request(requestOptions, (error, response, body) => {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                if (response.statusCode >= 200 && response.statusCode <= 299) {
+                    deferred.resolve({ response: response, body: body });
+                } else {
+                    deferred.reject({ response: response, body: body });
+                }
+            }
+        });
+
+        return deferred.promise;
+    }
+    /**
+     * Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
+     * Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
+     * @param petId ID of pet that needs to be fetched
+     */
+    public getPetByIdWithByteArray (petId: number) : Promise<{ response: http.ClientResponse; body: string;  }> {
+        const path = this.basePath + '/pet/{petId}?testing_byte_array=true'
+            .replace('{' + 'petId' + '}', String(petId));
+        let queryParameters: any = {};
+        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let formParams: any = {};
+
+
+        // verify required parameter 'petId' is set
+        if (!petId) {
+            throw new Error('Missing required parameter petId when calling getPetByIdWithByteArray');
+        }
+
+        let useFormData = false;
+
+        let deferred = promise.defer<{ response: http.ClientResponse; body: string;  }>();
+
+        let requestOptions: request.Options = {
+            method: 'GET',
+            qs: queryParameters,
+            headers: headerParams,
+            uri: path,
+            json: true,
+        }
+
+        this.authentications.api_key.applyToRequest(requestOptions);
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+
+        request(requestOptions, (error, response, body) => {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                if (response.statusCode >= 200 && response.statusCode <= 299) {
+                    deferred.resolve({ response: response, body: body });
+                } else {
+                    deferred.reject({ response: response, body: body });
+                }
+            }
+        });
+
+        return deferred.promise;
+    }
+    /**
+     * Fake endpoint to test byte array in body parameter for adding a new pet to the store
+     * 
+     * @param body Pet object in the form of byte array
+     */
+    public addPetUsingByteArray (body?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+        const path = this.basePath + '/pet?testing_byte_array=true';
+        let queryParameters: any = {};
+        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let formParams: any = {};
+
+
+        let useFormData = false;
+
+        let deferred = promise.defer<{ response: http.ClientResponse; body?: any;  }>();
+
+        let requestOptions: request.Options = {
+            method: 'POST',
+            qs: queryParameters,
+            headers: headerParams,
+            uri: path,
+            json: true,
+            body: body,
         }
 
         this.authentications.petstore_auth.applyToRequest(requestOptions);


### PR DESCRIPTION
As mentioned in http://typescript.codeplex.com/workitem/1073, model property with dash or other special characters should be double-quoted.

Updated TS (angular & node) petstore sample and test result looks good. 