### PR TITLE
adding support for java dates

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -109,11 +109,17 @@ class Decoders {
             }
             // Decoder for NSDate
             Decoders.addDecoder(clazz: NSDate.self) { (source: AnyObject) -> NSDate in
-                let sourceString = source as! String
-                for formatter in formatters {
-                    if let date = formatter.dateFromString(sourceString) {
-                        return date
+               if let sourceString = source as? String {
+                    for formatter in formatters {
+                        if let date = formatter.dateFromString(sourceString) {
+                            return date
+                        }
                     }
+                
+                }
+                if let sourceInt = source as? Int {
+                    // treat as a java date
+                    return NSDate(timeIntervalSince1970: Double(sourceInt / 1000) )
                 }
                 fatalError("formatter failed to parse \(sourceString)")
             } {{#models}}{{#model}}

--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -121,7 +121,7 @@ class Decoders {
                     // treat as a java date
                     return NSDate(timeIntervalSince1970: Double(sourceInt / 1000) )
                 }
-                fatalError("formatter failed to parse \(sourceString)")
+                fatalError("formatter failed to parse \(source)")
             } {{#models}}{{#model}}
 
 			// Decoder for [{{{classname}}}]


### PR DESCRIPTION
Hey guys,

I was having some trouble with generating an API for my jersey based java project (dropbox).  All of my dates generated for my responses were in java date format.  I added support for this format as a fallback when parsing dates. if you like it, take it :)