### PR TITLE
Adding PATCH header override the default Java client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -517,7 +517,10 @@ public class ApiClient {
       response = builder.type(contentType).put(ClientResponse.class, serialize(body, contentType, formParams));
     } else if ("DELETE".equals(method)) {
       response = builder.type(contentType).delete(ClientResponse.class, serialize(body, contentType, formParams));
-    } else {
+    } else if ("PATCH".equals(method)) {
+      response = builder.type(contentType).header("X-HTTP-Method-Override", "PATCH").post(ClientResponse.class, serialize(body, contentType, formParams));
+    }
+    else {
       throw new ApiException(500, "unknown method type " + method);
     }
     return response;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
@@ -41,7 +41,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-15T19:19:23.415+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class ApiClient {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private String basePath = "http://petstore.swagger.io/v2";
@@ -83,8 +83,8 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("petstore_auth", new OAuth());
     authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
+    authentications.put("petstore_auth", new OAuth());
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }
@@ -516,7 +516,10 @@ public class ApiClient {
       response = builder.type(contentType).put(ClientResponse.class, serialize(body, contentType, formParams));
     } else if ("DELETE".equals(method)) {
       response = builder.type(contentType).delete(ClientResponse.class, serialize(body, contentType, formParams));
-    } else {
+    } else if ("PATCH".equals(method)) {
+      response = builder.type(contentType).header("X-HTTP-Method-Override", "PATCH").post(ClientResponse.class, serialize(body, contentType, formParams));
+    }
+    else {
       throw new ApiException(500, "unknown method type " + method);
     }
     return response;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiException.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiException.java
