### PR TITLE
Fix 2156 - Use fixed date/time in operation.examples to avoid unnecessary diffs

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -93,9 +93,9 @@ public class ExampleGenerator {
                 };
             }
         } else if (property instanceof DateProperty) {
-            return new java.util.Date(System.currentTimeMillis());
+            return "2000-01-23T04:56:07.000+0000";
         } else if (property instanceof DateTimeProperty) {
-            return new java.util.Date(System.currentTimeMillis());
+            return "2000-01-23T04:56:07.000+0000";
         } else if (property instanceof DecimalProperty) {
             return new BigDecimal(1.3579);
         } else if (property instanceof DoubleProperty) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
@@ -16,10 +16,8 @@ import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import org.codehaus.plexus.util.StringUtils;
 
-import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -33,8 +31,6 @@ public class XmlExampleGenerator {
     public static String TAG_END = "</";
     private static String EMPTY = "";
     protected Map<String, Model> examples;
-    protected SimpleDateFormat dtFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-    protected SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
     public XmlExampleGenerator(Map<String, Model> examples) {
         this.examples = examples;
@@ -172,7 +168,7 @@ public class XmlExampleGenerator {
             if (property.getExample() != null) {
                 return property.getExample().toString();
             } else {
-                return dtFormat.format(new Date());
+                return "2000-01-23T04:56:07.000Z";
             }
         } else if (property instanceof StringProperty) {
             if (property.getExample() != null) {
@@ -184,7 +180,7 @@ public class XmlExampleGenerator {
             if (property.getExample() != null) {
                 return property.getExample().toString();
             } else {
-                return dateFormat.format(new Date());
+                return "2000-01-23T04:56:07.000Z";
             }
         } else if (property instanceof IntegerProperty) {
             if (property.getExample() != null) {

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -54,12 +54,12 @@ extension PetstoreClientAPI {
   "complete" : true,
   "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2016-02-13T08:19:01.757+0000"
+  "shipDate" : "2000-01-23T04:56:07.000+0000"
 }, contentType=application/json}, {example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2016-02-13T16:19:01.763Z</shipDate>
+  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
 </Order>, contentType=application/xml}]
@@ -69,12 +69,12 @@ extension PetstoreClientAPI {
   "complete" : true,
   "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2016-02-13T08:19:01.757+0000"
+  "shipDate" : "2000-01-23T04:56:07.000+0000"
 }, contentType=application/json}, {example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2016-02-13T16:19:01.763Z</shipDate>
+  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
 </Order>, contentType=application/xml}]
@@ -106,12 +106,12 @@ extension PetstoreClientAPI {
   "complete" : true,
   "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2016-02-13T08:19:01.765+0000"
+  "shipDate" : "2000-01-23T04:56:07.000+0000"
 }, contentType=application/json}, {example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2016-02-13T16:19:01.766Z</shipDate>
+  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
 </Order>, contentType=application/xml}]
@@ -121,12 +121,12 @@ extension PetstoreClientAPI {
   "complete" : true,
   "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2016-02-13T08:19:01.765+0000"
+  "shipDate" : "2000-01-23T04:56:07.000+0000"
 }, contentType=application/json}, {example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
-  <shipDate>2016-02-13T16:19:01.766Z</shipDate>
+  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
 </Order>, contentType=application/xml}]


### PR DESCRIPTION
Fix https://github.com/swagger-api/swagger-codegen/issues/2156

I initially thought to keep using `Date` class but its automatic timezone handling was a bit annoying and decided to use just a plain text representation.  Hope it is OK.