### PR TITLE
[ObjC] Fix #2121, generated method names don't follow coding convention

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -3,6 +3,7 @@ package io.swagger.codegen.languages;
 import io.swagger.codegen.CliOption;
 import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.DefaultCodegen;
@@ -13,6 +14,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
@@ -454,6 +457,21 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     
     public void setLicense(String license) {
         this.license = license;
+    }
+
+    @Override
+    public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
+        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+        if (operations != null) {
+            List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
+            for (CodegenOperation operation : ops) {
+                if (!operation.allParams.isEmpty()) {
+                    String firstParamName = operation.allParams.get(0).paramName;
+                    operation.vendorExtensions.put("firstParamAltName", camelize(firstParamName));
+                }
+            }
+        }
+        return objs;
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -499,19 +499,19 @@ static void (^reachabilityChangeBlock)(int);
 
 #pragma mark - Perform Request Methods
 
--(NSNumber*)  requestWithCompletionBlock: (NSString*) path
-                                  method: (NSString*) method
-                              pathParams: (NSDictionary *) pathParams
-                             queryParams: (NSDictionary*) queryParams
-                              formParams: (NSDictionary *) formParams
-                                   files: (NSDictionary *) files
-                                    body: (id) body
-                            headerParams: (NSDictionary*) headerParams
-                            authSettings: (NSArray *) authSettings
-                      requestContentType: (NSString*) requestContentType
-                     responseContentType: (NSString*) responseContentType
-                            responseType: (NSString *) responseType
-                         completionBlock: (void (^)(id, NSError *))completionBlock {
+-(NSNumber*) requestWithPath: (NSString*) path
+                      method: (NSString*) method
+                  pathParams: (NSDictionary *) pathParams
+                 queryParams: (NSDictionary*) queryParams
+                  formParams: (NSDictionary *) formParams
+                       files: (NSDictionary *) files
+                        body: (id) body
+                headerParams: (NSDictionary*) headerParams
+                authSettings: (NSArray *) authSettings
+          requestContentType: (NSString*) requestContentType
+         responseContentType: (NSString*) responseContentType
+                responseType: (NSString *) responseType
+             completionBlock: (void (^)(id, NSError *))completionBlock {
     // setting request serializer
     if ([requestContentType isEqualToString:@"application/json"]) {
         self.requestSerializer = [{{classPrefix}}JSONRequestSerializer serializer];

--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
@@ -186,19 +186,19 @@ extern NSString *const {{classPrefix}}ResponseObjectErrorKey;
  *
  * @return The request id.
  */
--(NSNumber*)  requestWithCompletionBlock:(NSString*) path
-                                  method:(NSString*) method
-                              pathParams:(NSDictionary *) pathParams
-                             queryParams:(NSDictionary*) queryParams
-                              formParams:(NSDictionary *) formParams
-                                   files:(NSDictionary *) files
-                                    body:(id) body
-                            headerParams:(NSDictionary*) headerParams
-                            authSettings: (NSArray *) authSettings
-                      requestContentType:(NSString*) requestContentType
-                     responseContentType:(NSString*) responseContentType
-                            responseType:(NSString *) responseType
-                         completionBlock:(void (^)(id, NSError *))completionBlock;
+-(NSNumber*) requestWithPath:(NSString*) path
+                      method:(NSString*) method
+                  pathParams:(NSDictionary *) pathParams
+                 queryParams:(NSDictionary*) queryParams
+                  formParams:(NSDictionary *) formParams
+                       files:(NSDictionary *) files
+                        body:(id) body
+                headerParams:(NSDictionary*) headerParams
+                authSettings:(NSArray *) authSettings
+          requestContentType:(NSString*) requestContentType
+         responseContentType:(NSString*) responseContentType
+                responseType:(NSString *) responseType
+             completionBlock:(void (^)(id, NSError *))completionBlock;
 
 /**
  * Sanitize object for request

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -79,10 +79,9 @@ static {{classname}}* singletonAPI = nil;
 ///
 /// {{/allParams}} @returns {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
 ///
--(NSNumber*) {{nickname}}WithCompletionBlock{{^allParams}}: {{/allParams}}{{#allParams}}{{#secondaryParam}} {{paramName}}{{/secondaryParam}}: ({{{dataType}}}) {{paramName}}
-        {{/allParams}}
-        {{#returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)({{{returnType}}} output, NSError* error))completionBlock { {{/returnBaseType}}
-        {{^returnBaseType}}{{#hasParams}}completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock { {{/returnBaseType}}
+-(NSNumber*) {{#vendorExtensions.x-objc-operationId}}{{vendorExtensions.x-objc-operationId}}{{/vendorExtensions.x-objc-operationId}}{{^vendorExtensions.x-objc-operationId}}{{nickname}}{{#hasParams}}With{{vendorExtensions.firstParamAltName}}{{/hasParams}}{{^hasParams}}WithCompletionHandler: {{/hasParams}}{{/vendorExtensions.x-objc-operationId}}{{#allParams}}{{#secondaryParam}}
+    {{paramName}}{{/secondaryParam}}: ({{{dataType}}}) {{paramName}}{{/allParams}}
+    {{#hasParams}}completionHandler: {{/hasParams}}(void (^)({{#returnBaseType}}{{{returnType}}} output, {{/returnBaseType}}NSError* error)) handler {
 
     {{#allParams}}{{#required}}
     // verify the required parameter '{{paramName}}' is set
@@ -164,22 +163,21 @@ static {{classname}}* singletonAPI = nil;
     }
     {{/requiredParams}}
     {{/requiredParamCount}}
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"{{httpMethod}}"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: {{^returnType}}nil{{/returnType}}{{#returnType}}@"{{{ returnType }}}"{{/returnType}}
-                                      completionBlock: ^(id data, NSError *error) {
-                  {{^returnType}}completionBlock(error);{{/returnType}}
-                  {{#returnType}}completionBlock(({{{ returnType }}})data, error);{{/returnType}}
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"{{httpMethod}}"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: {{^returnType}}nil{{/returnType}}{{#returnType}}@"{{{ returnType }}}"{{/returnType}}
+                           completionBlock: ^(id data, NSError *error) {
+                               handler({{#returnType}}({{{ returnType }}})data, {{/returnType}}error);
+                           }
           ];
 }
 

--- a/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
@@ -31,12 +31,9 @@
 /// {{/allParams}}
 ///
 /// @return {{{returnType}}}
--(NSNumber*) {{nickname}}WithCompletionBlock {{^allParams}}:{{/allParams}}{{#allParams}}{{#secondaryParam}}     {{paramName}}{{/secondaryParam}}:({{{dataType}}}) {{paramName}} {{#hasMore}}
-{{/hasMore}}{{/allParams}}
-    {{#returnBaseType}}{{#hasParams}}
-    completionHandler: {{/hasParams}}(void (^)({{{returnType}}} output, NSError* error))completionBlock;{{/returnBaseType}}
-    {{^returnBaseType}}{{#hasParams}}
-    completionHandler: {{/hasParams}}(void (^)(NSError* error))completionBlock;{{/returnBaseType}}
+-(NSNumber*) {{#vendorExtensions.x-objc-operationId}}{{vendorExtensions.x-objc-operationId}}{{/vendorExtensions.x-objc-operationId}}{{^vendorExtensions.x-objc-operationId}}{{nickname}}{{#hasParams}}With{{vendorExtensions.firstParamAltName}}{{/hasParams}}{{^hasParams}}WithCompletionHandler: {{/hasParams}}{{/vendorExtensions.x-objc-operationId}}{{#allParams}}{{#secondaryParam}}
+    {{paramName}}{{/secondaryParam}}: ({{{dataType}}}) {{paramName}}{{/allParams}}
+    {{#hasParams}}completionHandler: {{/hasParams}}(void (^)({{#returnBaseType}}{{{returnType}}} output, {{/returnBaseType}}NSError* error)) handler;
 
 {{newline}}
 {{/operation}}

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.h
@@ -190,19 +190,19 @@ extern NSString *const SWGResponseObjectErrorKey;
  *
  * @return The request id.
  */
--(NSNumber*)  requestWithCompletionBlock:(NSString*) path
-                                  method:(NSString*) method
-                              pathParams:(NSDictionary *) pathParams
-                             queryParams:(NSDictionary*) queryParams
-                              formParams:(NSDictionary *) formParams
-                                   files:(NSDictionary *) files
-                                    body:(id) body
-                            headerParams:(NSDictionary*) headerParams
-                            authSettings: (NSArray *) authSettings
-                      requestContentType:(NSString*) requestContentType
-                     responseContentType:(NSString*) responseContentType
-                            responseType:(NSString *) responseType
-                         completionBlock:(void (^)(id, NSError *))completionBlock;
+-(NSNumber*) requestWithPath:(NSString*) path
+                      method:(NSString*) method
+                  pathParams:(NSDictionary *) pathParams
+                 queryParams:(NSDictionary*) queryParams
+                  formParams:(NSDictionary *) formParams
+                       files:(NSDictionary *) files
+                        body:(id) body
+                headerParams:(NSDictionary*) headerParams
+                authSettings:(NSArray *) authSettings
+          requestContentType:(NSString*) requestContentType
+         responseContentType:(NSString*) responseContentType
+                responseType:(NSString *) responseType
+             completionBlock:(void (^)(id, NSError *))completionBlock;
 
 /**
  * Sanitize object for request

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
@@ -499,19 +499,19 @@ static void (^reachabilityChangeBlock)(int);
 
 #pragma mark - Perform Request Methods
 
--(NSNumber*)  requestWithCompletionBlock: (NSString*) path
-                                  method: (NSString*) method
-                              pathParams: (NSDictionary *) pathParams
-                             queryParams: (NSDictionary*) queryParams
-                              formParams: (NSDictionary *) formParams
-                                   files: (NSDictionary *) files
-                                    body: (id) body
-                            headerParams: (NSDictionary*) headerParams
-                            authSettings: (NSArray *) authSettings
-                      requestContentType: (NSString*) requestContentType
-                     responseContentType: (NSString*) responseContentType
-                            responseType: (NSString *) responseType
-                         completionBlock: (void (^)(id, NSError *))completionBlock {
+-(NSNumber*) requestWithPath: (NSString*) path
+                      method: (NSString*) method
+                  pathParams: (NSDictionary *) pathParams
+                 queryParams: (NSDictionary*) queryParams
+                  formParams: (NSDictionary *) formParams
+                       files: (NSDictionary *) files
+                        body: (id) body
+                headerParams: (NSDictionary*) headerParams
+                authSettings: (NSArray *) authSettings
+          requestContentType: (NSString*) requestContentType
+         responseContentType: (NSString*) responseContentType
+                responseType: (NSString *) responseType
+             completionBlock: (void (^)(id, NSError *))completionBlock {
     // setting request serializer
     if ([requestContentType isEqualToString:@"application/json"]) {
         self.requestSerializer = [SWGJSONRequestSerializer serializer];

--- a/samples/client/petstore/objc/SwaggerClient/SWGPetApi.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPetApi.h
@@ -28,10 +28,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) updatePetWithCompletionBlock :(SWGPet*) body 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) updatePetWithBody: (SWGPet*) body
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -43,10 +41,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) addPetWithCompletionBlock :(SWGPet*) body 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) addPetWithBody: (SWGPet*) body
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -58,10 +54,8 @@
 /// 
 ///
 /// @return NSArray<SWGPet>*
--(NSNumber*) findPetsByStatusWithCompletionBlock :(NSArray* /* NSString */) status 
-    
-    completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock;
-    
+-(NSNumber*) findPetsByStatusWithStatus: (NSArray* /* NSString */) status
+    completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error)) handler;
 
 
 ///
