### PR TITLE
Support for enums in query parameters (issue #1347)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 public class CodegenParameter {
     public Boolean isFormParam, isQueryParam, isPathParam, isHeaderParam,
-            isCookieParam, isBodyParam, hasMore, isContainer, 
+            isCookieParam, isBodyParam, hasMore, isContainer,
             secondaryParam, isCollectionFormatMulti;
-    public String baseName, paramName, dataType, collectionFormat, description, baseType, defaultValue;
+    public String baseName, paramName, dataType, datatypeWithEnum, collectionFormat, description, baseType, defaultValue;
     public String jsonSchema;
     public Boolean isString, isInteger, isLong, isFloat, isDouble, isByteArray, isBinary, isBoolean, isDate, isDateTime;
     public Boolean isListContainer, isMapContainer;
@@ -17,6 +17,7 @@ public class CodegenParameter {
     public boolean isEnum;
     public List<String> _enum;
     public Map<String, Object> allowableValues;
+    public CodegenProperty items;
     public Map<String, Object> vendorExtensions;
 
     /**
@@ -81,6 +82,7 @@ public class CodegenParameter {
         output.baseName = this.baseName;
         output.paramName = this.paramName;
         output.dataType = this.dataType;
+        output.datatypeWithEnum = this.datatypeWithEnum;
         output.collectionFormat = this.collectionFormat;
         output.isCollectionFormatMulti = this.isCollectionFormatMulti;
         output.description = this.description;
@@ -111,6 +113,9 @@ public class CodegenParameter {
         }
         if (this.allowableValues != null) {
             output.allowableValues = new HashMap<String, Object>(this.allowableValues);
+        }
+        if (this.items != null) {
+            output.items = this.items;
         }
         output.vendorExtensions = this.vendorExtensions;
         output.isBinary = this.isBinary;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1660,9 +1660,16 @@ public class DefaultCodegen {
             setParameterBooleanFlagWithCodegenProperty(p, model);
 
             p.dataType = model.datatype;
+            if(model.isEnum) {
+                p.datatypeWithEnum = model.datatypeWithEnum;
+            }
             p.isEnum = model.isEnum;
             p._enum = model._enum;
             p.allowableValues = model.allowableValues;
+            if(model.items != null && model.items.isEnum) {
+                p.datatypeWithEnum = model.datatypeWithEnum;
+                p.items = model.items;
+            }
             p.collectionFormat = collectionFormat;
             if(collectionFormat != null && collectionFormat.equals("multi")) {
                 p.isCollectionFormatMulti = true;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -81,6 +81,40 @@ public class CodegenTest {
         Assert.assertNull(statusParam.hasMore);
     }
 
+    @Test(description = "handle enum array in query parameter test")
+    public void enumArrayQueryParameterTest() {
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/petstore.json");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        final String path = "/pet/findByStatus";
+        final Operation p = model.getPaths().get(path).getGet();
+        final CodegenOperation op = codegen.fromOperation(path, "get", p, model.getDefinitions());
+
+        Assert.assertEquals(op.queryParams.size(), 1);
+
+        final CodegenParameter statusParam = op.queryParams.get(0);
+        Assert.assertEquals(statusParam.items.datatypeWithEnum, "StatusEnum");
+        Assert.assertNotNull(statusParam.items);
+        Assert.assertTrue(statusParam.items.isEnum);
+        Assert.assertEquals(statusParam.items._enum.size(), 3);
+    }
+
+    @Test(description = "handle enum in query parameter test")
+    public void enumQueryParameterTest() {
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/petstore.json");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        final String path = "/store/findByStatus";
+        final Operation p = model.getPaths().get(path).getGet();
+        final CodegenOperation op = codegen.fromOperation(path, "get", p, model.getDefinitions());
+
+        Assert.assertEquals(op.queryParams.size(), 1);
+
+        final CodegenParameter statusParam = op.queryParams.get(0);
+        Assert.assertEquals(statusParam.datatypeWithEnum, "StatusEnum");
+        Assert.assertTrue(statusParam.isEnum);
+        Assert.assertEquals(statusParam._enum.size(), 3);
+    }
+
+
     @Test(description = "handle required parameters from a 2.0 spec as required when figuring out Swagger types")
     public void requiredParametersTest() {
         final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/requiredTest.json");

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -156,7 +156,7 @@
           "pet"
         ],
         "summary": "Finds Pets by status",
-        "description": "Multiple status values can be provided with comma seperated strings",
+        "description": "Multiple status values can be provided with comma separated strings",
         "operationId": "findPetsByStatus",
         "produces": [
           "application/json",
@@ -166,13 +166,23 @@
           {
             "name": "status",
             "in": "query",
-            "description": "Status values that need to be considered for filter",
+            "description": "Status values that need to be considered for query",
             "required": false,
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "available",
+                "pending",
+                "sold"
+              ]
             },
             "collectionFormat": "multi",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ],
             "default": "available"
           }
         ],
@@ -558,6 +568,55 @@
           },
           "400": {
             "description": "Invalid Order"
+          }
+        },
+        "security": [
+          {
+            "test_api_client_id": [],
+            "test_api_client_secret": []
+          }
+        ]
+      }
+    },
+     "/store/findByStatus": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Finds orders by status",
+        "description": "A single status value can be provided as a string",
+        "operationId": "findOrdersByStatus",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status value that needs to be considered for query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ],
+            "default": "placed"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Order"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
           }
         },
         "security": [


### PR DESCRIPTION
@fehguy @wing328 

This is a fix to support enums in query parameters. Enum-related information was not being stored on `CodegenParameter` previously; it is now. Test cases have been added to make sure that the enum information is being properly processed from the model.

Let me know if this change is alright. Also, the SDK templates have not been updated to take this change into account. Since I'm most familiar with Java, I think I might be able to update the Java template to support enums, but I think it would be best to make that a separate pull-request (assuming this one is approved).