### PR TITLE
Move common functionality to new model base class

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -231,6 +231,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         supportingFiles.add(new SupportingFile("package.mustache", "", "package.json"));
         supportingFiles.add(new SupportingFile("index.mustache", sourceFolder, "index.js"));
         supportingFiles.add(new SupportingFile("ApiClient.mustache", sourceFolder, "ApiClient.js"));
+        supportingFiles.add(new SupportingFile("ApiModel.mustache", sourceFolder, "ApiModel.js"));
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiModel.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiModel.mustache
@@ -1,0 +1,33 @@
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // CommonJS-like environments that support module.exports, like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    if (!root.{{moduleName}}) {
+      root.{{moduleName}} = {};
+    }
+    root.{{moduleName}}.ApiModel = factory();
+  }
+}(this, function() {
+	'use strict';
+
+	/**
+	 Base class for all generated model classes,
+	 containing common functionality.
+	**/
+	var ApiModel = function(){}
+	ApiModel.prototype.toJson = function() { 
+		return JSON.stringify(this); 
+	}
+
+	if (module) {
+		module.ApiModel = ApiModel;
+	}
+
+	return ApiModel;
+
+}));

--- a/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
@@ -23,6 +23,7 @@
    * {{description}}
    **/{{/description}}
   var {{classname}} = function {{classname}}({{#mandatory}}{{this}}{{^-last}}, {{/-last}}{{/mandatory}}) { {{#parent}}/* extends {{{parent}}}*/{{/parent}}
+    ApiModel.call(this);
     {{#vars}}
     /**{{#description}}
      * {{{description}}}{{/description}}
@@ -31,7 +32,6 @@
      * minimum: {{minimum}}{{/minimum}}{{#maximum}}
      * maximum: {{maximum}}{{/maximum}}
      **/
-    ApiModel.call(this);
     this['{{baseName}}'] = {{#required}}{{name}}{{/required}}{{^required}}{{{defaultValue}}}{{/required}};
     {{/vars}}
   };

--- a/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'{{#imports}}, './{{import}}'{{/imports}}], factory);
+    define([undefined, '../ApiClient', '../ApiModel'{{#imports}}, './{{import}}'{{/imports}}], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'){{#imports}}, require('./{{import}}'){{/imports}});
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'){{#imports}}, require('./{{import}}'){{/imports}});
   } else {
     // Browser globals (root is window)
     if (!root.{{moduleName}}) {
       root.{{moduleName}} = {};
     }
-    factory(root.{{moduleName}}, root.{{moduleName}}.ApiClient{{#imports}}, root.{{moduleName}}.{{import}}{{/imports}});
+    factory(root.{{moduleName}}, root.{{moduleName}}.ApiClient, root.{{moduleName}}.ApiModel{{#imports}}, root.{{moduleName}}.{{import}}{{/imports}});
   }
-}(this, function(module, ApiClient{{#imports}}, {{import}}{{/imports}}) {
+}(this, function(module, ApiClient, ApiModel{{#imports}}, {{import}}{{/imports}}) {
   'use strict';
 
   {{#models}}{{#model}}
@@ -31,6 +31,7 @@
      * minimum: {{minimum}}{{/minimum}}{{#maximum}}
      * maximum: {{maximum}}{{/maximum}}
      **/
+    ApiModel.call(this);
     this['{{baseName}}'] = {{#required}}{{name}}{{/required}}{{^required}}{{{defaultValue}}}{{/required}};
     {{/vars}}
   };
@@ -68,10 +69,6 @@
   }
   {{/vars}}
   {{/omitModelMethods}}
-
-  {{classname}}.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
 
   if (module) {
     module.{{classname}} = {{classname}};

--- a/samples/client/petstore/javascript-promise/src/ApiModel.js
+++ b/samples/client/petstore/javascript-promise/src/ApiModel.js
@@ -1,0 +1,33 @@
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // CommonJS-like environments that support module.exports, like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    if (!root.SwaggerPetstore) {
+      root.SwaggerPetstore = {};
+    }
+    root.SwaggerPetstore.ApiModel = factory();
+  }
+}(this, function() {
+	'use strict';
+
+	/**
+	 Base class for all generated model classes,
+	 containing common functionality.
+	**/
+	var ApiModel = function(){}
+	ApiModel.prototype.toJson = function() { 
+		return JSON.stringify(this); 
+	}
+
+	if (module) {
+		module.ApiModel = ApiModel;
+	}
+
+	return ApiModel;
+
+}));

--- a/samples/client/petstore/javascript-promise/src/model/Category.js
+++ b/samples/client/petstore/javascript-promise/src/model/Category.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'], factory);
+    define([undefined, '../ApiClient', '../ApiModel'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel);
   }
-}(this, function(module, ApiClient) {
+}(this, function(module, ApiClient, ApiModel) {
   'use strict';
 
   
@@ -24,11 +24,13 @@
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['name'] = null;
     
   };
@@ -49,6 +51,7 @@
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -78,10 +81,7 @@
     this['name'] = name;
   }
   
-
-  Category.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.Category = Category;

--- a/samples/client/petstore/javascript-promise/src/model/Category.js
+++ b/samples/client/petstore/javascript-promise/src/model/Category.js
@@ -20,17 +20,16 @@
 
   
   var Category = function Category() { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['name'] = null;
     
   };

--- a/samples/client/petstore/javascript-promise/src/model/Order.js
+++ b/samples/client/petstore/javascript-promise/src/model/Order.js
@@ -48,42 +48,37 @@ var StatusEnum = function StatusEnum() {
 
   
   var Order = function Order() { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['petId'] = null;
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['quantity'] = null;
     
     /**
      * datatype: Date
      **/
-    ApiModel.call(this);
     this['shipDate'] = null;
     
     /**
      * Order Status
      * datatype: StatusEnum
      **/
-    ApiModel.call(this);
     this['status'] = null;
     
     /**
      * datatype: Boolean
      **/
-    ApiModel.call(this);
     this['complete'] = null;
     
   };

--- a/samples/client/petstore/javascript-promise/src/model/Order.js
+++ b/samples/client/petstore/javascript-promise/src/model/Order.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'], factory);
+    define([undefined, '../ApiClient', '../ApiModel'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel);
   }
-}(this, function(module, ApiClient) {
+}(this, function(module, ApiClient, ApiModel) {
   'use strict';
 
   
@@ -52,32 +52,38 @@ var StatusEnum = function StatusEnum() {
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['petId'] = null;
     
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['quantity'] = null;
     
     /**
      * datatype: Date
      **/
+    ApiModel.call(this);
     this['shipDate'] = null;
     
     /**
      * Order Status
      * datatype: StatusEnum
      **/
+    ApiModel.call(this);
     this['status'] = null;
     
     /**
      * datatype: Boolean
      **/
+    ApiModel.call(this);
     this['complete'] = null;
     
   };
@@ -114,6 +120,7 @@ var StatusEnum = function StatusEnum() {
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -201,10 +208,7 @@ var StatusEnum = function StatusEnum() {
     this['complete'] = complete;
   }
   
-
-  Order.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.Order = Order;

--- a/samples/client/petstore/javascript-promise/src/model/Pet.js
+++ b/samples/client/petstore/javascript-promise/src/model/Pet.js
@@ -48,44 +48,39 @@ var StatusEnum = function StatusEnum() {
 
   
   var Pet = function Pet(photoUrls, name) { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: Category
      **/
-    ApiModel.call(this);
     this['category'] = new Category();
     
     /**
      * datatype: String
      * required
      **/
-    ApiModel.call(this);
     this['name'] = name;
     
     /**
      * datatype: [String]
      * required
      **/
-    ApiModel.call(this);
     this['photoUrls'] = photoUrls;
     
     /**
      * datatype: [Tag]
      **/
-    ApiModel.call(this);
     this['tags'] = [];
     
     /**
      * pet status in the store
      * datatype: StatusEnum
      **/
-    ApiModel.call(this);
     this['status'] = null;
     
   };

--- a/samples/client/petstore/javascript-promise/src/model/Pet.js
+++ b/samples/client/petstore/javascript-promise/src/model/Pet.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient', './Category', './Tag'], factory);
+    define([undefined, '../ApiClient', '../ApiModel', './Category', './Tag'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'), require('./Category'), require('./Tag'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'), require('./Category'), require('./Tag'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.Category, root.SwaggerPetstore.Tag);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel, root.SwaggerPetstore.Category, root.SwaggerPetstore.Tag);
   }
-}(this, function(module, ApiClient, Category, Tag) {
+}(this, function(module, ApiClient, ApiModel, Category, Tag) {
   'use strict';
 
   
@@ -52,34 +52,40 @@ var StatusEnum = function StatusEnum() {
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: Category
      **/
+    ApiModel.call(this);
     this['category'] = new Category();
     
     /**
      * datatype: String
      * required
      **/
+    ApiModel.call(this);
     this['name'] = name;
     
     /**
      * datatype: [String]
      * required
      **/
+    ApiModel.call(this);
     this['photoUrls'] = photoUrls;
     
     /**
      * datatype: [Tag]
      **/
+    ApiModel.call(this);
     this['tags'] = [];
     
     /**
      * pet status in the store
      * datatype: StatusEnum
      **/
+    ApiModel.call(this);
     this['status'] = null;
     
   };
@@ -116,6 +122,7 @@ var StatusEnum = function StatusEnum() {
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -203,10 +210,7 @@ var StatusEnum = function StatusEnum() {
     this['status'] = status;
   }
   
-
-  Pet.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.Pet = Pet;

--- a/samples/client/petstore/javascript-promise/src/model/Tag.js
+++ b/samples/client/petstore/javascript-promise/src/model/Tag.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'], factory);
+    define([undefined, '../ApiClient', '../ApiModel'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel);
   }
-}(this, function(module, ApiClient) {
+}(this, function(module, ApiClient, ApiModel) {
   'use strict';
 
   
@@ -24,11 +24,13 @@
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['name'] = null;
     
   };
@@ -49,6 +51,7 @@
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -78,10 +81,7 @@
     this['name'] = name;
   }
   
-
-  Tag.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.Tag = Tag;

--- a/samples/client/petstore/javascript-promise/src/model/Tag.js
+++ b/samples/client/petstore/javascript-promise/src/model/Tag.js
@@ -20,17 +20,16 @@
 
   
   var Tag = function Tag() { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['name'] = null;
     
   };

--- a/samples/client/petstore/javascript-promise/src/model/User.js
+++ b/samples/client/petstore/javascript-promise/src/model/User.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'], factory);
+    define([undefined, '../ApiClient', '../ApiModel'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel);
   }
-}(this, function(module, ApiClient) {
+}(this, function(module, ApiClient, ApiModel) {
   'use strict';
 
   
@@ -24,42 +24,50 @@
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['username'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['firstName'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['lastName'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['email'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['password'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['phone'] = null;
     
     /**
      * User Status
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['userStatus'] = null;
     
   };
@@ -104,6 +112,7 @@
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -219,10 +228,7 @@
     this['userStatus'] = userStatus;
   }
   
-
-  User.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.User = User;

--- a/samples/client/petstore/javascript-promise/src/model/User.js
+++ b/samples/client/petstore/javascript-promise/src/model/User.js
@@ -20,54 +20,47 @@
 
   
   var User = function User() { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['username'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['firstName'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['lastName'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['email'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['password'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['phone'] = null;
     
     /**
      * User Status
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['userStatus'] = null;
     
   };

--- a/samples/client/petstore/javascript/src/ApiModel.js
+++ b/samples/client/petstore/javascript/src/ApiModel.js
@@ -1,0 +1,33 @@
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // CommonJS-like environments that support module.exports, like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    if (!root.SwaggerPetstore) {
+      root.SwaggerPetstore = {};
+    }
+    root.SwaggerPetstore.ApiModel = factory();
+  }
+}(this, function() {
+	'use strict';
+
+	/**
+	 Base class for all generated model classes,
+	 containing common functionality.
+	**/
+	var ApiModel = function(){}
+	ApiModel.prototype.toJson = function() { 
+		return JSON.stringify(this); 
+	}
+
+	if (module) {
+		module.ApiModel = ApiModel;
+	}
+
+	return ApiModel;
+
+}));

--- a/samples/client/petstore/javascript/src/model/Category.js
+++ b/samples/client/petstore/javascript/src/model/Category.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'], factory);
+    define([undefined, '../ApiClient', '../ApiModel'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel);
   }
-}(this, function(module, ApiClient) {
+}(this, function(module, ApiClient, ApiModel) {
   'use strict';
 
   
@@ -24,11 +24,13 @@
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['name'] = null;
     
   };
@@ -49,6 +51,7 @@
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -78,10 +81,7 @@
     this['name'] = name;
   }
   
-
-  Category.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.Category = Category;

--- a/samples/client/petstore/javascript/src/model/Category.js
+++ b/samples/client/petstore/javascript/src/model/Category.js
@@ -20,17 +20,16 @@
 
   
   var Category = function Category() { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['name'] = null;
     
   };

--- a/samples/client/petstore/javascript/src/model/Order.js
+++ b/samples/client/petstore/javascript/src/model/Order.js
@@ -48,42 +48,37 @@ var StatusEnum = function StatusEnum() {
 
   
   var Order = function Order() { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['petId'] = null;
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['quantity'] = null;
     
     /**
      * datatype: Date
      **/
-    ApiModel.call(this);
     this['shipDate'] = null;
     
     /**
      * Order Status
      * datatype: StatusEnum
      **/
-    ApiModel.call(this);
     this['status'] = null;
     
     /**
      * datatype: Boolean
      **/
-    ApiModel.call(this);
     this['complete'] = null;
     
   };

--- a/samples/client/petstore/javascript/src/model/Order.js
+++ b/samples/client/petstore/javascript/src/model/Order.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'], factory);
+    define([undefined, '../ApiClient', '../ApiModel'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel);
   }
-}(this, function(module, ApiClient) {
+}(this, function(module, ApiClient, ApiModel) {
   'use strict';
 
   
@@ -52,32 +52,38 @@ var StatusEnum = function StatusEnum() {
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['petId'] = null;
     
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['quantity'] = null;
     
     /**
      * datatype: Date
      **/
+    ApiModel.call(this);
     this['shipDate'] = null;
     
     /**
      * Order Status
      * datatype: StatusEnum
      **/
+    ApiModel.call(this);
     this['status'] = null;
     
     /**
      * datatype: Boolean
      **/
+    ApiModel.call(this);
     this['complete'] = null;
     
   };
@@ -114,6 +120,7 @@ var StatusEnum = function StatusEnum() {
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -201,10 +208,7 @@ var StatusEnum = function StatusEnum() {
     this['complete'] = complete;
   }
   
-
-  Order.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.Order = Order;

--- a/samples/client/petstore/javascript/src/model/Pet.js
+++ b/samples/client/petstore/javascript/src/model/Pet.js
@@ -48,44 +48,39 @@ var StatusEnum = function StatusEnum() {
 
   
   var Pet = function Pet(photoUrls, name) { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: Category
      **/
-    ApiModel.call(this);
     this['category'] = new Category();
     
     /**
      * datatype: String
      * required
      **/
-    ApiModel.call(this);
     this['name'] = name;
     
     /**
      * datatype: [String]
      * required
      **/
-    ApiModel.call(this);
     this['photoUrls'] = photoUrls;
     
     /**
      * datatype: [Tag]
      **/
-    ApiModel.call(this);
     this['tags'] = [];
     
     /**
      * pet status in the store
      * datatype: StatusEnum
      **/
-    ApiModel.call(this);
     this['status'] = null;
     
   };

--- a/samples/client/petstore/javascript/src/model/Pet.js
+++ b/samples/client/petstore/javascript/src/model/Pet.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient', './Category', './Tag'], factory);
+    define([undefined, '../ApiClient', '../ApiModel', './Category', './Tag'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'), require('./Category'), require('./Tag'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'), require('./Category'), require('./Tag'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.Category, root.SwaggerPetstore.Tag);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel, root.SwaggerPetstore.Category, root.SwaggerPetstore.Tag);
   }
-}(this, function(module, ApiClient, Category, Tag) {
+}(this, function(module, ApiClient, ApiModel, Category, Tag) {
   'use strict';
 
   
@@ -52,34 +52,40 @@ var StatusEnum = function StatusEnum() {
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: Category
      **/
+    ApiModel.call(this);
     this['category'] = new Category();
     
     /**
      * datatype: String
      * required
      **/
+    ApiModel.call(this);
     this['name'] = name;
     
     /**
      * datatype: [String]
      * required
      **/
+    ApiModel.call(this);
     this['photoUrls'] = photoUrls;
     
     /**
      * datatype: [Tag]
      **/
+    ApiModel.call(this);
     this['tags'] = [];
     
     /**
      * pet status in the store
      * datatype: StatusEnum
      **/
+    ApiModel.call(this);
     this['status'] = null;
     
   };
@@ -116,6 +122,7 @@ var StatusEnum = function StatusEnum() {
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -203,10 +210,7 @@ var StatusEnum = function StatusEnum() {
     this['status'] = status;
   }
   
-
-  Pet.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.Pet = Pet;

--- a/samples/client/petstore/javascript/src/model/Tag.js
+++ b/samples/client/petstore/javascript/src/model/Tag.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'], factory);
+    define([undefined, '../ApiClient', '../ApiModel'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel);
   }
-}(this, function(module, ApiClient) {
+}(this, function(module, ApiClient, ApiModel) {
   'use strict';
 
   
@@ -24,11 +24,13 @@
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['name'] = null;
     
   };
@@ -49,6 +51,7 @@
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -78,10 +81,7 @@
     this['name'] = name;
   }
   
-
-  Tag.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.Tag = Tag;

--- a/samples/client/petstore/javascript/src/model/Tag.js
+++ b/samples/client/petstore/javascript/src/model/Tag.js
@@ -20,17 +20,16 @@
 
   
   var Tag = function Tag() { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['name'] = null;
     
   };

--- a/samples/client/petstore/javascript/src/model/User.js
+++ b/samples/client/petstore/javascript/src/model/User.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define([undefined, '../ApiClient'], factory);
+    define([undefined, '../ApiClient', '../ApiModel'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(undefined, require('../ApiClient'));
+    module.exports = factory(undefined, require('../ApiClient'), require('../ApiModel'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient);
+    factory(root.SwaggerPetstore, root.SwaggerPetstore.ApiClient, root.SwaggerPetstore.ApiModel);
   }
-}(this, function(module, ApiClient) {
+}(this, function(module, ApiClient, ApiModel) {
   'use strict';
 
   
@@ -24,42 +24,50 @@
     /**
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['username'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['firstName'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['lastName'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['email'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['password'] = null;
     
     /**
      * datatype: String
      **/
+    ApiModel.call(this);
     this['phone'] = null;
     
     /**
      * User Status
      * datatype: Integer
      **/
+    ApiModel.call(this);
     this['userStatus'] = null;
     
   };
@@ -104,6 +112,7 @@
     return this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -219,10 +228,7 @@
     this['userStatus'] = userStatus;
   }
   
-
-  User.prototype.toJson = function() {
-    return JSON.stringify(this);
-  }
+  
 
   if (module) {
     module.User = User;

--- a/samples/client/petstore/javascript/src/model/User.js
+++ b/samples/client/petstore/javascript/src/model/User.js
@@ -20,54 +20,47 @@
 
   
   var User = function User() { 
+    ApiModel.call(this);
     
     /**
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['id'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['username'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['firstName'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['lastName'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['email'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['password'] = null;
     
     /**
      * datatype: String
      **/
-    ApiModel.call(this);
     this['phone'] = null;
     
     /**
      * User Status
      * datatype: Integer
      **/
-    ApiModel.call(this);
     this['userStatus'] = null;
     
   };


### PR DESCRIPTION
Fixes "additional comment (2)" in #2044.

The `toJson` method that currently exists (identically) in every model class is moved to a common base class, `ApiModel`, that is extended by all model classes (using prototype inheritance).

The new `ApiModel` base class may also be useful for other purposes (i.e. other common functionality among the model classes) in the future.

Note: This also includes the changes to the Petstore example files from https://github.com/swagger-api/swagger-codegen/pull/2071 because it would be impossible not to (since I had to regenerate the example files using the latest code).

A couple of debatable points:
- The name of the common base model class could be changed. It is currently `ApiModel`. Perhaps you prefer `BaseModel`, `ModelBase`, or just `Model`?
- The base model class could be put in the `model` dir. Currently it goes where `ApiClient.js` goes.