### PR TITLE
[Java] Remove unused jackson imports from Java models

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -9,6 +9,7 @@ import io.swagger.models.Swagger;
 import io.swagger.models.parameters.FormParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.*;
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -531,18 +532,18 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
             }
         }
 
-        if(model.isEnum == null || model.isEnum) {
+        if(!BooleanUtils.toBoolean(model.isEnum)) {
             // needed by all pojos, but not enums
             model.imports.add("ApiModelProperty");
             model.imports.add("ApiModel");
-            // comment out below as it's in the model template 
+            // comment out below as it's in the model template
             //model.imports.add("Objects");
 
             final String lib = getLibrary();
             if(StringUtils.isEmpty(lib) || "feign".equals(lib) || "jersey2".equals(lib)) {
                 model.imports.add("JsonProperty");
 
-                if(model.hasEnums != null || model.hasEnums == true) {
+                if(BooleanUtils.toBoolean(model.hasEnums)) {
                   model.imports.add("JsonValue");
                 }
             }
@@ -747,7 +748,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
                     }
                 }
             }
-            
+
             if(removedChildEnum) {
                 // If we removed an entry from this model's vars, we need to ensure hasMore is updated
                 int count = 0, numVars = codegenProperties.size();

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/model.mustache
@@ -47,16 +47,17 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
-    }
-    {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
-        {{/hasMore}}{{^hasMore}};{{/hasMore}}{{/vars}}{{/hasVars}}{{^hasVars}}
+    }{{#hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+    return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+        {{/hasMore}}{{/vars}}{{#parent}} &&
+        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
     return true;{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}});
