### PR TITLE
Fix for Python client upload list of files Issue #2036

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1411,6 +1411,8 @@ public class DefaultCodegen {
                 } else if (param instanceof FormParameter) {
                     if ("file".equalsIgnoreCase(((FormParameter) param).getType())) {
                         p.isFile = true;
+                    } else if("file".equals(p.baseType)){
+                    	p.isFile = true;
                     } else {
                         p.notFile = true;
                     }

--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -117,11 +117,11 @@ class {{classname}}(object):
             header_params['{{baseName}}'] = params['{{paramName}}']
 {{/headerParams}}
 
-        form_params = {}
+        form_params = []
         files = {}
 {{#formParams}}
         if '{{paramName}}' in params:
-            {{#notFile}}form_params['{{baseName}}'] = params['{{paramName}}']{{/notFile}}{{#isFile}}files['{{baseName}}'] = params['{{paramName}}']{{/isFile}}
+            {{#notFile}}form_params.append(('{{baseName}}', params['{{paramName}}'])){{/notFile}}{{#isFile}}files['{{baseName}}'] = params['{{paramName}}']{{/isFile}}
 {{/formParams}}
 
         body_params = None

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -402,7 +402,7 @@ class ApiClient(object):
                         filedata = f.read()
                         mimetype = mimetypes.\
                             guess_type(filename)[0] or 'application/octet-stream'
-                        params.append(tuple[k, tuple([filename, filedata, mimetype])])
+                        params.append(tuple([k, tuple([filename, filedata, mimetype])]))
 
         return params
 

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -395,8 +395,8 @@ class ApiClient(object):
             for k, v in iteritems(files):
                 if not v:
                     continue
-                all_files = v if type(v) is list else [v]
-                for n in all_files:
+                file_names = v if type(v) is list else [v]
+                for n in file_names:
                     with open(n, 'rb') as f:
                         filename = os.path.basename(f.name)
                         filedata = f.read()

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -386,10 +386,10 @@ class ApiClient(object):
         :param files: File parameters.
         :return: Form parameters with files.
         """
-        params = {}
+        params = []
 
         if post_params:
-            params.update(post_params)
+            params = post_params
 
         if files:
             for k, v in iteritems(files):
@@ -402,7 +402,7 @@ class ApiClient(object):
                         filedata = f.read()
                         mimetype = mimetypes.\
                             guess_type(filename)[0] or 'application/octet-stream'
-                        params[k] = tuple([filename, filedata, mimetype])
+                        params.append(tuple[k, tuple([filename, filedata, mimetype])])
 
         return params
 

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -395,13 +395,14 @@ class ApiClient(object):
             for k, v in iteritems(files):
                 if not v:
                     continue
-
-                with open(v, 'rb') as f:
-                    filename = os.path.basename(f.name)
-                    filedata = f.read()
-                    mimetype = mimetypes.\
-                        guess_type(filename)[0] or 'application/octet-stream'
-                    params[k] = tuple([filename, filedata, mimetype])
+                all_files = v if type(v) is list else [v]
+                for n in all_files:
+                    with open(n, 'rb') as f:
+                        filename = os.path.basename(f.name)
+                        filedata = f.read()
+                        mimetype = mimetypes.\
+                            guess_type(filename)[0] or 'application/octet-stream'
+                        params[k] = tuple([filename, filedata, mimetype])
 
         return params
 

--- a/samples/client/petstore/python/swagger_client/__init__.py
+++ b/samples/client/petstore/python/swagger_client/__init__.py
@@ -9,8 +9,8 @@ from .models.order import Order
 
 # import apis into sdk package
 from .apis.user_api import UserApi
-from .apis.pet_api import PetApi
 from .apis.store_api import StoreApi
+from .apis.pet_api import PetApi
 
 # import ApiClient
 from .api_client import ApiClient

--- a/samples/client/petstore/python/swagger_client/api_client.py
+++ b/samples/client/petstore/python/swagger_client/api_client.py
@@ -386,22 +386,23 @@ class ApiClient(object):
         :param files: File parameters.
         :return: Form parameters with files.
         """
-        params = {}
+        params = []
 
         if post_params:
-            params.update(post_params)
+            params = post_params
 
         if files:
             for k, v in iteritems(files):
                 if not v:
                     continue
-
-                with open(v, 'rb') as f:
-                    filename = os.path.basename(f.name)
-                    filedata = f.read()
-                    mimetype = mimetypes.\
-                        guess_type(filename)[0] or 'application/octet-stream'
-                    params[k] = tuple([filename, filedata, mimetype])
+                all_files = v if type(v) is list else [v]
+                for n in all_files:
+                    with open(n, 'rb') as f:
+                        filename = os.path.basename(f.name)
+                        filedata = f.read()
+                        mimetype = mimetypes.\
+                            guess_type(filename)[0] or 'application/octet-stream'
+                        params.append(tuple([k, tuple([filename, filedata, mimetype])]))
 
         return params
 

--- a/samples/client/petstore/python/swagger_client/apis/__init__.py
+++ b/samples/client/petstore/python/swagger_client/apis/__init__.py
@@ -2,5 +2,5 @@ from __future__ import absolute_import
 
 # import apis into api package
 from .user_api import UserApi
-from .pet_api import PetApi
 from .store_api import StoreApi
+from .pet_api import PetApi

--- a/samples/client/petstore/python/swagger_client/apis/pet_api.py
+++ b/samples/client/petstore/python/swagger_client/apis/pet_api.py
@@ -89,7 +89,7 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -165,7 +165,7 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -243,7 +243,7 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -319,7 +319,7 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -398,7 +398,7 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -479,12 +479,12 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
         if 'name' in params:
-            form_params['name'] = params['name']
+            form_params.append(('name', params['name']))
         if 'status' in params:
-            form_params['status'] = params['status']
+            form_params.append(('status', params['status']))
 
         body_params = None
 
@@ -565,7 +565,7 @@ class PetApi(object):
         if 'api_key' in params:
             header_params['api_key'] = params['api_key']
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -646,10 +646,10 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
         if 'additional_metadata' in params:
-            form_params['additionalMetadata'] = params['additional_metadata']
+            form_params.append(('additionalMetadata', params['additional_metadata']))
         if 'file' in params:
             files['file'] = params['file']
 
@@ -696,7 +696,7 @@ class PetApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param int pet_id: ID of pet that needs to be fetched (required)
-        :return: Binary
+        :return: str
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -729,7 +729,7 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -754,7 +754,7 @@ class PetApi(object):
                                             body=body_params,
                                             post_params=form_params,
                                             files=files,
-                                            response_type='Binary',
+                                            response_type='str',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'))
         return response
@@ -774,7 +774,7 @@ class PetApi(object):
 
         :param callback function: The callback function
             for asynchronous request. (optional)
-        :param Binary body: Pet object in the form of byte array
+        :param str body: Pet object in the form of byte array
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
@@ -803,7 +803,7 @@ class PetApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None

--- a/samples/client/petstore/python/swagger_client/apis/store_api.py
+++ b/samples/client/petstore/python/swagger_client/apis/store_api.py
@@ -88,7 +88,7 @@ class StoreApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -162,7 +162,7 @@ class StoreApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -243,7 +243,7 @@ class StoreApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -322,7 +322,7 @@ class StoreApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None

--- a/samples/client/petstore/python/swagger_client/apis/user_api.py
+++ b/samples/client/petstore/python/swagger_client/apis/user_api.py
@@ -89,7 +89,7 @@ class UserApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -165,7 +165,7 @@ class UserApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -241,7 +241,7 @@ class UserApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -322,7 +322,7 @@ class UserApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -395,7 +395,7 @@ class UserApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -474,7 +474,7 @@ class UserApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -554,7 +554,7 @@ class UserApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None
@@ -635,7 +635,7 @@ class UserApi(object):
 
         header_params = {}
 
-        form_params = {}
+        form_params = []
         files = {}
 
         body_params = None


### PR DESCRIPTION
Issue #2036 A fix to allow a list of files to be uploaded. The main change concerns the type of form_params being changed from a dict() to nested tuples in the form (key, (value)) to allow files with the same key not to be overwritten each iteration.