### PR TITLE
Fix handling of missing optional params

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
@@ -40,7 +40,9 @@
       return this;
     }
     {{#vars}}
-    this['{{baseName}}']{{{defaultValueWithParam}}}
+    if (data['{{baseName}}']) {
+      this['{{baseName}}']{{{defaultValueWithParam}}}
+    }
     {{/vars}}
     return this;
   }

--- a/samples/client/petstore/javascript-promise/src/model/Category.js
+++ b/samples/client/petstore/javascript-promise/src/model/Category.js
@@ -38,9 +38,13 @@
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['name'] = ApiClient.convertToType(data['name'], 'String');
+    if (data['name']) {
+      this['name'] = ApiClient.convertToType(data['name'], 'String');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript-promise/src/model/Order.js
+++ b/samples/client/petstore/javascript-promise/src/model/Order.js
@@ -87,17 +87,29 @@ var StatusEnum = function StatusEnum() {
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['petId'] = ApiClient.convertToType(data['petId'], 'Integer');
+    if (data['petId']) {
+      this['petId'] = ApiClient.convertToType(data['petId'], 'Integer');
+    }
     
-    this['quantity'] = ApiClient.convertToType(data['quantity'], 'Integer');
+    if (data['quantity']) {
+      this['quantity'] = ApiClient.convertToType(data['quantity'], 'Integer');
+    }
     
-    this['shipDate'] = ApiClient.convertToType(data['shipDate'], 'Date');
+    if (data['shipDate']) {
+      this['shipDate'] = ApiClient.convertToType(data['shipDate'], 'Date');
+    }
     
-    this['status'] = ApiClient.convertToType(data['status'], 'String');
+    if (data['status']) {
+      this['status'] = ApiClient.convertToType(data['status'], 'String');
+    }
     
-    this['complete'] = ApiClient.convertToType(data['complete'], 'Boolean');
+    if (data['complete']) {
+      this['complete'] = ApiClient.convertToType(data['complete'], 'Boolean');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript-promise/src/model/Pet.js
+++ b/samples/client/petstore/javascript-promise/src/model/Pet.js
@@ -89,17 +89,29 @@ var StatusEnum = function StatusEnum() {
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['category'].constructFromObject(data['category']);
+    if (data['category']) {
+      this['category'].constructFromObject(data['category']);
+    }
     
-    this['name'] = ApiClient.convertToType(data['name'], 'String');
+    if (data['name']) {
+      this['name'] = ApiClient.convertToType(data['name'], 'String');
+    }
     
-    this['photoUrls'] = ApiClient.convertToType(data['photoUrls'], ['String']);
+    if (data['photoUrls']) {
+      this['photoUrls'] = ApiClient.convertToType(data['photoUrls'], ['String']);
+    }
     
-    this['tags'] = ApiClient.convertToType(data['tags'], [Tag]);
+    if (data['tags']) {
+      this['tags'] = ApiClient.convertToType(data['tags'], [Tag]);
+    }
     
-    this['status'] = ApiClient.convertToType(data['status'], 'String');
+    if (data['status']) {
+      this['status'] = ApiClient.convertToType(data['status'], 'String');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript-promise/src/model/Tag.js
+++ b/samples/client/petstore/javascript-promise/src/model/Tag.js
@@ -38,9 +38,13 @@
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['name'] = ApiClient.convertToType(data['name'], 'String');
+    if (data['name']) {
+      this['name'] = ApiClient.convertToType(data['name'], 'String');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript-promise/src/model/User.js
+++ b/samples/client/petstore/javascript-promise/src/model/User.js
@@ -69,21 +69,37 @@
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['username'] = ApiClient.convertToType(data['username'], 'String');
+    if (data['username']) {
+      this['username'] = ApiClient.convertToType(data['username'], 'String');
+    }
     
-    this['firstName'] = ApiClient.convertToType(data['firstName'], 'String');
+    if (data['firstName']) {
+      this['firstName'] = ApiClient.convertToType(data['firstName'], 'String');
+    }
     
-    this['lastName'] = ApiClient.convertToType(data['lastName'], 'String');
+    if (data['lastName']) {
+      this['lastName'] = ApiClient.convertToType(data['lastName'], 'String');
+    }
     
-    this['email'] = ApiClient.convertToType(data['email'], 'String');
+    if (data['email']) {
+      this['email'] = ApiClient.convertToType(data['email'], 'String');
+    }
     
-    this['password'] = ApiClient.convertToType(data['password'], 'String');
+    if (data['password']) {
+      this['password'] = ApiClient.convertToType(data['password'], 'String');
+    }
     
-    this['phone'] = ApiClient.convertToType(data['phone'], 'String');
+    if (data['phone']) {
+      this['phone'] = ApiClient.convertToType(data['phone'], 'String');
+    }
     
-    this['userStatus'] = ApiClient.convertToType(data['userStatus'], 'Integer');
+    if (data['userStatus']) {
+      this['userStatus'] = ApiClient.convertToType(data['userStatus'], 'Integer');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript/src/model/Category.js
+++ b/samples/client/petstore/javascript/src/model/Category.js
@@ -38,9 +38,13 @@
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['name'] = ApiClient.convertToType(data['name'], 'String');
+    if (data['name']) {
+      this['name'] = ApiClient.convertToType(data['name'], 'String');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript/src/model/Order.js
+++ b/samples/client/petstore/javascript/src/model/Order.js
@@ -87,17 +87,29 @@ var StatusEnum = function StatusEnum() {
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['petId'] = ApiClient.convertToType(data['petId'], 'Integer');
+    if (data['petId']) {
+      this['petId'] = ApiClient.convertToType(data['petId'], 'Integer');
+    }
     
-    this['quantity'] = ApiClient.convertToType(data['quantity'], 'Integer');
+    if (data['quantity']) {
+      this['quantity'] = ApiClient.convertToType(data['quantity'], 'Integer');
+    }
     
-    this['shipDate'] = ApiClient.convertToType(data['shipDate'], 'Date');
+    if (data['shipDate']) {
+      this['shipDate'] = ApiClient.convertToType(data['shipDate'], 'Date');
+    }
     
-    this['status'] = ApiClient.convertToType(data['status'], 'String');
+    if (data['status']) {
+      this['status'] = ApiClient.convertToType(data['status'], 'String');
+    }
     
-    this['complete'] = ApiClient.convertToType(data['complete'], 'Boolean');
+    if (data['complete']) {
+      this['complete'] = ApiClient.convertToType(data['complete'], 'Boolean');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript/src/model/Pet.js
+++ b/samples/client/petstore/javascript/src/model/Pet.js
@@ -89,17 +89,29 @@ var StatusEnum = function StatusEnum() {
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['category'].constructFromObject(data['category']);
+    if (data['category']) {
+      this['category'].constructFromObject(data['category']);
+    }
     
-    this['name'] = ApiClient.convertToType(data['name'], 'String');
+    if (data['name']) {
+      this['name'] = ApiClient.convertToType(data['name'], 'String');
+    }
     
-    this['photoUrls'] = ApiClient.convertToType(data['photoUrls'], ['String']);
+    if (data['photoUrls']) {
+      this['photoUrls'] = ApiClient.convertToType(data['photoUrls'], ['String']);
+    }
     
-    this['tags'] = ApiClient.convertToType(data['tags'], [Tag]);
+    if (data['tags']) {
+      this['tags'] = ApiClient.convertToType(data['tags'], [Tag]);
+    }
     
-    this['status'] = ApiClient.convertToType(data['status'], 'String');
+    if (data['status']) {
+      this['status'] = ApiClient.convertToType(data['status'], 'String');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript/src/model/Tag.js
+++ b/samples/client/petstore/javascript/src/model/Tag.js
@@ -38,9 +38,13 @@
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['name'] = ApiClient.convertToType(data['name'], 'String');
+    if (data['name']) {
+      this['name'] = ApiClient.convertToType(data['name'], 'String');
+    }
     
     return this;
   }

--- a/samples/client/petstore/javascript/src/model/User.js
+++ b/samples/client/petstore/javascript/src/model/User.js
@@ -69,21 +69,37 @@
       return this;
     }
     
-    this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    if (data['id']) {
+      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+    }
     
-    this['username'] = ApiClient.convertToType(data['username'], 'String');
+    if (data['username']) {
+      this['username'] = ApiClient.convertToType(data['username'], 'String');
+    }
     
-    this['firstName'] = ApiClient.convertToType(data['firstName'], 'String');
+    if (data['firstName']) {
+      this['firstName'] = ApiClient.convertToType(data['firstName'], 'String');
+    }
     
-    this['lastName'] = ApiClient.convertToType(data['lastName'], 'String');
+    if (data['lastName']) {
+      this['lastName'] = ApiClient.convertToType(data['lastName'], 'String');
+    }
     
-    this['email'] = ApiClient.convertToType(data['email'], 'String');
+    if (data['email']) {
+      this['email'] = ApiClient.convertToType(data['email'], 'String');
+    }
     
-    this['password'] = ApiClient.convertToType(data['password'], 'String');
+    if (data['password']) {
+      this['password'] = ApiClient.convertToType(data['password'], 'String');
+    }
     
-    this['phone'] = ApiClient.convertToType(data['phone'], 'String');
+    if (data['phone']) {
+      this['phone'] = ApiClient.convertToType(data['phone'], 'String');
+    }
     
-    this['userStatus'] = ApiClient.convertToType(data['userStatus'], 'Integer');
+    if (data['userStatus']) {
+      this['userStatus'] = ApiClient.convertToType(data['userStatus'], 'Integer');
+    }
     
     return this;
   }


### PR DESCRIPTION
Fixes #2103 

In the `constructFromObject` methods, we were always setting all the
parameters, including optional ones that were missing in the `data`
object. Because of the `convertToType` calls, this had the effect
of producing the *strings* `"undefined"` or `"null"` as property
values on the constructed object! This obviously leads to difficult
bugs.

This commit makes sure that we first check that the data field
exists in the data object. Note that both `null` and `undefined`
values will be skipped.