### PR TITLE
Handle empty response.body from superagent

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -208,7 +208,9 @@
     // See http://visionmedia.github.io/superagent/#parsing-response-bodies
     var data = response.body;
     if (data == null) {
-      return null;
+      // Superagent does not always produce a body; use the unparsed response
+      // as a fallback
+      data = response.text;
     }
     return ApiClient.convertToType(data, returnType);
   };

--- a/samples/client/petstore/javascript-promise/package.json
+++ b/samples/client/petstore/javascript-promise/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "mocha": "~2.3.4",
+    "sinon": "1.17.3",
     "expect.js": "~0.3.1"
   }
 }

--- a/samples/client/petstore/javascript-promise/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/PetApi.js
@@ -41,6 +41,7 @@
       var formParams = {
       };
 
+      var authNames = ['petstore_auth'];
       var contentTypes = ['application/json', 'application/xml'];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -48,7 +49,7 @@
       return this.apiClient.callApi(
         '/pet', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -73,6 +74,7 @@
       var formParams = {
       };
 
+      var authNames = ['petstore_auth'];
       var contentTypes = ['application/json', 'application/xml'];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -80,7 +82,7 @@
       return this.apiClient.callApi(
         '/pet', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -107,6 +109,7 @@
       var formParams = {
       };
 
+      var authNames = ['petstore_auth'];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = [Pet];
@@ -114,7 +117,7 @@
       return this.apiClient.callApi(
         '/pet/findByStatus', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -141,6 +144,7 @@
       var formParams = {
       };
 
+      var authNames = ['petstore_auth'];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = [Pet];
@@ -148,7 +152,7 @@
       return this.apiClient.callApi(
         '/pet/findByTags', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -180,6 +184,7 @@
       var formParams = {
       };
 
+      var authNames = ['petstore_auth', 'api_key'];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = Pet;
@@ -187,7 +192,7 @@
       return this.apiClient.callApi(
         '/pet/{petId}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -222,6 +227,7 @@
         'status': status
       };
 
+      var authNames = ['petstore_auth'];
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -229,7 +235,7 @@
       return this.apiClient.callApi(
         '/pet/{petId}', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -262,6 +268,7 @@
       var formParams = {
       };
 
+      var authNames = ['petstore_auth'];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -269,7 +276,7 @@
       return this.apiClient.callApi(
         '/pet/{petId}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -304,6 +311,7 @@
         'file': file
       };
 
+      var authNames = ['petstore_auth'];
       var contentTypes = ['multipart/form-data'];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -311,7 +319,7 @@
       return this.apiClient.callApi(
         '/pet/{petId}/uploadImage', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -343,6 +351,7 @@
       var formParams = {
       };
 
+      var authNames = ['petstore_auth', 'api_key'];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = 'String';
@@ -350,7 +359,7 @@
       return this.apiClient.callApi(
         '/pet/{petId}?testing_byte_array=true', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -375,6 +384,7 @@
       var formParams = {
       };
 
+      var authNames = ['petstore_auth'];
       var contentTypes = ['application/json', 'application/xml'];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -382,7 +392,7 @@
       return this.apiClient.callApi(
         '/pet?testing_byte_array=true', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }

--- a/samples/client/petstore/javascript-promise/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/StoreApi.js
@@ -41,6 +41,7 @@
       var formParams = {
       };
 
+      var authNames = ['api_key'];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = {'String': 'Integer'};
@@ -48,7 +49,7 @@
       return this.apiClient.callApi(
         '/store/inventory', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -74,6 +75,7 @@
       var formParams = {
       };
 
+      var authNames = ['test_api_client_id', 'test_api_client_secret'];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = Order;
@@ -81,7 +83,7 @@
       return this.apiClient.callApi(
         '/store/order', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -113,6 +115,7 @@
       var formParams = {
       };
 
+      var authNames = ['test_api_key_query', 'test_api_key_header'];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = Order;
@@ -120,7 +123,7 @@
       return this.apiClient.callApi(
         '/store/order/{orderId}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -151,6 +154,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -158,7 +162,7 @@
       return this.apiClient.callApi(
         '/store/order/{orderId}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }

--- a/samples/client/petstore/javascript-promise/src/api/UserApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/UserApi.js
@@ -41,6 +41,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -48,7 +49,7 @@
       return this.apiClient.callApi(
         '/user', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -73,6 +74,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -80,7 +82,7 @@
       return this.apiClient.callApi(
         '/user/createWithArray', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -105,6 +107,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -112,7 +115,7 @@
       return this.apiClient.callApi(
         '/user/createWithList', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -141,6 +144,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = 'String';
@@ -148,7 +152,7 @@
       return this.apiClient.callApi(
         '/user/login', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -172,6 +176,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -179,7 +184,7 @@
       return this.apiClient.callApi(
         '/user/logout', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -211,6 +216,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = User;
@@ -218,7 +224,7 @@
       return this.apiClient.callApi(
         '/user/{username}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -250,6 +256,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -257,7 +264,7 @@
       return this.apiClient.callApi(
         '/user/{username}', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }
@@ -288,6 +295,7 @@
       var formParams = {
       };
 
+      var authNames = [];
       var contentTypes = [];
       var accepts = ['application/json', 'application/xml'];
       var returnType = null;
@@ -295,7 +303,7 @@
       return this.apiClient.callApi(
         '/user/{username}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType
       );
       
     }

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -211,7 +211,9 @@
     // See http://visionmedia.github.io/superagent/#parsing-response-bodies
     var data = response.body;
     if (data == null) {
-      return null;
+      // Superagent does not always produce a body; use the unparsed response
+      // as a fallback
+      data = response.text;
     }
     return ApiClient.convertToType(data, returnType);
   };


### PR DESCRIPTION
Superagent does not always produce a `body`. See
http://visionmedia.github.io/superagent/ for details. When it
doesn't, we should deserialize the raw `response.text` rather
than returning `null`. Currently, the JS client always returns
`null` when the return type is String! This commit fixes
that.