### PR TITLE
[Swift] fix issue 1994: make sure we don't crash if rawValue returns nil when…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -126,7 +126,7 @@ class Decoders {
             Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject) -> {{{classname}}} in
                 let sourceDictionary = source as! [NSObject:AnyObject]
                 let instance = {{classname}}(){{#vars}}{{#isEnum}}
-                instance.{{name}} = (sourceDictionary["{{name}}"] as? String).map { {{classname}}.{{datatypeWithEnum}}(rawValue: $0)! }{{#unwrapRequired}}{{#required}}!{{/required}}{{/unwrapRequired}} {{/isEnum}}{{^isEnum}}
+                instance.{{name}} = {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{name}}"] as? String) ?? ""){{#unwrapRequired}}{{#required}}!{{/required}}{{/unwrapRequired}} {{/isEnum}}{{^isEnum}}
                 instance.{{name}} = Decoders.decode{{^unwrapRequired}}Optional{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}Optional{{/required}}{{/unwrapRequired}}(clazz: {{{baseType}}}.self, source: sourceDictionary["{{name}}"]{{#unwrapRequired}}{{#required}}!{{/required}}{{/unwrapRequired}}){{/isEnum}}{{/vars}}
                 return instance
             }{{/model}}

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -373,5 +373,6 @@ extension PetstoreClientAPI {
 
             return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: false)
         }
+    
     }
 }

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -374,5 +374,59 @@ extension PetstoreClientAPI {
             return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: false)
         }
     
+        /**
+         
+         Fake endpoint to test byte array return by 'Find pet by ID'
+         
+         - GET /pet/{petId}?testing_byte_array=true
+         - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
+         - API Key:
+           - type: apiKey api_key 
+           - name: api_key
+         - examples: [{contentType=application/json, example=""}, {contentType=application/xml, example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e}]
+         - examples: [{contentType=application/json, example=""}, {contentType=application/xml, example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e}]
+         
+         - parameter petId: (path) ID of pet that needs to be fetched
+
+         - returns: RequestBuilder<Binary> 
+         */
+        public class func getPetByIdWithByteArray(petId petId: Int) -> RequestBuilder<Binary> {
+            var path = "/pet/{petId}?testing_byte_array=true"
+            path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
+            let URLString = PetstoreClientAPI.basePath + path
+            
+            let nillableParameters: [String:AnyObject?] = [:]
+            let parameters = APIHelper.rejectNil(nillableParameters)
+
+            let requestBuilder: RequestBuilder<Binary>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
+        }
+    
+        /**
+         
+         Fake endpoint to test byte array in body parameter for adding a new pet to the store
+         
+         - POST /pet?testing_byte_array=true
+         - 
+         - OAuth:
+           - type: oauth2
+           - name: petstore_auth
+         
+         - parameter body: (body) Pet object in the form of byte array
+
+         - returns: RequestBuilder<Void> 
+         */
+        public class func addPetUsingByteArray(body body: Binary?) -> RequestBuilder<Void> {
+            let path = "/pet?testing_byte_array=true"
+            let URLString = PetstoreClientAPI.basePath + path
+            
+            let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
+        }
+    
     }
 }

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -373,60 +373,6 @@ extension PetstoreClientAPI {
 
             return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: false)
         }
-    
-        /**
-         
-         Fake endpoint to test byte array return by 'Find pet by ID'
-         
-         - GET /pet/{petId}?testing_byte_array=true
-         - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-         - API Key:
-           - type: apiKey api_key 
-           - name: api_key
-         - examples: [{contentType=application/json, example=""}, {contentType=application/xml, example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e}]
-         - examples: [{contentType=application/json, example=""}, {contentType=application/xml, example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e}]
-         
-         - parameter petId: (path) ID of pet that needs to be fetched
-
-         - returns: RequestBuilder<Binary> 
-         */
-        public class func getPetByIdWithByteArray(petId petId: Int) -> RequestBuilder<Binary> {
-            var path = "/pet/{petId}?testing_byte_array=true"
-            path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<Binary>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Fake endpoint to test byte array in body parameter for adding a new pet to the store
-         
-         - POST /pet?testing_byte_array=true
-         - 
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         
-         - parameter body: (body) Pet object in the form of byte array
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func addPetUsingByteArray(body body: Binary?) -> RequestBuilder<Void> {
-            let path = "/pet?testing_byte_array=true"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
+        
     }
 }

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -373,6 +373,5 @@ extension PetstoreClientAPI {
 
             return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: false)
         }
