### PR TITLE
Use static model factory methods

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -339,10 +339,10 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
 
     @Override
     public String toDefaultValueWithParam(String name, Property p) {
+        String type = normalizeType(getTypeDeclaration(p));
         if (p instanceof RefProperty) {
-            return ".constructFromObject(data['" + name + "']);";
+            return " = " + type + ".constructFromObject(data['" + name + "']);";
         } else {
-          String type = normalizeType(getTypeDeclaration(p));
           return " = ApiClient.convertToType(data['" + name + "'], " + type + ");";
         }
     }

--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -262,8 +262,7 @@
       default:
         if (typeof type === 'function') {
           // for model type like: User
-          var model = new type();
-          model.constructFromObject(data);
+          var model = type.constructFromObject(data);
           return model;
         } else if (Array.isArray(type)) {
           // for array type like: ['String']

--- a/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
@@ -35,16 +35,17 @@
     {{/vars}}
   };
 
-  {{classname}}.prototype.constructFromObject = function(data) {
+  {{classname}}.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new {{classname}}();
     {{#vars}}
     if (data['{{baseName}}']) {
-      this['{{baseName}}']{{{defaultValueWithParam}}}
+      _this['{{baseName}}']{{{defaultValueWithParam}}}
     }
     {{/vars}}
-    return this;
+    return _this;
   }
 
   {{^omitModelMethods}}

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -250,8 +250,7 @@
       default:
         if (typeof type === 'function') {
           // for model type like: User
-          var model = new type();
-          model.constructFromObject(data);
+          var model = type.constructFromObject(data);
           return model;
         } else if (Array.isArray(type)) {
           // for array type like: ['String']

--- a/samples/client/petstore/javascript-promise/src/model/Category.js
+++ b/samples/client/petstore/javascript-promise/src/model/Category.js
@@ -33,22 +33,24 @@
     
   };
 
-  Category.prototype.constructFromObject = function(data) {
+  Category.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new Category();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['name']) {
-      this['name'] = ApiClient.convertToType(data['name'], 'String');
+      _this['name'] = ApiClient.convertToType(data['name'], 'String');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -77,6 +79,7 @@
   Category.prototype.setName = function(name) {
     this['name'] = name;
   }
+  
   
 
   Category.prototype.toJson = function() {

--- a/samples/client/petstore/javascript-promise/src/model/Order.js
+++ b/samples/client/petstore/javascript-promise/src/model/Order.js
@@ -82,38 +82,40 @@ var StatusEnum = function StatusEnum() {
     
   };
 
-  Order.prototype.constructFromObject = function(data) {
+  Order.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new Order();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['petId']) {
-      this['petId'] = ApiClient.convertToType(data['petId'], 'Integer');
+      _this['petId'] = ApiClient.convertToType(data['petId'], 'Integer');
     }
     
     if (data['quantity']) {
-      this['quantity'] = ApiClient.convertToType(data['quantity'], 'Integer');
+      _this['quantity'] = ApiClient.convertToType(data['quantity'], 'Integer');
     }
     
     if (data['shipDate']) {
-      this['shipDate'] = ApiClient.convertToType(data['shipDate'], 'Date');
+      _this['shipDate'] = ApiClient.convertToType(data['shipDate'], 'Date');
     }
     
     if (data['status']) {
-      this['status'] = ApiClient.convertToType(data['status'], 'String');
+      _this['status'] = ApiClient.convertToType(data['status'], 'String');
     }
     
     if (data['complete']) {
-      this['complete'] = ApiClient.convertToType(data['complete'], 'Boolean');
+      _this['complete'] = ApiClient.convertToType(data['complete'], 'Boolean');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -200,6 +202,7 @@ var StatusEnum = function StatusEnum() {
   Order.prototype.setComplete = function(complete) {
     this['complete'] = complete;
   }
+  
   
 
   Order.prototype.toJson = function() {

--- a/samples/client/petstore/javascript-promise/src/model/Pet.js
+++ b/samples/client/petstore/javascript-promise/src/model/Pet.js
@@ -84,38 +84,40 @@ var StatusEnum = function StatusEnum() {
     
   };
 
-  Pet.prototype.constructFromObject = function(data) {
+  Pet.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new Pet();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['category']) {
-      this['category'].constructFromObject(data['category']);
+      _this['category'] = Category.constructFromObject(data['category']);
     }
     
     if (data['name']) {
-      this['name'] = ApiClient.convertToType(data['name'], 'String');
+      _this['name'] = ApiClient.convertToType(data['name'], 'String');
     }
     
     if (data['photoUrls']) {
-      this['photoUrls'] = ApiClient.convertToType(data['photoUrls'], ['String']);
+      _this['photoUrls'] = ApiClient.convertToType(data['photoUrls'], ['String']);
     }
     
     if (data['tags']) {
-      this['tags'] = ApiClient.convertToType(data['tags'], [Tag]);
+      _this['tags'] = ApiClient.convertToType(data['tags'], [Tag]);
     }
     
     if (data['status']) {
-      this['status'] = ApiClient.convertToType(data['status'], 'String');
+      _this['status'] = ApiClient.convertToType(data['status'], 'String');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -202,6 +204,7 @@ var StatusEnum = function StatusEnum() {
   Pet.prototype.setStatus = function(status) {
     this['status'] = status;
   }
+  
   
 
   Pet.prototype.toJson = function() {

--- a/samples/client/petstore/javascript-promise/src/model/Tag.js
+++ b/samples/client/petstore/javascript-promise/src/model/Tag.js
@@ -33,22 +33,24 @@
     
   };
 
-  Tag.prototype.constructFromObject = function(data) {
+  Tag.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new Tag();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['name']) {
-      this['name'] = ApiClient.convertToType(data['name'], 'String');
+      _this['name'] = ApiClient.convertToType(data['name'], 'String');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -77,6 +79,7 @@
   Tag.prototype.setName = function(name) {
     this['name'] = name;
   }
+  
   
 
   Tag.prototype.toJson = function() {

--- a/samples/client/petstore/javascript-promise/src/model/User.js
+++ b/samples/client/petstore/javascript-promise/src/model/User.js
@@ -64,46 +64,48 @@
     
   };
 
-  User.prototype.constructFromObject = function(data) {
+  User.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new User();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['username']) {
-      this['username'] = ApiClient.convertToType(data['username'], 'String');
+      _this['username'] = ApiClient.convertToType(data['username'], 'String');
     }
     
     if (data['firstName']) {
-      this['firstName'] = ApiClient.convertToType(data['firstName'], 'String');
+      _this['firstName'] = ApiClient.convertToType(data['firstName'], 'String');
     }
     
     if (data['lastName']) {
-      this['lastName'] = ApiClient.convertToType(data['lastName'], 'String');
+      _this['lastName'] = ApiClient.convertToType(data['lastName'], 'String');
     }
     
     if (data['email']) {
-      this['email'] = ApiClient.convertToType(data['email'], 'String');
+      _this['email'] = ApiClient.convertToType(data['email'], 'String');
     }
     
     if (data['password']) {
-      this['password'] = ApiClient.convertToType(data['password'], 'String');
+      _this['password'] = ApiClient.convertToType(data['password'], 'String');
     }
     
     if (data['phone']) {
-      this['phone'] = ApiClient.convertToType(data['phone'], 'String');
+      _this['phone'] = ApiClient.convertToType(data['phone'], 'String');
     }
     
     if (data['userStatus']) {
-      this['userStatus'] = ApiClient.convertToType(data['userStatus'], 'Integer');
+      _this['userStatus'] = ApiClient.convertToType(data['userStatus'], 'Integer');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -218,6 +220,7 @@
   User.prototype.setUserStatus = function(userStatus) {
     this['userStatus'] = userStatus;
   }
+  
   
 
   User.prototype.toJson = function() {

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -250,8 +250,7 @@
       default:
         if (typeof type === 'function') {
           // for model type like: User
-          var model = new type();
-          model.constructFromObject(data);
+          var model = type.constructFromObject(data);
           return model;
         } else if (Array.isArray(type)) {
           // for array type like: ['String']

--- a/samples/client/petstore/javascript/src/model/Category.js
+++ b/samples/client/petstore/javascript/src/model/Category.js
@@ -33,22 +33,24 @@
     
   };
 
-  Category.prototype.constructFromObject = function(data) {
+  Category.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new Category();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['name']) {
-      this['name'] = ApiClient.convertToType(data['name'], 'String');
+      _this['name'] = ApiClient.convertToType(data['name'], 'String');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -77,6 +79,7 @@
   Category.prototype.setName = function(name) {
     this['name'] = name;
   }
+  
   
 
   Category.prototype.toJson = function() {

--- a/samples/client/petstore/javascript/src/model/Order.js
+++ b/samples/client/petstore/javascript/src/model/Order.js
@@ -82,38 +82,40 @@ var StatusEnum = function StatusEnum() {
     
   };
 
-  Order.prototype.constructFromObject = function(data) {
+  Order.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new Order();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['petId']) {
-      this['petId'] = ApiClient.convertToType(data['petId'], 'Integer');
+      _this['petId'] = ApiClient.convertToType(data['petId'], 'Integer');
     }
     
     if (data['quantity']) {
-      this['quantity'] = ApiClient.convertToType(data['quantity'], 'Integer');
+      _this['quantity'] = ApiClient.convertToType(data['quantity'], 'Integer');
     }
     
     if (data['shipDate']) {
-      this['shipDate'] = ApiClient.convertToType(data['shipDate'], 'Date');
+      _this['shipDate'] = ApiClient.convertToType(data['shipDate'], 'Date');
     }
     
     if (data['status']) {
-      this['status'] = ApiClient.convertToType(data['status'], 'String');
+      _this['status'] = ApiClient.convertToType(data['status'], 'String');
     }
     
     if (data['complete']) {
-      this['complete'] = ApiClient.convertToType(data['complete'], 'Boolean');
+      _this['complete'] = ApiClient.convertToType(data['complete'], 'Boolean');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -200,6 +202,7 @@ var StatusEnum = function StatusEnum() {
   Order.prototype.setComplete = function(complete) {
     this['complete'] = complete;
   }
+  
   
 
   Order.prototype.toJson = function() {

--- a/samples/client/petstore/javascript/src/model/Pet.js
+++ b/samples/client/petstore/javascript/src/model/Pet.js
@@ -84,38 +84,40 @@ var StatusEnum = function StatusEnum() {
     
   };
 
-  Pet.prototype.constructFromObject = function(data) {
+  Pet.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new Pet();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['category']) {
-      this['category'].constructFromObject(data['category']);
+      _this['category'] = Category.constructFromObject(data['category']);
     }
     
     if (data['name']) {
-      this['name'] = ApiClient.convertToType(data['name'], 'String');
+      _this['name'] = ApiClient.convertToType(data['name'], 'String');
     }
     
     if (data['photoUrls']) {
-      this['photoUrls'] = ApiClient.convertToType(data['photoUrls'], ['String']);
+      _this['photoUrls'] = ApiClient.convertToType(data['photoUrls'], ['String']);
     }
     
     if (data['tags']) {
-      this['tags'] = ApiClient.convertToType(data['tags'], [Tag]);
+      _this['tags'] = ApiClient.convertToType(data['tags'], [Tag]);
     }
     
     if (data['status']) {
-      this['status'] = ApiClient.convertToType(data['status'], 'String');
+      _this['status'] = ApiClient.convertToType(data['status'], 'String');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -202,6 +204,7 @@ var StatusEnum = function StatusEnum() {
   Pet.prototype.setStatus = function(status) {
     this['status'] = status;
   }
+  
   
 
   Pet.prototype.toJson = function() {

--- a/samples/client/petstore/javascript/src/model/Tag.js
+++ b/samples/client/petstore/javascript/src/model/Tag.js
@@ -33,22 +33,24 @@
     
   };
 
-  Tag.prototype.constructFromObject = function(data) {
+  Tag.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new Tag();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['name']) {
-      this['name'] = ApiClient.convertToType(data['name'], 'String');
+      _this['name'] = ApiClient.convertToType(data['name'], 'String');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -77,6 +79,7 @@
   Tag.prototype.setName = function(name) {
     this['name'] = name;
   }
+  
   
 
   Tag.prototype.toJson = function() {

--- a/samples/client/petstore/javascript/src/model/User.js
+++ b/samples/client/petstore/javascript/src/model/User.js
@@ -64,46 +64,48 @@
     
   };
 
-  User.prototype.constructFromObject = function(data) {
+  User.constructFromObject = function(data) {
     if (!data) {
-      return this;
+      return null;
     }
+    var _this = new User();
     
     if (data['id']) {
-      this['id'] = ApiClient.convertToType(data['id'], 'Integer');
+      _this['id'] = ApiClient.convertToType(data['id'], 'Integer');
     }
     
     if (data['username']) {
-      this['username'] = ApiClient.convertToType(data['username'], 'String');
+      _this['username'] = ApiClient.convertToType(data['username'], 'String');
     }
     
     if (data['firstName']) {
-      this['firstName'] = ApiClient.convertToType(data['firstName'], 'String');
+      _this['firstName'] = ApiClient.convertToType(data['firstName'], 'String');
     }
     
     if (data['lastName']) {
-      this['lastName'] = ApiClient.convertToType(data['lastName'], 'String');
+      _this['lastName'] = ApiClient.convertToType(data['lastName'], 'String');
     }
     
     if (data['email']) {
-      this['email'] = ApiClient.convertToType(data['email'], 'String');
+      _this['email'] = ApiClient.convertToType(data['email'], 'String');
     }
     
     if (data['password']) {
-      this['password'] = ApiClient.convertToType(data['password'], 'String');
+      _this['password'] = ApiClient.convertToType(data['password'], 'String');
     }
     
     if (data['phone']) {
-      this['phone'] = ApiClient.convertToType(data['phone'], 'String');
+      _this['phone'] = ApiClient.convertToType(data['phone'], 'String');
     }
     
     if (data['userStatus']) {
-      this['userStatus'] = ApiClient.convertToType(data['userStatus'], 'Integer');
+      _this['userStatus'] = ApiClient.convertToType(data['userStatus'], 'Integer');
     }
     
-    return this;
+    return _this;
   }
 
+  
   
   /**
    * @return {Integer}
@@ -218,6 +220,7 @@
   User.prototype.setUserStatus = function(userStatus) {
     this['userStatus'] = userStatus;
   }
+  
   
 
   User.prototype.toJson = function() {


### PR DESCRIPTION
Fixes #2113 

The `constructFromObject` factory methods should be class methods
(or "static" methods), not instance methods.

With this commit, ApiClient no longer calls the model constructors
directly. Instead, it calls the new static factory method to get the
new instance. If there is no data on the top level, null is returned.

It is still possible for users to call the model constructors
directly, of course.