### PR TITLE
Don't force explicit configuration of CA cert location

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -75,9 +75,10 @@ module {{moduleName}}
         :ssl_verifypeer => @config.verify_ssl,
         :sslcert => @config.cert_file,
         :sslkey => @config.key_file,
-        :cainfo => @config.ssl_ca_cert,
         :verbose => @config.debugging
       }
+
+      req_opts[:cainfo] = @config.ssl_ca_cert if @config.ssl_ca_cert
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -75,9 +75,10 @@ module Petstore
         :ssl_verifypeer => @config.verify_ssl,
         :sslcert => @config.cert_file,
         :sslkey => @config.key_file,
-        :cainfo => @config.ssl_ca_cert,
         :verbose => @config.debugging
       }
+
+      req_opts[:cainfo] = @config.ssl_ca_cert if @config.ssl_ca_cert
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])


### PR DESCRIPTION
In order to allow openssl to figure out the location of CA certificates
on its own, don't apply the `ssl_ca_cert` configuration parameter if it
is not explicitly set.