@@ -73,10 +67,8 @@
 /// 
 ///
 /// @return NSArray<SWGPet>*
--(NSNumber*) findPetsByTagsWithCompletionBlock :(NSArray* /* NSString */) tags 
-    
-    completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock;
-    
+-(NSNumber*) findPetsByTagsWithTags: (NSArray* /* NSString */) tags
+    completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error)) handler;
 
 
 ///
@@ -88,10 +80,8 @@
 /// 
 ///
 /// @return SWGPet*
--(NSNumber*) getPetByIdWithCompletionBlock :(NSNumber*) petId 
-    
-    completionHandler: (void (^)(SWGPet* output, NSError* error))completionBlock;
-    
+-(NSNumber*) getPetByIdWithPetId: (NSNumber*) petId
+    completionHandler: (void (^)(SWGPet* output, NSError* error)) handler;
 
 
 ///
@@ -105,12 +95,10 @@
 /// 
 ///
 /// @return 
--(NSNumber*) updatePetWithFormWithCompletionBlock :(NSString*) petId 
-     name:(NSString*) name 
-     status:(NSString*) status 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) updatePetWithFormWithPetId: (NSString*) petId
+    name: (NSString*) name
+    status: (NSString*) status
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -123,11 +111,9 @@
 /// 
 ///
 /// @return 
