### PR TITLE
Fixed constantize for sub response object

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -168,7 +168,7 @@ module {{moduleName}}
         end
       else
         # models, e.g. Pet
-        {{moduleName}}.const_get(return_type).new.tap do |model|
+        {{moduleName}}.const_get(return_type.split("_").map{|v| v[0].upcase + v[1..-1] }.join).new.tap do |model|
           model.build_from_hash data
         end
       end


### PR DESCRIPTION
There is an issue with complex response types and Ruby
Response example:
```yaml
responses: 
  200: 
    description: "A code "
    schema: 
      type: "object"
      properties: 
        response: 
          $ref: "#/definitions/LinkResponse"
```
The return type value in all places looks like this:
```ruby
:return_type => 'inline_response_200'
```
and in the api code there is a call to ``` .const_get(return_type).new ``` and it can't find the const.