### PR TITLE
Correct NullPointerException during unit tests

### DIFF
--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/jaxrs/JaxRSServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/jaxrs/JaxRSServerOptionsTest.java
@@ -11,7 +11,7 @@ import mockit.Tested;
 public class JaxRSServerOptionsTest extends JavaClientOptionsTest {
 
     @Tested
-    private JavaJerseyServerCodegen clientCodegen;
+    private JavaJerseyServerCodegen clientCodegen = new JavaJerseyServerCodegen();
 
     public JaxRSServerOptionsTest() {
         super(new JaxRSServerOptionsProvider());


### PR DESCRIPTION
During Maven build (goal clean install) on Windows 7 (not tested on
other OS), a NullPointerException occurs. Tests in error are
JaxRSServrOptionTests. The @Tested JavaJerseyServerCodegen is not
instantiated, so a NullPointerException occurs.

Stack trace:
checkOptionsProcessing(io.swagger.codegen.jaxrs.JaxRSServerOptionsTest)
Time elapsed: 0 sec  <<< FAILURE!
java.lang.NullPointerException
at
io.swagger.codegen.AbstractOptionsTest.checkOptionsProcessing(AbstractOptionsTest.java:28)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

Tests in error:
Failed tests:
checkOptionsHelp(io.swagger.codegen.jaxrs.JaxRSServerOptionsTest)
checkOptionsProcessing(io.swagger.codegen.jaxrs.JaxRSServerOptionsTest)

Tests run: 297, Failures: 2, Errors: 0, Skipped: 0