### PR TITLE
Added discriminator support to Objective-C

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -8,6 +8,7 @@ public class CodegenModel {
     public String parent, parentSchema;
     public String name, classname, description, classVarName, modelJson, dataType;
     public String unescapedDescription;
+    public String discriminator;
     public String defaultValue;
     public List<CodegenProperty> vars = new ArrayList<CodegenProperty>();
     public List<String> allowableValues;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -864,6 +864,10 @@ public class DefaultCodegen {
         m.externalDocs = model.getExternalDocs();
         m.vendorExtensions = model.getVendorExtensions();
 
+        if (model instanceof ModelImpl) {
+            m.discriminator = ((ModelImpl) model).getDiscriminator();
+        }
+
 
         if (model instanceof ArrayModel) {
             ArrayModel am = (ArrayModel) model;

--- a/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
@@ -16,6 +16,31 @@
   return self;
 }
 
+{{#discriminator}}
+/**
+ Maps "discriminator" value to the sub-class name, so that inheritance is supported.
+ */
+- (id)initWithDictionary:(NSDictionary *)dict error:(NSError *__autoreleasing *)err {
+
+
+    NSString * discriminatedClassName = [dict valueForKey:@"{{discriminator}}"];
+
+    if(discriminatedClassName == nil ){
+         return [super initWithDictionary:dict error:err];
+    }
+
+    Class class = NSClassFromString([@"{{classPrefix}}" stringByAppendingString:discriminatedClassName]);
+
+    if([self class ] == class) {
+        return [super initWithDictionary:dict error:err];
+    }
+
+
+    return [[class alloc] initWithDictionary:dict error: err];
+
+}
+{{/discriminator}}
+
 /**
  * Maps json key to property name.
  * This method is used by `JSONModel`.

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/objc/ObjcModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/objc/ObjcModelTest.java
@@ -35,7 +35,8 @@ public class ObjcModelTest {
                 .property("name", new StringProperty())
                 .property("createdAt", new DateTimeProperty())
                 .required("id")
-                .required("name");
+                .required("name")
+                .discriminator("test");
         final DefaultCodegen codegen = new ObjcClientCodegen();
         final CodegenModel cm = codegen.fromModel("sample", model);
 
@@ -43,6 +44,7 @@ public class ObjcModelTest {
         Assert.assertEquals(cm.classname, "SWGSample");
         Assert.assertEquals(cm.description, "a sample model");
         Assert.assertEquals(cm.vars.size(), 3);
+        Assert.assertEquals(cm.discriminator,"test");
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");

--- a/modules/swagger-codegen/src/test/resources/2_0/discriminatorTest.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/discriminatorTest.json
@@ -1,0 +1,76 @@
+{
+  "swagger" : "2.0",
+  "info" : {},
+  "basePath" : "/v1",
+  "tags" : [ {
+    "name" : "pets",
+    "description" : "some pets"
+  }],
+  "paths" : {
+    "/pets" : {
+      "get" : {
+        "tags" : [ "pets" ],
+        "summary" : "Get your pets",
+        "description" : "Returns pets of different types",
+        "operationId" : "getPets",
+        "consumes" : [ "application/x-www-form-urlencoded" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Animal"
+            }
+          },
+          "409" : {
+            "description" : "User already has an account or an account request."
+          },
+          "500" : {
+            "description" : "Error creating the account request"
+          }
+        }
+      }
+    }
+  },
+
+  "definitions" : {
+    "Dog" : {
+      "allOf" : [ {
+        "$ref" : "#/definitions/Animal"
+      }, {
+        "type" : "object",
+        "properties" : {
+          "breed" : {
+            "type" : "string"
+          }
+        }
+      } ]
+    },
+    "Cat" : {
+      "allOf" : [ {
+        "$ref" : "#/definitions/Animal"
+      }, {
+        "type" : "object",
+        "properties" : {
+          "declawed" : {
+            "type" : "boolean"
+          }
+        }
+      } ]
+    },
+    "Animal" : {
+      "type" : "object",
+      "discriminator": "className",
+      "required": [
+        "className"
+      ],
+      "properties" : {
+        "className" : {
+          "type" : "string"
+        }
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
The swagger spec includes a discriminator field for Models. This discriminator value is the name of the property on the model that contains the name of the intended subtype for a given object. See discriminator under Fixed Fields in this page

http://swagger.io/specification/#schemaObject

This pull request adds a mustache conditional template to the objective-c model-object template for when the discriminator is defined for a given swagger model. The condition adds a custom initWithDictionary method that uses the value found in the dictionary to determine the appropriate class to return. This causes the discriminator value to be automatically applied per the spec. This implementation fails gracefully when the discriminator is defined but not supplied. The implementation fails hard when the discriminator is defined, and the value defines a class that is not present at runtime. 

Implementing this support required adding the discriminator value from the Swagger Model to CodeGen Model converter. This property can be used to add inheritance support to other languages. 