### PR TITLE
Fixes typo template folder for javascript in bin-promise-script

### DIFF
--- a/bin/javascript-promise-petstore.sh
+++ b/bin/javascript-promise-petstore.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/javascript \
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript \
 -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l javascript \
 -o samples/client/petstore/javascript-promise \
 --additional-properties usePromises=true"


### PR DESCRIPTION
the folder name for the template starts with a capital letter.