### PR TITLE
ruby: Fix boolean convertion on json to model attribute.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
@@ -31,7 +31,7 @@
       when :Float
         value.to_f
       when :BOOLEAN
-        if value =~ /^(true|t|yes|y|1)$/i
+        if value.to_s =~ /^(true|t|yes|y|1)$/i
           true
         else
           false

--- a/samples/client/petstore/ruby/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/category.rb
@@ -110,7 +110,7 @@ module Petstore
       when :Float
         value.to_f
       when :BOOLEAN
-        if value =~ /^(true|t|yes|y|1)$/i
+        if value.to_s =~ /^(true|t|yes|y|1)$/i
           true
         else
           false

--- a/samples/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/order.rb
@@ -160,7 +160,7 @@ module Petstore
       when :Float
         value.to_f
       when :BOOLEAN
-        if value =~ /^(true|t|yes|y|1)$/i
+        if value.to_s =~ /^(true|t|yes|y|1)$/i
           true
         else
           false

--- a/samples/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -164,7 +164,7 @@ module Petstore
       when :Float
         value.to_f
       when :BOOLEAN
-        if value =~ /^(true|t|yes|y|1)$/i
+        if value.to_s =~ /^(true|t|yes|y|1)$/i
           true
         else
           false

--- a/samples/client/petstore/ruby/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/tag.rb
@@ -110,7 +110,7 @@ module Petstore
       when :Float
         value.to_f
       when :BOOLEAN
-        if value =~ /^(true|t|yes|y|1)$/i
+        if value.to_s =~ /^(true|t|yes|y|1)$/i
           true
         else
           false

--- a/samples/client/petstore/ruby/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/user.rb
@@ -171,7 +171,7 @@ module Petstore
       when :Float
         value.to_f
       when :BOOLEAN
-        if value =~ /^(true|t|yes|y|1)$/i
+        if value.to_s =~ /^(true|t|yes|y|1)$/i
           true
         else
           false

--- a/samples/client/petstore/ruby/spec/base_object_spec.rb
+++ b/samples/client/petstore/ruby/spec/base_object_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 class ArrayMapObject < Petstore::Category
-  attr_accessor :int_arr, :pet_arr, :int_map, :pet_map, :int_arr_map, :pet_arr_map
+  attr_accessor :int_arr, :pet_arr, :int_map, :pet_map, :int_arr_map, :pet_arr_map, :boolean_true_arr, :boolean_false_arr
 
   def self.attribute_map
     {
@@ -10,7 +10,9 @@ class ArrayMapObject < Petstore::Category
       :int_map => :int_map,
       :pet_map => :pet_map,
       :int_arr_map => :int_arr_map,
-      :pet_arr_map => :pet_arr_map
+      :pet_arr_map => :pet_arr_map,
+      :boolean_true_arr  => :boolean_true_arr,
+      :boolean_false_arr => :boolean_false_arr,
     }
   end
 
@@ -21,7 +23,9 @@ class ArrayMapObject < Petstore::Category
       :int_map => :'Hash<String, Integer>',
       :pet_map => :'Hash<String, Pet>',
       :int_arr_map => :'Hash<String, Array<Integer>>',
-      :pet_arr_map => :'Hash<String, Array<Pet>>'
+      :pet_arr_map => :'Hash<String, Array<Pet>>',
+      :boolean_true_arr  => :'Array<BOOLEAN>',
+      :boolean_false_arr => :'Array<BOOLEAN>',
     }
   end
 end
@@ -37,7 +41,9 @@ describe 'BaseObject' do
        int_map: {'int' => 123},
        pet_map: {'pet' => {name: 'Kitty'}},
        int_arr_map: {'int_arr' => [123, 456]},
-       pet_arr_map: {'pet_arr' => [{name: 'Kitty'}]}
+       pet_arr_map: {'pet_arr' => [{name: 'Kitty'}]},
+       boolean_true_arr:  [true, "true", "TruE", 1, "y", "yes", "1", "t", "T"],
+       boolean_false_arr: [false, "", 0, "0", "f", nil, "null"],
       }
     end
 
@@ -71,11 +77,24 @@ describe 'BaseObject' do
       pet = arr.first
       pet.should be_a(Petstore::Pet)
       pet.name.should == 'Kitty'
+
+      obj.boolean_true_arr.should be_a(Array)
+      obj.boolean_true_arr.each do |b|
+        b.should eq true
+      end
+
+      obj.boolean_false_arr.should be_a(Array)
+      obj.boolean_false_arr.each do |b|
+        b.should eq false
+      end
     end
 
     it 'works for #to_hash' do
       obj.build_from_hash(data)
-      obj.to_hash.should == data
+      expect_data = data.dup
+      expect_data[:boolean_true_arr].map! {true}
+      expect_data[:boolean_false_arr].map! {false}
+      obj.to_hash.should == expect_data
     end
   end
 end


### PR DESCRIPTION
Current code will converts boolean true of json to false
because ruby's boolean is not matched with any regex.

Here is single line patch to convert string explicitly before regex check.

```
sugi@tempest:~% irb
irb(main):001:0> true =~ /true/
nil
irb(main):002:0> "true" =~ /true/
0
irb(main):003:0> 
sugi@tempest:~% ruby1.8 -e 'p true =~ /true/'
false
sugi@tempest:~% ruby1.9.1 -e 'p true =~ /true/' 
nil
sugi@tempest:~% ruby1.9.3 -e 'p true =~ /true/'
nil
sugi@tempest:~% ruby2.0 -e 'p true =~ /true/'
nil
sugi@tempest:~% ruby2.1 -e 'p true =~ /true/' 
nil
sugi@tempest:~% ruby2.2 -e 'p true =~ /true/' 
nil
```