### PR TITLE
issue #1875 fixing -Dapis= work for -l html, provding test.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtmlGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtmlGenerator.java
@@ -101,20 +101,4 @@ public class StaticHtmlGenerator extends DefaultCodegen implements CodegenConfig
         }
         return objs;
     }
-
-    @Override
-    public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
-        List<CodegenOperation> opList = operations.get(ALL_OPERATIONS);
-        if (opList == null) {
-            opList = new ArrayList<CodegenOperation>();
-            operations.put(ALL_OPERATIONS, opList);
-        }
-        for (CodegenOperation addedOperation : opList) {
-            if (addedOperation.operationId.equals(co.operationId) && addedOperation.path.equals(co.path) && addedOperation.httpMethod.equals(co.httpMethod)) {
-                addedOperation.tags.addAll(co.tags);
-                return;
-            }
-        }
-        opList.add(co);
-    }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
@@ -170,7 +170,7 @@ public class DefaultGeneratorTest {
         //generate content first time without skipOverwrite flag, so all generated files should be recorded
         new DefaultGenerator().opts(clientOptInput).generate();
         final File order = new File(output, MODEL_ORDER_FILE);
-        assertTrue(order.exists());
+        assertTrue(order.exists(),""+order.getAbsolutePath());
 
         //change content of one file
         changeContent(order);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
@@ -1,6 +1,5 @@
 package io.swagger.codegen;
 
-import io.swagger.codegen.config.CodegenConfigurator;
 import io.swagger.codegen.languages.JavaClientCodegen;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
@@ -165,22 +164,13 @@ public class DefaultGeneratorTest {
         final Swagger swagger = new SwaggerParser().read("src/test/resources/petstore.json");
         CodegenConfig codegenConfig = new JavaClientCodegen();
         codegenConfig.setOutputDir(output.getAbsolutePath());
-        {
-            new CodegenConfigurator().setVerbose(true).toClientOptInput();
-        }
 
         ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
 
-        final File order = new File(output, MODEL_ORDER_FILE);
-        System.out.println(""+order.getAbsolutePath()+" exists:"+order.exists());
         //generate content first time without skipOverwrite flag, so all generated files should be recorded
         new DefaultGenerator().opts(clientOptInput).generate();
-        {
-            new CodegenConfigurator().setVerbose(true).toClientOptInput();
-        }
-
-        
-        assertTrue(order.exists(),"can't find: "+order.getAbsolutePath()+" output dir is:"+ (output.getAbsolutePath())+" it exists:"+output.exists() );
+        final File order = new File(output, MODEL_ORDER_FILE);
+        assertTrue(order.exists());
 
         //change content of one file
         changeContent(order);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
@@ -170,7 +170,7 @@ public class DefaultGeneratorTest {
         //generate content first time without skipOverwrite flag, so all generated files should be recorded
         new DefaultGenerator().opts(clientOptInput).generate();
         final File order = new File(output, MODEL_ORDER_FILE);
-        assertTrue(order.exists(),""+order.getAbsolutePath());
+        assertTrue(order.exists(),"can't find: "+order.getAbsolutePath()+" output dir is:"+ (output.getAbsolutePath())+" it exists:"+output.exists() );
 
         //change content of one file
         changeContent(order);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
@@ -1,5 +1,6 @@
 package io.swagger.codegen;
 
+import io.swagger.codegen.config.CodegenConfigurator;
 import io.swagger.codegen.languages.JavaClientCodegen;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
@@ -164,12 +165,21 @@ public class DefaultGeneratorTest {
         final Swagger swagger = new SwaggerParser().read("src/test/resources/petstore.json");
         CodegenConfig codegenConfig = new JavaClientCodegen();
         codegenConfig.setOutputDir(output.getAbsolutePath());
+        {
+            new CodegenConfigurator().setVerbose(true).toClientOptInput();
+        }
 
         ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
 
+        final File order = new File(output, MODEL_ORDER_FILE);
+        System.out.println(""+order.getAbsolutePath()+" exists:"+order.exists());
         //generate content first time without skipOverwrite flag, so all generated files should be recorded
         new DefaultGenerator().opts(clientOptInput).generate();
-        final File order = new File(output, MODEL_ORDER_FILE);
+        {
+            new CodegenConfigurator().setVerbose(true).toClientOptInput();
+        }
+
+        
         assertTrue(order.exists(),"can't find: "+order.getAbsolutePath()+" output dir is:"+ (output.getAbsolutePath())+" it exists:"+output.exists() );
 
         //change content of one file

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/statichtml/StaticHtmlTagsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/statichtml/StaticHtmlTagsTest.java
@@ -83,7 +83,9 @@ public class StaticHtmlTagsTest {
                     "something has been changed in code and now code bypass the mock above...");
         } finally {
             if (apisBackup!=null) {
-              System.setProperty("apis", apisBackup);
+                System.setProperty("apis", apisBackup);
+            }else{
+                System.clearProperty("apis");  
             }
         }
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/statichtml/StaticHtmlTagsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/statichtml/StaticHtmlTagsTest.java
@@ -1,0 +1,132 @@
+package io.swagger.codegen.statichtml;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.rules.TemporaryFolder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import io.swagger.codegen.ClientOptInput;
+import io.swagger.codegen.ClientOpts;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.DefaultGenerator;
+import io.swagger.codegen.languages.StaticHtmlGenerator;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Swagger;
+import io.swagger.parser.SwaggerParser;
+
+public class StaticHtmlTagsTest {
+
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        folder.create();
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        folder.delete();
+    }
+    
+    @Test 
+    public void testApiTags() throws Exception {
+        final Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/petstore.json");
+
+        final int maxTagsToTest = 2; // how to flip it randomly from 2 to 1, and shuffle ops?
+        // if an op has a few tags it will be duplicated here, but it's exactly what we expect in doc
+        final List<Operation> expectedOperations = new ArrayList<Operation>();
+        
+        final String capitalCommatizedTags = pickupFewTagsAndOps(swagger,
+                maxTagsToTest, expectedOperations);
+        
+        final Collection<Object> seenOperations = new ArrayList<Object>();
+        CodegenConfig codegenConfig =  new StaticHtmlGenerator(){ // new StaticDocCodegen(){
+            public  Map<String, Object> postProcessSupportingFileData(Map<String, Object> objs)  {
+                //System.out.println(getOperations(objs));
+                final Collection<?> actualOperations = getOperations(objs);
+                seenOperations.addAll(actualOperations);
+                assertEquals(actualOperations.size(), expectedOperations.size(), 
+                        "Expectig the same size of ops for -Dapis="+capitalCommatizedTags +
+                        " in fact, actual "+actualOperations+" doesn't seem like expecting " 
+                                + expectedOperations);
+                return objs;
+            }
+        };
+        codegenConfig.setOutputDir(folder.getRoot().getAbsolutePath());
+            
+        ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger)
+                .config(codegenConfig);
+
+        final String apisBackup = System.setProperty("apis", capitalCommatizedTags);
+        try {
+            DefaultGenerator gen = new DefaultGenerator();
+            gen.opts(clientOptInput);
+            gen.generate();
+            assertEquals(seenOperations.isEmpty(), false, 
+                    "something has been changed in code and now code bypass the mock above...");
+        } finally {
+            if (apisBackup!=null) {
+              System.setProperty("apis", apisBackup);
+            }
+        }
+    }
+
+    protected String pickupFewTagsAndOps(final Swagger swagger,
+            final int maxTagsToTest, final Collection<Operation> expectedOperations) {
+        Set<String> expectedTags = new HashSet<String>();
+        for ( Path path:swagger.getPaths().values() ) {
+            for ( Operation op : path.getOperations() ) {
+                for ( String tag : op.getTags() ) {
+                    if (expectedTags.size() < maxTagsToTest) {
+                        expectedTags.add(tag);
+                        expectedOperations.add(op);
+                    } else {
+                        if ( expectedTags.contains(tag) ) {
+                            expectedOperations.add(op);
+                        }
+                    }
+                }
+            }
+        }
+        
+        final String capitalCommatizedTags = StringUtils.join(
+                Lists.transform(Lists.newArrayList(expectedTags), 
+                        new Function<String, String>() { 
+            @Nullable
+            @Override
+            public String apply(final String input) {
+                return StringUtils.capitalize(input);
+            }
+        }), ",");
+        return capitalCommatizedTags;
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    protected static Collection getOperations(Map<String, Object> objs) {
+        final ArrayList rez = new ArrayList();
+        final Map apiInfo = (Map)objs.get("apiInfo");
+        for(Object apiElem : ((List)apiInfo.get("apis"))){ 
+            Map<String, Object> api = (Map<String, Object>) apiElem;
+            rez.addAll( (Collection) // what if the same op goes on two tags??
+            ((Map)api.get("operations")).get("operation"));
+        }
+        return rez;
+    }
+}


### PR DESCRIPTION
here we go. I checked generated files with -Dapis= -DsupportingFiles= manually. I also checked that StaticHtmlTagsTest.java test is representative, eg. if you put  StaticDocCodegen as a mock it pass well. Note, I don't use mock library, but miss randomized test library.

Nevertheless, let me know if I can improve it. Thanks! 