### PR TITLE
build.gradle missing 2 libs (pom.xml has)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/build.gradle.mustache
@@ -108,7 +108,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
+    compile "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:$jackson_version"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:2.1.5"
     compile "joda-time:joda-time:$jodatime_version"
+    compile "com.brsanthu:migbase64:2.2"
     testCompile "junit:junit:$junit_version"
 }


### PR DESCRIPTION
jackson-jaxrs-json-provider & com.brsanthu:migbase64 are missing from the build.gradle mustache template (but the pom.xml one has them)

PS: Why are there no automated tests that detect this?