### PR TITLE
Do not create empty objects in model constructors

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -17,9 +17,17 @@ import io.swagger.models.Model;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -55,7 +63,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     protected String localVariablePrefix = "";
     protected boolean usePromises = false;
     protected boolean omitModelMethods = false;
-    
+
     public JavascriptClientCodegen() {
         super();
         outputFolder = "generated-code/js";
@@ -64,7 +72,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         templateDir = "Javascript";
         apiPackage = "api";
         modelPackage = "model";
-        
+
         // reference: http://www.w3schools.com/js/js_reserved.asp
         reservedWords = new HashSet<String>(
                 Arrays.asList(
@@ -326,15 +334,43 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
 
     @Override
     public String toDefaultValue(Property p) {
-        if (p instanceof ArrayProperty) {
-            return "[]";
-        } else if (p instanceof MapProperty) {
-            return "{}";
-        } else if (p instanceof RefProperty) {
-            return "new " + getTypeDeclaration(p) + "()";
+        if (p instanceof StringProperty) {
+            StringProperty dp = (StringProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault();
+            }
+        } else if (p instanceof BooleanProperty) {
+            BooleanProperty dp = (BooleanProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        } else if (p instanceof DateProperty) {
+            // TODO
+        } else if (p instanceof DateTimeProperty) {
+            // TODO
+        } else if (p instanceof DoubleProperty) {
+            DoubleProperty dp = (DoubleProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        } else if (p instanceof FloatProperty) {
+            FloatProperty dp = (FloatProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        } else if (p instanceof IntegerProperty) {
+            IntegerProperty dp = (IntegerProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
+        } else if (p instanceof LongProperty) {
+            LongProperty dp = (LongProperty) p;
+            if (dp.getDefault() != null) {
+                return dp.getDefault().toString();
+            }
         }
 
-        return super.toDefaultValue(p);
+        return null;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/model.mustache
@@ -19,16 +19,23 @@
    * {{description}}
    **/{{/description}}
   var {{classname}} = function {{classname}}({{#mandatory}}{{this}}{{^-last}}, {{/-last}}{{/mandatory}}) { {{#parent}}/* extends {{{parent}}}*/{{/parent}}
-    {{#vars}}
+    {{#vars}}{{#required}}
     /**{{#description}}
      * {{{description}}}{{/description}}
-     * datatype: {{{datatypeWithEnum}}}{{#required}}
-     * required{{/required}}{{#minimum}}
+     * datatype: {{{datatypeWithEnum}}}
+     * required {{#minimum}}
      * minimum: {{minimum}}{{/minimum}}{{#maximum}}
      * maximum: {{maximum}}{{/maximum}}
      **/
-    this['{{baseName}}'] = {{#required}}{{name}}{{/required}}{{^required}}{{{defaultValue}}}{{/required}};
-    {{/vars}}
+    this['{{baseName}}'] = {{name}};{{/required}}{{^required}}{{#defaultValue}}
+    /**{{#description}}
+     * {{{description}}}{{/description}}
+     * datatype: {{{datatypeWithEnum}}}
+     * required {{#minimum}}
+     * minimum: {{minimum}}{{/minimum}}{{#maximum}}
+     * maximum: {{maximum}}{{/maximum}}
+     **/
+    this['{{baseName}}'] = {{{defaultValue}}};{{/defaultValue}}{{/required}}{{/vars}}
   };
 
   {{classname}}.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript-promise/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/PetApi.js
@@ -102,7 +102,7 @@
       var pathParams = {
       };
       var queryParams = {
-        'status': this.buildCollectionParam(status, 'multi')
+        'status': this.apiClient.buildCollectionParam(status, 'multi')
       };
       var headerParams = {
       };
@@ -137,7 +137,7 @@
       var pathParams = {
       };
       var queryParams = {
-        'tags': this.buildCollectionParam(tags, 'multi')
+        'tags': this.apiClient.buildCollectionParam(tags, 'multi')
       };
       var headerParams = {
       };

--- a/samples/client/petstore/javascript-promise/src/index.js
+++ b/samples/client/petstore/javascript-promise/src/index.js
@@ -1,21 +1,21 @@
 (function(factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['./ApiClient', './model/User', './model/Category', './model/Pet', './model/Tag', './model/Order', './api/UserApi', './api/StoreApi', './api/PetApi'], factory);
+    define(['./ApiClient', './model/Order', './model/User', './model/Category', './model/Tag', './model/Pet', './api/UserApi', './api/StoreApi', './api/PetApi'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('./ApiClient'), require('./model/User'), require('./model/Category'), require('./model/Pet'), require('./model/Tag'), require('./model/Order'), require('./api/UserApi'), require('./api/StoreApi'), require('./api/PetApi'));
+    module.exports = factory(require('./ApiClient'), require('./model/Order'), require('./model/User'), require('./model/Category'), require('./model/Tag'), require('./model/Pet'), require('./api/UserApi'), require('./api/StoreApi'), require('./api/PetApi'));
   }
-}(function(ApiClient, User, Category, Pet, Tag, Order, UserApi, StoreApi, PetApi) {
+}(function(ApiClient, Order, User, Category, Tag, Pet, UserApi, StoreApi, PetApi) {
   'use strict';
 
   return {
     ApiClient: ApiClient,
+    Order: Order,
     User: User,
     Category: Category,
-    Pet: Pet,
     Tag: Tag,
-    Order: Order,
+    Pet: Pet,
     UserApi: UserApi,
     StoreApi: StoreApi,
     PetApi: PetApi

--- a/samples/client/petstore/javascript-promise/src/model/Category.js
+++ b/samples/client/petstore/javascript-promise/src/model/Category.js
@@ -18,16 +18,6 @@
   
   var Category = function Category() { 
     
-    /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['name'] = null;
-    
   };
 
   Category.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript-promise/src/model/Order.js
+++ b/samples/client/petstore/javascript-promise/src/model/Order.js
@@ -18,37 +18,6 @@
   
   var Order = function Order() { 
     
-    /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: Integer
-     **/
-    this['petId'] = null;
-    
-    /**
-     * datatype: Integer
-     **/
-    this['quantity'] = null;
-    
-    /**
-     * datatype: Date
-     **/
-    this['shipDate'] = null;
-    
-    /**
-     * Order Status
-     * datatype: StatusEnum
-     **/
-    this['status'] = null;
-    
-    /**
-     * datatype: Boolean
-     **/
-    this['complete'] = null;
-    
   };
 
   Order.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript-promise/src/model/Pet.js
+++ b/samples/client/petstore/javascript-promise/src/model/Pet.js
@@ -19,38 +19,15 @@
   var Pet = function Pet(photoUrls, name) { 
     
     /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: Category
-     **/
-    this['category'] = new Category();
-    
-    /**
      * datatype: String
-     * required
+     * required 
      **/
     this['name'] = name;
-    
     /**
      * datatype: [String]
-     * required
+     * required 
      **/
     this['photoUrls'] = photoUrls;
-    
-    /**
-     * datatype: [Tag]
-     **/
-    this['tags'] = [];
-    
-    /**
-     * pet status in the store
-     * datatype: StatusEnum
-     **/
-    this['status'] = null;
-    
   };
 
   Pet.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript-promise/src/model/Tag.js
+++ b/samples/client/petstore/javascript-promise/src/model/Tag.js
@@ -18,16 +18,6 @@
   
   var Tag = function Tag() { 
     
-    /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['name'] = null;
-    
   };
 
   Tag.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript-promise/src/model/User.js
+++ b/samples/client/petstore/javascript-promise/src/model/User.js
@@ -18,47 +18,6 @@
   
   var User = function User() { 
     
-    /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['username'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['firstName'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['lastName'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['email'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['password'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['phone'] = null;
-    
-    /**
-     * User Status
-     * datatype: Integer
-     **/
-    this['userStatus'] = null;
-    
   };
 
   User.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript/src/index.js
+++ b/samples/client/petstore/javascript/src/index.js
@@ -1,21 +1,21 @@
 (function(factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['./ApiClient', './model/User', './model/Category', './model/Pet', './model/Tag', './model/Order', './api/UserApi', './api/StoreApi', './api/PetApi'], factory);
+    define(['./ApiClient', './model/Order', './model/User', './model/Category', './model/Tag', './model/Pet', './api/UserApi', './api/StoreApi', './api/PetApi'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('./ApiClient'), require('./model/User'), require('./model/Category'), require('./model/Pet'), require('./model/Tag'), require('./model/Order'), require('./api/UserApi'), require('./api/StoreApi'), require('./api/PetApi'));
+    module.exports = factory(require('./ApiClient'), require('./model/Order'), require('./model/User'), require('./model/Category'), require('./model/Tag'), require('./model/Pet'), require('./api/UserApi'), require('./api/StoreApi'), require('./api/PetApi'));
   }
-}(function(ApiClient, User, Category, Pet, Tag, Order, UserApi, StoreApi, PetApi) {
+}(function(ApiClient, Order, User, Category, Tag, Pet, UserApi, StoreApi, PetApi) {
   'use strict';
 
   return {
     ApiClient: ApiClient,
+    Order: Order,
     User: User,
     Category: Category,
-    Pet: Pet,
     Tag: Tag,
-    Order: Order,
+    Pet: Pet,
     UserApi: UserApi,
     StoreApi: StoreApi,
     PetApi: PetApi

--- a/samples/client/petstore/javascript/src/model/Category.js
+++ b/samples/client/petstore/javascript/src/model/Category.js
@@ -18,16 +18,6 @@
   
   var Category = function Category() { 
     
-    /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['name'] = null;
-    
   };
 
   Category.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript/src/model/Order.js
+++ b/samples/client/petstore/javascript/src/model/Order.js
@@ -18,37 +18,6 @@
   
   var Order = function Order() { 
     
-    /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: Integer
-     **/
-    this['petId'] = null;
-    
-    /**
-     * datatype: Integer
-     **/
-    this['quantity'] = null;
-    
-    /**
-     * datatype: Date
-     **/
-    this['shipDate'] = null;
-    
-    /**
-     * Order Status
-     * datatype: StatusEnum
-     **/
-    this['status'] = null;
-    
-    /**
-     * datatype: Boolean
-     **/
-    this['complete'] = null;
-    
   };
 
   Order.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript/src/model/Pet.js
+++ b/samples/client/petstore/javascript/src/model/Pet.js
@@ -19,38 +19,15 @@
   var Pet = function Pet(photoUrls, name) { 
     
     /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: Category
-     **/
-    this['category'] = new Category();
-    
-    /**
      * datatype: String
-     * required
+     * required 
      **/
     this['name'] = name;
-    
     /**
      * datatype: [String]
-     * required
+     * required 
      **/
     this['photoUrls'] = photoUrls;
-    
-    /**
-     * datatype: [Tag]
-     **/
-    this['tags'] = [];
-    
-    /**
-     * pet status in the store
-     * datatype: StatusEnum
-     **/
-    this['status'] = null;
-    
   };
 
   Pet.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript/src/model/Tag.js
+++ b/samples/client/petstore/javascript/src/model/Tag.js
@@ -18,16 +18,6 @@
   
   var Tag = function Tag() { 
     
-    /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['name'] = null;
-    
   };
 
   Tag.constructFromObject = function(data) {

--- a/samples/client/petstore/javascript/src/model/User.js
+++ b/samples/client/petstore/javascript/src/model/User.js
@@ -18,47 +18,6 @@
   
   var User = function User() { 
     
-    /**
-     * datatype: Integer
-     **/
-    this['id'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['username'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['firstName'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['lastName'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['email'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['password'] = null;
-    
-    /**
-     * datatype: String
-     **/
-    this['phone'] = null;
-    
-    /**
-     * User Status
-     * datatype: Integer
-     **/
-    this['userStatus'] = null;
-    
   };
 
   User.constructFromObject = function(data) {


### PR DESCRIPTION
Fixes #2142 

This removes the creation of empty instances
for optional parameters in the model constructors. The problem is that
when the data for these fields is not present, we are left with "empty"
instances, which is not desirable, for several reasons:

1. It means that we cannot check for the presence of a field using the
   usual JS idiom `if (object.field) {...}`.
2. It wastes memory with useless fields and objects.

Note: This completely removes the creation of "default" values
in the constructors. I don't know if there is some other case
where this is a useful thing (are there other kinds of defaults
besides empty instances of model classes?).