--(NSNumber*) deletePetWithCompletionBlock :(NSNumber*) petId 
-     apiKey:(NSString*) apiKey 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) deletePetWithPetId: (NSNumber*) petId
+    apiKey: (NSString*) apiKey
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -141,12 +127,10 @@
 /// 
 ///
 /// @return 
--(NSNumber*) uploadFileWithCompletionBlock :(NSNumber*) petId 
-     additionalMetadata:(NSString*) additionalMetadata 
-     file:(NSURL*) file 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) uploadFileWithPetId: (NSNumber*) petId
+    additionalMetadata: (NSString*) additionalMetadata
+    file: (NSURL*) file
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -158,10 +142,8 @@
 /// 
 ///
 /// @return NSString*
--(NSNumber*) getPetByIdWithByteArrayWithCompletionBlock :(NSNumber*) petId 
-    
-    completionHandler: (void (^)(NSString* output, NSError* error))completionBlock;
-    
+-(NSNumber*) getPetByIdWithByteArrayWithPetId: (NSNumber*) petId
+    completionHandler: (void (^)(NSString* output, NSError* error)) handler;
 
 
 ///
@@ -173,10 +155,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) addPetUsingByteArrayWithCompletionBlock :(NSString*) body 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) addPetUsingByteArrayWithBody: (NSString*) body
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 

--- a/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGPetApi.m
@@ -76,10 +76,8 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) updatePetWithCompletionBlock: (SWGPet*) body
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) updatePetWithBody: (SWGPet*) body
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
 
@@ -128,22 +126,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"PUT"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"PUT"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -154,10 +151,8 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) addPetWithCompletionBlock: (SWGPet*) body
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) addPetWithBody: (SWGPet*) body
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
 
@@ -206,22 +201,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"POST"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"POST"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -232,10 +226,8 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns NSArray<SWGPet>*
 ///
