### PR TITLE
Correct exporting of enum classes

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/enumClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/enumClass.mustache
@@ -1,17 +1,10 @@
-
-//export module
-if ( typeof define === "function" && define.amd ) {
-	define('{{datatypeWithEnum}}', [], function() {
-        return {{datatypeWithEnum}};
-	 });
-}
-
 var {{datatypeWithEnum}} = {
 {{#allowableValues}}{{#enumVars}}
-	/**
-	 * @const
-	 */
-	{{name}}: "{{value}}"{{^-last}},
-	{{/-last}}{{/enumVars}}{{/allowableValues}}
+	  /**
+	   * @const
+	   */
+	  {{name}}: "{{value}}"{{^-last}},
+	  {{/-last}}{{/enumVars}}{{/allowableValues}}
+  };
 
-}
+  {{classname}}.{{datatypeWithEnum}} = {{datatypeWithEnum}};

--- a/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
@@ -14,11 +14,7 @@
   }
 }(this, function(module, ApiClient{{#imports}}, {{import}}{{/imports}}) {
   'use strict';
-
   {{#models}}{{#model}}
-  {{#vars}}{{#isEnum}}{{>enumClass}}{{/isEnum}}{{#items.isEnum}}{{#items}}
-  {{>enumClass}}{{/items}}*/{{/items.isEnum}}{{/vars}}
-
   {{#description}}/**
    * {{description}}
    **/{{/description}}
@@ -73,6 +69,9 @@
   {{classname}}.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  {{#vars}}{{#isEnum}}{{>enumClass}}{{/isEnum}}{{#items.isEnum}}{{#items}}
+  {{>enumClass}}{{/items}}*/{{/items.isEnum}}{{/vars}}
 
   if (module) {
     module.{{classname}} = {{classname}};

--- a/samples/client/petstore/javascript-promise/src/model/Category.js
+++ b/samples/client/petstore/javascript-promise/src/model/Category.js
@@ -14,10 +14,7 @@
   }
 }(this, function(module, ApiClient) {
   'use strict';
-
   
-  
-
   
   var Category = function Category() { 
     
@@ -85,6 +82,8 @@
   Category.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  
 
   if (module) {
     module.Category = Category;

--- a/samples/client/petstore/javascript-promise/src/model/Order.js
+++ b/samples/client/petstore/javascript-promise/src/model/Order.js
@@ -14,36 +14,7 @@
   }
 }(this, function(module, ApiClient) {
   'use strict';
-
   
-  
-//export module
-if ( typeof define === "function" && define.amd ) {
-	define('StatusEnum', [], function() {
-        return StatusEnum;
-	 });
-}
-
-var StatusEnum = {
-
-	/**
-	 * @const
-	 */
-	PLACED: "placed",
-	
-	/**
-	 * @const
-	 */
-	APPROVED: "approved",
-	
-	/**
-	 * @const
-	 */
-	DELIVERED: "delivered"
-
-}
-
-
   
   var Order = function Order() { 
     
@@ -206,6 +177,27 @@ var StatusEnum = {
   Order.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  var StatusEnum = {
+
+	  /**
+	   * @const
+	   */
+	  PLACED: "placed",
+	  
+	  /**
+	   * @const
+	   */
+	  APPROVED: "approved",
+	  
+	  /**
+	   * @const
+	   */
+	  DELIVERED: "delivered"
+  };
+
+  Order.StatusEnum = StatusEnum;
+
 
   if (module) {
     module.Order = Order;

--- a/samples/client/petstore/javascript-promise/src/model/Pet.js
+++ b/samples/client/petstore/javascript-promise/src/model/Pet.js
@@ -14,36 +14,7 @@
   }
 }(this, function(module, ApiClient, Category, Tag) {
   'use strict';
-
   
-  
-//export module
-if ( typeof define === "function" && define.amd ) {
-	define('StatusEnum', [], function() {
-        return StatusEnum;
-	 });
-}
-
-var StatusEnum = {
-
-	/**
-	 * @const
-	 */
-	AVAILABLE: "available",
-	
-	/**
-	 * @const
-	 */
-	PENDING: "pending",
-	
-	/**
-	 * @const
-	 */
-	SOLD: "sold"
-
-}
-
-
   
   var Pet = function Pet(photoUrls, name) { 
     
@@ -208,6 +179,27 @@ var StatusEnum = {
   Pet.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  var StatusEnum = {
+
+	  /**
+	   * @const
+	   */
+	  AVAILABLE: "available",
+	  
+	  /**
+	   * @const
+	   */
+	  PENDING: "pending",
+	  
+	  /**
+	   * @const
+	   */
+	  SOLD: "sold"
+  };
+
+  Pet.StatusEnum = StatusEnum;
+
 
   if (module) {
     module.Pet = Pet;

--- a/samples/client/petstore/javascript-promise/src/model/Tag.js
+++ b/samples/client/petstore/javascript-promise/src/model/Tag.js
@@ -14,10 +14,7 @@
   }
 }(this, function(module, ApiClient) {
   'use strict';
-
   
-  
-
   
   var Tag = function Tag() { 
     
@@ -85,6 +82,8 @@
   Tag.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  
 
   if (module) {
     module.Tag = Tag;

--- a/samples/client/petstore/javascript-promise/src/model/User.js
+++ b/samples/client/petstore/javascript-promise/src/model/User.js
@@ -14,10 +14,7 @@
   }
 }(this, function(module, ApiClient) {
   'use strict';
-
   
-  
-
   
   var User = function User() { 
     
@@ -226,6 +223,8 @@
   User.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  
 
   if (module) {
     module.User = User;

--- a/samples/client/petstore/javascript/src/model/Category.js
+++ b/samples/client/petstore/javascript/src/model/Category.js
@@ -14,10 +14,7 @@
   }
 }(this, function(module, ApiClient) {
   'use strict';
-
   
-  
-
   
   var Category = function Category() { 
     
@@ -85,6 +82,8 @@
   Category.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  
 
   if (module) {
     module.Category = Category;

--- a/samples/client/petstore/javascript/src/model/Order.js
+++ b/samples/client/petstore/javascript/src/model/Order.js
@@ -14,36 +14,7 @@
   }
 }(this, function(module, ApiClient) {
   'use strict';
-
   
-  
-//export module
-if ( typeof define === "function" && define.amd ) {
-	define('StatusEnum', [], function() {
-        return StatusEnum;
-	 });
-}
-
-var StatusEnum = {
-
-	/**
-	 * @const
-	 */
-	PLACED: "placed",
-	
-	/**
-	 * @const
-	 */
-	APPROVED: "approved",
-	
-	/**
-	 * @const
-	 */
-	DELIVERED: "delivered"
-
-}
-
-
   
   var Order = function Order() { 
     
@@ -206,6 +177,27 @@ var StatusEnum = {
   Order.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  var StatusEnum = {
+
+	  /**
+	   * @const
+	   */
+	  PLACED: "placed",
+	  
+	  /**
+	   * @const
+	   */
+	  APPROVED: "approved",
+	  
+	  /**
+	   * @const
+	   */
+	  DELIVERED: "delivered"
+  };
+
+  Order.StatusEnum = StatusEnum;
+
 
   if (module) {
     module.Order = Order;

--- a/samples/client/petstore/javascript/src/model/Pet.js
+++ b/samples/client/petstore/javascript/src/model/Pet.js
@@ -14,36 +14,7 @@
   }
 }(this, function(module, ApiClient, Category, Tag) {
   'use strict';
-
   
-  
-//export module
-if ( typeof define === "function" && define.amd ) {
-	define('StatusEnum', [], function() {
-        return StatusEnum;
-	 });
-}
-
-var StatusEnum = {
-
-	/**
-	 * @const
-	 */
-	AVAILABLE: "available",
-	
-	/**
-	 * @const
-	 */
-	PENDING: "pending",
-	
-	/**
-	 * @const
-	 */
-	SOLD: "sold"
-
-}
-
-
   
   var Pet = function Pet(photoUrls, name) { 
     
@@ -208,6 +179,27 @@ var StatusEnum = {
   Pet.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  var StatusEnum = {
+
+	  /**
+	   * @const
+	   */
+	  AVAILABLE: "available",
+	  
+	  /**
+	   * @const
+	   */
+	  PENDING: "pending",
+	  
+	  /**
+	   * @const
+	   */
+	  SOLD: "sold"
+  };
+
+  Pet.StatusEnum = StatusEnum;
+
 
   if (module) {
     module.Pet = Pet;

--- a/samples/client/petstore/javascript/src/model/Tag.js
+++ b/samples/client/petstore/javascript/src/model/Tag.js
@@ -14,10 +14,7 @@
   }
 }(this, function(module, ApiClient) {
   'use strict';
-
   
-  
-
   
   var Tag = function Tag() { 
     
@@ -85,6 +82,8 @@
   Tag.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  
 
   if (module) {
     module.Tag = Tag;

--- a/samples/client/petstore/javascript/src/model/User.js
+++ b/samples/client/petstore/javascript/src/model/User.js
@@ -14,10 +14,7 @@
   }
 }(this, function(module, ApiClient) {
   'use strict';
-
   
-  
-
   
   var User = function User() { 
     
@@ -226,6 +223,8 @@
   User.prototype.toJson = function() {
     return JSON.stringify(this);
   }
+
+  
 
   if (module) {
     module.User = User;


### PR DESCRIPTION
Fixes #2102.

This attaches the enum classes to the main model class. This also ensures that the enum is exported along with the model. There is no longer a need for a separate export of the enum.

The enums now looks similar to a local class in Java, which seems appropriate, since they are indeed local to the model class being defined.

Note: This conflicts with https://github.com/swagger-api/swagger-codegen/pull/2115
Take them in any order, and I'll rebase accordingly. We need both to really fix the enums, but the two PRs address two different issues.