### PR TITLE
[JavaScript] Lock version of superagent to fix testing issues

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/package.mustache
@@ -8,7 +8,7 @@
     "test": "./node_modules/mocha/bin/mocha --recursive"
   },
   "dependencies": {
-    "superagent": "^1.7.1"
+    "superagent": "1.7.1"
   },
   "devDependencies": {
     "mocha": "~2.3.4",

--- a/samples/client/petstore/javascript/package.json
+++ b/samples/client/petstore/javascript/package.json
@@ -8,7 +8,7 @@
     "test": "./node_modules/mocha/bin/mocha --recursive"
   },
   "dependencies": {
-    "superagent": "^1.7.1"
+    "superagent": "1.7.1"
   },
   "devDependencies": {
     "mocha": "~2.3.4",

--- a/samples/client/petstore/javascript/test/run_tests.html
+++ b/samples/client/petstore/javascript/test/run_tests.html
@@ -17,7 +17,7 @@
     });
   </script>
 
-  <script src="https://cdn.rawgit.com/stephanebachelier/superagent-dist/1.6.1/superagent.js"></script>
+  <script src="../node_modules/superagent/superagent.js"></script>
 
   <script src="../src/model/Category.js"></script>
   <script src="../src/model/Tag.js"></script>


### PR DESCRIPTION
Lock version of superagent t 1.7.1 to avoid an unexpected behavior on request.header in 1.7.2: Node version's request.header uses lower-case keys while browser version's request.header keeps current case.

See also visionmedia/superagent#873