### PR TITLE
Add option to omit getters/setters on models

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -44,6 +44,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     private static final String PROJECT_VERSION = "projectVersion";
     private static final String PROJECT_LICENSE_NAME = "projectLicenseName";
     private static final String USE_PROMISES = "usePromises";
+    private static final String OMIT_MODEL_METHODS = "omitModelMethods";
 
     protected String projectName;
     protected String moduleName;
@@ -53,6 +54,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     protected String sourceFolder = "src";
     protected String localVariablePrefix = "";
     protected boolean usePromises = false;
+    protected boolean omitModelMethods = false;
     
     public JavascriptClientCodegen() {
         super();
@@ -104,6 +106,9 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
                 "name of the license the project uses (Default: using info.license.name)"));
         cliOptions.add(new CliOption(USE_PROMISES,
                 "use Promises as return values from the client API, instead of superagent callbacks")
+                .defaultValue(Boolean.FALSE.toString()));
+        cliOptions.add(new CliOption(OMIT_MODEL_METHODS,
+                "omits generation of getters and setters for model classes")
                 .defaultValue(Boolean.FALSE.toString()));
     }
 
@@ -174,7 +179,10 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         if (additionalProperties.containsKey(USE_PROMISES)) {
             usePromises = Boolean.parseBoolean((String)additionalProperties.get(USE_PROMISES));
         }
-        
+        if (additionalProperties.containsKey(OMIT_MODEL_METHODS)) {
+            omitModelMethods =  Boolean.parseBoolean((String)additionalProperties.get(OMIT_MODEL_METHODS));
+        }
+
         if (swagger.getInfo() != null) {
             Info info = swagger.getInfo();
             if (StringUtils.isBlank(projectName) && info.getTitle() != null) {
@@ -218,6 +226,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         additionalProperties.put(CodegenConstants.LOCAL_VARIABLE_PREFIX, localVariablePrefix);
         additionalProperties.put(CodegenConstants.SOURCE_FOLDER, sourceFolder);
         additionalProperties.put(USE_PROMISES, usePromises);
+        additionalProperties.put(OMIT_MODEL_METHODS, omitModelMethods);
 
         supportingFiles.add(new SupportingFile("package.mustache", "", "package.json"));
         supportingFiles.add(new SupportingFile("index.mustache", sourceFolder, "index.js"));

--- a/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
@@ -45,6 +45,7 @@
     return this;
   }
 
+  {{^omitModelMethods}}
   {{#vars}}
   /**{{#description}}
    * get {{{description}}}{{/description}}{{#minimum}}
@@ -64,6 +65,7 @@
     this['{{baseName}}'] = {{name}};
   }
   {{/vars}}
+  {{/omitModelMethods}}
 
   {{classname}}.prototype.toJson = function() {
     return JSON.stringify(this);


### PR DESCRIPTION
Adds an option to the JS client generator, `omitModelMethods`, which causes it to not generate getters and setters for the model classes.

These methods are often not needed or desired, especially when the returned objects are to be further processed and turned into other structures anyway (e.g. [Immutable.js](https://facebook.github.io/immutable-js/) records).