+    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
   }
 
   @Override

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -38,17 +38,17 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
-    }
+    }{{#hasVars}}
     {{classname}} {{classVarName}} = ({{classname}}) o;
-
-    return true {{#hasVars}}&& {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
-        {{/hasMore}}{{/vars}}{{/hasVars}}
-    {{#parent}}&& super.equals(o){{/parent}};
+    return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+        {{/hasMore}}{{/vars}}{{#parent}} &&
+        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    return true;{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}},{{/hasVars}} super.hashCode(){{/parent}});
+    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
   }
 
   @Override

--- a/samples/client/petstore/java/default/README.md
+++ b/samples/client/petstore/java/default/README.md
@@ -20,7 +20,7 @@ mvn deploy
 
 Refer to the [official documentation](https://maven.apache.org/plugins/maven-deploy-plugin/usage.html) for more information.
 
-After the client libarary is installed/deployed, you can use it in your Maven project by adding the following to your *pom.xml*:
+After the client library is installed/deployed, you can use it in your Maven project by adding the following to your *pom.xml*:
 
 ```xml
 <dependency>

--- a/samples/client/petstore/java/default/build.gradle
+++ b/samples/client/petstore/java/default/build.gradle
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = 'io.swagger'
 version = '1.0.0'
 

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/ApiClient.java
@@ -41,7 +41,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:20.498+08:00")
 public class ApiClient {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private String basePath = "http://petstore.swagger.io/v2";
@@ -83,8 +83,12 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     authentications.put("petstore_auth", new OAuth());
+    authentications.put("test_api_client_id", new ApiKeyAuth("header", "x-test_api_client_id"));
+    authentications.put("test_api_client_secret", new ApiKeyAuth("header", "x-test_api_client_secret"));
+    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
+    authentications.put("test_api_key_query", new ApiKeyAuth("query", "test_api_key_query"));
+    authentications.put("test_api_key_header", new ApiKeyAuth("header", "test_api_key_header"));
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/PetApi.java
@@ -12,7 +12,7 @@ import java.io.File;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:20.498+08:00")
 public class PetApi {
   private ApiClient apiClient;
 
@@ -238,7 +238,7 @@ public class PetApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] { "api_key" };
+    String[] authNames = new String[] { "petstore_auth", "api_key" };
 
     
     GenericType<Pet> returnType = new GenericType<Pet>() {};
@@ -438,7 +438,7 @@ public class PetApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] { "api_key" };
+    String[] authNames = new String[] { "petstore_auth", "api_key" };
 
     
     GenericType<byte[]> returnType = new GenericType<byte[]>() {};

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/api/StoreApi.java
@@ -12,7 +12,7 @@ import io.swagger.client.model.Order;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:20.498+08:00")
 public class StoreApi {
   private ApiClient apiClient;
 
@@ -106,7 +106,7 @@ public class StoreApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] {  };
+    String[] authNames = new String[] { "test_api_client_id", "test_api_client_secret" };
 
     
     GenericType<Order> returnType = new GenericType<Order>() {};
@@ -153,7 +153,7 @@ public class StoreApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] {  };
+    String[] authNames = new String[] { "test_api_key_query", "test_api_key_header" };
 
     
     GenericType<Order> returnType = new GenericType<Order>() {};

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Category.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:20.498+08:00")
 public class Category   {
   
   private Long id = null;
@@ -63,10 +62,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-
-    return true && Objects.equals(id, category.id) &&
-        Objects.equals(name, category.name)
-    ;
+    return Objects.equals(this.id, category.id) &&
+        Objects.equals(this.name, category.name);
   }
 
   @Override

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Order.java
@@ -11,7 +11,7 @@ import java.util.Date;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:20.498+08:00")
 public class Order   {
   
   private Long id = null;
@@ -161,14 +161,12 @@ public class Order   {
       return false;
     }
     Order order = (Order) o;
-
-    return true && Objects.equals(id, order.id) &&
-        Objects.equals(petId, order.petId) &&
-        Objects.equals(quantity, order.quantity) &&
-        Objects.equals(shipDate, order.shipDate) &&
-        Objects.equals(status, order.status) &&
-        Objects.equals(complete, order.complete)
-    ;
+    return Objects.equals(this.id, order.id) &&
+        Objects.equals(this.petId, order.petId) &&
+        Objects.equals(this.quantity, order.quantity) &&
+        Objects.equals(this.shipDate, order.shipDate) &&
+        Objects.equals(this.status, order.status) &&
+        Objects.equals(this.complete, order.complete);
   }
 
   @Override

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Pet.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:20.498+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -163,14 +163,12 @@ public class Pet   {
       return false;
     }
     Pet pet = (Pet) o;
-
-    return true && Objects.equals(id, pet.id) &&
-        Objects.equals(category, pet.category) &&
-        Objects.equals(name, pet.name) &&
-        Objects.equals(photoUrls, pet.photoUrls) &&
-        Objects.equals(tags, pet.tags) &&
-        Objects.equals(status, pet.status)
-    ;
+    return Objects.equals(this.id, pet.id) &&
+        Objects.equals(this.category, pet.category) &&
+        Objects.equals(this.name, pet.name) &&
+        Objects.equals(this.photoUrls, pet.photoUrls) &&
+        Objects.equals(this.tags, pet.tags) &&
+        Objects.equals(this.status, pet.status);
   }
 
   @Override

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/Tag.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:20.498+08:00")
 public class Tag   {
   
   private Long id = null;
@@ -63,10 +62,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-
-    return true && Objects.equals(id, tag.id) &&
-        Objects.equals(name, tag.name)
-    ;
+    return Objects.equals(this.id, tag.id) &&
+        Objects.equals(this.name, tag.name);
   }
 
   @Override

--- a/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/default/src/main/java/io/swagger/client/model/User.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-12T18:48:10.013-08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:20.498+08:00")
 public class User   {
   
   private Long id = null;
@@ -178,16 +177,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-
-    return true && Objects.equals(id, user.id) &&
-        Objects.equals(username, user.username) &&
-        Objects.equals(firstName, user.firstName) &&
-        Objects.equals(lastName, user.lastName) &&
-        Objects.equals(email, user.email) &&
-        Objects.equals(password, user.password) &&
-        Objects.equals(phone, user.phone) &&
-        Objects.equals(userStatus, user.userStatus)
-    ;
+    return Objects.equals(this.id, user.id) &&
+        Objects.equals(this.username, user.username) &&
+        Objects.equals(this.firstName, user.firstName) &&
+        Objects.equals(this.lastName, user.lastName) &&
+        Objects.equals(this.email, user.email) &&
+        Objects.equals(this.password, user.password) &&
+        Objects.equals(this.phone, user.phone) &&
+        Objects.equals(this.userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/client/petstore/java/default/src/test/java/io/swagger/client/ApiClientTest.java
+++ b/samples/client/petstore/java/default/src/test/java/io/swagger/client/ApiClientTest.java
@@ -131,7 +131,13 @@ public class ApiClientTest {
 
     @Test
     public void testSetApiKeyAndPrefix() {
-        ApiKeyAuth auth = (ApiKeyAuth) apiClient.getAuthentications().get("api_key");
+        ApiKeyAuth auth = null;
+        for (Authentication _auth : apiClient.getAuthentications().values()) {
+            if (_auth instanceof ApiKeyAuth) {
+                auth = (ApiKeyAuth) _auth;
+                break;
+            }
+        }
         auth.setApiKey(null);
         auth.setApiKeyPrefix(null);
 

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = 'io.swagger'
 version = '1.0.0'
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
@@ -18,7 +18,7 @@ import feign.slf4j.Slf4jLogger;
 import io.swagger.client.auth.*;
 import io.swagger.client.auth.OAuth.AccessTokenListener;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-11T21:48:33.457Z")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:23.375+08:00")
 public class ApiClient {
   public interface Api {}
 
@@ -42,8 +42,16 @@ public class ApiClient {
       RequestInterceptor auth;
       if (authName == "petstore_auth") { 
         auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
+      } else if (authName == "test_api_client_id") { 
+        auth = new ApiKeyAuth("header", "x-test_api_client_id");
+      } else if (authName == "test_api_client_secret") { 
+        auth = new ApiKeyAuth("header", "x-test_api_client_secret");
       } else if (authName == "api_key") { 
         auth = new ApiKeyAuth("header", "api_key");
+      } else if (authName == "test_api_key_query") { 
+        auth = new ApiKeyAuth("query", "test_api_key_query");
+      } else if (authName == "test_api_key_header") { 
+        auth = new ApiKeyAuth("header", "test_api_key_header");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
       }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
@@ -8,7 +8,7 @@ import java.io.File;
 import java.util.*;
 import feign.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-11T21:48:33.457Z")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:23.375+08:00")
 public interface PetApi extends ApiClient.Api {
 
 
@@ -121,5 +121,31 @@ public interface PetApi extends ApiClient.Api {
     "Accepts: application/json",
   })
   void uploadFile(@Param("petId") Long petId, @Param("additionalMetadata") String additionalMetadata, @Param("file") File file);
+  
+  /**
+   * Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
+   * Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
+   * @param petId ID of pet that needs to be fetched
+   * @return byte[]
+   */
+  @RequestLine("GET /pet/{petId}?testing_byte_array=true")
+  @Headers({
+    "Content-type: application/json",
+    "Accepts: application/json",
+  })
+  byte[] getPetByIdWithByteArray(@Param("petId") Long petId);
+  
+  /**
+   * Fake endpoint to test byte array in body parameter for adding a new pet to the store
+   * 
+   * @param body Pet object in the form of byte array
+   * @return void
+   */
+  @RequestLine("POST /pet?testing_byte_array=true")
+  @Headers({
+    "Content-type: application/json",
+    "Accepts: application/json",
+  })
+  void addPetUsingByteArray(byte[] body);
   
 }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Category.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-11T21:48:33.457Z")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:23.375+08:00")
 public class Category   {
   
   private Long id = null;
@@ -19,8 +18,13 @@ public class Category   {
   
   /**
    **/
+  public Category id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -32,8 +36,13 @@ public class Category   {
   
   /**
    **/
+  public Category name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("name")
   public String getName() {
     return name;
@@ -45,7 +54,7 @@ public class Category   {
   
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -53,10 +62,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-
-    return true && Objects.equals(id, category.id) &&
-        Objects.equals(name, category.name)
-    ;
+    return Objects.equals(this.id, category.id) &&
+        Objects.equals(this.name, category.name);
   }
 
   @Override
@@ -79,7 +86,7 @@ public class Category   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
@@ -11,7 +11,7 @@ import java.util.Date;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-11T21:48:33.457Z")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:23.375+08:00")
 public class Order   {
   
   private Long id = null;
@@ -44,8 +44,13 @@ public class Order   {
   
   /**
    **/
+  public Order id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -57,8 +62,13 @@ public class Order   {
   
   /**
    **/
+  public Order petId(Long petId) {
+    this.petId = petId;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("petId")
   public Long getPetId() {
     return petId;
@@ -70,8 +80,13 @@ public class Order   {
   
   /**
    **/
+  public Order quantity(Integer quantity) {
+    this.quantity = quantity;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("quantity")
   public Integer getQuantity() {
     return quantity;
@@ -83,8 +98,13 @@ public class Order   {
   
   /**
    **/
+  public Order shipDate(Date shipDate) {
+    this.shipDate = shipDate;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("shipDate")
   public Date getShipDate() {
     return shipDate;
@@ -97,8 +117,13 @@ public class Order   {
   /**
    * Order Status
    **/
+  public Order status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "Order Status")
+  @ApiModelProperty(example = "null", value = "Order Status")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
@@ -110,8 +135,13 @@ public class Order   {
   
   /**
    **/
+  public Order complete(Boolean complete) {
+    this.complete = complete;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("complete")
   public Boolean getComplete() {
     return complete;
@@ -123,7 +153,7 @@ public class Order   {
   
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -131,14 +161,12 @@ public class Order   {
       return false;
     }
     Order order = (Order) o;
-
-    return true && Objects.equals(id, order.id) &&
-        Objects.equals(petId, order.petId) &&
-        Objects.equals(quantity, order.quantity) &&
-        Objects.equals(shipDate, order.shipDate) &&
-        Objects.equals(status, order.status) &&
-        Objects.equals(complete, order.complete)
-    ;
+    return Objects.equals(this.id, order.id) &&
+        Objects.equals(this.petId, order.petId) &&
+        Objects.equals(this.quantity, order.quantity) &&
+        Objects.equals(this.shipDate, order.shipDate) &&
+        Objects.equals(this.status, order.status) &&
+        Objects.equals(this.complete, order.complete);
   }
 
   @Override
@@ -165,7 +193,7 @@ public class Order   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-11T21:48:33.457Z")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:23.375+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -46,8 +46,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -59,8 +64,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet category(Category category) {
+    this.category = category;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("category")
   public Category getCategory() {
     return category;
@@ -72,8 +82,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
   public String getName() {
     return name;
@@ -85,8 +100,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet photoUrls(List<String> photoUrls) {
+    this.photoUrls = photoUrls;
+    return this;
+  }
+
   
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(example = "null", required = true, value = "")
   @JsonProperty("photoUrls")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -98,8 +118,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet tags(List<Tag> tags) {
+    this.tags = tags;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("tags")
   public List<Tag> getTags() {
     return tags;
@@ -112,8 +137,13 @@ public class Pet   {
   /**
    * pet status in the store
    **/
+  public Pet status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "pet status in the store")
+  @ApiModelProperty(example = "null", value = "pet status in the store")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
@@ -125,7 +155,7 @@ public class Pet   {
   
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -133,14 +163,12 @@ public class Pet   {
       return false;
     }
     Pet pet = (Pet) o;
-
-    return true && Objects.equals(id, pet.id) &&
-        Objects.equals(category, pet.category) &&
-        Objects.equals(name, pet.name) &&
-        Objects.equals(photoUrls, pet.photoUrls) &&
-        Objects.equals(tags, pet.tags) &&
-        Objects.equals(status, pet.status)
-    ;
+    return Objects.equals(this.id, pet.id) &&
+        Objects.equals(this.category, pet.category) &&
+        Objects.equals(this.name, pet.name) &&
+        Objects.equals(this.photoUrls, pet.photoUrls) &&
+        Objects.equals(this.tags, pet.tags) &&
+        Objects.equals(this.status, pet.status);
   }
 
   @Override
@@ -167,7 +195,7 @@ public class Pet   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Tag.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-11T21:48:33.457Z")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:23.375+08:00")
 public class Tag   {
   
   private Long id = null;
@@ -19,8 +18,13 @@ public class Tag   {
   
   /**
    **/
+  public Tag id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -32,8 +36,13 @@ public class Tag   {
   
   /**
    **/
+  public Tag name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("name")
   public String getName() {
     return name;
@@ -45,7 +54,7 @@ public class Tag   {
   
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -53,10 +62,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-
-    return true && Objects.equals(id, tag.id) &&
-        Objects.equals(name, tag.name)
-    ;
+    return Objects.equals(this.id, tag.id) &&
+        Objects.equals(this.name, tag.name);
   }
 
   @Override
@@ -79,7 +86,7 @@ public class Tag   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/User.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-11T21:48:33.457Z")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:23.375+08:00")
 public class User   {
   
   private Long id = null;
@@ -25,8 +24,13 @@ public class User   {
   
   /**
    **/
+  public User id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -38,8 +42,13 @@ public class User   {
   
   /**
    **/
+  public User username(String username) {
+    this.username = username;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("username")
   public String getUsername() {
     return username;
@@ -51,8 +60,13 @@ public class User   {
   
   /**
    **/
+  public User firstName(String firstName) {
+    this.firstName = firstName;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("firstName")
   public String getFirstName() {
     return firstName;
@@ -64,8 +78,13 @@ public class User   {
   
   /**
    **/
+  public User lastName(String lastName) {
+    this.lastName = lastName;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("lastName")
   public String getLastName() {
     return lastName;
@@ -77,8 +96,13 @@ public class User   {
   
   /**
    **/
+  public User email(String email) {
+    this.email = email;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("email")
   public String getEmail() {
     return email;
@@ -90,8 +114,13 @@ public class User   {
   
   /**
    **/
+  public User password(String password) {
+    this.password = password;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("password")
   public String getPassword() {
     return password;
@@ -103,8 +132,13 @@ public class User   {
   
   /**
    **/
+  public User phone(String phone) {
+    this.phone = phone;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("phone")
   public String getPhone() {
     return phone;
@@ -117,8 +151,13 @@ public class User   {
   /**
    * User Status
    **/
+  public User userStatus(Integer userStatus) {
+    this.userStatus = userStatus;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "User Status")
+  @ApiModelProperty(example = "null", value = "User Status")
   @JsonProperty("userStatus")
   public Integer getUserStatus() {
     return userStatus;
@@ -130,7 +169,7 @@ public class User   {
   
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -138,16 +177,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-
-    return true && Objects.equals(id, user.id) &&
-        Objects.equals(username, user.username) &&
-        Objects.equals(firstName, user.firstName) &&
-        Objects.equals(lastName, user.lastName) &&
-        Objects.equals(email, user.email) &&
-        Objects.equals(password, user.password) &&
-        Objects.equals(phone, user.phone) &&
-        Objects.equals(userStatus, user.userStatus)
-    ;
+    return Objects.equals(this.id, user.id) &&
+        Objects.equals(this.username, user.username) &&
+        Objects.equals(this.firstName, user.firstName) &&
+        Objects.equals(this.lastName, user.lastName) &&
+        Objects.equals(this.email, user.email) &&
+        Objects.equals(this.password, user.password) &&
+        Objects.equals(this.phone, user.phone) &&
+        Objects.equals(this.userStatus, user.userStatus);
   }
 
   @Override
@@ -176,7 +213,7 @@ public class User   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/client/petstore/java/jersey2/build.gradle
+++ b/samples/client/petstore/java/jersey2/build.gradle
@@ -1,3 +1,6 @@
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
 group = 'io.swagger'
 version = '1.0.0'
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
@@ -48,7 +48,7 @@ import io.swagger.client.auth.HttpBasicAuth;
 import io.swagger.client.auth.ApiKeyAuth;
 import io.swagger.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-28T16:23:25.238+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:21.885+08:00")
 public class ApiClient {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   private String basePath = "http://petstore.swagger.io/v2";
@@ -85,7 +85,11 @@ public class ApiClient {
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
     authentications.put("petstore_auth", new OAuth());
+    authentications.put("test_api_client_id", new ApiKeyAuth("header", "x-test_api_client_id"));
+    authentications.put("test_api_client_secret", new ApiKeyAuth("header", "x-test_api_client_secret"));
     authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
+    authentications.put("test_api_key_query", new ApiKeyAuth("query", "test_api_key_query"));
+    authentications.put("test_api_key_header", new ApiKeyAuth("header", "test_api_key_header"));
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
@@ -12,7 +12,7 @@ import java.io.File;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-28T16:23:25.238+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:21.885+08:00")
 public class PetApi {
   private ApiClient apiClient;
 
@@ -238,7 +238,7 @@ public class PetApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] { "api_key" };
+    String[] authNames = new String[] { "petstore_auth", "api_key" };
 
     
     GenericType<Pet> returnType = new GenericType<Pet>() {};
@@ -438,7 +438,7 @@ public class PetApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] { "api_key" };
+    String[] authNames = new String[] { "petstore_auth", "api_key" };
 
     
     GenericType<byte[]> returnType = new GenericType<byte[]>() {};

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/StoreApi.java
@@ -12,7 +12,7 @@ import io.swagger.client.model.Order;
 
 import java.util.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-28T16:23:25.238+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:21.885+08:00")
 public class StoreApi {
   private ApiClient apiClient;
 
@@ -106,7 +106,7 @@ public class StoreApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] {  };
+    String[] authNames = new String[] { "test_api_client_id", "test_api_client_secret" };
 
     
     GenericType<Order> returnType = new GenericType<Order>() {};
@@ -153,7 +153,7 @@ public class StoreApi {
     };
     final String contentType = apiClient.selectHeaderContentType(contentTypes);
 
-    String[] authNames = new String[] {  };
+    String[] authNames = new String[] { "test_api_key_query", "test_api_key_header" };
 
     
     GenericType<Order> returnType = new GenericType<Order>() {};

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Category.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-28T16:23:25.238+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:21.885+08:00")
 public class Category   {
   
   private Long id = null;
@@ -19,8 +18,13 @@ public class Category   {
   
   /**
    **/
+  public Category id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -32,8 +36,13 @@ public class Category   {
   
   /**
    **/
+  public Category name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("name")
   public String getName() {
     return name;
@@ -53,10 +62,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-
-    return true && Objects.equals(id, category.id) &&
-        Objects.equals(name, category.name)
-    ;
+    return Objects.equals(this.id, category.id) &&
+        Objects.equals(this.name, category.name);
   }
 
   @Override

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
@@ -11,7 +11,7 @@ import java.util.Date;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-28T16:23:25.238+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:21.885+08:00")
 public class Order   {
   
   private Long id = null;
@@ -44,8 +44,13 @@ public class Order   {
   
   /**
    **/
+  public Order id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -57,8 +62,13 @@ public class Order   {
   
   /**
    **/
+  public Order petId(Long petId) {
+    this.petId = petId;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("petId")
   public Long getPetId() {
     return petId;
@@ -70,8 +80,13 @@ public class Order   {
   
   /**
    **/
+  public Order quantity(Integer quantity) {
+    this.quantity = quantity;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("quantity")
   public Integer getQuantity() {
     return quantity;
@@ -83,8 +98,13 @@ public class Order   {
   
   /**
    **/
+  public Order shipDate(Date shipDate) {
+    this.shipDate = shipDate;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("shipDate")
   public Date getShipDate() {
     return shipDate;
@@ -97,8 +117,13 @@ public class Order   {
   /**
    * Order Status
    **/
+  public Order status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "Order Status")
+  @ApiModelProperty(example = "null", value = "Order Status")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
@@ -110,8 +135,13 @@ public class Order   {
   
   /**
    **/
+  public Order complete(Boolean complete) {
+    this.complete = complete;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("complete")
   public Boolean getComplete() {
     return complete;
@@ -131,14 +161,12 @@ public class Order   {
       return false;
     }
     Order order = (Order) o;
-
-    return true && Objects.equals(id, order.id) &&
-        Objects.equals(petId, order.petId) &&
-        Objects.equals(quantity, order.quantity) &&
-        Objects.equals(shipDate, order.shipDate) &&
-        Objects.equals(status, order.status) &&
-        Objects.equals(complete, order.complete)
-    ;
+    return Objects.equals(this.id, order.id) &&
+        Objects.equals(this.petId, order.petId) &&
+        Objects.equals(this.quantity, order.quantity) &&
+        Objects.equals(this.shipDate, order.shipDate) &&
+        Objects.equals(this.status, order.status) &&
+        Objects.equals(this.complete, order.complete);
   }
 
   @Override

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-28T16:23:25.238+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:21.885+08:00")
 public class Pet   {
   
   private Long id = null;
@@ -46,8 +46,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -59,8 +64,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet category(Category category) {
+    this.category = category;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("category")
   public Category getCategory() {
     return category;
@@ -72,8 +82,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
   public String getName() {
     return name;
@@ -85,8 +100,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet photoUrls(List<String> photoUrls) {
+    this.photoUrls = photoUrls;
+    return this;
+  }
+
   
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(example = "null", required = true, value = "")
   @JsonProperty("photoUrls")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -98,8 +118,13 @@ public class Pet   {
   
   /**
    **/
+  public Pet tags(List<Tag> tags) {
+    this.tags = tags;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("tags")
   public List<Tag> getTags() {
     return tags;
@@ -112,8 +137,13 @@ public class Pet   {
   /**
    * pet status in the store
    **/
+  public Pet status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "pet status in the store")
+  @ApiModelProperty(example = "null", value = "pet status in the store")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
@@ -133,14 +163,12 @@ public class Pet   {
       return false;
     }
     Pet pet = (Pet) o;
-
-    return true && Objects.equals(id, pet.id) &&
-        Objects.equals(category, pet.category) &&
-        Objects.equals(name, pet.name) &&
-        Objects.equals(photoUrls, pet.photoUrls) &&
-        Objects.equals(tags, pet.tags) &&
-        Objects.equals(status, pet.status)
-    ;
+    return Objects.equals(this.id, pet.id) &&
+        Objects.equals(this.category, pet.category) &&
+        Objects.equals(this.name, pet.name) &&
+        Objects.equals(this.photoUrls, pet.photoUrls) &&
+        Objects.equals(this.tags, pet.tags) &&
+        Objects.equals(this.status, pet.status);
   }
 
   @Override

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Tag.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-28T16:23:25.238+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:21.885+08:00")
 public class Tag   {
   
   private Long id = null;
@@ -19,8 +18,13 @@ public class Tag   {
   
   /**
    **/
+  public Tag id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -32,8 +36,13 @@ public class Tag   {
   
   /**
    **/
+  public Tag name(String name) {
+    this.name = name;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("name")
   public String getName() {
     return name;
@@ -53,10 +62,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-
-    return true && Objects.equals(id, tag.id) &&
-        Objects.equals(name, tag.name)
-    ;
+    return Objects.equals(this.id, tag.id) &&
+        Objects.equals(this.name, tag.name);
   }
 
   @Override

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/User.java
@@ -2,7 +2,6 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -10,7 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-01-28T16:23:25.238+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-02-17T17:16:21.885+08:00")
 public class User   {
   
   private Long id = null;
@@ -25,8 +24,13 @@ public class User   {
   
   /**
    **/
+  public User id(Long id) {
+    this.id = id;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -38,8 +42,13 @@ public class User   {
   
   /**
    **/
+  public User username(String username) {
+    this.username = username;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("username")
   public String getUsername() {
     return username;
@@ -51,8 +60,13 @@ public class User   {
   
   /**
    **/
+  public User firstName(String firstName) {
+    this.firstName = firstName;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("firstName")
   public String getFirstName() {
     return firstName;
@@ -64,8 +78,13 @@ public class User   {
   
   /**
    **/
+  public User lastName(String lastName) {
+    this.lastName = lastName;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("lastName")
   public String getLastName() {
     return lastName;
@@ -77,8 +96,13 @@ public class User   {
   
   /**
    **/
+  public User email(String email) {
+    this.email = email;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("email")
   public String getEmail() {
     return email;
@@ -90,8 +114,13 @@ public class User   {
   
   /**
    **/
+  public User password(String password) {
+    this.password = password;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("password")
   public String getPassword() {
     return password;
@@ -103,8 +132,13 @@ public class User   {
   
   /**
    **/
+  public User phone(String phone) {
+    this.phone = phone;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "null", value = "")
   @JsonProperty("phone")
   public String getPhone() {
     return phone;
@@ -117,8 +151,13 @@ public class User   {
   /**
    * User Status
    **/
+  public User userStatus(Integer userStatus) {
+    this.userStatus = userStatus;
+    return this;
+  }
+
   
-  @ApiModelProperty(value = "User Status")
+  @ApiModelProperty(example = "null", value = "User Status")
   @JsonProperty("userStatus")
   public Integer getUserStatus() {
     return userStatus;
@@ -138,16 +177,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-
-    return true && Objects.equals(id, user.id) &&
-        Objects.equals(username, user.username) &&
-        Objects.equals(firstName, user.firstName) &&
-        Objects.equals(lastName, user.lastName) &&
-        Objects.equals(email, user.email) &&
-        Objects.equals(password, user.password) &&
-        Objects.equals(phone, user.phone) &&
-        Objects.equals(userStatus, user.userStatus)
-    ;
+    return Objects.equals(this.id, user.id) &&
+        Objects.equals(this.username, user.username) &&
+        Objects.equals(this.firstName, user.firstName) &&
+        Objects.equals(this.lastName, user.lastName) &&
+        Objects.equals(this.email, user.email) &&
+        Objects.equals(this.password, user.password) &&
+        Objects.equals(this.phone, user.phone) &&
+        Objects.equals(this.userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/client/petstore/java/jersey2/src/test/java/io/swagger/client/ApiClientTest.java
+++ b/samples/client/petstore/java/jersey2/src/test/java/io/swagger/client/ApiClientTest.java
@@ -131,7 +131,13 @@ public class ApiClientTest {
 
     @Test
     public void testSetApiKeyAndPrefix() {
-        ApiKeyAuth auth = (ApiKeyAuth) apiClient.getAuthentications().get("api_key");
+        ApiKeyAuth auth = null;
+        for (Authentication _auth : apiClient.getAuthentications().values()) {
+            if (_auth instanceof ApiKeyAuth) {
+                auth = (ApiKeyAuth) _auth;
+                break;
+            }
+        }
         auth.setApiKey(null);
         auth.setApiKeyPrefix(null);
 

--- a/samples/client/petstore/java/okhttp-gson/README.md
+++ b/samples/client/petstore/java/okhttp-gson/README.md
@@ -20,7 +20,7 @@ mvn deploy
 
 Refer to the [official documentation](https://maven.apache.org/plugins/maven-deploy-plugin/usage.html) for more information.
 
-After the client libarary is installed/deployed, you can use it in your Maven project by adding the following to your *pom.xml*:
+After the client library is installed/deployed, you can use it in your Maven project by adding the following to your *pom.xml*:
 
 ```xml
 <dependency>

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -145,8 +145,12 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
     authentications.put("petstore_auth", new OAuth());
+    authentications.put("test_api_client_id", new ApiKeyAuth("header", "x-test_api_client_id"));
+    authentications.put("test_api_client_secret", new ApiKeyAuth("header", "x-test_api_client_secret"));
+    authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
+    authentications.put("test_api_key_query", new ApiKeyAuth("query", "test_api_key_query"));
+    authentications.put("test_api_key_header", new ApiKeyAuth("header", "test_api_key_header"));
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
@@ -491,7 +491,7 @@ public class PetApi {
       });
     }
 
-    String[] authNames = new String[] { "api_key" };
+    String[] authNames = new String[] { "petstore_auth", "api_key" };
     return apiClient.buildCall(path, "GET", queryParams, postBody, headerParams, formParams, authNames, progressRequestListener);
   }
 
@@ -936,7 +936,7 @@ public class PetApi {
       });
     }
 
-    String[] authNames = new String[] { "api_key" };
+    String[] authNames = new String[] { "petstore_auth", "api_key" };
     return apiClient.buildCall(path, "GET", queryParams, postBody, headerParams, formParams, authNames, progressRequestListener);
   }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
