### PR TITLE
Remove snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The OpenAPI Specification has undergone 3 revisions since initial creation in 20
 Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 -------------------------- | ------------ | -------------------------- | -----
 2.1.6-SNAPSHOT             |              | 1.0, 1.1, 1.2, 2.0   | [master](https://github.com/swagger-api/swagger-codegen)
-2.1.5 (**current stable**) | 2015-01-06   | 1.0, 1.1, 1.2, 2.0   | [tag v2.1.5](https://github.com/swagger-api/swagger-codegen/tree/v2.1.4)
+2.1.5 (**current stable**) | 2015-01-06   | 1.0, 1.1, 1.2, 2.0   | [tag v2.1.5](https://github.com/swagger-api/swagger-codegen/tree/v2.1.5)
 2.0.17                     | 2014-08-22   | 1.1, 1.2             | [tag v2.0.17](https://github.com/swagger-api/swagger-codegen/tree/v2.0.17)
 1.0.4                      | 2012-04-12   | 1.0, 1.1             | [tag v1.0.4](https://github.com/swagger-api/swagger-codegen/tree/swagger-codegen_2.9.1-1.1)
 

--- a/bin/cb-search-service.sh
+++ b/bin/cb-search-service.sh
@@ -1,0 +1,1 @@
+/crunchbase/search-service/bin/cb-search-service.sh

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -34,6 +34,7 @@ public class CodegenProperty {
     public Boolean hasMore, required, secondaryParam;
     public Boolean isPrimitiveType, isContainer, isNotContainer;
     public boolean isEnum;
+    public Boolean baseNameTypeArray = Boolean.TRUE;
     public Boolean isReadOnly = false;
     public List<String> _enum;
     public Map<String, Object> allowableValues;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -904,6 +904,8 @@ public class DefaultCodegen {
         property.vendorExtensions = p.getVendorExtensions();
 
         String type = getSwaggerType(p);
+        property.baseNameTypeArray = p instanceof ArrayProperty;
+
         if (p instanceof AbstractNumericProperty) {
             AbstractNumericProperty np = (AbstractNumericProperty) p;
             property.minimum = np.getMinimum();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -71,7 +71,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
         if(generateApis == null && generateModels == null && generateSupportingFiles == null) {
             // no specifics are set, generate everything
-            generateApis = true; generateModels = true; generateSupportingFiles = true;
+            generateApis = false; generateModels = true; generateSupportingFiles = true;
         }
         else {
             if(generateApis == null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -177,16 +177,9 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
 
         // use constant model/api package (folder path)
         setModelPackage("models");
-        setApiPackage("api");
-
-        supportingFiles.add(new SupportingFile("gemspec.mustache", "", gemName + ".gemspec"));
-        supportingFiles.add(new SupportingFile("gem.mustache", libFolder, gemName + ".rb"));
+        setApiPackage("");
         String gemFolder = libFolder + File.separator + gemName;
-        supportingFiles.add(new SupportingFile("api_client.mustache", gemFolder, "api_client.rb"));
-        supportingFiles.add(new SupportingFile("api_error.mustache", gemFolder, "api_error.rb"));
-        supportingFiles.add(new SupportingFile("configuration.mustache", gemFolder, "configuration.rb"));
-        supportingFiles.add(new SupportingFile("version.mustache", gemFolder, "version.rb"));
-        String modelFolder = gemFolder + File.separator + modelPackage.replace("/", File.separator);
+        String modelFolder = modelPackage.replace("/", File.separator);
     }
 
 
@@ -226,12 +219,12 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String apiFileFolder() {
-        return outputFolder + File.separator + libFolder + File.separator + gemName + File.separator + apiPackage.replace("/", File.separator);
+        return "";
     }
 
     @Override
     public String modelFileFolder() {
-        return outputFolder + File.separator + libFolder + File.separator + gemName + File.separator + modelPackage.replace("/", File.separator);
+        return outputFolder + File.separator + gemName;
     }
 
     @Override
@@ -392,7 +385,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toModelImport(String name) {
-        return gemName + "/" + modelPackage() + "/" + toModelFilename(name);
+        return modelPackage() + "/" + toModelFilename(name);
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
@@ -18,50 +18,6 @@
       self
     end
 
-    def _deserialize(type, value)
-      case type.to_sym
-      when :DateTime
-        DateTime.parse(value)
-      when :Date
-        Date.parse(value)
-      when :String
-        value.to_s
-      when :Integer
-        value.to_i
-      when :Float
-        value.to_f
-      when :BOOLEAN
-        if value =~ /^(true|t|yes|y|1)$/i
-          true
-        else
-          false
-        end
-      when /\AArray<(?<inner_type>.+)>\z/
-        inner_type = Regexp.last_match[:inner_type]
-        value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
-        k_type = Regexp.last_match[:k_type]
-        v_type = Regexp.last_match[:v_type]
-        {}.tap do |hash|
-          value.each do |k, v|
-            hash[_deserialize(k_type, k)] = _deserialize(v_type, v)
-          end
-        end
-      else # model
-        _model = {{moduleName}}.const_get(type).new
-        _model.build_from_hash(value)
-      end
-    end
-
-    def to_s
-      to_hash.to_s
-    end
-
-    # to_body is an alias to to_body (backward compatibility))
-    def to_body
-      to_hash
-    end
-
     # return the object in the form of hash
     def to_hash
       hash = {}

--- a/modules/swagger-codegen/src/main/resources/ruby/gem.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/gem.mustache
@@ -1,20 +1,9 @@
-# Common files
-require '{{gemName}}/api_client'
-require '{{gemName}}/api_error'
-require '{{gemName}}/version'
-require '{{gemName}}/configuration'
+$LOAD_PATH.unshift(File.dirname(__FILE__))
 
 # Models
 {{#models}}
 require '{{importPath}}'
 {{/models}}
-
-# APIs
-{{#apiInfo}}
-{{#apis}}
-require '{{importPath}}'
-{{/apis}}
-{{/apiInfo}}
 
 module {{moduleName}}
   class << self

--- a/modules/swagger-codegen/src/main/resources/ruby/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/model.mustache
@@ -24,6 +24,14 @@ module {{moduleName}}{{#models}}{{#model}}{{#description}}
       }
     end
 
+    # Attribute type mapping.
+    def self.get_enum_values
+    {
+        {{#vars}}{{^baseNameTypeArray}}:'{{{name}}}' => {{{moduleName}}}::{{{datatype}}}.send(:enum_value){{#hasMore}},{{/hasMore}}{{/baseNameTypeArray}}
+        {{/vars}}
+    }
+    end
+
     def initialize(attributes = {})
       return unless attributes.is_a?(Hash)
 
@@ -40,27 +48,14 @@ module {{moduleName}}{{#models}}{{#model}}{{#description}}
       end
       {{/vars}}
     end
+
 {{#vars}}{{#isEnum}}
     # Custom attribute writer method checking allowed values (enum).
-    def {{{name}}}=({{{name}}})
+    def self.enum_{{{name}}}
       allowed_values = [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]
-      if {{{name}}} && !allowed_values.include?({{{name}}})
-        fail "invalid value for '{{{name}}}', must be one of #{allowed_values}"
-      end
-      @{{{name}}} = {{{name}}}
+      allowed_values
     end
 {{/isEnum}}{{/vars}}
-    # Check equality by comparing each attribute.
-    def ==(o)
-      return true if self.equal?(o)
-      self.class == o.class{{#vars}} &&
-          {{name}} == o.{{name}}{{/vars}}
-    end
-
-    # @see the `==` method
-    def eql?(o)
-      self == o
-    end
 
     # Calculate hash code according to all attributes.
     def hash

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.17-SNAPSHOT</swagger-parser-version>
+        <swagger-parser-version>1.0.17</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>2.3.4</felix-version>
         <swagger-core-version>1.5.6</swagger-core-version>


### PR DESCRIPTION
Removed -SNAPSHOT from dependency version in pom.xml.   1.0.17 is now gold in the sonatype repo, so 1.0.17-SNAPSHOT has been removed.