@@ -3,7 +3,7 @@ package io.swagger.client;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class ApiException extends Exception {
   private int code = 0;
   private Map<String, List<String>> responseHeaders = null;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/Configuration.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/Configuration.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class Configuration {
   private static ApiClient defaultApiClient = new ApiClient();
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/Pair.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/Pair.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/StringUtil.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/StringUtil.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
@@ -12,7 +12,7 @@ import java.io.File;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-15T19:19:23.415+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class PetApi {
   private ApiClient apiClient;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/StoreApi.java
@@ -12,7 +12,7 @@ import io.swagger.client.model.Order;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class StoreApi {
   private ApiClient apiClient;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/UserApi.java
@@ -12,7 +12,7 @@ import java.util.*;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class UserApi {
   private ApiClient apiClient;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/ApiKeyAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/HttpBasicAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/HttpBasicAuth.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import java.io.UnsupportedEncodingException;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/auth/OAuth.java
@@ -5,7 +5,7 @@ import io.swagger.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-05T14:39:16.440+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class OAuth implements Authentication {
   private String accessToken;
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-15T19:19:23.415+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class Category   {
   
   private Long id = null;
@@ -19,8 +19,13 @@ public class Category   {
   
   /**
    **/
+  public Category id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -32,8 +37,13 @@ public class Category   {
   
   /**
    **/
+  public Category name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("name")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
@@ -11,7 +11,7 @@ import java.util.Date;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-15T19:19:23.415+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class Order   {
   
   private Long id = null;
@@ -44,8 +44,13 @@ public class Order   {
   
   /**
    **/
+  public Order id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -57,8 +62,13 @@ public class Order   {
   
   /**
    **/
+  public Order petId(Long petId) {
+    this.petId = petId;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("petId")
   public Long getPetId() {
     return petId;
@@ -70,8 +80,13 @@ public class Order   {
   
   /**
    **/
+  public Order quantity(Integer quantity) {
+    this.quantity = quantity;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("quantity")
   public Integer getQuantity() {
     return quantity;
@@ -83,8 +98,13 @@ public class Order   {
   
   /**
    **/
+  public Order shipDate(Date shipDate) {
+    this.shipDate = shipDate;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("shipDate")
   public Date getShipDate() {
     return shipDate;
@@ -97,8 +117,13 @@ public class Order   {
   /**
    * Order Status
    **/
+  public Order status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "Order Status")
+  @ApiModelProperty(example = "null", value = "Order Status")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
@@ -110,8 +135,13 @@ public class Order   {
   
   /**
    **/
+  public Order complete(Boolean complete) {
+    this.complete = complete;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("complete")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-15T19:19:23.415+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class Pet   {
   
   private Long id = null;
@@ -46,8 +46,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -59,8 +64,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet category(Category category) {
+    this.category = category;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("category")
   public Category getCategory() {
     return category;
@@ -72,8 +82,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
   public String getName() {
     return name;
@@ -85,8 +100,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet photoUrls(List<String> photoUrls) {
+    this.photoUrls = photoUrls;
+    return this;
+  }
+
   
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(example = "null", required = true, value = "")
   @JsonProperty("photoUrls")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -98,8 +118,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet tags(List<Tag> tags) {
+    this.tags = tags;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("tags")
   public List<Tag> getTags() {
     return tags;
@@ -112,8 +137,13 @@ public class Pet   {
   /**
    * pet status in the store
    **/
+  public Pet status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "pet status in the store")
+  @ApiModelProperty(example = "null", value = "pet status in the store")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-15T19:19:23.415+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class Tag   {
   
   private Long id = null;
@@ -19,8 +19,13 @@ public class Tag   {
   
   /**
    **/
+  public Tag id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -32,8 +37,13 @@ public class Tag   {
   
   /**
    **/
+  public Tag name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("name")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-15T19:19:23.415+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
 public class User   {
   
   private Long id = null;
@@ -25,8 +25,13 @@ public class User   {
   
   /**
    **/
+  public User id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -38,8 +43,13 @@ public class User   {
   
   /**
    **/
+  public User username(String username) {
+    this.username = username;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("username")
   public String getUsername() {
     return username;
@@ -51,8 +61,13 @@ public class User   {
   
   /**
    **/
+  public User firstName(String firstName) {
+    this.firstName = firstName;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("firstName")
   public String getFirstName() {
     return firstName;
@@ -64,8 +79,13 @@ public class User   {
   
   /**
    **/
+  public User lastName(String lastName) {
+    this.lastName = lastName;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("lastName")
   public String getLastName() {
     return lastName;
@@ -77,8 +97,13 @@ public class User   {
   
   /**
    **/
+  public User email(String email) {
+    this.email = email;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("email")
   public String getEmail() {
     return email;
@@ -90,8 +115,13 @@ public class User   {
   
   /**
    **/
+  public User password(String password) {
+    this.password = password;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("password")
   public String getPassword() {
     return password;
@@ -103,8 +133,13 @@ public class User   {
   
   /**
    **/
+  public User phone(String phone) {
+    this.phone = phone;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("phone")
   public String getPhone() {
     return phone;
@@ -117,8 +152,13 @@ public class User   {
   /**
    * User Status
    **/
+  public User userStatus(Integer userStatus) {
+    this.userStatus = userStatus;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "User Status")
+  @ApiModelProperty(example = "null", value = "User Status")
   @JsonProperty("userStatus")
   public Integer getUserStatus() {
     return userStatus;


### PR DESCRIPTION
This "fixes" https://github.com/swagger-api/swagger-codegen/issues/1924 .

The solution was to add the `X-HTTP-Method-Override` to the `POST` call. Using this change, swagger-codegen clients will actually make PATCH requests with POST as the verb, but with a header of `X-HTTP-Method-Override` set to PATCH. It is then the responsibility of the server to recognize the header and swap out the HTTP verb accordingly in a request filtering mechanisgm such as a `com.sun.jersey.spi.container.ContainerRequestFilter`.

Currently, this workaround, and corresponding handling on the server side, is the only way to reliably perform PATCH using Jersey 1.x.
See: http://theza.ch/2009/06/17/override-the-http-request-method-in-jersey/

Note: I have a lot of changes in this diff spit out by the generator; I think someone before me forgot to commit the generated code, perhaps.
