### PR TITLE
Fixes typo in template folder for javascript in bin-script

### DIFF
--- a/bin/javascript-petstore.sh
+++ b/bin/javascript-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/javascript -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l javascript -o samples/client/petstore/javascript"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l javascript -o samples/client/petstore/javascript"
 
 java -DappName=PetstoreClient $JAVA_OPTS -jar $executable $ags


### PR DESCRIPTION
The template folder for javascript starts wit a capital letter. Shell script will fail on linux because of java.io.FileNotFoundException for the module.mustache