### PR TITLE
Feature/1255 suffix+prefix for model name

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -73,6 +73,12 @@ public class Generate implements Runnable {
     @Option(name = {"--model-package"}, title = "model package", description = CodegenConstants.MODEL_PACKAGE_DESC)
     private String modelPackage;
 
+    @Option(name = {"--model-name-prefix"}, title = "model name prefix", description = CodegenConstants.MODEL_NAME_PREFIX_DESC)
+    private String modelNamePrefix;
+
+    @Option(name = {"--model-name-suffix"}, title = "model name suffix", description = CodegenConstants.MODEL_NAME_SUFFIX_DESC)
+    private String modelNameSuffix;
+
     @Option(name = {"--instantiation-types"}, title = "instantiation types", description = "sets instantiation type mappings in the format of type=instantiatedType,type=instantiatedType." +
             "For example (in Java): array=ArrayList,map=HashMap. In other words array types will get instantiated as ArrayList in generated code.")
     private String instantiationTypes;
@@ -154,6 +160,14 @@ public class Generate implements Runnable {
 
         if(isNotEmpty(modelPackage)) {
             configurator.setModelPackage(modelPackage);
+        }
+
+        if(isNotEmpty(modelNamePrefix)){
+            configurator.setModelNamePrefix(modelNamePrefix);
+        }
+
+        if(isNotEmpty(modelNameSuffix)){
+            configurator.setModelNameSuffix(modelNameSuffix);
         }
 
         if(isNotEmpty(invokerPackage)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -82,4 +82,9 @@ public class CodegenConstants {
 
     public static enum MODEL_PROPERTY_NAMING_TYPE {camelCase, PascalCase, snake_case, original}
 
+    public static final String MODEL_NAME_PREFIX = "modelNamePrefix";
+    public static final String MODEL_NAME_PREFIX_DESC = "Prefix that will be prepended to all model names. Default is the empty string.";
+
+    public static final String MODEL_NAME_SUFFIX = "modelNameSuffix";
+    public static final String MODEL_NAME_SUFFIX_DESC = "Suffix that will be appended to all model names. Default is the empty string.";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -63,6 +63,7 @@ public class DefaultCodegen {
     protected Set<String> languageSpecificPrimitives = new HashSet<String>();
     protected Map<String, String> importMapping = new HashMap<String, String>();
     protected String modelPackage = "", apiPackage = "", fileSuffix;
+    protected String modelNamePrefix = "", modelNameSuffix = "";
     protected String testPackage = "";
     protected Map<String, String> apiTemplateFiles = new HashMap<String, String>();
     protected Map<String, String> modelTemplateFiles = new HashMap<String, String>();
@@ -826,8 +827,8 @@ public class DefaultCodegen {
      * @param name the name of the model
      * @return capitalized model name
      */
-    public String toModelName(String name) {
-        return initialCaps(name);
+    public String toModelName(final String name) {
+        return initialCaps(modelNamePrefix + name + modelNameSuffix);
     }
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -108,6 +108,14 @@ public class DefaultCodegen {
             this.setEnsureUniqueParams(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.ENSURE_UNIQUE_PARAMS).toString()));
         }
+
+        if(additionalProperties.containsKey(CodegenConstants.MODEL_NAME_PREFIX)){
+            this.setModelNamePrefix((String) additionalProperties.get(CodegenConstants.MODEL_NAME_PREFIX));
+        }
+
+        if(additionalProperties.containsKey(CodegenConstants.MODEL_NAME_SUFFIX)){
+            this.setModelNameSuffix((String) additionalProperties.get(CodegenConstants.MODEL_NAME_SUFFIX));
+        }
     }
 
     // override with any special post-processing for all models
@@ -282,6 +290,14 @@ public class DefaultCodegen {
 
     public void setModelPackage(String modelPackage) {
         this.modelPackage = modelPackage;
+    }
+
+    public void setModelNamePrefix(String modelNamePrefix){
+        this.modelNamePrefix = modelNamePrefix;
+    }
+
+    public void setModelNameSuffix(String modelNameSuffix){
+        this.modelNameSuffix = modelNameSuffix;
     }
 
     public void setApiPackage(String apiPackage) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -48,6 +48,8 @@ public class CodegenConfigurator {
     private String apiPackage;
     private String modelPackage;
     private String invokerPackage;
+    private String modelNamePrefix;
+    private String modelNameSuffix;
     private String groupId;
     private String artifactId;
     private String artifactVersion;
@@ -94,6 +96,24 @@ public class CodegenConfigurator {
 
     public CodegenConfigurator setModelPackage(String modelPackage) {
         this.modelPackage = modelPackage;
+        return this;
+    }
+
+    public String getModelNamePrefix() {
+        return modelNamePrefix;
+    }
+
+    public CodegenConfigurator setModelNamePrefix(String prefix) {
+        this.modelNamePrefix = prefix;
+        return this;
+    }
+
+    public String getModelNameSuffix() {
+        return modelNameSuffix;
+    }
+
+    public CodegenConfigurator setModelNameSuffix(String suffix) {
+        this.modelNameSuffix = suffix;
         return this;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -320,6 +320,8 @@ public class CodegenConfigurator {
         checkAndSetAdditionalProperty(artifactId, CodegenConstants.ARTIFACT_ID);
         checkAndSetAdditionalProperty(artifactVersion, CodegenConstants.ARTIFACT_VERSION);
         checkAndSetAdditionalProperty(templateDir, toAbsolutePathStr(templateDir), CodegenConstants.TEMPLATE_DIR);
+        checkAndSetAdditionalProperty(modelNamePrefix, CodegenConstants.MODEL_NAME_PREFIX);
+        checkAndSetAdditionalProperty(modelNameSuffix, CodegenConstants.MODEL_NAME_SUFFIX);
 
         handleDynamicProperties(config);
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
@@ -468,7 +468,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toModelName(String name) {
-        name = sanitizeName(name);
+        name = sanitizeName(modelNamePrefix + name + modelNameSuffix);
 
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(name)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -219,9 +219,6 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
             importMapping.remove("DateTime");
             instantiationTypes.put("array", "java.util.ArrayList");
             instantiationTypes.put("map", "java.util.HashMap");
-        } else {
-            languageSpecificPrimitives.add("List");
-            languageSpecificPrimitives.add("Map");
         }
 
         this.sanitizeConfig();
@@ -490,7 +487,8 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         String type = null;
         if (typeMapping.containsKey(swaggerType)) {
             type = typeMapping.get(swaggerType);
-            if (languageSpecificPrimitives.contains(type) || type.indexOf(".") >= 0) {
+            if (languageSpecificPrimitives.contains(type) || type.indexOf(".") >= 0 ||
+                type.equals("Map") || type.equals("List")) {
                 return type;
             }
         } else {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -219,6 +219,9 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
             importMapping.remove("DateTime");
             instantiationTypes.put("array", "java.util.ArrayList");
             instantiationTypes.put("map", "java.util.HashMap");
+        } else {
+            languageSpecificPrimitives.add("List");
+            languageSpecificPrimitives.add("Map");
         }
 
         this.sanitizeConfig();
@@ -377,6 +380,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toModelName(String name) {
+        name = super.toModelName(name);
         name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
         // camelize the model name

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -376,22 +376,21 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    public String toModelName(String name) {
-        name = super.toModelName(name);
-        name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+    public String toModelName(final String name) {
+        final String sanitizedName = sanitizeName(modelNamePrefix + name + modelNameSuffix);
 
         // camelize the model name
         // phone_number => PhoneNumber
-        name = camelize(name);
+        final String camelizedName = camelize(sanitizedName);
 
         // model name cannot use reserved keyword, e.g. return
-        if (isReservedWord(name)) {
-            String modelName = "Object" + name;
-            LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to " + modelName);
+        if (isReservedWord(camelizedName)) {
+            final String modelName = "Object" + camelizedName;
+            LOGGER.warn(camelizedName + " (reserved word) cannot be used as model name. Renamed to " + modelName);
             return modelName;
         }
 
-        return name;
+        return camelizedName;
     }
 
     @Override


### PR DESCRIPTION
This fixes most of #1255 by adding the options `--model-name-prefix` and `--model-name-suffix` to the CLI, with corresponding changes to DefaultCodegen and CodegenConfigurator.

For C# and Java generators we (@jimschubert and me) also added support code as they override `DefaultCodegen.toModelName`.
I guess this needs to be changed for quite some other languages too.

We also need some unit tests for this functionality, these are not yet included. (The existing unit tests still run without changes, as none of them uses these options.)