--(NSNumber*) findPetsByStatusWithCompletionBlock: (NSArray* /* NSString */) status
-        
-        completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock { 
-        
+-(NSNumber*) findPetsByStatusWithStatus: (NSArray* /* NSString */) status
+    completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error)) handler {
 
     
 
@@ -290,22 +282,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"NSArray<SWGPet>*"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((NSArray<SWGPet>*)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"NSArray<SWGPet>*"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((NSArray<SWGPet>*)data, error);
+                           }
           ];
 }
 
@@ -316,10 +307,8 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns NSArray<SWGPet>*
 ///
--(NSNumber*) findPetsByTagsWithCompletionBlock: (NSArray* /* NSString */) tags
-        
-        completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error))completionBlock { 
-        
+-(NSNumber*) findPetsByTagsWithTags: (NSArray* /* NSString */) tags
+    completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error)) handler {
 
     
 
@@ -374,22 +363,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"NSArray<SWGPet>*"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((NSArray<SWGPet>*)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"NSArray<SWGPet>*"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((NSArray<SWGPet>*)data, error);
+                           }
           ];
 }
 
@@ -400,10 +388,8 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns SWGPet*
 ///
--(NSNumber*) getPetByIdWithCompletionBlock: (NSNumber*) petId
-        
-        completionHandler: (void (^)(SWGPet* output, NSError* error))completionBlock { 
-        
+-(NSNumber*) getPetByIdWithPetId: (NSNumber*) petId
+    completionHandler: (void (^)(SWGPet* output, NSError* error)) handler {
 
     
     // verify the required parameter 'petId' is set
@@ -460,22 +446,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"SWGPet*"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((SWGPet*)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"SWGPet*"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((SWGPet*)data, error);
+                           }
           ];
 }
 
@@ -490,12 +475,10 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) updatePetWithFormWithCompletionBlock: (NSString*) petId
-         name: (NSString*) name
-         status: (NSString*) status
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) updatePetWithFormWithPetId: (NSString*) petId
+    name: (NSString*) name
+    status: (NSString*) status
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
     // verify the required parameter 'petId' is set
@@ -564,22 +547,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"POST"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"POST"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -592,11 +574,9 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) deletePetWithCompletionBlock: (NSNumber*) petId
-         apiKey: (NSString*) apiKey
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) deletePetWithPetId: (NSNumber*) petId
+    apiKey: (NSString*) apiKey
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
     // verify the required parameter 'petId' is set
@@ -656,22 +636,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"DELETE"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"DELETE"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -686,12 +665,10 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) uploadFileWithCompletionBlock: (NSNumber*) petId
-         additionalMetadata: (NSString*) additionalMetadata
-         file: (NSURL*) file
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) uploadFileWithPetId: (NSNumber*) petId
+    additionalMetadata: (NSString*) additionalMetadata
+    file: (NSURL*) file
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
     // verify the required parameter 'petId' is set
@@ -758,22 +735,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"POST"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"POST"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -784,10 +760,8 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns NSString*
 ///
--(NSNumber*) getPetByIdWithByteArrayWithCompletionBlock: (NSNumber*) petId
-        
-        completionHandler: (void (^)(NSString* output, NSError* error))completionBlock { 
-        
+-(NSNumber*) getPetByIdWithByteArrayWithPetId: (NSNumber*) petId
+    completionHandler: (void (^)(NSString* output, NSError* error)) handler {
 
     
     // verify the required parameter 'petId' is set
@@ -844,22 +818,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"NSString*"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((NSString*)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"NSString*"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((NSString*)data, error);
+                           }
           ];
 }
 
@@ -870,10 +843,8 @@ static SWGPetApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) addPetUsingByteArrayWithCompletionBlock: (NSString*) body
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) addPetUsingByteArrayWithBody: (NSString*) body
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
 
@@ -922,22 +893,21 @@ static SWGPetApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"POST"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"POST"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 

--- a/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.h
@@ -27,9 +27,8 @@
 /// 
 ///
 /// @return NSDictionary* /* NSString, NSNumber */
--(NSNumber*) getInventoryWithCompletionBlock :
-    (void (^)(NSDictionary* /* NSString, NSNumber */ output, NSError* error))completionBlock;
-    
+-(NSNumber*) getInventoryWithCompletionHandler: 
+    (void (^)(NSDictionary* /* NSString, NSNumber */ output, NSError* error)) handler;
 
 
 ///
@@ -41,10 +40,8 @@
 /// 
 ///
 /// @return SWGOrder*
--(NSNumber*) placeOrderWithCompletionBlock :(SWGOrder*) body 
-    
-    completionHandler: (void (^)(SWGOrder* output, NSError* error))completionBlock;
-    
+-(NSNumber*) placeOrderWithBody: (SWGOrder*) body
+    completionHandler: (void (^)(SWGOrder* output, NSError* error)) handler;
 
 
 ///
@@ -56,10 +53,8 @@
 /// 
 ///
 /// @return SWGOrder*
