### PR TITLE
Conitnue fixing of #2037

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -97,8 +97,9 @@ class {{classname}}(object):
                 ))
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda k, v: (k, v.to_dict()) if hasattr(v, "to_dict") else (k, v),
-                    value.iteritems()
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
                 ))
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()

--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -95,14 +95,14 @@ class {{classname}}(object):
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
                     value
                 ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             elif isinstance(value, dict):
                 result[attr] = dict(map(
                     lambda item: (item[0], item[1].to_dict())
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))
-            elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
             else:
                 result[attr] = value
 

--- a/samples/client/petstore/python/swagger_client/models/category.py
+++ b/samples/client/petstore/python/swagger_client/models/category.py
@@ -108,8 +108,9 @@ class Category(object):
                 ))
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda k, v: (k, v.to_dict()) if hasattr(v, "to_dict") else (k, v),
-                    value.iteritems()
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
                 ))
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()

--- a/samples/client/petstore/python/swagger_client/models/category.py
+++ b/samples/client/petstore/python/swagger_client/models/category.py
@@ -106,14 +106,14 @@ class Category(object):
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
                     value
                 ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             elif isinstance(value, dict):
                 result[attr] = dict(map(
                     lambda item: (item[0], item[1].to_dict())
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))
-            elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
             else:
                 result[attr] = value
 

--- a/samples/client/petstore/python/swagger_client/models/order.py
+++ b/samples/client/petstore/python/swagger_client/models/order.py
@@ -212,14 +212,14 @@ class Order(object):
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
                     value
                 ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             elif isinstance(value, dict):
                 result[attr] = dict(map(
                     lambda item: (item[0], item[1].to_dict())
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))
-            elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
             else:
                 result[attr] = value
 

--- a/samples/client/petstore/python/swagger_client/models/order.py
+++ b/samples/client/petstore/python/swagger_client/models/order.py
@@ -214,8 +214,9 @@ class Order(object):
                 ))
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda k, v: (k, v.to_dict()) if hasattr(v, "to_dict") else (k, v),
-                    value.iteritems()
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
                 ))
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()

--- a/samples/client/petstore/python/swagger_client/models/pet.py
+++ b/samples/client/petstore/python/swagger_client/models/pet.py
@@ -212,14 +212,14 @@ class Pet(object):
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
                     value
                 ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             elif isinstance(value, dict):
                 result[attr] = dict(map(
                     lambda item: (item[0], item[1].to_dict())
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))
-            elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
             else:
                 result[attr] = value
 

--- a/samples/client/petstore/python/swagger_client/models/pet.py
+++ b/samples/client/petstore/python/swagger_client/models/pet.py
@@ -214,8 +214,9 @@ class Pet(object):
                 ))
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda k, v: (k, v.to_dict()) if hasattr(v, "to_dict") else (k, v),
-                    value.iteritems()
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
                 ))
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()

--- a/samples/client/petstore/python/swagger_client/models/tag.py
+++ b/samples/client/petstore/python/swagger_client/models/tag.py
@@ -106,14 +106,14 @@ class Tag(object):
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
                     value
                 ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             elif isinstance(value, dict):
                 result[attr] = dict(map(
                     lambda item: (item[0], item[1].to_dict())
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))
-            elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
             else:
                 result[attr] = value
 

--- a/samples/client/petstore/python/swagger_client/models/tag.py
+++ b/samples/client/petstore/python/swagger_client/models/tag.py
@@ -108,8 +108,9 @@ class Tag(object):
                 ))
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda k, v: (k, v.to_dict()) if hasattr(v, "to_dict") else (k, v),
-                    value.iteritems()
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
                 ))
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()

--- a/samples/client/petstore/python/swagger_client/models/user.py
+++ b/samples/client/petstore/python/swagger_client/models/user.py
@@ -258,8 +258,9 @@ class User(object):
                 ))
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda k, v: (k, v.to_dict()) if hasattr(v, "to_dict") else (k, v),
-                    value.iteritems()
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
                 ))
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()

--- a/samples/client/petstore/python/swagger_client/models/user.py
+++ b/samples/client/petstore/python/swagger_client/models/user.py
@@ -256,14 +256,14 @@ class User(object):
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
                     value
                 ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
             elif isinstance(value, dict):
                 result[attr] = dict(map(
                     lambda item: (item[0], item[1].to_dict())
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))
-            elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
             else:
                 result[attr] = value
 


### PR DESCRIPTION
This PR is additional work on #2037, and is a fixed version of addition made in #2058.

1. After creating #2058 to comply with python 3.4 found a bug when using on python 2.7, the current method should comply with both.
2. Performance optimization by switching the order of the `elif`, since I guess `additionalProperties` is probably less used and should be checked last
3. Style optimization by warping lines and staying below 79 chars

