### PR TITLE
avoid inner class

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2095,14 +2095,6 @@ public class DefaultCodegen {
             word = m.replaceAll(rep);
         }
 
-        // Replace two underscores with $ to support inner classes.
-        p = Pattern.compile("(__)(.)");
-        m = p.matcher(word);
-        while (m.find()) {
-            word = m.replaceFirst("\\$" + m.group(2).toUpperCase());
-            m = p.matcher(word);
-        }
-
         // Remove all underscores
         p = Pattern.compile("(_)(.)");
         m = p.matcher(word);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -372,10 +372,6 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         return camelize(name);
     }
 
-    public static String camelize(String word) {
-        return DefaultCodegen.camelize(word).replaceAll("\\$", "");
-    }
-
     @Override
     public String toModelFilename(String name) {
         // should be the same as the model name

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -372,6 +372,10 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         return camelize(name);
     }
 
+    public static String camelize(String word) {
+        return DefaultCodegen.camelize(word).replaceAll("\\$", "");
+    }
+
     @Override
     public String toModelFilename(String name) {
         // should be the same as the model name

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -20,6 +20,7 @@ import io.swagger.models.properties.StringProperty;
 
 import com.google.common.collect.Sets;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -455,5 +456,29 @@ public class JavaModelTest {
         final CodegenParameter cm = codegen.fromParameter(parameter, null);
 
         Assert.assertNull(cm.allowableValues);
+    }
+
+    @DataProvider(name = "modelNames")
+    public static Object[][] primeNumbers() {
+        return new Object[][] {
+                {"sample", "Sample"},
+                {"sample_name", "SampleName"},
+                {"sample__name", "SampleName"},
+                {"/sample", "Sample"},
+                {"\\sample", "Sample"},
+                {"sample.name", "SampleName"},
+                {"_sample", "Sample"},
+                {"Sample", "Sample"},
+        };
+    }
+
+    @Test(dataProvider = "modelNames", description = "avoid inner class")
+    public void modelNameTest(String name, String expectedName) {
+        final Model model = new ModelImpl();
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        final CodegenModel cm = codegen.fromModel(name, model);
+
+        Assert.assertEquals(cm.name, name);
+        Assert.assertEquals(cm.classname, expectedName);
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
@@ -241,4 +241,20 @@ public class PhpModelTest {
         Assert.assertEquals(cm.imports.size(), 2);
         Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
     }
+
+    @Test(description = "avoid $ in class and file name, cased by two underscore in the model name.")
+    public void ModelTest() {
+        final Model model = new ModelImpl()
+                .description("a map model")
+                .additionalProperties(new RefProperty("#/definitions/Children"));
+        final DefaultCodegen codegen = new PhpClientCodegen();
+        final CodegenModel cm = codegen.fromModel("sample__model", model);
+
+        Assert.assertEquals(cm.name, "sample__model");
+        Assert.assertEquals(cm.classname, "SampleModel");
+        Assert.assertEquals(cm.description, "a map model");
+        Assert.assertEquals(cm.vars.size(), 0);
+        Assert.assertEquals(cm.imports.size(), 2);
+        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+    }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
@@ -16,6 +16,7 @@ import io.swagger.models.properties.StringProperty;
 
 import com.google.common.collect.Sets;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @SuppressWarnings("static-method")
@@ -242,19 +243,26 @@ public class PhpModelTest {
         Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
     }
 
-    @Test(description = "avoid $ in class and file name, cased by two underscore in the model name.")
-    public void ModelTest() {
-        final Model model = new ModelImpl()
-                .description("a map model")
-                .additionalProperties(new RefProperty("#/definitions/Children"));
-        final DefaultCodegen codegen = new PhpClientCodegen();
-        final CodegenModel cm = codegen.fromModel("sample__model", model);
+    @DataProvider(name = "modelNames")
+    public static Object[][] primeNumbers() {
+        return new Object[][] {
+            {"sample", "Sample"},
+            {"sample_name", "SampleName"},
+            {"sample__name", "SampleName"},
+            {"/sample", "Sample"},
+            {"\\sample", "\\Sample"},
+            {"sample.name", "SampleName"},
+            {"_sample", "Sample"},
+        };
+    }
 
-        Assert.assertEquals(cm.name, "sample__model");
-        Assert.assertEquals(cm.classname, "SampleModel");
-        Assert.assertEquals(cm.description, "a map model");
-        Assert.assertEquals(cm.vars.size(), 0);
-        Assert.assertEquals(cm.imports.size(), 2);
-        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
+    @Test(dataProvider = "modelNames", description = "avoid inner class")
+    public void modelNameTest(String name, String expectedName) {
+        final Model model = new ModelImpl();
+        final DefaultCodegen codegen = new PhpClientCodegen();
+        final CodegenModel cm = codegen.fromModel(name, model);
+
+        Assert.assertEquals(cm.name, name);
+        Assert.assertEquals(cm.classname, expectedName);
     }
 }


### PR DESCRIPTION
it is cased because the property start with underscore and
object is created on th fly

fix #2191