-        
     }
 }

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -52,14 +52,14 @@ extension PetstoreClientAPI {
   "petId" : 123456789,
   "quantity" : 123,
   "id" : 123456789,
-  "shipDate" : "2016-02-07T13:55:23.709+0000",
+  "shipDate" : "2016-02-09T17:19:56.091+0000",
   "complete" : true,
   "status" : "aeiou"
 }}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2016-02-07T05:55:23.712Z</shipDate>
+  <shipDate>2016-02-09T09:19:56.093Z</shipDate>
   <status>string</status>
   <complete>true</complete>
 </Order>}]
@@ -67,14 +67,14 @@ extension PetstoreClientAPI {
   "petId" : 123456789,
   "quantity" : 123,
   "id" : 123456789,
-  "shipDate" : "2016-02-07T13:55:23.709+0000",
+  "shipDate" : "2016-02-09T17:19:56.091+0000",
   "complete" : true,
   "status" : "aeiou"
 }}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2016-02-07T05:55:23.712Z</shipDate>
+  <shipDate>2016-02-09T09:19:56.093Z</shipDate>
   <status>string</status>
   <complete>true</complete>
 </Order>}]
@@ -104,14 +104,14 @@ extension PetstoreClientAPI {
   "petId" : 123456789,
   "quantity" : 123,
   "id" : 123456789,
-  "shipDate" : "2016-02-07T13:55:23.713+0000",
+  "shipDate" : "2016-02-09T17:19:56.094+0000",
   "complete" : true,
   "status" : "aeiou"
 }}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2016-02-07T05:55:23.713Z</shipDate>
+  <shipDate>2016-02-09T09:19:56.094Z</shipDate>
   <status>string</status>
   <complete>true</complete>
 </Order>}]
@@ -119,14 +119,14 @@ extension PetstoreClientAPI {
   "petId" : 123456789,
   "quantity" : 123,
   "id" : 123456789,
-  "shipDate" : "2016-02-07T13:55:23.713+0000",
+  "shipDate" : "2016-02-09T17:19:56.094+0000",
   "complete" : true,
   "status" : "aeiou"
 }}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2016-02-07T05:55:23.713Z</shipDate>
+  <shipDate>2016-02-09T09:19:56.094Z</shipDate>
   <status>string</status>
   <complete>true</complete>
 </Order>}]

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -165,7 +165,7 @@ class Decoders {
                 instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"])
                 instance.photoUrls = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["photoUrls"])
                 instance.tags = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["tags"])
-                instance.status = (sourceDictionary["status"] as? String).map { Pet.Status(rawValue: $0)! } 
+                instance.status = Pet.Status(rawValue: (sourceDictionary["status"] as? String) ?? "") 
                 return instance
             }
 			
@@ -196,7 +196,7 @@ class Decoders {
                 instance.petId = Decoders.decodeOptional(clazz: Int.self, source: sourceDictionary["petId"])
                 instance.quantity = Decoders.decodeOptional(clazz: Int.self, source: sourceDictionary["quantity"])
                 instance.shipDate = Decoders.decodeOptional(clazz: NSDate.self, source: sourceDictionary["shipDate"])
-                instance.status = (sourceDictionary["status"] as? String).map { Order.Status(rawValue: $0)! } 
+                instance.status = Order.Status(rawValue: (sourceDictionary["status"] as? String) ?? "") 
                 instance.complete = Decoders.decodeOptional(clazz: Bool.self, source: sourceDictionary["complete"])
                 return instance
             }


### PR DESCRIPTION
… trying to create an enumeration - instead return nil which allows the instance variable to be nil in this case (it will still try to unwrap the optional though if you declare the enumeration as a required property)

note: there aren't really any tests I can add to validate this since the service is always returning valid enumerations.  but I did update the sample code.
