### PR TITLE
Fix #1487, TypeScript-Angular output path wrong if apiPackage not the…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -14,7 +14,13 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 	public String getHelp() {
 		return "Generates a TypeScript AngularJS client library.";
 	}
-
+	
+	@Override
+    public void processOpts() {
+        super.processOpts();
+	    supportingFiles.add(new SupportingFile("api.d.mustache", apiPackage().replace('.', File.separatorChar), "api.d.ts"));
+	}
+	
 	public TypeScriptAngularClientCodegen() {
 	    super();
 	    outputFolder = "generated-code/typescript-angular";
@@ -23,6 +29,5 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 	    embeddedTemplateDir = templateDir = "TypeScript-Angular";
 	    apiPackage = "API.Client";
 	    modelPackage = "API.Client";
-	    supportingFiles.add(new SupportingFile("api.d.mustache", apiPackage().replace('.', File.separatorChar), "api.d.ts"));
 	}
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -14,11 +14,16 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
         return "Generates a TypeScript nodejs client library.";
     }
 
+	@Override
+    public void processOpts() {
+        super.processOpts();
+        supportingFiles.add(new SupportingFile("api.mustache", null, "api.ts"));
+    }
+    
     public TypeScriptNodeClientCodegen() {
         super();
         outputFolder = "generated-code/typescript-node";
         embeddedTemplateDir = templateDir = "TypeScript-node";
-        supportingFiles.add(new SupportingFile("api.mustache", null, "api.ts"));
     }
 
 }


### PR DESCRIPTION
The Typescript-Angular codegen added the api.d.mustache files in the constructor & picked up the output patch from the default value for apiPackage (API.Client).

Moving the add to the end of processOpts picks up the overridden value for apiPackage & outputs the file where it should be.

I've made the same change in Typescript-Node to avoid the same bug if the output is changed to fully qualified paths at a later date.