--(NSNumber*) getOrderByIdWithCompletionBlock :(NSString*) orderId 
-    
-    completionHandler: (void (^)(SWGOrder* output, NSError* error))completionBlock;
-    
+-(NSNumber*) getOrderByIdWithOrderId: (NSString*) orderId
+    completionHandler: (void (^)(SWGOrder* output, NSError* error)) handler;
 
 
 ///
@@ -71,10 +66,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) deleteOrderWithCompletionBlock :(NSString*) orderId 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) deleteOrderWithOrderId: (NSString*) orderId
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 

--- a/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGStoreApi.m
@@ -74,9 +74,8 @@ static SWGStoreApi* singletonAPI = nil;
 /// Returns a map of status codes to quantities
 ///  @returns NSDictionary* /* NSString, NSNumber */
 ///
--(NSNumber*) getInventoryWithCompletionBlock: 
-        (void (^)(NSDictionary* /* NSString, NSNumber */ output, NSError* error))completionBlock { 
-        
+-(NSNumber*) getInventoryWithCompletionHandler: 
+    (void (^)(NSDictionary* /* NSString, NSNumber */ output, NSError* error)) handler {
 
     
 
@@ -125,22 +124,21 @@ static SWGStoreApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"NSDictionary* /* NSString, NSNumber */"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((NSDictionary* /* NSString, NSNumber */)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"NSDictionary* /* NSString, NSNumber */"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((NSDictionary* /* NSString, NSNumber */)data, error);
+                           }
           ];
 }
 
@@ -151,10 +149,8 @@ static SWGStoreApi* singletonAPI = nil;
 ///
 ///  @returns SWGOrder*
 ///
--(NSNumber*) placeOrderWithCompletionBlock: (SWGOrder*) body
-        
-        completionHandler: (void (^)(SWGOrder* output, NSError* error))completionBlock { 
-        
+-(NSNumber*) placeOrderWithBody: (SWGOrder*) body
+    completionHandler: (void (^)(SWGOrder* output, NSError* error)) handler {
 
     
 
@@ -203,22 +199,21 @@ static SWGStoreApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"POST"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"SWGOrder*"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((SWGOrder*)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"POST"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"SWGOrder*"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((SWGOrder*)data, error);
+                           }
           ];
 }
 
@@ -229,10 +224,8 @@ static SWGStoreApi* singletonAPI = nil;
 ///
 ///  @returns SWGOrder*
 ///
--(NSNumber*) getOrderByIdWithCompletionBlock: (NSString*) orderId
-        
-        completionHandler: (void (^)(SWGOrder* output, NSError* error))completionBlock { 
-        
+-(NSNumber*) getOrderByIdWithOrderId: (NSString*) orderId
+    completionHandler: (void (^)(SWGOrder* output, NSError* error)) handler {
 
     
     // verify the required parameter 'orderId' is set
@@ -289,22 +282,21 @@ static SWGStoreApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"SWGOrder*"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((SWGOrder*)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"SWGOrder*"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((SWGOrder*)data, error);
+                           }
           ];
 }
 
@@ -315,10 +307,8 @@ static SWGStoreApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) deleteOrderWithCompletionBlock: (NSString*) orderId
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) deleteOrderWithOrderId: (NSString*) orderId
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
     // verify the required parameter 'orderId' is set
@@ -375,22 +365,21 @@ static SWGStoreApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"DELETE"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"DELETE"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 

--- a/samples/client/petstore/objc/SwaggerClient/SWGUserApi.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGUserApi.h
@@ -28,10 +28,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) createUserWithCompletionBlock :(SWGUser*) body 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) createUserWithBody: (SWGUser*) body
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -43,10 +41,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) createUsersWithArrayInputWithCompletionBlock :(NSArray<SWGUser>*) body 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) createUsersWithArrayInputWithBody: (NSArray<SWGUser>*) body
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -58,10 +54,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) createUsersWithListInputWithCompletionBlock :(NSArray<SWGUser>*) body 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) createUsersWithListInputWithBody: (NSArray<SWGUser>*) body
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -74,11 +68,9 @@
 /// 
 ///
 /// @return NSString*
--(NSNumber*) loginUserWithCompletionBlock :(NSString*) username 
-     password:(NSString*) password 
-    
-    completionHandler: (void (^)(NSString* output, NSError* error))completionBlock;
-    
+-(NSNumber*) loginUserWithUsername: (NSString*) username
+    password: (NSString*) password
+    completionHandler: (void (^)(NSString* output, NSError* error)) handler;
 
 
 ///
@@ -89,9 +81,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) logoutUserWithCompletionBlock :
-    
-    (void (^)(NSError* error))completionBlock;
+-(NSNumber*) logoutUserWithCompletionHandler: 
+    (void (^)(NSError* error)) handler;
 
 
 ///
@@ -103,10 +94,8 @@
 /// 
 ///
 /// @return SWGUser*
