### PR TITLE
Fix for issue #2117

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -41,7 +41,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     }
     {{classname}} {{classVarName}} = ({{classname}}) o;
 
-    return true {{#hasVars}}&& {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+    return true {{#hasVars}}&& {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
         {{/hasMore}}{{/vars}}{{/hasVars}}
     {{#parent}}&& super.equals(o){{/parent}};
   }


### PR DESCRIPTION
@wing328  @fehguy Sorry for being late on this - was with family over the weekend!

This change adds `this` to field names in `equals` within `pojo.mustache` so that an incorrect `equals` method is not generated in cases where a class has an internal field that is the same as the `classVarName` of the class.