### PR TITLE
[PHP] Use String instead of Byte Array

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -101,7 +101,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("array", "array");
         typeMapping.put("list", "array");
         typeMapping.put("object", "object");
-        typeMapping.put("binary", "ByteArray");
+        typeMapping.put("binary", "string");
 
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));

--- a/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
@@ -230,7 +230,7 @@ class ApiClient
             throw new ApiException("API call to $url timed out: ".serialize($response_info), 0, null, null);
         } elseif ($response_info['http_code'] >= 200 && $response_info['http_code'] <= 299 ) {
             // return raw body if response is a file
-            if ($responseType == '\SplFileObject' || $responseType == 'ByteArray') {
+            if ($responseType == '\SplFileObject' || $responseType == 'string') {
                 return array($http_body, $response_info['http_code'], $http_header);
             }
 

--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -241,8 +241,6 @@ class ObjectSerializer
                 $values[] = self::deserialize($value, $subClass);
             }
             $deserialized = $values;
-        } elseif ($class === 'ByteArray') { // byte array
-            $deserialized = (string)$data;
         } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
         } elseif (in_array($class, array({{&primitives}}))) {

--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -242,7 +242,7 @@ class ObjectSerializer
             }
             $deserialized = $values;
         } elseif ($class === 'ByteArray') { // byte array
-            $deserialized = unpack('C*', (string)$data);
+            $deserialized = (string)$data;
         } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
         } elseif (in_array($class, array({{&primitives}}))) {

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -188,7 +188,7 @@ use \{{invokerPackage}}\ObjectSerializer;
         {{#bodyParams}}// body params
         $_tempBody = null;
         if (isset(${{paramName}})) {
-            {{^isBinary}}$_tempBody = ${{paramName}};{{/isBinary}}{{#isBinary}}$_tempBody = call_user_func_array('pack', array_merge(array('C*'), ${{paramName}}));{{/isBinary}}
+            $_tempBody = ${{paramName}};
         }{{/bodyParams}}
   
         // for model (json/xml)

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -884,7 +884,7 @@ class PetApi
      * Fake endpoint to test byte array return by 'Find pet by ID'
      *
      * @param int $pet_id ID of pet that needs to be fetched (required)
-     * @return ByteArray
+     * @return string
      * @throws \Swagger\Client\ApiException on non-2xx response
      */
     public function petPetIdtestingByteArraytrueGet($pet_id)
@@ -900,7 +900,7 @@ class PetApi
      * Fake endpoint to test byte array return by 'Find pet by ID'
      *
      * @param int $pet_id ID of pet that needs to be fetched (required)
-     * @return Array of ByteArray, HTTP status code, HTTP response headers (array of strings)
+     * @return Array of string, HTTP status code, HTTP response headers (array of strings)
      * @throws \Swagger\Client\ApiException on non-2xx response
      */
     public function petPetIdtestingByteArraytrueGetWithHttpInfo($pet_id)
@@ -964,19 +964,19 @@ class PetApi
             list($response, $statusCode, $httpHeader) = $this->apiClient->callApi(
                 $resourcePath, 'GET',
                 $queryParams, $httpBody,
-                $headerParams, 'ByteArray'
+                $headerParams, 'string'
             );
             
             if (!$response) {
                 return array(null, $statusCode, $httpHeader);
             }
 
-            return array(\Swagger\Client\ObjectSerializer::deserialize($response, 'ByteArray', $httpHeader), $statusCode, $httpHeader);
+            return array(\Swagger\Client\ObjectSerializer::deserialize($response, 'string', $httpHeader), $statusCode, $httpHeader);
             
         } catch (ApiException $e) {
             switch ($e->getCode()) { 
             case 200:
-                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), 'ByteArray', $e->getResponseHeaders());
+                $data = \Swagger\Client\ObjectSerializer::deserialize($e->getResponseBody(), 'string', $e->getResponseHeaders());
                 $e->setResponseObject($data);
                 break;
             }
@@ -990,7 +990,7 @@ class PetApi
      *
      * Fake endpoint to test byte array in body parameter for adding a new pet to the store
      *
-     * @param ByteArray $body Pet object in the form of byte array (optional)
+     * @param string $body Pet object in the form of byte array (optional)
      * @return void
      * @throws \Swagger\Client\ApiException on non-2xx response
      */
@@ -1006,7 +1006,7 @@ class PetApi
      *
      * Fake endpoint to test byte array in body parameter for adding a new pet to the store
      *
-     * @param ByteArray $body Pet object in the form of byte array (optional)
+     * @param string $body Pet object in the form of byte array (optional)
      * @return Array of null, HTTP status code, HTTP response headers (array of strings)
      * @throws \Swagger\Client\ApiException on non-2xx response
      */

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -1036,7 +1036,7 @@ class PetApi
         // body params
         $_tempBody = null;
         if (isset($body)) {
-            $_tempBody = call_user_func_array('pack', array_merge(array('C*'), $body));
+            $_tempBody = $body;
         }
   
         // for model (json/xml)

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php
@@ -230,7 +230,7 @@ class ApiClient
             throw new ApiException("API call to $url timed out: ".serialize($response_info), 0, null, null);
         } elseif ($response_info['http_code'] >= 200 && $response_info['http_code'] <= 299 ) {
             // return raw body if response is a file
-            if ($responseType == '\SplFileObject' || $responseType == 'ByteArray') {
+            if ($responseType == '\SplFileObject' || $responseType == 'string') {
                 return array($http_body, $response_info['http_code'], $http_header);
             }
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -241,8 +241,6 @@ class ObjectSerializer
                 $values[] = self::deserialize($value, $subClass);
             }
             $deserialized = $values;
-        } elseif ($class === 'ByteArray') { // byte array
-            $deserialized = (string)$data;
         } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
         } elseif (in_array($class, array('integer', 'int', 'void', 'number', 'object', 'double', 'float', 'byte', 'DateTime', 'string', 'mixed', 'boolean', 'bool'))) {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -242,7 +242,7 @@ class ObjectSerializer
             }
             $deserialized = $values;
         } elseif ($class === 'ByteArray') { // byte array
-            $deserialized = unpack('C*', (string)$data);
+            $deserialized = (string)$data;
         } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
         } elseif (in_array($class, array('integer', 'int', 'void', 'number', 'object', 'double', 'float', 'byte', 'DateTime', 'string', 'mixed', 'boolean', 'bool'))) {

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -279,7 +279,7 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
         // add a new pet (model)
         $object_serializer = new Swagger\Client\ObjectSerializer();
         $pet_json_string = json_encode($object_serializer->sanitizeForSerialization($new_pet));
-        $add_response = $pet_api->addPetUsingByteArray(unpack('C*', $pet_json_string));
+        $add_response = $pet_api->addPetUsingByteArray($pet_json_string);
         // return nothing (void)
         $this->assertSame($add_response, NULL);
         // verify added Pet
@@ -330,9 +330,9 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
         // test getPetByIdWithByteArray 
         $pet_id = 10005;
         $bytes = $pet_api->petPetIdtestingByteArraytrueGet($pet_id);
-        $json = json_decode(call_user_func_array('pack', array_merge(array('C*'), $bytes )), true);
+        $json = json_decode($bytes, true);
 
-        $this->assertInternalType("array", $bytes);
+        $this->assertInternalType("string", $bytes);
 
         $this->assertSame($json['id'], $pet_id);
         // not testing name as it's tested by addPetUsingByteArray


### PR DESCRIPTION
When `{ "type": "string", format": "binary" }` is requested, it's internally represented as a `ByteArray`, which was then translated into PHP as a literal byte array. A literal byte array in PHP is `[72, 101, 108, 108, 111]` and is not a format supported by any file, echoing, or any standard library operations other than general array handling.

I propose that a "binary string" should represent just that in PHP, an unencoded string. This allows access to the full standard library of tools for dealing with strings as bytes, including file writing and echoing.

This should have some notable performance improvements for end-users as the previous fix was essentially to do the following, which ends up making 4 copies of the data as it passes through the various layers of unpacking, and repacking.

```php
# customer code                                                 swagger code
#            copy                      copy                     copy         original
$string = call_user_func_array('pack', array_merge(array('C*'), unpack("C*", (string)response)) )
```

I tried fixing the response type in documentation to string instead of ByteArray by manipulating the mapping, but this runs into issues with bypassing the raw decoding in ApiClient.php and then gets decoded as a JSON object. I'm open to advice on how to fix this.