### PR TITLE
[Java Client] Add Eclipse and IntelliJ IDEA support in build.gradle.mustache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ samples/client/petstore/python/dev-requirements.txt.log
 
 samples/client/petstore/csharp/SwaggerClientTest/bin/Debug/
 samples/client/petstore/csharp/SwaggerClientTest/obj/Debug/
+**/.gradle/

--- a/modules/swagger-codegen/src/main/resources/Groovy/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Groovy/build.gradle.mustache
@@ -1,5 +1,7 @@
 apply plugin: 'groovy'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 def artifactory = 'buildserver.supportspace.com'
 group = 'com.supportspace'
 archivesBaseName = 'swagger-gen-groovy'

--- a/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = '{{groupId}}'
 version = '{{artifactVersion}}'
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = '{{groupId}}'
 version = '{{artifactVersion}}'
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = '{{groupId}}'
 version = '{{artifactVersion}}'
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = '{{groupId}}'
 version = '{{artifactVersion}}'
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = '{{groupId}}'
 version = '{{artifactVersion}}'
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = '{{groupId}}'
 version = '{{artifactVersion}}'
 


### PR DESCRIPTION
I added gradle IDE plugins in `build.gradle.mustache`.

I don't commit the sample changes. I think we should add sample directory in `.gitignore`. 

Let users try codegen and generate samples.