--(NSNumber*) getUserByNameWithCompletionBlock :(NSString*) username 
-    
-    completionHandler: (void (^)(SWGUser* output, NSError* error))completionBlock;
-    
+-(NSNumber*) getUserByNameWithUsername: (NSString*) username
+    completionHandler: (void (^)(SWGUser* output, NSError* error)) handler;
 
 
 ///
@@ -119,11 +108,9 @@
 /// 
 ///
 /// @return 
--(NSNumber*) updateUserWithCompletionBlock :(NSString*) username 
-     body:(SWGUser*) body 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) updateUserWithUsername: (NSString*) username
+    body: (SWGUser*) body
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 ///
@@ -135,10 +122,8 @@
 /// 
 ///
 /// @return 
--(NSNumber*) deleteUserWithCompletionBlock :(NSString*) username 
-    
-    
-    completionHandler: (void (^)(NSError* error))completionBlock;
+-(NSNumber*) deleteUserWithUsername: (NSString*) username
+    completionHandler: (void (^)(NSError* error)) handler;
 
 
 

--- a/samples/client/petstore/objc/SwaggerClient/SWGUserApi.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGUserApi.m
@@ -76,10 +76,8 @@ static SWGUserApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) createUserWithCompletionBlock: (SWGUser*) body
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) createUserWithBody: (SWGUser*) body
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
 
@@ -128,22 +126,21 @@ static SWGUserApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"POST"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"POST"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -154,10 +151,8 @@ static SWGUserApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) createUsersWithArrayInputWithCompletionBlock: (NSArray<SWGUser>*) body
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) createUsersWithArrayInputWithBody: (NSArray<SWGUser>*) body
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
 
@@ -206,22 +201,21 @@ static SWGUserApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"POST"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"POST"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -232,10 +226,8 @@ static SWGUserApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) createUsersWithListInputWithCompletionBlock: (NSArray<SWGUser>*) body
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) createUsersWithListInputWithBody: (NSArray<SWGUser>*) body
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
 
@@ -284,22 +276,21 @@ static SWGUserApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"POST"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"POST"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -312,11 +303,9 @@ static SWGUserApi* singletonAPI = nil;
 ///
 ///  @returns NSString*
 ///
--(NSNumber*) loginUserWithCompletionBlock: (NSString*) username
-         password: (NSString*) password
-        
-        completionHandler: (void (^)(NSString* output, NSError* error))completionBlock { 
-        
+-(NSNumber*) loginUserWithUsername: (NSString*) username
+    password: (NSString*) password
+    completionHandler: (void (^)(NSString* output, NSError* error)) handler {
 
     
 
@@ -373,22 +362,21 @@ static SWGUserApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"NSString*"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((NSString*)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"NSString*"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((NSString*)data, error);
+                           }
           ];
 }
 
@@ -397,9 +385,8 @@ static SWGUserApi* singletonAPI = nil;
 /// 
 ///  @returns void
 ///
--(NSNumber*) logoutUserWithCompletionBlock: 
-        
-        (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) logoutUserWithCompletionHandler: 
+    (void (^)(NSError* error)) handler {
 
     
 
@@ -448,22 +435,21 @@ static SWGUserApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -474,10 +460,8 @@ static SWGUserApi* singletonAPI = nil;
 ///
 ///  @returns SWGUser*
 ///
--(NSNumber*) getUserByNameWithCompletionBlock: (NSString*) username
-        
-        completionHandler: (void (^)(SWGUser* output, NSError* error))completionBlock { 
-        
+-(NSNumber*) getUserByNameWithUsername: (NSString*) username
+    completionHandler: (void (^)(SWGUser* output, NSError* error)) handler {
 
     
     // verify the required parameter 'username' is set
@@ -534,22 +518,21 @@ static SWGUserApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"GET"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: @"SWGUser*"
-                                      completionBlock: ^(id data, NSError *error) {
-                  
-                  completionBlock((SWGUser*)data, error);
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"GET"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: @"SWGUser*"
+                           completionBlock: ^(id data, NSError *error) {
+                               handler((SWGUser*)data, error);
+                           }
           ];
 }
 
@@ -562,11 +545,9 @@ static SWGUserApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) updateUserWithCompletionBlock: (NSString*) username
-         body: (SWGUser*) body
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) updateUserWithUsername: (NSString*) username
+    body: (SWGUser*) body
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
     // verify the required parameter 'username' is set
@@ -623,22 +604,21 @@ static SWGUserApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"PUT"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"PUT"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 
@@ -649,10 +629,8 @@ static SWGUserApi* singletonAPI = nil;
 ///
 ///  @returns void
 ///
