### PR TITLE
[Haskell] minor fix to template location for haskell-servant

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
@@ -74,7 +74,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
      * Template Location.  This is the location which templates will be read from.  The generator
      * will use the resource stream to attempt to read the templates.
      */
-    embeddedTemplateDir = templateDir = "haskell";
+    embeddedTemplateDir = templateDir = "haskell-servant";
 
     /**
      * Api Package.  Optional, if needed, this can be used in templates

--- a/samples/server/petstore/haskell-servant/client/Main.hs
+++ b/samples/server/petstore/haskell-servant/client/Main.hs
@@ -21,8 +21,8 @@ import Model.Pet
 import Model.Tag
 import Model.Order
 import Api.UserApi
-import Api.StoreApi
 import Api.PetApi
+import Api.StoreApi
 
 -- userClient :: IO ()
 -- userClient = do 

--- a/samples/server/petstore/haskell-servant/haskell-servant-codegen.cabal
+++ b/samples/server/petstore/haskell-servant/haskell-servant-codegen.cabal
@@ -2,7 +2,7 @@ name:                haskell-servant-codegen
 version:             0.1.0.0
 synopsis:            Swagger-codegen example for Haskell servant
 description:         Please see README.md
-homepage:            http://github.com/algas/haskell-servant-codegen#readme
+homepage:            https://github.com/swagger-api/swagger-codegen#readme
 license:             Apache-2.0
 license-file:        LICENSE
 author:              Masahiro Yamauchi
@@ -22,8 +22,8 @@ library
                      , Model.Tag
                      , Model.Order
                      , Api.UserApi
-                     , Api.StoreApi
                      , Api.PetApi
+                     , Api.StoreApi
                      , Apis
   ghc-options:         -Wall
   build-depends:       base
@@ -62,7 +62,3 @@ executable server
                      , servant-mock
                      , haskell-servant-codegen
   default-language:    Haskell2010
-
-source-repository head
-  type:     git
-  location: https://github.com/algas/haskell-servant-codegen

--- a/samples/server/petstore/haskell-servant/lib/Api/PetApi.hs
+++ b/samples/server/petstore/haskell-servant/lib/Api/PetApi.hs
@@ -14,6 +14,8 @@ module Api.PetApi (
     , updatePetWithForm
     , deletePet
     , uploadFile
+    , getPetByIdWithByteArray
+    , addPetUsingByteArray
     , proxyPetApi
     , PetApi
     ) where
@@ -30,6 +32,7 @@ import qualified Data.Text as T
 import Utils
 import Test.QuickCheck
 import Model.Pet
+import Model.Binary
 
 
 
@@ -62,6 +65,8 @@ instance Arbitrary FormadditionalMetadatafile where
     arbitrary = FormadditionalMetadatafile <$> arbitrary <*> arbitrary
 
 
+
+
 type PetApi = "pet" :> ReqBody '[JSON] Pet :> Put '[JSON] () -- updatePet
     :<|> "pet" :> ReqBody '[JSON] Pet :> Post '[JSON] () -- addPet
     :<|> "pet" :> "findByStatus" :> QueryParam "status" [String] :> Get '[JSON] [Pet] -- findPetsByStatus
@@ -70,6 +75,8 @@ type PetApi = "pet" :> ReqBody '[JSON] Pet :> Put '[JSON] () -- updatePet
     :<|> "pet" :> Capture "petId" String :> ReqBody '[FormUrlEncoded] Formnamestatus :> Post '[JSON] () -- updatePetWithForm
     :<|> "pet" :> Capture "petId" Integer :> Header "api_key" String :> Delete '[JSON] () -- deletePet
     :<|> "pet" :> Capture "petId" Integer :> "uploadImage" :> ReqBody '[FormUrlEncoded] FormadditionalMetadatafile :> Post '[JSON] () -- uploadFile
+    :<|> "pet" :> Capture "petId" Integer?testing_byte_array=true :> Get '[JSON] Binary -- getPetByIdWithByteArray
+    :<|> "pet?testing_byte_array=true" :> ReqBody '[JSON] Binary :> Post '[JSON] () -- addPetUsingByteArray
 
 proxyPetApi :: Proxy PetApi
 proxyPetApi = Proxy
@@ -101,4 +108,6 @@ updatePet
     :<|> updatePetWithForm
     :<|> deletePet
     :<|> uploadFile
+    :<|> getPetByIdWithByteArray
+    :<|> addPetUsingByteArray
     = client proxyPetApi $ BaseUrl Http host port

--- a/samples/server/petstore/haskell-servant/lib/Apis.hs
+++ b/samples/server/petstore/haskell-servant/lib/Apis.hs
@@ -9,8 +9,8 @@ module Apis (
     ) where
 
 import Api.UserApi (UserApi)
-import Api.StoreApi (StoreApi)
 import Api.PetApi (PetApi)
+import Api.StoreApi (StoreApi)
 
 import Data.Proxy
 import Servant.API
@@ -18,7 +18,7 @@ import Test.QuickCheck
 import qualified Data.Map as Map
 import Utils
 
-type API = UserApi :<|> StoreApi :<|> PetApi
+type API = UserApi :<|> PetApi :<|> StoreApi
 
 api :: Proxy API
 api = Proxy


### PR DESCRIPTION
Tested and no longer have issue running `./bin/haskell-servant-petstore.sh` 