@@ -180,7 +180,7 @@ public class StoreApi {
       });
     }
 
-    String[] authNames = new String[] {  };
+    String[] authNames = new String[] { "test_api_client_id", "test_api_client_secret" };
     return apiClient.buildCall(path, "POST", queryParams, postBody, headerParams, formParams, authNames, progressRequestListener);
   }
 
@@ -288,7 +288,7 @@ public class StoreApi {
       });
     }
 
-    String[] authNames = new String[] {  };
+    String[] authNames = new String[] { "test_api_key_query", "test_api_key_header" };
     return apiClient.buildCall(path, "GET", queryParams, postBody, headerParams, formParams, authNames, progressRequestListener);
   }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Category.java
@@ -52,8 +52,8 @@ public class Category   {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(id, category.id) &&
-        Objects.equals(name, category.name);
+    return Objects.equals(this.id, category.id) &&
+        Objects.equals(this.name, category.name);
   }
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Order.java
@@ -133,12 +133,12 @@ public enum StatusEnum {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(id, order.id) &&
-        Objects.equals(petId, order.petId) &&
-        Objects.equals(quantity, order.quantity) &&
-        Objects.equals(shipDate, order.shipDate) &&
-        Objects.equals(status, order.status) &&
-        Objects.equals(complete, order.complete);
+    return Objects.equals(this.id, order.id) &&
+        Objects.equals(this.petId, order.petId) &&
+        Objects.equals(this.quantity, order.quantity) &&
+        Objects.equals(this.shipDate, order.shipDate) &&
+        Objects.equals(this.status, order.status) &&
+        Objects.equals(this.complete, order.complete);
   }
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Pet.java
@@ -135,12 +135,12 @@ public enum StatusEnum {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(id, pet.id) &&
-        Objects.equals(category, pet.category) &&
-        Objects.equals(name, pet.name) &&
-        Objects.equals(photoUrls, pet.photoUrls) &&
-        Objects.equals(tags, pet.tags) &&
-        Objects.equals(status, pet.status);
+    return Objects.equals(this.id, pet.id) &&
+        Objects.equals(this.category, pet.category) &&
+        Objects.equals(this.name, pet.name) &&
+        Objects.equals(this.photoUrls, pet.photoUrls) &&
+        Objects.equals(this.tags, pet.tags) &&
+        Objects.equals(this.status, pet.status);
   }
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Tag.java
@@ -52,8 +52,8 @@ public class Tag   {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(id, tag.id) &&
-        Objects.equals(name, tag.name);
+    return Objects.equals(this.id, tag.id) &&
+        Objects.equals(this.name, tag.name);
   }
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/User.java
@@ -137,14 +137,14 @@ public class User   {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(id, user.id) &&
-        Objects.equals(username, user.username) &&
-        Objects.equals(firstName, user.firstName) &&
-        Objects.equals(lastName, user.lastName) &&
-        Objects.equals(email, user.email) &&
-        Objects.equals(password, user.password) &&
-        Objects.equals(phone, user.phone) &&
-        Objects.equals(userStatus, user.userStatus);
+    return Objects.equals(this.id, user.id) &&
+        Objects.equals(this.username, user.username) &&
+        Objects.equals(this.firstName, user.firstName) &&
+        Objects.equals(this.lastName, user.lastName) &&
+        Objects.equals(this.email, user.email) &&
+        Objects.equals(this.password, user.password) &&
+        Objects.equals(this.phone, user.phone) &&
+        Objects.equals(this.userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ApiClientTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ApiClientTest.java
@@ -170,7 +170,13 @@ public class ApiClientTest {
 
     @Test
     public void testSetApiKeyAndPrefix() {
-        ApiKeyAuth auth = (ApiKeyAuth) apiClient.getAuthentications().get("api_key");
+        ApiKeyAuth auth = null;
+        for (Authentication _auth : apiClient.getAuthentications().values()) {
+            if (_auth instanceof ApiKeyAuth) {
+                auth = (ApiKeyAuth) _auth;
+                break;
+            }
+        }
         auth.setApiKey(null);
         auth.setApiKeyPrefix(null);
 


### PR DESCRIPTION
* Remove unused jackson imports from Java models by fixing the logic of enum Boolean checking.
* Remove the `true &&` prefix from the `equals` method in models.
* Apply some changes of Java-default to Java-okhttp-gson, i.e. adding `this` and parent model handling.
* Some improvements on spaces and blank lines.
* Generate latest Java clients for Petstore: Java default, feign, jersey2 and okhttp-gson.