### PR TITLE
[Swift] fix issue 1994: make sure we don't crash if rawValue returns …

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/Models.mustache
@@ -126,7 +126,7 @@ class Decoders {
             Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject) -> {{{classname}}} in
                 let sourceDictionary = source as! [NSObject:AnyObject]
                 let instance = {{classname}}(){{#vars}}{{#isEnum}}
-                instance.{{name}} = (sourceDictionary["{{name}}"] as? String).map { {{classname}}.{{datatypeWithEnum}}(rawValue: $0)! }{{#unwrapRequired}}{{#required}}!{{/required}}{{/unwrapRequired}} {{/isEnum}}{{^isEnum}}
+                instance.{{name}} = {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{name}}"] as? String) ?? ""){{#unwrapRequired}}{{#required}}!{{/required}}{{/unwrapRequired}} {{/isEnum}}{{^isEnum}}
                 instance.{{name}} = Decoders.decode{{^unwrapRequired}}Optional{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}Optional{{/required}}{{/unwrapRequired}}(clazz: {{{baseType}}}.self, source: sourceDictionary["{{name}}"]{{#unwrapRequired}}{{#required}}!{{/required}}{{/unwrapRequired}}){{/isEnum}}{{/vars}}
                 return instance
             }{{/model}}

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -165,7 +165,7 @@ class Decoders {
                 instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"])
                 instance.photoUrls = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["photoUrls"])
                 instance.tags = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["tags"])
-                instance.status = (sourceDictionary["status"] as? String).map { Pet.Status(rawValue: $0)! } 
+                instance.status = Pet.Status(rawValue: (sourceDictionary["status"] as? String) ?? "") 
                 return instance
             }
 			
@@ -196,7 +196,7 @@ class Decoders {
                 instance.petId = Decoders.decodeOptional(clazz: Int.self, source: sourceDictionary["petId"])
                 instance.quantity = Decoders.decodeOptional(clazz: Int.self, source: sourceDictionary["quantity"])
                 instance.shipDate = Decoders.decodeOptional(clazz: NSDate.self, source: sourceDictionary["shipDate"])
-                instance.status = (sourceDictionary["status"] as? String).map { Order.Status(rawValue: $0)! } 
+                instance.status = Order.Status(rawValue: (sourceDictionary["status"] as? String) ?? "") 
                 instance.complete = Decoders.decodeOptional(clazz: Bool.self, source: sourceDictionary["complete"])
                 return instance
             }


### PR DESCRIPTION
…nil when trying to create an enumeration - instead return nil which allows the instance variable to be nil in this case (it will still try to unwrap the optional though if you declare the enumeration as a required property)

note: there aren't really any tests I can add to validate this since the service is always returning valid enumerations. but I did update the sample code.