### PR TITLE
[Ruby] Handle empty/reserved operation id

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -38,6 +38,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
     protected String gemAuthor = "";
     protected String gemAuthorEmail = "";
 
+    protected static int emptyMethodNameCounter = 0;
 
     public RubyClientCodegen() {
         super();
@@ -409,14 +410,18 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toOperationId(String operationId) {
-        // throw exception if method name is empty
+        // rename to empty_method_name_1 (e.g.) if method name is empty
         if (StringUtils.isEmpty(operationId)) {
-            throw new RuntimeException("Empty method name (operationId) not allowed");
+            operationId = underscore("empty_method_name_" + emptyMethodNameCounter++);
+            LOGGER.warn("Empty method name (operationId) found. Renamed to " + operationId);
+            return operationId;
         }
 
         // method name cannot use reserved keyword, e.g. return
         if (reservedWords.contains(operationId)) {
-            throw new RuntimeException(operationId + " (reserved word) cannot be used as method name");
+            String newOperationId = underscore("call_" + operationId);
+            LOGGER.warn(operationId + " (reserved word) cannot be used as method name. Renamed to " + newOperationId);
+            return newOperationId;
         }
 
         return underscore(sanitizeName(operationId));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -360,7 +360,9 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
 
         // model name cannot use reserved keyword, e.g. return
         if (reservedWords.contains(name)) {
-            throw new RuntimeException(name + " (reserved word) cannot be used as a model name");
+            String modelName = camelize("object_" + name);
+            LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to " + modelName);
+            return modelName;
         }
 
         // camelize the model name
@@ -372,7 +374,9 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
     public String toModelFilename(String name) {
         // model name cannot use reserved keyword, e.g. return
         if (reservedWords.contains(name)) {
-            throw new RuntimeException(name + " (reserved word) cannot be used as a model name");
+            String filename = underscore("object_" + name);
+            LOGGER.warn(name + " (reserved word) cannot be used as model filename. Renamed to " + filename);
+            return filename;
         }
 
         // underscore the model file name

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -263,7 +263,7 @@
         ],
         "parameters": [
           {
-            "name": "package",
+            "name": "petId",
             "in": "path",
             "description": "ID of pet that needs to be fetched",
             "required": true,

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -506,29 +506,29 @@ module Petstore
 
     # Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
     # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
-    # @param pet_id ID of pet that needs to be fetched
+    # @param package ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
     # @return [String]
-    def get_pet_by_id_with_byte_array(pet_id, opts = {})
-      data, status_code, headers = get_pet_by_id_with_byte_array_with_http_info(pet_id, opts)
+    def pet_pet_idtesting_byte_arraytrue_get(package, opts = {})
+      data, status_code, headers = pet_pet_idtesting_byte_arraytrue_get_with_http_info(package, opts)
       return data
     end
 
     # Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
     # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
-    # @param pet_id ID of pet that needs to be fetched
+    # @param package ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
-    def get_pet_by_id_with_byte_array_with_http_info(pet_id, opts = {})
+    def pet_pet_idtesting_byte_arraytrue_get_with_http_info(package, opts = {})
       if @api_client.config.debugging
-        @api_client.config.logger.debug "Calling API: PetApi#get_pet_by_id_with_byte_array ..."
+        @api_client.config.logger.debug "Calling API: PetApi#pet_pet_idtesting_byte_arraytrue_get ..."
       end
       
-      # verify the required parameter 'pet_id' is set
-      fail "Missing the required parameter 'pet_id' when calling get_pet_by_id_with_byte_array" if pet_id.nil?
+      # verify the required parameter 'package' is set
+      fail "Missing the required parameter 'package' when calling pet_pet_idtesting_byte_arraytrue_get" if package.nil?
       
       # resource path
-      path = "/pet/{petId}?testing_byte_array=true".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
+      path = "/pet/{petId}?testing_byte_array=true".sub('{format}','json').sub('{' + 'package' + '}', package.to_s)
 
       # query parameters
       query_params = {}
@@ -559,7 +559,7 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'String')
       if @api_client.config.debugging
-        @api_client.config.logger.debug "API called: PetApi#get_pet_by_id_with_byte_array\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+        @api_client.config.logger.debug "API called: PetApi#pet_pet_idtesting_byte_arraytrue_get\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -506,29 +506,29 @@ module Petstore
 
     # Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
     # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
-    # @param package ID of pet that needs to be fetched
+    # @param pet_id ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
     # @return [String]
-    def pet_pet_idtesting_byte_arraytrue_get(package, opts = {})
-      data, status_code, headers = pet_pet_idtesting_byte_arraytrue_get_with_http_info(package, opts)
+    def pet_pet_idtesting_byte_arraytrue_get(pet_id, opts = {})
+      data, status_code, headers = pet_pet_idtesting_byte_arraytrue_get_with_http_info(pet_id, opts)
       return data
     end
 
     # Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
     # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
-    # @param package ID of pet that needs to be fetched
+    # @param pet_id ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
-    def pet_pet_idtesting_byte_arraytrue_get_with_http_info(package, opts = {})
+    def pet_pet_idtesting_byte_arraytrue_get_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: PetApi#pet_pet_idtesting_byte_arraytrue_get ..."
       end
       
-      # verify the required parameter 'package' is set
-      fail "Missing the required parameter 'package' when calling pet_pet_idtesting_byte_arraytrue_get" if package.nil?
+      # verify the required parameter 'pet_id' is set
+      fail "Missing the required parameter 'pet_id' when calling pet_pet_idtesting_byte_arraytrue_get" if pet_id.nil?
       
       # resource path
-      path = "/pet/{petId}?testing_byte_array=true".sub('{format}','json').sub('{' + 'package' + '}', package.to_s)
+      path = "/pet/{petId}?testing_byte_array=true".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
       query_params = {}

--- a/samples/client/petstore/ruby/spec/api/PetApi_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/PetApi_spec.rb
@@ -172,7 +172,7 @@ describe 'PetApi' do
   # unit tests for pet_pet_idtesting_byte_arraytrue_get
   # Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
   # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
-  # @param package ID of pet that needs to be fetched
+  # @param pet_id ID of pet that needs to be fetched
   # @param [Hash] opts the optional parameters
   # @return [String]
   describe 'pet_pet_idtesting_byte_arraytrue_get test' do

--- a/samples/client/petstore/ruby/spec/api/PetApi_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/PetApi_spec.rb
@@ -169,13 +169,13 @@ describe 'PetApi' do
     end
   end
 
-  # unit tests for get_pet_by_id_with_byte_array
+  # unit tests for pet_pet_idtesting_byte_arraytrue_get
   # Fake endpoint to test byte array return by &#39;Find pet by ID&#39;
   # Returns a pet when ID &lt; 10.  ID &gt; 10 or nonintegers will simulate API error conditions
-  # @param pet_id ID of pet that needs to be fetched
+  # @param package ID of pet that needs to be fetched
   # @param [Hash] opts the optional parameters
   # @return [String]
-  describe 'get_pet_by_id_with_byte_array test' do
+  describe 'pet_pet_idtesting_byte_arraytrue_get test' do
     it "should work" do
       # assertion here
       # should be_a()

--- a/samples/client/petstore/ruby/spec/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/pet_spec.rb
@@ -100,7 +100,7 @@ describe "Pet" do
       str = serialize_json(pet)
       @pet_api.add_pet_using_byte_array(body: str)
 
-      fetched_str = @pet_api.get_pet_by_id_with_byte_array(pet.id)
+      fetched_str = @pet_api.pet_pet_idtesting_byte_arraytrue_get(pet.id)
       fetched_str.should be_a(String)
       fetched = deserialize_json(fetched_str, 'Pet')
       fetched.should be_a(Petstore::Pet)


### PR DESCRIPTION
Handle empty/reserved operation id by using a normalized one instead of throwing errors.