--(NSNumber*) deleteUserWithCompletionBlock: (NSString*) username
-        
-        
-        completionHandler: (void (^)(NSError* error))completionBlock { 
+-(NSNumber*) deleteUserWithUsername: (NSString*) username
+    completionHandler: (void (^)(NSError* error)) handler {
 
     
     // verify the required parameter 'username' is set
@@ -709,22 +687,21 @@ static SWGUserApi* singletonAPI = nil;
     
 
     
-    return [self.apiClient requestWithCompletionBlock: resourcePath
-                                               method: @"DELETE"
-                                           pathParams: pathParams
-                                          queryParams: queryParams
-                                           formParams: formParams
-                                                files: files
-                                                 body: bodyParam
-                                         headerParams: headerParams
-                                         authSettings: authSettings
-                                   requestContentType: requestContentType
-                                  responseContentType: responseContentType
-                                         responseType: nil
-                                      completionBlock: ^(id data, NSError *error) {
-                  completionBlock(error);
-                  
-              }
+    return [self.apiClient requestWithPath: resourcePath
+                                    method: @"DELETE"
+                                pathParams: pathParams
+                               queryParams: queryParams
+                                formParams: formParams
+                                     files: files
+                                      body: bodyParam
+                              headerParams: headerParams
+                              authSettings: authSettings
+                        requestContentType: requestContentType
+                       responseContentType: responseContentType
+                              responseType: nil
+                           completionBlock: ^(id data, NSError *error) {
+                               handler(error);
+                           }
           ];
 }
 

--- a/samples/client/petstore/objc/SwaggerClientTests/SwaggerClient/SWGViewController.m
+++ b/samples/client/petstore/objc/SwaggerClientTests/SwaggerClient/SWGViewController.m
@@ -27,7 +27,7 @@
     
     SWGPetApi *api = [[SWGPetApi alloc] init];
     NSURL *file = [NSURL fileURLWithPath:@"/Users/geekerzp/tmp/test.jpg"];
-    [api uploadFileWithCompletionBlock:@2 additionalMetadata:@2 file:file completionHandler:^(NSError *error) {
+    [api uploadFileWithPetId:@2 additionalMetadata:@2 file:file completionHandler:^(NSError *error) {
         NSLog(@"*** error: %@", error);
     }];
 }

--- a/samples/client/petstore/objc/SwaggerClientTests/Tests/PetApiTest.m
+++ b/samples/client/petstore/objc/SwaggerClientTests/Tests/PetApiTest.m
@@ -35,12 +35,12 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testGetPetById"];
     SWGPet* pet = [self createPet];
 
-    [api addPetWithCompletionBlock:pet completionHandler:^(NSError *error) {
+    [api addPetWithBody:pet completionHandler:^(NSError *error) {
         if(error){
             XCTFail(@"got error %@", error);
         }
         NSLog(@"%@", [pet _id]);
-        [api getPetByIdWithCompletionBlock:[pet _id] completionHandler:^(SWGPet *output, NSError *error) {
+        [api getPetByIdWithPetId:[pet _id] completionHandler:^(SWGPet *output, NSError *error) {
             if(error){
                 XCTFail(@"got error %@", error);
             }
@@ -75,12 +75,12 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testUpdatePet"];
     SWGPet* pet = [self createPet];
 
-    [api addPetWithCompletionBlock:pet completionHandler:^(NSError *error) {
+    [api addPetWithBody:pet completionHandler:^(NSError *error) {
         if(error) {
             XCTFail(@"got error %@", error);
         }
         else {
-            [api getPetByIdWithCompletionBlock:[NSString stringWithFormat:@"%@",[pet _id]] completionHandler:^(SWGPet *output, NSError *error) {
+            [api getPetByIdWithPetId:[pet _id] completionHandler:^(SWGPet *output, NSError *error) {
                 if(error) {
                     XCTFail(@"got error %@", error);
                 }
@@ -94,12 +94,12 @@
                     [pet setName:@"programmer"];
                     [pet setStatus:@"confused"];
 
-                    [api updatePetWithCompletionBlock:pet
+                    [api updatePetWithBody:pet
                                     completionHandler:^(NSError *error) {
                                         if(error) {
                                             XCTFail(@"got error %@", error);
                                         }
-                                        [api getPetByIdWithCompletionBlock:[pet _id] completionHandler:^(SWGPet *output, NSError *error) {
+                                        [api getPetByIdWithPetId:[pet _id] completionHandler:^(SWGPet *output, NSError *error) {
                                             if(error) {
                                                 XCTFail(@"got error %@", error);
                                             }
@@ -167,13 +167,13 @@ which causes an exception when deserializing the data
     NSLog(@"%@", pet._id);
     pet.tags = [[NSArray alloc] initWithObjects:tag, nil];
 
-    [api addPetWithCompletionBlock:pet completionHandler:^(NSError *error) {
+    [api addPetWithBody:pet completionHandler:^(NSError *error) {
         if(error) {
             XCTFail(@"got error %@", error);
         }
         NSArray* tags = [[NSArray alloc] initWithObjects:@"tony", nil];
 
-        [api findPetsByTagsWithCompletionBlock:tags completionHandler:^(NSArray *output, NSError *error) {
+        [api findPetsByTagsWithTags:tags completionHandler:^(NSArray *output, NSError *error) {
             if(error){
                 XCTFail(@"got error %@", error);
             }
@@ -200,15 +200,15 @@ which causes an exception when deserializing the data
 
     SWGPet* pet = [self createPet];
 
-    [api addPetWithCompletionBlock:pet completionHandler:^(NSError *error) {
+    [api addPetWithBody:pet completionHandler:^(NSError *error) {
         if(error){
             XCTFail(@"got error %@", error);
         }
-        [api deletePetWithCompletionBlock:pet._id apiKey:@"" completionHandler:^(NSError *error) {
+        [api deletePetWithPetId:pet._id apiKey:@"" completionHandler:^(NSError *error) {
             if(error){
                 XCTFail(@"got error %@", error);
             }
-            [api getPetByIdWithCompletionBlock:[pet _id] completionHandler:^(SWGPet *output, NSError *error) {
+            [api getPetByIdWithPetId:[pet _id] completionHandler:^(SWGPet *output, NSError *error) {
                 if(error) {
                     // good
                     [expectation fulfill];
@@ -228,7 +228,7 @@ which causes an exception when deserializing the data
     
     NSURL *fileURL = [self createTempFile];
     
-    [api uploadFileWithCompletionBlock:@1 additionalMetadata:@"special-metadata" file:fileURL completionHandler:^(NSError *error) {
+    [api uploadFileWithPetId:@1 additionalMetadata:@"special-metadata" file:fileURL completionHandler:^(NSError *error) {
         if(error) {
             // good
             XCTFail(@"expected a failure");
@@ -246,7 +246,7 @@ which causes an exception when deserializing the data
     
     NSURL *fileURL = [self createTempFile];
     
-    [api uploadFileWithCompletionBlock:@1 additionalMetadata:nil file:fileURL completionHandler:^(NSError *error) {
+    [api uploadFileWithPetId:@1 additionalMetadata:nil file:fileURL completionHandler:^(NSError *error) {
         if (error) {
             XCTFail(@"expected a failure");
         }
@@ -261,7 +261,7 @@ which causes an exception when deserializing the data
 - (void)TestUploadWithoutFile {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testUploadWithoutFile"];
     
-    [api uploadFileWithCompletionBlock:@1 additionalMetadata:@"special-metadata" file:nil completionHandler:^(NSError *error) {
+    [api uploadFileWithPetId:@1 additionalMetadata:@"special-metadata" file:nil completionHandler:^(NSError *error) {
         if(error) {
             XCTFail(@"failed to upload");
             

--- a/samples/client/petstore/objc/SwaggerClientTests/Tests/StoreApiTest.m
+++ b/samples/client/petstore/objc/SwaggerClientTests/Tests/StoreApiTest.m
@@ -22,7 +22,7 @@
 - (void)testGetInventory {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testGetPetByStatus"];
     
-    [self.api getInventoryWithCompletionBlock:^(NSDictionary *output, NSError *error) {
+    [self.api getInventoryWithCompletionHandler:^(NSDictionary *output, NSError *error) {
         
         if (error) {
             XCTFail(@"got error %@", error);

--- a/samples/client/petstore/objc/SwaggerClientTests/Tests/UserApiTest.m
+++ b/samples/client/petstore/objc/SwaggerClientTests/Tests/UserApiTest.m
@@ -22,7 +22,7 @@
 - (void)testLoginUser {
     XCTestExpectation *expectation = [self expectationWithDescription:@"test login user"];
     
-    [self.api loginUserWithCompletionBlock:@"test username" password:@"test password" completionHandler:^(NSString *output, NSError *error) {
+    [self.api loginUserWithUsername:@"test username" password:@"test password" completionHandler:^(NSString *output, NSError *error) {
         if (error) {
             XCTFail(@"got error %@", error);
         }


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-codegen/issues/2121

Since I needed to reference both the untouched and the camelize names of the first argument in the mustache files,  `CodegenOperation.firstParamAltName` has been introduced.

Now generated method names look like the following, e.g.:
```objc
-(NSNumber*) coffeeShopUpdateAllWithWhere: (NSString*) where
    data: (XXCoffeeShop*) data
    completionHandler: (void (^)(XXInlineResponse2001* output, NSError* error)) handler;
```
instead of:
```objc
-(NSNumber*) coffeeShopUpdateAllWithCompletionBlock :(NSString*) where 
     data:(XXCoffeeShop*) data 
    
    completionHandler: (void (^)(XXInlineResponse2001* output, NSError* error))completionBlock;
```
Note that the argument variable name for `completionHandler` has also been updated from `completionBlock` to `handler`, following the signature of a popular method of `ModalWindowController`:
```objc
    - (void)makeKeyAndOrderFront:(id)sender
                   modalToWindow:(NSWindow*)window
                      sourceRect:(NSRect)rect
               completionHandler:(void (^)(NSInteger result))handler;
```
Also, the name of `-[ApiClient requestWithCompletionBlock:...]` too has been updated to `-[ApiClient requestWithPath:...]` to follow the convention.

@wing328 I have tested the changes against my test cases but haven't made any changes in the test cases and the samples.  Would you please tell me what I need to do for those?