### PR TITLE
[Swift] fix issue 1992 - ensure that our variable names don't match the names…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -185,7 +185,7 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
 
   @Override
   public String escapeReservedWord(String name) {
-    return "Swagger" + name;  // add an underscore to the name
+    return "_" + name;  // add an underscore to the name
   }
 
   @Override
@@ -260,7 +260,11 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
       codegenProperty.allowableValues.put("values", swiftEnums);
       codegenProperty.datatypeWithEnum =
               StringUtils.left(codegenProperty.datatypeWithEnum, codegenProperty.datatypeWithEnum.length() - "Enum".length());
-      if (reservedWords.contains(codegenProperty.datatypeWithEnum)) {
+      // Ensure that the enum type doesn't match a reserved word or
+      // the variable name doesn't match the generated enum type or the
+      // Swift compiler will generate an error
+      if (reservedWords.contains(codegenProperty.datatypeWithEnum) ||
+          name.equals(codegenProperty.datatypeWithEnum)) {
         codegenProperty.datatypeWithEnum = escapeReservedWord(codegenProperty.datatypeWithEnum);
       }
     }


### PR DESCRIPTION
… of the generated enums or we will get a compiler error.  Also fix the escaping of reserved words to use an underscore as the comment implies instead of the word Swagger.

See issue:
https://github.com/swagger-api/swagger-codegen/issues/1992