### PR TITLE
Fix #2120, #2157 - Update Swift API method generation for ease of use

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -37,10 +37,12 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
   public static final String POD_DESCRIPTION = "podDescription";
   public static final String POD_SCREENSHOTS = "podScreenshots";
   public static final String POD_DOCUMENTATION_URL = "podDocumentationURL";
+  public static final String SWIFT_USE_API_NAMESPACE = "swiftUseApiNamespace";
   protected static final String LIBRARY_PROMISE_KIT = "PromiseKit";
   protected static final String[] RESPONSE_LIBRARIES = { LIBRARY_PROMISE_KIT };
   protected String projectName = "SwaggerClient";
   protected boolean unwrapRequired;
+  protected boolean swiftUseApiNamespace;
   protected String[] responseAs = new String[0];
   protected String sourceFolder = "Classes" + File.separator + "Swaggers";
   private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{[a-zA-Z_]+\\}");
@@ -143,6 +145,7 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
     cliOptions.add(new CliOption(POD_DESCRIPTION, "Description used for Podspec"));
     cliOptions.add(new CliOption(POD_SCREENSHOTS, "Screenshots used for Podspec"));
     cliOptions.add(new CliOption(POD_DOCUMENTATION_URL, "Documentation URL used for Podspec"));
+    cliOptions.add(new CliOption(SWIFT_USE_API_NAMESPACE, "Flag to make all the API classes inner-class of {{projectName}}API"));
   }
 
   @Override
@@ -176,6 +179,12 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
     if (ArrayUtils.contains(responseAs, LIBRARY_PROMISE_KIT)) {
       additionalProperties.put("usePromiseKit", true);
     }
+
+    // Setup swiftUseApiNamespace option, which makes all the API classes inner-class of {{projectName}}API
+    if (additionalProperties.containsKey(SWIFT_USE_API_NAMESPACE)) {
+      swiftUseApiNamespace = Boolean.parseBoolean(String.valueOf(additionalProperties.get(SWIFT_USE_API_NAMESPACE)));
+    }
+    additionalProperties.put(SWIFT_USE_API_NAMESPACE, swiftUseApiNamespace);
 
     supportingFiles.add(new SupportingFile("Podspec.mustache", "", projectName + ".podspec"));
     supportingFiles.add(new SupportingFile("Cartfile.mustache", "", "Cartfile"));

--- a/modules/swagger-codegen/src/main/resources/swift/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/api.mustache
@@ -16,6 +16,40 @@ extension {{projectName}}API {
         /**
          {{#summary}}
          {{{summary}}}
+         {{/summary}}{{#allParams}}
+         - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}}{{/allParams}}
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func {{operationId}}({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}completion: (({{#returnType}}data: {{{returnType}}}?, {{/returnType}}error: ErrorType?) -> Void)) {
+            {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute { (response, error) -> Void in
+                completion({{#returnType}}data: response?.body, {{/returnType}}error: error);
+            }
+        }
+
+{{#usePromiseKit}}
+        /**
+         {{#summary}}
+         {{{summary}}}
+         {{/summary}}{{#allParams}}
+         - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}}{{/allParams}}
+         - returns: Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
+         */
+        public class func {{operationId}}({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+            let deferred = Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.pendingPromise()
+            {{operationId}}({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) { {{#returnType}}data, {{/returnType}}error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill({{#returnType}}data!{{/returnType}})
+                }
+            }
+            return deferred.promise
+        }
+{{/usePromiseKit}}
+
+        /**
+         {{#summary}}
+         {{{summary}}}
          {{/summary}}
          - {{httpMethod}} {{path}}{{#notes}}
          - {{{notes}}}{{/notes}}{{#subresourceOperation}}
@@ -32,7 +66,7 @@ extension {{projectName}}API {
 
          - returns: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
          */
-        public class func {{operationId}}({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+        public class func {{operationId}}WithRequestBuilder({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
             {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{^secondaryParam}}var{{/secondaryParam}}{{/pathParams}} path = "{{path}}"{{#pathParams}}
             path = path.stringByReplacingOccurrencesOfString("{{=<% %>=}}{<%paramName%>}<%={{ }}=%>", withString: "\({{paramName}})", options: .LiteralSearch, range: nil){{/pathParams}}
             let URLString = {{projectName}}API.basePath + path

--- a/modules/swagger-codegen/src/main/resources/swift/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/api.mustache
@@ -8,82 +8,88 @@
 import Alamofire{{#usePromiseKit}}
 import PromiseKit{{/usePromiseKit}}
 
+{{#swiftUseApiNamespace}}
 extension {{projectName}}API {
-    {{#description}}
-    /** {{description}} */{{/description}}
-    public class {{classname}}: APIBase {
-    {{#operation}}
-        /**
-         {{#summary}}
-         {{{summary}}}
-         {{/summary}}{{#allParams}}
-         - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}}{{/allParams}}
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func {{operationId}}({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}completion: (({{#returnType}}data: {{{returnType}}}?, {{/returnType}}error: ErrorType?) -> Void)) {
-            {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute { (response, error) -> Void in
-                completion({{#returnType}}data: response?.body, {{/returnType}}error: error);
-            }
+{{/swiftUseApiNamespace}}
+
+{{#description}}
+/** {{description}} */{{/description}}
+public class {{classname}}: APIBase {
+{{#operation}}
+    /**
+     {{#summary}}
+     {{{summary}}}
+     {{/summary}}{{#allParams}}
+     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}}{{/allParams}}
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func {{operationId}}({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}completion: (({{#returnType}}data: {{{returnType}}}?, {{/returnType}}error: ErrorType?) -> Void)) {
+        {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute { (response, error) -> Void in
+            completion({{#returnType}}data: response?.body, {{/returnType}}error: error);
         }
+    }
 
 {{#usePromiseKit}}
-        /**
-         {{#summary}}
-         {{{summary}}}
-         {{/summary}}{{#allParams}}
-         - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}}{{/allParams}}
-         - returns: Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
-         */
-        public class func {{operationId}}({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
-            let deferred = Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.pendingPromise()
-            {{operationId}}({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) { {{#returnType}}data, {{/returnType}}error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill({{#returnType}}data!{{/returnType}})
-                }
+    /**
+     {{#summary}}
+     {{{summary}}}
+     {{/summary}}{{#allParams}}
+     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}}{{/allParams}}
+     - returns: Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
+     */
+    public class func {{operationId}}({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+        let deferred = Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.pendingPromise()
+        {{operationId}}({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) { {{#returnType}}data, {{/returnType}}error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill({{#returnType}}data!{{/returnType}})
             }
-            return deferred.promise
         }
+        return deferred.promise
+    }
 {{/usePromiseKit}}
 
-        /**
-         {{#summary}}
-         {{{summary}}}
-         {{/summary}}
-         - {{httpMethod}} {{path}}{{#notes}}
-         - {{{notes}}}{{/notes}}{{#subresourceOperation}}
-         - subresourceOperation: {{subresourceOperation}}{{/subresourceOperation}}{{#defaultResponse}}
-         - defaultResponse: {{defaultResponse}}{{/defaultResponse}}{{#authMethods}}
-         - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
-           - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
-           - name: {{name}}{{/authMethods}}{{#responseHeaders}}
-         - responseHeaders: {{responseHeaders}}{{/responseHeaders}}{{#examples}}
-         - examples: {{{examples}}}{{/examples}}{{#externalDocs}}
-         - externalDocs: {{externalDocs}}{{/externalDocs}}{{#hasParams}}
-         {{/hasParams}}{{#allParams}}
-         - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}}{{/allParams}}
+    /**
+     {{#summary}}
+     {{{summary}}}
+     {{/summary}}
+     - {{httpMethod}} {{path}}{{#notes}}
+     - {{{notes}}}{{/notes}}{{#subresourceOperation}}
+     - subresourceOperation: {{subresourceOperation}}{{/subresourceOperation}}{{#defaultResponse}}
+     - defaultResponse: {{defaultResponse}}{{/defaultResponse}}{{#authMethods}}
+     - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
+       - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
+       - name: {{name}}{{/authMethods}}{{#responseHeaders}}
+     - responseHeaders: {{responseHeaders}}{{/responseHeaders}}{{#examples}}
+     - examples: {{{examples}}}{{/examples}}{{#externalDocs}}
+     - externalDocs: {{externalDocs}}{{/externalDocs}}{{#hasParams}}
+     {{/hasParams}}{{#allParams}}
+     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}}{{/allParams}}
 
-         - returns: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
-         */
-        public class func {{operationId}}WithRequestBuilder({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
-            {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{^secondaryParam}}var{{/secondaryParam}}{{/pathParams}} path = "{{path}}"{{#pathParams}}
-            path = path.stringByReplacingOccurrencesOfString("{{=<% %>=}}{<%paramName%>}<%={{ }}=%>", withString: "\({{paramName}})", options: .LiteralSearch, range: nil){{/pathParams}}
-            let URLString = {{projectName}}API.basePath + path
-            {{#bodyParam}}
-            let parameters = {{paramName}}{{^required}}?{{/required}}.encodeToJSON() as? [String:AnyObject]{{/bodyParam}}{{^bodyParam}}
-            let nillableParameters: [String:AnyObject?] = {{^queryParams}}{{^formParams}}[:]{{/formParams}}{{#formParams}}{{^secondaryParam}}[{{/secondaryParam}}
-                "{{paramName}}": {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
-            ]{{/hasMore}}{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}[{{/secondaryParam}}
-                "{{paramName}}": {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
-            ]{{/hasMore}}{{/queryParams}}
-            let parameters = APIHelper.rejectNil(nillableParameters){{/bodyParam}}
+     - returns: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
+     */
+    public class func {{operationId}}WithRequestBuilder({{#allParams}}{{^secondaryParam}}{{paramName}} {{/secondaryParam}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+        {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{^secondaryParam}}var{{/secondaryParam}}{{/pathParams}} path = "{{path}}"{{#pathParams}}
+        path = path.stringByReplacingOccurrencesOfString("{{=<% %>=}}{<%paramName%>}<%={{ }}=%>", withString: "\({{paramName}})", options: .LiteralSearch, range: nil){{/pathParams}}
+        let URLString = {{projectName}}API.basePath + path
+        {{#bodyParam}}
+        let parameters = {{paramName}}{{^required}}?{{/required}}.encodeToJSON() as? [String:AnyObject]{{/bodyParam}}{{^bodyParam}}
+        let nillableParameters: [String:AnyObject?] = {{^queryParams}}{{^formParams}}[:]{{/formParams}}{{#formParams}}{{^secondaryParam}}[{{/secondaryParam}}
+            "{{paramName}}": {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
+        ]{{/hasMore}}{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}[{{/secondaryParam}}
+            "{{paramName}}": {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
+        ]{{/hasMore}}{{/queryParams}}
+        let parameters = APIHelper.rejectNil(nillableParameters){{/bodyParam}}
 
-            let requestBuilder: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = {{projectName}}API.requestBuilderFactory.getBuilder()
+        let requestBuilder: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = {{projectName}}API.requestBuilderFactory.getBuilder()
 
-            return requestBuilder.init(method: "{{httpMethod}}", URLString: URLString, parameters: parameters, isBody: {{^queryParams}}{{^formParams}}true{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/queryParams}}{{#formParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/formParams}})
-        }
-    {{/operation}}
+        return requestBuilder.init(method: "{{httpMethod}}", URLString: URLString, parameters: parameters, isBody: {{^queryParams}}{{^formParams}}true{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/queryParams}}{{#formParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/formParams}})
     }
+
+{{/operation}}
 }
+{{#swiftUseApiNamespace}}
+}
+{{/swiftUseApiNamespace}}
 {{/operations}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwiftOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SwiftOptionsProvider.java
@@ -25,6 +25,7 @@ public class SwiftOptionsProvider implements OptionsProvider {
     public static final String POD_DESCRIPTION_VALUE = "podDescription";
     public static final String POD_SCREENSHOTS_VALUE = "podScreenshots";
     public static final String POD_DOCUMENTATION_URL_VALUE = "podDocumentationURL";
+    public static final String SWIFT_USE_API_NAMESPACE_VALUE = "swiftUseApiNamespace";
 
     @Override
     public String getLanguage() {
@@ -50,6 +51,7 @@ public class SwiftOptionsProvider implements OptionsProvider {
                 .put(SwiftCodegen.POD_DESCRIPTION, POD_DESCRIPTION_VALUE)
                 .put(SwiftCodegen.POD_SCREENSHOTS, POD_SCREENSHOTS_VALUE)
                 .put(SwiftCodegen.POD_DOCUMENTATION_URL, POD_DOCUMENTATION_URL_VALUE)
+                .put(SwiftCodegen.SWIFT_USE_API_NAMESPACE, SWIFT_USE_API_NAMESPACE_VALUE)
                 .build();
     }
 

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -8,759 +8,757 @@
 import Alamofire
 import PromiseKit
 
-extension PetstoreClientAPI {
-    
-    public class PetAPI: APIBase {
-    
-        /**
-         
-         Update an existing pet
-         
-         - parameter body: (body) Pet object that needs to be added to the store
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func updatePet(body body: Pet?, completion: ((error: ErrorType?) -> Void)) {
-            updatePetWithRequestBuilder(body: body).execute { (response, error) -> Void in
-                completion(error: error);
-            }
+
+
+public class PetAPI: APIBase {
+    /**
+     
+     Update an existing pet
+     
+     - parameter body: (body) Pet object that needs to be added to the store
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func updatePet(body body: Pet?, completion: ((error: ErrorType?) -> Void)) {
+        updatePetWithRequestBuilder(body: body).execute { (response, error) -> Void in
+            completion(error: error);
         }
-
-        /**
-         
-         Update an existing pet
-         
-         - parameter body: (body) Pet object that needs to be added to the store
-         - returns: Promise<Void>
-         */
-        public class func updatePet(body body: Pet?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            updatePet(body: body) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Update an existing pet
-         
-         - PUT /pet
-         - 
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         
-         - parameter body: (body) Pet object that needs to be added to the store
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func updatePetWithRequestBuilder(body body: Pet?) -> RequestBuilder<Void> {
-            let path = "/pet"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "PUT", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Add a new pet to the store
-         
-         - parameter body: (body) Pet object that needs to be added to the store
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func addPet(body body: Pet?, completion: ((error: ErrorType?) -> Void)) {
-            addPetWithRequestBuilder(body: body).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         Add a new pet to the store
-         
-         - parameter body: (body) Pet object that needs to be added to the store
-         - returns: Promise<Void>
-         */
-        public class func addPet(body body: Pet?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            addPet(body: body) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Add a new pet to the store
-         
-         - POST /pet
-         - 
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         
-         - parameter body: (body) Pet object that needs to be added to the store
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func addPetWithRequestBuilder(body body: Pet?) -> RequestBuilder<Void> {
-            let path = "/pet"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Finds Pets by status
-         
-         - parameter status: (query) Status values that need to be considered for filter
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func findPetsByStatus(status status: [String]?, completion: ((data: [Pet]?, error: ErrorType?) -> Void)) {
-            findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
-            }
-        }
-
-        /**
-         
-         Finds Pets by status
-         
-         - parameter status: (query) Status values that need to be considered for filter
-         - returns: Promise<[Pet]>
-         */
-        public class func findPetsByStatus(status status: [String]?) -> Promise<[Pet]> {
-            let deferred = Promise<[Pet]>.pendingPromise()
-            findPetsByStatus(status: status) { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Finds Pets by status
-         
-         - GET /pet/findByStatus
-         - Multiple status values can be provided with comma seperated strings
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
-  "id" : 123456789,
-  "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
-  },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
-  <id>123456</id>
-  <name>doggie</name>
-  <photoUrls>
-    <photoUrls>string</photoUrls>
-  </photoUrls>
-  <tags>
-  </tags>
-  <status>string</status>
-</Pet>, contentType=application/xml}]
-         - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
-  "id" : 123456789,
-  "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
-  },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
-  <id>123456</id>
-  <name>doggie</name>
-  <photoUrls>
-    <photoUrls>string</photoUrls>
-  </photoUrls>
-  <tags>
-  </tags>
-  <status>string</status>
-</Pet>, contentType=application/xml}]
-         
-         - parameter status: (query) Status values that need to be considered for filter
-
-         - returns: RequestBuilder<[Pet]> 
-         */
-        public class func findPetsByStatusWithRequestBuilder(status status: [String]?) -> RequestBuilder<[Pet]> {
-            let path = "/pet/findByStatus"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [
-                "status": status
-            ]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: false)
-        }
-    
-        /**
-         
-         Finds Pets by tags
-         
-         - parameter tags: (query) Tags to filter by
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func findPetsByTags(tags tags: [String]?, completion: ((data: [Pet]?, error: ErrorType?) -> Void)) {
-            findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
-            }
-        }
-
-        /**
-         
-         Finds Pets by tags
-         
-         - parameter tags: (query) Tags to filter by
-         - returns: Promise<[Pet]>
-         */
-        public class func findPetsByTags(tags tags: [String]?) -> Promise<[Pet]> {
-            let deferred = Promise<[Pet]>.pendingPromise()
-            findPetsByTags(tags: tags) { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Finds Pets by tags
-         
-         - GET /pet/findByTags
-         - Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
-  "id" : 123456789,
-  "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
-  },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
-  <id>123456</id>
-  <name>doggie</name>
-  <photoUrls>
-    <photoUrls>string</photoUrls>
-  </photoUrls>
-  <tags>
-  </tags>
-  <status>string</status>
-</Pet>, contentType=application/xml}]
-         - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
-  "id" : 123456789,
-  "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
-  },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
-  <id>123456</id>
-  <name>doggie</name>
-  <photoUrls>
-    <photoUrls>string</photoUrls>
-  </photoUrls>
-  <tags>
-  </tags>
-  <status>string</status>
-</Pet>, contentType=application/xml}]
-         
-         - parameter tags: (query) Tags to filter by
-
-         - returns: RequestBuilder<[Pet]> 
-         */
-        public class func findPetsByTagsWithRequestBuilder(tags tags: [String]?) -> RequestBuilder<[Pet]> {
-            let path = "/pet/findByTags"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [
-                "tags": tags
-            ]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: false)
-        }
-    
-        /**
-         
-         Find pet by ID
-         
-         - parameter petId: (path) ID of pet that needs to be fetched
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func getPetById(petId petId: Int, completion: ((data: Pet?, error: ErrorType?) -> Void)) {
-            getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
-            }
-        }
-
-        /**
-         
-         Find pet by ID
-         
-         - parameter petId: (path) ID of pet that needs to be fetched
-         - returns: Promise<Pet>
-         */
-        public class func getPetById(petId petId: Int) -> Promise<Pet> {
-            let deferred = Promise<Pet>.pendingPromise()
-            getPetById(petId: petId) { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Find pet by ID
-         
-         - GET /pet/{petId}
-         - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-         - API Key:
-           - type: apiKey api_key 
-           - name: api_key
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
-  "id" : 123456789,
-  "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
-  },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
-  <id>123456</id>
-  <name>doggie</name>
-  <photoUrls>
-    <photoUrls>string</photoUrls>
-  </photoUrls>
-  <tags>
-  </tags>
-  <status>string</status>
-</Pet>, contentType=application/xml}]
-         - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
-  "id" : 123456789,
-  "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
-  },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
-  <id>123456</id>
-  <name>doggie</name>
-  <photoUrls>
-    <photoUrls>string</photoUrls>
-  </photoUrls>
-  <tags>
-  </tags>
-  <status>string</status>
-</Pet>, contentType=application/xml}]
-         
-         - parameter petId: (path) ID of pet that needs to be fetched
-
-         - returns: RequestBuilder<Pet> 
-         */
-        public class func getPetByIdWithRequestBuilder(petId petId: Int) -> RequestBuilder<Pet> {
-            var path = "/pet/{petId}"
-            path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<Pet>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Updates a pet in the store with form data
-         
-         - parameter petId: (path) ID of pet that needs to be updated
-         - parameter name: (form) Updated name of the pet
-         - parameter status: (form) Updated status of the pet
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func updatePetWithForm(petId petId: String, name: String?, status: String?, completion: ((error: ErrorType?) -> Void)) {
-            updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         Updates a pet in the store with form data
-         
-         - parameter petId: (path) ID of pet that needs to be updated
-         - parameter name: (form) Updated name of the pet
-         - parameter status: (form) Updated status of the pet
-         - returns: Promise<Void>
-         */
-        public class func updatePetWithForm(petId petId: String, name: String?, status: String?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            updatePetWithForm(petId: petId, name: name, status: status) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Updates a pet in the store with form data
-         
-         - POST /pet/{petId}
-         - 
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         
-         - parameter petId: (path) ID of pet that needs to be updated
-         - parameter name: (form) Updated name of the pet
-         - parameter status: (form) Updated status of the pet
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func updatePetWithFormWithRequestBuilder(petId petId: String, name: String?, status: String?) -> RequestBuilder<Void> {
-            var path = "/pet/{petId}"
-            path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [
-                "name": name,
-                "status": status
-            ]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: false)
-        }
-    
-        /**
-         
-         Deletes a pet
-         
-         - parameter petId: (path) Pet id to delete
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func deletePet(petId petId: Int, completion: ((error: ErrorType?) -> Void)) {
-            deletePetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         Deletes a pet
-         
-         - parameter petId: (path) Pet id to delete
-         - returns: Promise<Void>
-         */
-        public class func deletePet(petId petId: Int) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            deletePet(petId: petId) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Deletes a pet
-         
-         - DELETE /pet/{petId}
-         - 
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         
-         - parameter petId: (path) Pet id to delete
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func deletePetWithRequestBuilder(petId petId: Int) -> RequestBuilder<Void> {
-            var path = "/pet/{petId}"
-            path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         uploads an image
-         
-         - parameter petId: (path) ID of pet to update
-         - parameter additionalMetadata: (form) Additional data to pass to server
-         - parameter file: (form) file to upload
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func uploadFile(petId petId: Int, additionalMetadata: String?, file: NSURL?, completion: ((error: ErrorType?) -> Void)) {
-            uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         uploads an image
-         
-         - parameter petId: (path) ID of pet to update
-         - parameter additionalMetadata: (form) Additional data to pass to server
-         - parameter file: (form) file to upload
-         - returns: Promise<Void>
-         */
-        public class func uploadFile(petId petId: Int, additionalMetadata: String?, file: NSURL?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         uploads an image
-         
-         - POST /pet/{petId}/uploadImage
-         - 
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         
-         - parameter petId: (path) ID of pet to update
-         - parameter additionalMetadata: (form) Additional data to pass to server
-         - parameter file: (form) file to upload
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func uploadFileWithRequestBuilder(petId petId: Int, additionalMetadata: String?, file: NSURL?) -> RequestBuilder<Void> {
-            var path = "/pet/{petId}/uploadImage"
-            path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [
-                "additionalMetadata": additionalMetadata,
-                "file": file
-            ]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: false)
-        }
-    
-        /**
-         
-         Fake endpoint to test byte array return by 'Find pet by ID'
-         
-         - parameter petId: (path) ID of pet that needs to be fetched
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func petPetIdtestingByteArraytrueGet(petId petId: Int, completion: ((data: String?, error: ErrorType?) -> Void)) {
-            petPetIdtestingByteArraytrueGetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
-            }
-        }
-
-        /**
-         
-         Fake endpoint to test byte array return by 'Find pet by ID'
-         
-         - parameter petId: (path) ID of pet that needs to be fetched
-         - returns: Promise<String>
-         */
-        public class func petPetIdtestingByteArraytrueGet(petId petId: Int) -> Promise<String> {
-            let deferred = Promise<String>.pendingPromise()
-            petPetIdtestingByteArraytrueGet(petId: petId) { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Fake endpoint to test byte array return by 'Find pet by ID'
-         
-         - GET /pet/{petId}?testing_byte_array=true
-         - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-         - API Key:
-           - type: apiKey api_key 
-           - name: api_key
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         - examples: [{example="", contentType=application/json}, {example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e, contentType=application/xml}]
-         - examples: [{example="", contentType=application/json}, {example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e, contentType=application/xml}]
-         
-         - parameter petId: (path) ID of pet that needs to be fetched
-
-         - returns: RequestBuilder<String> 
-         */
-        public class func petPetIdtestingByteArraytrueGetWithRequestBuilder(petId petId: Int) -> RequestBuilder<String> {
-            var path = "/pet/{petId}?testing_byte_array=true"
-            path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Fake endpoint to test byte array in body parameter for adding a new pet to the store
-         
-         - parameter body: (body) Pet object in the form of byte array
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func addPetUsingByteArray(body body: String?, completion: ((error: ErrorType?) -> Void)) {
-            addPetUsingByteArrayWithRequestBuilder(body: body).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         Fake endpoint to test byte array in body parameter for adding a new pet to the store
-         
-         - parameter body: (body) Pet object in the form of byte array
-         - returns: Promise<Void>
-         */
-        public class func addPetUsingByteArray(body body: String?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            addPetUsingByteArray(body: body) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Fake endpoint to test byte array in body parameter for adding a new pet to the store
-         
-         - POST /pet?testing_byte_array=true
-         - 
-         - OAuth:
-           - type: oauth2
-           - name: petstore_auth
-         
-         - parameter body: (body) Pet object in the form of byte array
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func addPetUsingByteArrayWithRequestBuilder(body body: String?) -> RequestBuilder<Void> {
-            let path = "/pet?testing_byte_array=true"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
     }
+
+    /**
+     
+     Update an existing pet
+     
+     - parameter body: (body) Pet object that needs to be added to the store
+     - returns: Promise<Void>
+     */
+    public class func updatePet(body body: Pet?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        updatePet(body: body) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Update an existing pet
+     
+     - PUT /pet
+     - 
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     
+     - parameter body: (body) Pet object that needs to be added to the store
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func updatePetWithRequestBuilder(body body: Pet?) -> RequestBuilder<Void> {
+        let path = "/pet"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "PUT", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Add a new pet to the store
+     
+     - parameter body: (body) Pet object that needs to be added to the store
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func addPet(body body: Pet?, completion: ((error: ErrorType?) -> Void)) {
+        addPetWithRequestBuilder(body: body).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     Add a new pet to the store
+     
+     - parameter body: (body) Pet object that needs to be added to the store
+     - returns: Promise<Void>
+     */
+    public class func addPet(body body: Pet?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        addPet(body: body) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Add a new pet to the store
+     
+     - POST /pet
+     - 
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     
+     - parameter body: (body) Pet object that needs to be added to the store
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func addPetWithRequestBuilder(body body: Pet?) -> RequestBuilder<Void> {
+        let path = "/pet"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Finds Pets by status
+     
+     - parameter status: (query) Status values that need to be considered for filter
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func findPetsByStatus(status status: [String]?, completion: ((data: [Pet]?, error: ErrorType?) -> Void)) {
+        findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
+        }
+    }
+
+    /**
+     
+     Finds Pets by status
+     
+     - parameter status: (query) Status values that need to be considered for filter
+     - returns: Promise<[Pet]>
+     */
+    public class func findPetsByStatus(status status: [String]?) -> Promise<[Pet]> {
+        let deferred = Promise<[Pet]>.pendingPromise()
+        findPetsByStatus(status: status) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Finds Pets by status
+     
+     - GET /pet/findByStatus
+     - Multiple status values can be provided with comma seperated strings
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     - examples: [{example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
+  "id" : 123456789,
+  "category" : {
+    "id" : 123456789,
+    "name" : "aeiou"
+  },
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}, {example=<Pet>
+  <id>123456</id>
+  <name>doggie</name>
+  <photoUrls>
+    <photoUrls>string</photoUrls>
+  </photoUrls>
+  <tags>
+  </tags>
+  <status>string</status>
+</Pet>, contentType=application/xml}]
+     - examples: [{example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
+  "id" : 123456789,
+  "category" : {
+    "id" : 123456789,
+    "name" : "aeiou"
+  },
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}, {example=<Pet>
+  <id>123456</id>
+  <name>doggie</name>
+  <photoUrls>
+    <photoUrls>string</photoUrls>
+  </photoUrls>
+  <tags>
+  </tags>
+  <status>string</status>
+</Pet>, contentType=application/xml}]
+     
+     - parameter status: (query) Status values that need to be considered for filter
+
+     - returns: RequestBuilder<[Pet]> 
+     */
+    public class func findPetsByStatusWithRequestBuilder(status status: [String]?) -> RequestBuilder<[Pet]> {
+        let path = "/pet/findByStatus"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [
+            "status": status
+        ]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: false)
+    }
+
+    /**
+     
+     Finds Pets by tags
+     
+     - parameter tags: (query) Tags to filter by
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func findPetsByTags(tags tags: [String]?, completion: ((data: [Pet]?, error: ErrorType?) -> Void)) {
+        findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
+        }
+    }
+
+    /**
+     
+     Finds Pets by tags
+     
+     - parameter tags: (query) Tags to filter by
+     - returns: Promise<[Pet]>
+     */
+    public class func findPetsByTags(tags tags: [String]?) -> Promise<[Pet]> {
+        let deferred = Promise<[Pet]>.pendingPromise()
+        findPetsByTags(tags: tags) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Finds Pets by tags
+     
+     - GET /pet/findByTags
+     - Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     - examples: [{example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
+  "id" : 123456789,
+  "category" : {
+    "id" : 123456789,
+    "name" : "aeiou"
+  },
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}, {example=<Pet>
+  <id>123456</id>
+  <name>doggie</name>
+  <photoUrls>
+    <photoUrls>string</photoUrls>
+  </photoUrls>
+  <tags>
+  </tags>
+  <status>string</status>
+</Pet>, contentType=application/xml}]
+     - examples: [{example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
+  "id" : 123456789,
+  "category" : {
+    "id" : 123456789,
+    "name" : "aeiou"
+  },
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}, {example=<Pet>
+  <id>123456</id>
+  <name>doggie</name>
+  <photoUrls>
+    <photoUrls>string</photoUrls>
+  </photoUrls>
+  <tags>
+  </tags>
+  <status>string</status>
+</Pet>, contentType=application/xml}]
+     
+     - parameter tags: (query) Tags to filter by
+
+     - returns: RequestBuilder<[Pet]> 
+     */
+    public class func findPetsByTagsWithRequestBuilder(tags tags: [String]?) -> RequestBuilder<[Pet]> {
+        let path = "/pet/findByTags"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [
+            "tags": tags
+        ]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: false)
+    }
+
+    /**
+     
+     Find pet by ID
+     
+     - parameter petId: (path) ID of pet that needs to be fetched
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func getPetById(petId petId: Int, completion: ((data: Pet?, error: ErrorType?) -> Void)) {
+        getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
+        }
+    }
+
+    /**
+     
+     Find pet by ID
+     
+     - parameter petId: (path) ID of pet that needs to be fetched
+     - returns: Promise<Pet>
+     */
+    public class func getPetById(petId petId: Int) -> Promise<Pet> {
+        let deferred = Promise<Pet>.pendingPromise()
+        getPetById(petId: petId) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Find pet by ID
+     
+     - GET /pet/{petId}
+     - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     - examples: [{example={
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
+  "id" : 123456789,
+  "category" : {
+    "id" : 123456789,
+    "name" : "aeiou"
+  },
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}, {example=<Pet>
+  <id>123456</id>
+  <name>doggie</name>
+  <photoUrls>
+    <photoUrls>string</photoUrls>
+  </photoUrls>
+  <tags>
+  </tags>
+  <status>string</status>
+</Pet>, contentType=application/xml}]
+     - examples: [{example={
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
+  "id" : 123456789,
+  "category" : {
+    "id" : 123456789,
+    "name" : "aeiou"
+  },
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}, {example=<Pet>
+  <id>123456</id>
+  <name>doggie</name>
+  <photoUrls>
+    <photoUrls>string</photoUrls>
+  </photoUrls>
+  <tags>
+  </tags>
+  <status>string</status>
+</Pet>, contentType=application/xml}]
+     
+     - parameter petId: (path) ID of pet that needs to be fetched
+
+     - returns: RequestBuilder<Pet> 
+     */
+    public class func getPetByIdWithRequestBuilder(petId petId: Int) -> RequestBuilder<Pet> {
+        var path = "/pet/{petId}"
+        path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<Pet>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Updates a pet in the store with form data
+     
+     - parameter petId: (path) ID of pet that needs to be updated
+     - parameter name: (form) Updated name of the pet
+     - parameter status: (form) Updated status of the pet
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func updatePetWithForm(petId petId: String, name: String?, status: String?, completion: ((error: ErrorType?) -> Void)) {
+        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     Updates a pet in the store with form data
+     
+     - parameter petId: (path) ID of pet that needs to be updated
+     - parameter name: (form) Updated name of the pet
+     - parameter status: (form) Updated status of the pet
+     - returns: Promise<Void>
+     */
+    public class func updatePetWithForm(petId petId: String, name: String?, status: String?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        updatePetWithForm(petId: petId, name: name, status: status) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Updates a pet in the store with form data
+     
+     - POST /pet/{petId}
+     - 
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     
+     - parameter petId: (path) ID of pet that needs to be updated
+     - parameter name: (form) Updated name of the pet
+     - parameter status: (form) Updated status of the pet
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func updatePetWithFormWithRequestBuilder(petId petId: String, name: String?, status: String?) -> RequestBuilder<Void> {
+        var path = "/pet/{petId}"
+        path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [
+            "name": name,
+            "status": status
+        ]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: false)
+    }
+
+    /**
+     
+     Deletes a pet
+     
+     - parameter petId: (path) Pet id to delete
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func deletePet(petId petId: Int, completion: ((error: ErrorType?) -> Void)) {
+        deletePetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     Deletes a pet
+     
+     - parameter petId: (path) Pet id to delete
+     - returns: Promise<Void>
+     */
+    public class func deletePet(petId petId: Int) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        deletePet(petId: petId) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Deletes a pet
+     
+     - DELETE /pet/{petId}
+     - 
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     
+     - parameter petId: (path) Pet id to delete
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func deletePetWithRequestBuilder(petId petId: Int) -> RequestBuilder<Void> {
+        var path = "/pet/{petId}"
+        path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     uploads an image
+     
+     - parameter petId: (path) ID of pet to update
+     - parameter additionalMetadata: (form) Additional data to pass to server
+     - parameter file: (form) file to upload
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func uploadFile(petId petId: Int, additionalMetadata: String?, file: NSURL?, completion: ((error: ErrorType?) -> Void)) {
+        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     uploads an image
+     
+     - parameter petId: (path) ID of pet to update
+     - parameter additionalMetadata: (form) Additional data to pass to server
+     - parameter file: (form) file to upload
+     - returns: Promise<Void>
+     */
+    public class func uploadFile(petId petId: Int, additionalMetadata: String?, file: NSURL?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     uploads an image
+     
+     - POST /pet/{petId}/uploadImage
+     - 
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     
+     - parameter petId: (path) ID of pet to update
+     - parameter additionalMetadata: (form) Additional data to pass to server
+     - parameter file: (form) file to upload
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func uploadFileWithRequestBuilder(petId petId: Int, additionalMetadata: String?, file: NSURL?) -> RequestBuilder<Void> {
+        var path = "/pet/{petId}/uploadImage"
+        path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [
+            "additionalMetadata": additionalMetadata,
+            "file": file
+        ]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: false)
+    }
+
+    /**
+     
+     Fake endpoint to test byte array return by 'Find pet by ID'
+     
+     - parameter petId: (path) ID of pet that needs to be fetched
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func petPetIdtestingByteArraytrueGet(petId petId: Int, completion: ((data: String?, error: ErrorType?) -> Void)) {
+        petPetIdtestingByteArraytrueGetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
+        }
+    }
+
+    /**
+     
+     Fake endpoint to test byte array return by 'Find pet by ID'
+     
+     - parameter petId: (path) ID of pet that needs to be fetched
+     - returns: Promise<String>
+     */
+    public class func petPetIdtestingByteArraytrueGet(petId petId: Int) -> Promise<String> {
+        let deferred = Promise<String>.pendingPromise()
+        petPetIdtestingByteArraytrueGet(petId: petId) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Fake endpoint to test byte array return by 'Find pet by ID'
+     
+     - GET /pet/{petId}?testing_byte_array=true
+     - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     - examples: [{example="", contentType=application/json}, {example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e, contentType=application/xml}]
+     - examples: [{example="", contentType=application/json}, {example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e, contentType=application/xml}]
+     
+     - parameter petId: (path) ID of pet that needs to be fetched
+
+     - returns: RequestBuilder<String> 
+     */
+    public class func petPetIdtestingByteArraytrueGetWithRequestBuilder(petId petId: Int) -> RequestBuilder<String> {
+        var path = "/pet/{petId}?testing_byte_array=true"
+        path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Fake endpoint to test byte array in body parameter for adding a new pet to the store
+     
+     - parameter body: (body) Pet object in the form of byte array
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func addPetUsingByteArray(body body: String?, completion: ((error: ErrorType?) -> Void)) {
+        addPetUsingByteArrayWithRequestBuilder(body: body).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     Fake endpoint to test byte array in body parameter for adding a new pet to the store
+     
+     - parameter body: (body) Pet object in the form of byte array
+     - returns: Promise<Void>
+     */
+    public class func addPetUsingByteArray(body body: String?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        addPetUsingByteArray(body: body) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Fake endpoint to test byte array in body parameter for adding a new pet to the store
+     
+     - POST /pet?testing_byte_array=true
+     - 
+     - OAuth:
+       - type: oauth2
+       - name: petstore_auth
+     
+     - parameter body: (body) Pet object in the form of byte array
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func addPetUsingByteArrayWithRequestBuilder(body body: String?) -> RequestBuilder<Void> {
+        let path = "/pet?testing_byte_array=true"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
 }

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -16,6 +16,38 @@ extension PetstoreClientAPI {
          
          Update an existing pet
          
+         - parameter body: (body) Pet object that needs to be added to the store
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func updatePet(body body: Pet?, completion: ((error: ErrorType?) -> Void)) {
+            updatePetWithRequestBuilder(body: body).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Update an existing pet
+         
+         - parameter body: (body) Pet object that needs to be added to the store
+         - returns: Promise<Void>
+         */
+        public class func updatePet(body body: Pet?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            updatePet(body: body) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Update an existing pet
+         
          - PUT /pet
          - 
          - OAuth:
@@ -26,7 +58,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func updatePet(body body: Pet?) -> RequestBuilder<Void> {
+        public class func updatePetWithRequestBuilder(body body: Pet?) -> RequestBuilder<Void> {
             let path = "/pet"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -41,6 +73,38 @@ extension PetstoreClientAPI {
          
          Add a new pet to the store
          
+         - parameter body: (body) Pet object that needs to be added to the store
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func addPet(body body: Pet?, completion: ((error: ErrorType?) -> Void)) {
+            addPetWithRequestBuilder(body: body).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Add a new pet to the store
+         
+         - parameter body: (body) Pet object that needs to be added to the store
+         - returns: Promise<Void>
+         */
+        public class func addPet(body body: Pet?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            addPet(body: body) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Add a new pet to the store
+         
          - POST /pet
          - 
          - OAuth:
@@ -51,7 +115,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func addPet(body body: Pet?) -> RequestBuilder<Void> {
+        public class func addPetWithRequestBuilder(body body: Pet?) -> RequestBuilder<Void> {
             let path = "/pet"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -62,6 +126,38 @@ extension PetstoreClientAPI {
             return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
         }
     
+        /**
+         
+         Finds Pets by status
+         
+         - parameter status: (query) Status values that need to be considered for filter
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func findPetsByStatus(status status: [String]?, completion: ((data: [Pet]?, error: ErrorType?) -> Void)) {
+            findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Finds Pets by status
+         
+         - parameter status: (query) Status values that need to be considered for filter
+         - returns: Promise<[Pet]>
+         */
+        public class func findPetsByStatus(status status: [String]?) -> Promise<[Pet]> {
+            let deferred = Promise<[Pet]>.pendingPromise()
+            findPetsByStatus(status: status) { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
         /**
          
          Finds Pets by status
@@ -122,7 +218,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<[Pet]> 
          */
-        public class func findPetsByStatus(status status: [String]?) -> RequestBuilder<[Pet]> {
+        public class func findPetsByStatusWithRequestBuilder(status status: [String]?) -> RequestBuilder<[Pet]> {
             let path = "/pet/findByStatus"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -136,6 +232,38 @@ extension PetstoreClientAPI {
             return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: false)
         }
     
+        /**
+         
+         Finds Pets by tags
+         
+         - parameter tags: (query) Tags to filter by
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func findPetsByTags(tags tags: [String]?, completion: ((data: [Pet]?, error: ErrorType?) -> Void)) {
+            findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Finds Pets by tags
+         
+         - parameter tags: (query) Tags to filter by
+         - returns: Promise<[Pet]>
+         */
+        public class func findPetsByTags(tags tags: [String]?) -> Promise<[Pet]> {
+            let deferred = Promise<[Pet]>.pendingPromise()
+            findPetsByTags(tags: tags) { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
         /**
          
          Finds Pets by tags
@@ -196,7 +324,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<[Pet]> 
          */
-        public class func findPetsByTags(tags tags: [String]?) -> RequestBuilder<[Pet]> {
+        public class func findPetsByTagsWithRequestBuilder(tags tags: [String]?) -> RequestBuilder<[Pet]> {
             let path = "/pet/findByTags"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -214,11 +342,46 @@ extension PetstoreClientAPI {
          
          Find pet by ID
          
+         - parameter petId: (path) ID of pet that needs to be fetched
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func getPetById(petId petId: Int, completion: ((data: Pet?, error: ErrorType?) -> Void)) {
+            getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Find pet by ID
+         
+         - parameter petId: (path) ID of pet that needs to be fetched
+         - returns: Promise<Pet>
+         */
+        public class func getPetById(petId petId: Int) -> Promise<Pet> {
+            let deferred = Promise<Pet>.pendingPromise()
+            getPetById(petId: petId) { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Find pet by ID
+         
          - GET /pet/{petId}
          - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
          - API Key:
            - type: apiKey api_key 
            - name: api_key
+         - OAuth:
+           - type: oauth2
+           - name: petstore_auth
          - examples: [{example={
   "tags" : [ {
     "id" : 123456789,
@@ -270,7 +433,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Pet> 
          */
-        public class func getPetById(petId petId: Int) -> RequestBuilder<Pet> {
+        public class func getPetByIdWithRequestBuilder(petId petId: Int) -> RequestBuilder<Pet> {
             var path = "/pet/{petId}"
             path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path
@@ -287,6 +450,42 @@ extension PetstoreClientAPI {
          
          Updates a pet in the store with form data
          
+         - parameter petId: (path) ID of pet that needs to be updated
+         - parameter name: (form) Updated name of the pet
+         - parameter status: (form) Updated status of the pet
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func updatePetWithForm(petId petId: String, name: String?, status: String?, completion: ((error: ErrorType?) -> Void)) {
+            updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Updates a pet in the store with form data
+         
+         - parameter petId: (path) ID of pet that needs to be updated
+         - parameter name: (form) Updated name of the pet
+         - parameter status: (form) Updated status of the pet
+         - returns: Promise<Void>
+         */
+        public class func updatePetWithForm(petId petId: String, name: String?, status: String?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            updatePetWithForm(petId: petId, name: name, status: status) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Updates a pet in the store with form data
+         
          - POST /pet/{petId}
          - 
          - OAuth:
@@ -299,7 +498,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func updatePetWithForm(petId petId: String, name: String?, status: String?) -> RequestBuilder<Void> {
+        public class func updatePetWithFormWithRequestBuilder(petId petId: String, name: String?, status: String?) -> RequestBuilder<Void> {
             var path = "/pet/{petId}"
             path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path
@@ -319,6 +518,38 @@ extension PetstoreClientAPI {
          
          Deletes a pet
          
+         - parameter petId: (path) Pet id to delete
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func deletePet(petId petId: Int, completion: ((error: ErrorType?) -> Void)) {
+            deletePetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Deletes a pet
+         
+         - parameter petId: (path) Pet id to delete
+         - returns: Promise<Void>
+         */
+        public class func deletePet(petId petId: Int) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            deletePet(petId: petId) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Deletes a pet
+         
          - DELETE /pet/{petId}
          - 
          - OAuth:
@@ -329,7 +560,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func deletePet(petId petId: Int) -> RequestBuilder<Void> {
+        public class func deletePetWithRequestBuilder(petId petId: Int) -> RequestBuilder<Void> {
             var path = "/pet/{petId}"
             path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path
@@ -346,6 +577,42 @@ extension PetstoreClientAPI {
          
          uploads an image
          
+         - parameter petId: (path) ID of pet to update
+         - parameter additionalMetadata: (form) Additional data to pass to server
+         - parameter file: (form) file to upload
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func uploadFile(petId petId: Int, additionalMetadata: String?, file: NSURL?, completion: ((error: ErrorType?) -> Void)) {
+            uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         uploads an image
+         
+         - parameter petId: (path) ID of pet to update
+         - parameter additionalMetadata: (form) Additional data to pass to server
+         - parameter file: (form) file to upload
+         - returns: Promise<Void>
+         */
+        public class func uploadFile(petId petId: Int, additionalMetadata: String?, file: NSURL?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         uploads an image
+         
          - POST /pet/{petId}/uploadImage
          - 
          - OAuth:
@@ -358,7 +625,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func uploadFile(petId petId: Int, additionalMetadata: String?, file: NSURL?) -> RequestBuilder<Void> {
+        public class func uploadFileWithRequestBuilder(petId petId: Int, additionalMetadata: String?, file: NSURL?) -> RequestBuilder<Void> {
             var path = "/pet/{petId}/uploadImage"
             path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path
@@ -378,11 +645,46 @@ extension PetstoreClientAPI {
          
          Fake endpoint to test byte array return by 'Find pet by ID'
          
+         - parameter petId: (path) ID of pet that needs to be fetched
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func petPetIdtestingByteArraytrueGet(petId petId: Int, completion: ((data: String?, error: ErrorType?) -> Void)) {
+            petPetIdtestingByteArraytrueGetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Fake endpoint to test byte array return by 'Find pet by ID'
+         
+         - parameter petId: (path) ID of pet that needs to be fetched
+         - returns: Promise<String>
+         */
+        public class func petPetIdtestingByteArraytrueGet(petId petId: Int) -> Promise<String> {
+            let deferred = Promise<String>.pendingPromise()
+            petPetIdtestingByteArraytrueGet(petId: petId) { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Fake endpoint to test byte array return by 'Find pet by ID'
+         
          - GET /pet/{petId}?testing_byte_array=true
          - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
          - API Key:
            - type: apiKey api_key 
            - name: api_key
+         - OAuth:
+           - type: oauth2
+           - name: petstore_auth
          - examples: [{example="", contentType=application/json}, {example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e, contentType=application/xml}]
          - examples: [{example="", contentType=application/json}, {example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e, contentType=application/xml}]
          
@@ -390,7 +692,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<String> 
          */
-        public class func getPetByIdWithByteArray(petId petId: Int) -> RequestBuilder<String> {
+        public class func petPetIdtestingByteArraytrueGetWithRequestBuilder(petId petId: Int) -> RequestBuilder<String> {
             var path = "/pet/{petId}?testing_byte_array=true"
             path = path.stringByReplacingOccurrencesOfString("{petId}", withString: "\(petId)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path
@@ -407,6 +709,38 @@ extension PetstoreClientAPI {
          
          Fake endpoint to test byte array in body parameter for adding a new pet to the store
          
+         - parameter body: (body) Pet object in the form of byte array
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func addPetUsingByteArray(body body: String?, completion: ((error: ErrorType?) -> Void)) {
+            addPetUsingByteArrayWithRequestBuilder(body: body).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Fake endpoint to test byte array in body parameter for adding a new pet to the store
+         
+         - parameter body: (body) Pet object in the form of byte array
+         - returns: Promise<Void>
+         */
+        public class func addPetUsingByteArray(body body: String?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            addPetUsingByteArray(body: body) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Fake endpoint to test byte array in body parameter for adding a new pet to the store
+         
          - POST /pet?testing_byte_array=true
          - 
          - OAuth:
@@ -417,7 +751,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func addPetUsingByteArray(body body: String?) -> RequestBuilder<Void> {
+        public class func addPetUsingByteArrayWithRequestBuilder(body body: String?) -> RequestBuilder<Void> {
             let path = "/pet?testing_byte_array=true"
             let URLString = PetstoreClientAPI.basePath + path
             

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -16,6 +16,36 @@ extension PetstoreClientAPI {
          
          Returns pet inventories by status
          
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func getInventory(completion: ((data: [String:Int]?, error: ErrorType?) -> Void)) {
+            getInventoryWithRequestBuilder().execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Returns pet inventories by status
+         
+         - returns: Promise<[String:Int]>
+         */
+        public class func getInventory() -> Promise<[String:Int]> {
+            let deferred = Promise<[String:Int]>.pendingPromise()
+            getInventory() { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Returns pet inventories by status
+         
          - GET /store/inventory
          - Returns a map of status codes to quantities
          - API Key:
@@ -30,7 +60,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<[String:Int]> 
          */
-        public class func getInventory() -> RequestBuilder<[String:Int]> {
+        public class func getInventoryWithRequestBuilder() -> RequestBuilder<[String:Int]> {
             let path = "/store/inventory"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -46,8 +76,46 @@ extension PetstoreClientAPI {
          
          Place an order for a pet
          
+         - parameter body: (body) order placed for purchasing the pet
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func placeOrder(body body: Order?, completion: ((data: Order?, error: ErrorType?) -> Void)) {
+            placeOrderWithRequestBuilder(body: body).execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Place an order for a pet
+         
+         - parameter body: (body) order placed for purchasing the pet
+         - returns: Promise<Order>
+         */
+        public class func placeOrder(body body: Order?) -> Promise<Order> {
+            let deferred = Promise<Order>.pendingPromise()
+            placeOrder(body: body) { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Place an order for a pet
+         
          - POST /store/order
          - 
+         - API Key:
+           - type: apiKey x-test_api_client_id 
+           - name: test_api_client_id
+         - API Key:
+           - type: apiKey x-test_api_client_secret 
+           - name: test_api_client_secret
          - examples: [{example={
   "id" : 123456789,
   "petId" : 123456789,
@@ -83,7 +151,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Order> 
          */
-        public class func placeOrder(body body: Order?) -> RequestBuilder<Order> {
+        public class func placeOrderWithRequestBuilder(body body: Order?) -> RequestBuilder<Order> {
             let path = "/store/order"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -98,8 +166,46 @@ extension PetstoreClientAPI {
          
          Find purchase order by ID
          
+         - parameter orderId: (path) ID of pet that needs to be fetched
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func getOrderById(orderId orderId: String, completion: ((data: Order?, error: ErrorType?) -> Void)) {
+            getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Find purchase order by ID
+         
+         - parameter orderId: (path) ID of pet that needs to be fetched
+         - returns: Promise<Order>
+         */
+        public class func getOrderById(orderId orderId: String) -> Promise<Order> {
+            let deferred = Promise<Order>.pendingPromise()
+            getOrderById(orderId: orderId) { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Find purchase order by ID
+         
          - GET /store/order/{orderId}
          - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+         - API Key:
+           - type: apiKey test_api_key_header 
+           - name: test_api_key_header
+         - API Key:
+           - type: apiKey test_api_key_query (QUERY)
+           - name: test_api_key_query
          - examples: [{example={
   "id" : 123456789,
   "petId" : 123456789,
@@ -135,7 +241,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Order> 
          */
-        public class func getOrderById(orderId orderId: String) -> RequestBuilder<Order> {
+        public class func getOrderByIdWithRequestBuilder(orderId orderId: String) -> RequestBuilder<Order> {
             var path = "/store/order/{orderId}"
             path = path.stringByReplacingOccurrencesOfString("{orderId}", withString: "\(orderId)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path
@@ -152,6 +258,38 @@ extension PetstoreClientAPI {
          
          Delete purchase order by ID
          
+         - parameter orderId: (path) ID of the order that needs to be deleted
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func deleteOrder(orderId orderId: String, completion: ((error: ErrorType?) -> Void)) {
+            deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Delete purchase order by ID
+         
+         - parameter orderId: (path) ID of the order that needs to be deleted
+         - returns: Promise<Void>
+         */
+        public class func deleteOrder(orderId orderId: String) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            deleteOrder(orderId: orderId) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Delete purchase order by ID
+         
          - DELETE /store/order/{orderId}
          - For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
          
@@ -159,7 +297,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func deleteOrder(orderId orderId: String) -> RequestBuilder<Void> {
+        public class func deleteOrderWithRequestBuilder(orderId orderId: String) -> RequestBuilder<Void> {
             var path = "/store/order/{orderId}"
             path = path.stringByReplacingOccurrencesOfString("{orderId}", withString: "\(orderId)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -8,307 +8,305 @@
 import Alamofire
 import PromiseKit
 
-extension PetstoreClientAPI {
-    
-    public class StoreAPI: APIBase {
-    
-        /**
-         
-         Returns pet inventories by status
-         
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func getInventory(completion: ((data: [String:Int]?, error: ErrorType?) -> Void)) {
-            getInventoryWithRequestBuilder().execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
-            }
+
+
+public class StoreAPI: APIBase {
+    /**
+     
+     Returns pet inventories by status
+     
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func getInventory(completion: ((data: [String:Int]?, error: ErrorType?) -> Void)) {
+        getInventoryWithRequestBuilder().execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
         }
-
-        /**
-         
-         Returns pet inventories by status
-         
-         - returns: Promise<[String:Int]>
-         */
-        public class func getInventory() -> Promise<[String:Int]> {
-            let deferred = Promise<[String:Int]>.pendingPromise()
-            getInventory() { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Returns pet inventories by status
-         
-         - GET /store/inventory
-         - Returns a map of status codes to quantities
-         - API Key:
-           - type: apiKey api_key 
-           - name: api_key
-         - examples: [{example={
-  "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
-         - examples: [{example={
-  "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
-
-         - returns: RequestBuilder<[String:Int]> 
-         */
-        public class func getInventoryWithRequestBuilder() -> RequestBuilder<[String:Int]> {
-            let path = "/store/inventory"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<[String:Int]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Place an order for a pet
-         
-         - parameter body: (body) order placed for purchasing the pet
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func placeOrder(body body: Order?, completion: ((data: Order?, error: ErrorType?) -> Void)) {
-            placeOrderWithRequestBuilder(body: body).execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
-            }
-        }
-
-        /**
-         
-         Place an order for a pet
-         
-         - parameter body: (body) order placed for purchasing the pet
-         - returns: Promise<Order>
-         */
-        public class func placeOrder(body body: Order?) -> Promise<Order> {
-            let deferred = Promise<Order>.pendingPromise()
-            placeOrder(body: body) { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Place an order for a pet
-         
-         - POST /store/order
-         - 
-         - API Key:
-           - type: apiKey x-test_api_client_id 
-           - name: test_api_client_id
-         - API Key:
-           - type: apiKey x-test_api_client_secret 
-           - name: test_api_client_secret
-         - examples: [{example={
-  "id" : 123456789,
-  "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
-  "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-}, contentType=application/json}, {example=<Order>
-  <id>123456</id>
-  <petId>123456</petId>
-  <quantity>0</quantity>
-  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
-  <status>string</status>
-  <complete>true</complete>
-</Order>, contentType=application/xml}]
-         - examples: [{example={
-  "id" : 123456789,
-  "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
-  "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-}, contentType=application/json}, {example=<Order>
-  <id>123456</id>
-  <petId>123456</petId>
-  <quantity>0</quantity>
-  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
-  <status>string</status>
-  <complete>true</complete>
-</Order>, contentType=application/xml}]
-         
-         - parameter body: (body) order placed for purchasing the pet
-
-         - returns: RequestBuilder<Order> 
-         */
-        public class func placeOrderWithRequestBuilder(body body: Order?) -> RequestBuilder<Order> {
-            let path = "/store/order"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Find purchase order by ID
-         
-         - parameter orderId: (path) ID of pet that needs to be fetched
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func getOrderById(orderId orderId: String, completion: ((data: Order?, error: ErrorType?) -> Void)) {
-            getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
-            }
-        }
-
-        /**
-         
-         Find purchase order by ID
-         
-         - parameter orderId: (path) ID of pet that needs to be fetched
-         - returns: Promise<Order>
-         */
-        public class func getOrderById(orderId orderId: String) -> Promise<Order> {
-            let deferred = Promise<Order>.pendingPromise()
-            getOrderById(orderId: orderId) { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Find purchase order by ID
-         
-         - GET /store/order/{orderId}
-         - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-         - API Key:
-           - type: apiKey test_api_key_header 
-           - name: test_api_key_header
-         - API Key:
-           - type: apiKey test_api_key_query (QUERY)
-           - name: test_api_key_query
-         - examples: [{example={
-  "id" : 123456789,
-  "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
-  "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-}, contentType=application/json}, {example=<Order>
-  <id>123456</id>
-  <petId>123456</petId>
-  <quantity>0</quantity>
-  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
-  <status>string</status>
-  <complete>true</complete>
-</Order>, contentType=application/xml}]
-         - examples: [{example={
-  "id" : 123456789,
-  "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
-  "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-}, contentType=application/json}, {example=<Order>
-  <id>123456</id>
-  <petId>123456</petId>
-  <quantity>0</quantity>
-  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
-  <status>string</status>
-  <complete>true</complete>
-</Order>, contentType=application/xml}]
-         
-         - parameter orderId: (path) ID of pet that needs to be fetched
-
-         - returns: RequestBuilder<Order> 
-         */
-        public class func getOrderByIdWithRequestBuilder(orderId orderId: String) -> RequestBuilder<Order> {
-            var path = "/store/order/{orderId}"
-            path = path.stringByReplacingOccurrencesOfString("{orderId}", withString: "\(orderId)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Delete purchase order by ID
-         
-         - parameter orderId: (path) ID of the order that needs to be deleted
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func deleteOrder(orderId orderId: String, completion: ((error: ErrorType?) -> Void)) {
-            deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         Delete purchase order by ID
-         
-         - parameter orderId: (path) ID of the order that needs to be deleted
-         - returns: Promise<Void>
-         */
-        public class func deleteOrder(orderId orderId: String) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            deleteOrder(orderId: orderId) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Delete purchase order by ID
-         
-         - DELETE /store/order/{orderId}
-         - For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-         
-         - parameter orderId: (path) ID of the order that needs to be deleted
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func deleteOrderWithRequestBuilder(orderId orderId: String) -> RequestBuilder<Void> {
-            var path = "/store/order/{orderId}"
-            path = path.stringByReplacingOccurrencesOfString("{orderId}", withString: "\(orderId)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
     }
+
+    /**
+     
+     Returns pet inventories by status
+     
+     - returns: Promise<[String:Int]>
+     */
+    public class func getInventory() -> Promise<[String:Int]> {
+        let deferred = Promise<[String:Int]>.pendingPromise()
+        getInventory() { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Returns pet inventories by status
+     
+     - GET /store/inventory
+     - Returns a map of status codes to quantities
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - examples: [{example={
+  "key" : 123
+}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
+     - examples: [{example={
+  "key" : 123
+}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
+
+     - returns: RequestBuilder<[String:Int]> 
+     */
+    public class func getInventoryWithRequestBuilder() -> RequestBuilder<[String:Int]> {
+        let path = "/store/inventory"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<[String:Int]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Place an order for a pet
+     
+     - parameter body: (body) order placed for purchasing the pet
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func placeOrder(body body: Order?, completion: ((data: Order?, error: ErrorType?) -> Void)) {
+        placeOrderWithRequestBuilder(body: body).execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
+        }
+    }
+
+    /**
+     
+     Place an order for a pet
+     
+     - parameter body: (body) order placed for purchasing the pet
+     - returns: Promise<Order>
+     */
+    public class func placeOrder(body body: Order?) -> Promise<Order> {
+        let deferred = Promise<Order>.pendingPromise()
+        placeOrder(body: body) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Place an order for a pet
+     
+     - POST /store/order
+     - 
+     - API Key:
+       - type: apiKey x-test_api_client_id 
+       - name: test_api_client_id
+     - API Key:
+       - type: apiKey x-test_api_client_secret 
+       - name: test_api_client_secret
+     - examples: [{example={
+  "id" : 123456789,
+  "petId" : 123456789,
+  "complete" : true,
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+0000"
+}, contentType=application/json}, {example=<Order>
+  <id>123456</id>
+  <petId>123456</petId>
+  <quantity>0</quantity>
+  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
+  <status>string</status>
+  <complete>true</complete>
+</Order>, contentType=application/xml}]
+     - examples: [{example={
+  "id" : 123456789,
+  "petId" : 123456789,
+  "complete" : true,
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+0000"
+}, contentType=application/json}, {example=<Order>
+  <id>123456</id>
+  <petId>123456</petId>
+  <quantity>0</quantity>
+  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
+  <status>string</status>
+  <complete>true</complete>
+</Order>, contentType=application/xml}]
+     
+     - parameter body: (body) order placed for purchasing the pet
+
+     - returns: RequestBuilder<Order> 
+     */
+    public class func placeOrderWithRequestBuilder(body body: Order?) -> RequestBuilder<Order> {
+        let path = "/store/order"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+        let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Find purchase order by ID
+     
+     - parameter orderId: (path) ID of pet that needs to be fetched
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func getOrderById(orderId orderId: String, completion: ((data: Order?, error: ErrorType?) -> Void)) {
+        getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
+        }
+    }
+
+    /**
+     
+     Find purchase order by ID
+     
+     - parameter orderId: (path) ID of pet that needs to be fetched
+     - returns: Promise<Order>
+     */
+    public class func getOrderById(orderId orderId: String) -> Promise<Order> {
+        let deferred = Promise<Order>.pendingPromise()
+        getOrderById(orderId: orderId) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Find purchase order by ID
+     
+     - GET /store/order/{orderId}
+     - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+     - API Key:
+       - type: apiKey test_api_key_header 
+       - name: test_api_key_header
+     - API Key:
+       - type: apiKey test_api_key_query (QUERY)
+       - name: test_api_key_query
+     - examples: [{example={
+  "id" : 123456789,
+  "petId" : 123456789,
+  "complete" : true,
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+0000"
+}, contentType=application/json}, {example=<Order>
+  <id>123456</id>
+  <petId>123456</petId>
+  <quantity>0</quantity>
+  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
+  <status>string</status>
+  <complete>true</complete>
+</Order>, contentType=application/xml}]
+     - examples: [{example={
+  "id" : 123456789,
+  "petId" : 123456789,
+  "complete" : true,
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+0000"
+}, contentType=application/json}, {example=<Order>
+  <id>123456</id>
+  <petId>123456</petId>
+  <quantity>0</quantity>
+  <shipDate>2000-01-23T04:56:07.000Z</shipDate>
+  <status>string</status>
+  <complete>true</complete>
+</Order>, contentType=application/xml}]
+     
+     - parameter orderId: (path) ID of pet that needs to be fetched
+
+     - returns: RequestBuilder<Order> 
+     */
+    public class func getOrderByIdWithRequestBuilder(orderId orderId: String) -> RequestBuilder<Order> {
+        var path = "/store/order/{orderId}"
+        path = path.stringByReplacingOccurrencesOfString("{orderId}", withString: "\(orderId)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Delete purchase order by ID
+     
+     - parameter orderId: (path) ID of the order that needs to be deleted
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func deleteOrder(orderId orderId: String, completion: ((error: ErrorType?) -> Void)) {
+        deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     Delete purchase order by ID
+     
+     - parameter orderId: (path) ID of the order that needs to be deleted
+     - returns: Promise<Void>
+     */
+    public class func deleteOrder(orderId orderId: String) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        deleteOrder(orderId: orderId) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Delete purchase order by ID
+     
+     - DELETE /store/order/{orderId}
+     - For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     
+     - parameter orderId: (path) ID of the order that needs to be deleted
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func deleteOrderWithRequestBuilder(orderId orderId: String) -> RequestBuilder<Void> {
+        var path = "/store/order/{orderId}"
+        path = path.stringByReplacingOccurrencesOfString("{orderId}", withString: "\(orderId)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
 }

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -16,6 +16,38 @@ extension PetstoreClientAPI {
          
          Create user
          
+         - parameter body: (body) Created user object
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func createUser(body body: User?, completion: ((error: ErrorType?) -> Void)) {
+            createUserWithRequestBuilder(body: body).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Create user
+         
+         - parameter body: (body) Created user object
+         - returns: Promise<Void>
+         */
+        public class func createUser(body body: User?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            createUser(body: body) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Create user
+         
          - POST /user
          - This can only be done by the logged in user.
          
@@ -23,7 +55,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func createUser(body body: User?) -> RequestBuilder<Void> {
+        public class func createUserWithRequestBuilder(body body: User?) -> RequestBuilder<Void> {
             let path = "/user"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -38,6 +70,38 @@ extension PetstoreClientAPI {
          
          Creates list of users with given input array
          
+         - parameter body: (body) List of user object
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func createUsersWithArrayInput(body body: [User]?, completion: ((error: ErrorType?) -> Void)) {
+            createUsersWithArrayInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Creates list of users with given input array
+         
+         - parameter body: (body) List of user object
+         - returns: Promise<Void>
+         */
+        public class func createUsersWithArrayInput(body body: [User]?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            createUsersWithArrayInput(body: body) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Creates list of users with given input array
+         
          - POST /user/createWithArray
          - 
          
@@ -45,7 +109,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func createUsersWithArrayInput(body body: [User]?) -> RequestBuilder<Void> {
+        public class func createUsersWithArrayInputWithRequestBuilder(body body: [User]?) -> RequestBuilder<Void> {
             let path = "/user/createWithArray"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -60,6 +124,38 @@ extension PetstoreClientAPI {
          
          Creates list of users with given input array
          
+         - parameter body: (body) List of user object
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func createUsersWithListInput(body body: [User]?, completion: ((error: ErrorType?) -> Void)) {
+            createUsersWithListInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Creates list of users with given input array
+         
+         - parameter body: (body) List of user object
+         - returns: Promise<Void>
+         */
+        public class func createUsersWithListInput(body body: [User]?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            createUsersWithListInput(body: body) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Creates list of users with given input array
+         
          - POST /user/createWithList
          - 
          
@@ -67,7 +163,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func createUsersWithListInput(body body: [User]?) -> RequestBuilder<Void> {
+        public class func createUsersWithListInputWithRequestBuilder(body body: [User]?) -> RequestBuilder<Void> {
             let path = "/user/createWithList"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -82,6 +178,40 @@ extension PetstoreClientAPI {
          
          Logs user into the system
          
+         - parameter username: (query) The user name for login
+         - parameter password: (query) The password for login in clear text
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func loginUser(username username: String?, password: String?, completion: ((data: String?, error: ErrorType?) -> Void)) {
+            loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Logs user into the system
+         
+         - parameter username: (query) The user name for login
+         - parameter password: (query) The password for login in clear text
+         - returns: Promise<String>
+         */
+        public class func loginUser(username username: String?, password: String?) -> Promise<String> {
+            let deferred = Promise<String>.pendingPromise()
+            loginUser(username: username, password: password) { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Logs user into the system
+         
          - GET /user/login
          - 
          - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
@@ -92,7 +222,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<String> 
          */
-        public class func loginUser(username username: String?, password: String?) -> RequestBuilder<String> {
+        public class func loginUserWithRequestBuilder(username username: String?, password: String?) -> RequestBuilder<String> {
             let path = "/user/login"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -111,12 +241,42 @@ extension PetstoreClientAPI {
          
          Logs out current logged in user session
          
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func logoutUser(completion: ((error: ErrorType?) -> Void)) {
+            logoutUserWithRequestBuilder().execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Logs out current logged in user session
+         
+         - returns: Promise<Void>
+         */
+        public class func logoutUser() -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            logoutUser() { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Logs out current logged in user session
+         
          - GET /user/logout
          - 
 
          - returns: RequestBuilder<Void> 
          */
-        public class func logoutUser() -> RequestBuilder<Void> {
+        public class func logoutUserWithRequestBuilder() -> RequestBuilder<Void> {
             let path = "/user/logout"
             let URLString = PetstoreClientAPI.basePath + path
             
@@ -128,6 +288,38 @@ extension PetstoreClientAPI {
             return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
         }
     
+        /**
+         
+         Get user by user name
+         
+         - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func getUserByName(username username: String, completion: ((data: User?, error: ErrorType?) -> Void)) {
+            getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
+                completion(data: response?.body, error: error);
+            }
+        }
+
+        /**
+         
+         Get user by user name
+         
+         - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
+         - returns: Promise<User>
+         */
+        public class func getUserByName(username username: String) -> Promise<User> {
+            let deferred = Promise<User>.pendingPromise()
+            getUserByName(username: username) { data, error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill(data!)
+                }
+            }
+            return deferred.promise
+        }
+
         /**
          
          Get user by user name
@@ -149,7 +341,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<User> 
          */
-        public class func getUserByName(username username: String) -> RequestBuilder<User> {
+        public class func getUserByNameWithRequestBuilder(username username: String) -> RequestBuilder<User> {
             var path = "/user/{username}"
             path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path
@@ -166,6 +358,40 @@ extension PetstoreClientAPI {
          
          Updated user
          
+         - parameter username: (path) name that need to be deleted
+         - parameter body: (body) Updated user object
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func updateUser(username username: String, body: User?, completion: ((error: ErrorType?) -> Void)) {
+            updateUserWithRequestBuilder(username: username, body: body).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Updated user
+         
+         - parameter username: (path) name that need to be deleted
+         - parameter body: (body) Updated user object
+         - returns: Promise<Void>
+         */
+        public class func updateUser(username username: String, body: User?) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            updateUser(username: username, body: body) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Updated user
+         
          - PUT /user/{username}
          - This can only be done by the logged in user.
          
@@ -174,7 +400,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func updateUser(username username: String, body: User?) -> RequestBuilder<Void> {
+        public class func updateUserWithRequestBuilder(username username: String, body: User?) -> RequestBuilder<Void> {
             var path = "/user/{username}"
             path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path
@@ -190,6 +416,38 @@ extension PetstoreClientAPI {
          
          Delete user
          
+         - parameter username: (path) The name that needs to be deleted
+         - parameter completion: completion handler to receive the data and the error objects
+         */
+        public class func deleteUser(username username: String, completion: ((error: ErrorType?) -> Void)) {
+            deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
+                completion(error: error);
+            }
+        }
+
+        /**
+         
+         Delete user
+         
+         - parameter username: (path) The name that needs to be deleted
+         - returns: Promise<Void>
+         */
+        public class func deleteUser(username username: String) -> Promise<Void> {
+            let deferred = Promise<Void>.pendingPromise()
+            deleteUser(username: username) { error in
+                if let error = error {
+                    deferred.reject(error)
+                } else {
+                    deferred.fulfill()
+                }
+            }
+            return deferred.promise
+        }
+
+        /**
+         
+         Delete user
+         
          - DELETE /user/{username}
          - This can only be done by the logged in user.
          
@@ -197,7 +455,7 @@ extension PetstoreClientAPI {
 
          - returns: RequestBuilder<Void> 
          */
-        public class func deleteUser(username username: String) -> RequestBuilder<Void> {
+        public class func deleteUserWithRequestBuilder(username username: String) -> RequestBuilder<Void> {
             var path = "/user/{username}"
             path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
             let URLString = PetstoreClientAPI.basePath + path

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -8,325 +8,324 @@
 import Alamofire
 import PromiseKit
 
-extension PetstoreClientAPI {
-    
-    public class UserAPI: APIBase {
-    
-        /**
-         
-         Create user
-         
-         - parameter body: (body) Created user object
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func createUser(body body: User?, completion: ((error: ErrorType?) -> Void)) {
-            createUserWithRequestBuilder(body: body).execute { (response, error) -> Void in
-                completion(error: error);
+
+
+public class UserAPI: APIBase {
+    /**
+     
+     Create user
+     
+     - parameter body: (body) Created user object
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func createUser(body body: User?, completion: ((error: ErrorType?) -> Void)) {
+        createUserWithRequestBuilder(body: body).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     Create user
+     
+     - parameter body: (body) Created user object
+     - returns: Promise<Void>
+     */
+    public class func createUser(body body: User?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        createUser(body: body) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
             }
         }
+        return deferred.promise
+    }
 
-        /**
-         
-         Create user
-         
-         - parameter body: (body) Created user object
-         - returns: Promise<Void>
-         */
-        public class func createUser(body body: User?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            createUser(body: body) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
+    /**
+     
+     Create user
+     
+     - POST /user
+     - This can only be done by the logged in user.
+     
+     - parameter body: (body) Created user object
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func createUserWithRequestBuilder(body body: User?) -> RequestBuilder<Void> {
+        let path = "/user"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Creates list of users with given input array
+     
+     - parameter body: (body) List of user object
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func createUsersWithArrayInput(body body: [User]?, completion: ((error: ErrorType?) -> Void)) {
+        createUsersWithArrayInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
+            completion(error: error);
         }
+    }
 
-        /**
-         
-         Create user
-         
-         - POST /user
-         - This can only be done by the logged in user.
-         
-         - parameter body: (body) Created user object
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func createUserWithRequestBuilder(body body: User?) -> RequestBuilder<Void> {
-            let path = "/user"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Creates list of users with given input array
-         
-         - parameter body: (body) List of user object
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func createUsersWithArrayInput(body body: [User]?, completion: ((error: ErrorType?) -> Void)) {
-            createUsersWithArrayInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         Creates list of users with given input array
-         
-         - parameter body: (body) List of user object
-         - returns: Promise<Void>
-         */
-        public class func createUsersWithArrayInput(body body: [User]?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            createUsersWithArrayInput(body: body) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Creates list of users with given input array
-         
-         - POST /user/createWithArray
-         - 
-         
-         - parameter body: (body) List of user object
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func createUsersWithArrayInputWithRequestBuilder(body body: [User]?) -> RequestBuilder<Void> {
-            let path = "/user/createWithArray"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Creates list of users with given input array
-         
-         - parameter body: (body) List of user object
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func createUsersWithListInput(body body: [User]?, completion: ((error: ErrorType?) -> Void)) {
-            createUsersWithListInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
-                completion(error: error);
+    /**
+     
+     Creates list of users with given input array
+     
+     - parameter body: (body) List of user object
+     - returns: Promise<Void>
+     */
+    public class func createUsersWithArrayInput(body body: [User]?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        createUsersWithArrayInput(body: body) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
             }
         }
+        return deferred.promise
+    }
 
-        /**
-         
-         Creates list of users with given input array
-         
-         - parameter body: (body) List of user object
-         - returns: Promise<Void>
-         */
-        public class func createUsersWithListInput(body body: [User]?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            createUsersWithListInput(body: body) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
+    /**
+     
+     Creates list of users with given input array
+     
+     - POST /user/createWithArray
+     - 
+     
+     - parameter body: (body) List of user object
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func createUsersWithArrayInputWithRequestBuilder(body body: [User]?) -> RequestBuilder<Void> {
+        let path = "/user/createWithArray"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Creates list of users with given input array
+     
+     - parameter body: (body) List of user object
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func createUsersWithListInput(body body: [User]?, completion: ((error: ErrorType?) -> Void)) {
+        createUsersWithListInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
+            completion(error: error);
         }
+    }
 
-        /**
-         
-         Creates list of users with given input array
-         
-         - POST /user/createWithList
-         - 
-         
-         - parameter body: (body) List of user object
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func createUsersWithListInputWithRequestBuilder(body body: [User]?) -> RequestBuilder<Void> {
-            let path = "/user/createWithList"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Logs user into the system
-         
-         - parameter username: (query) The user name for login
-         - parameter password: (query) The password for login in clear text
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func loginUser(username username: String?, password: String?, completion: ((data: String?, error: ErrorType?) -> Void)) {
-            loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
-            }
-        }
-
-        /**
-         
-         Logs user into the system
-         
-         - parameter username: (query) The user name for login
-         - parameter password: (query) The password for login in clear text
-         - returns: Promise<String>
-         */
-        public class func loginUser(username username: String?, password: String?) -> Promise<String> {
-            let deferred = Promise<String>.pendingPromise()
-            loginUser(username: username, password: password) { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Logs user into the system
-         
-         - GET /user/login
-         - 
-         - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
-         - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
-         
-         - parameter username: (query) The user name for login
-         - parameter password: (query) The password for login in clear text
-
-         - returns: RequestBuilder<String> 
-         */
-        public class func loginUserWithRequestBuilder(username username: String?, password: String?) -> RequestBuilder<String> {
-            let path = "/user/login"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [
-                "username": username,
-                "password": password
-            ]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: false)
-        }
-    
-        /**
-         
-         Logs out current logged in user session
-         
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func logoutUser(completion: ((error: ErrorType?) -> Void)) {
-            logoutUserWithRequestBuilder().execute { (response, error) -> Void in
-                completion(error: error);
+    /**
+     
+     Creates list of users with given input array
+     
+     - parameter body: (body) List of user object
+     - returns: Promise<Void>
+     */
+    public class func createUsersWithListInput(body body: [User]?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        createUsersWithListInput(body: body) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
             }
         }
+        return deferred.promise
+    }
 
-        /**
-         
-         Logs out current logged in user session
-         
-         - returns: Promise<Void>
-         */
-        public class func logoutUser() -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            logoutUser() { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
+    /**
+     
+     Creates list of users with given input array
+     
+     - POST /user/createWithList
+     - 
+     
+     - parameter body: (body) List of user object
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func createUsersWithListInputWithRequestBuilder(body body: [User]?) -> RequestBuilder<Void> {
+        let path = "/user/createWithList"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "POST", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Logs user into the system
+     
+     - parameter username: (query) The user name for login
+     - parameter password: (query) The password for login in clear text
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func loginUser(username username: String?, password: String?, completion: ((data: String?, error: ErrorType?) -> Void)) {
+        loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
+        }
+    }
+
+    /**
+     
+     Logs user into the system
+     
+     - parameter username: (query) The user name for login
+     - parameter password: (query) The password for login in clear text
+     - returns: Promise<String>
+     */
+    public class func loginUser(username username: String?, password: String?) -> Promise<String> {
+        let deferred = Promise<String>.pendingPromise()
+        loginUser(username: username, password: password) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
             }
-            return deferred.promise
         }
+        return deferred.promise
+    }
 
-        /**
-         
-         Logs out current logged in user session
-         
-         - GET /user/logout
-         - 
+    /**
+     
+     Logs user into the system
+     
+     - GET /user/login
+     - 
+     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
+     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
+     
+     - parameter username: (query) The user name for login
+     - parameter password: (query) The password for login in clear text
 
-         - returns: RequestBuilder<Void> 
-         */
-        public class func logoutUserWithRequestBuilder() -> RequestBuilder<Void> {
-            let path = "/user/logout"
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
+     - returns: RequestBuilder<String> 
+     */
+    public class func loginUserWithRequestBuilder(username username: String?, password: String?) -> RequestBuilder<String> {
+        let path = "/user/login"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [
+            "username": username,
+            "password": password
+        ]
+        let parameters = APIHelper.rejectNil(nillableParameters)
 
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+        let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: false)
+    }
+
+    /**
+     
+     Logs out current logged in user session
+     
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func logoutUser(completion: ((error: ErrorType?) -> Void)) {
+        logoutUserWithRequestBuilder().execute { (response, error) -> Void in
+            completion(error: error);
         }
-    
-        /**
-         
-         Get user by user name
-         
-         - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func getUserByName(username username: String, completion: ((data: User?, error: ErrorType?) -> Void)) {
-            getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
-                completion(data: response?.body, error: error);
+    }
+
+    /**
+     
+     Logs out current logged in user session
+     
+     - returns: Promise<Void>
+     */
+    public class func logoutUser() -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        logoutUser() { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
             }
         }
+        return deferred.promise
+    }
 
-        /**
-         
-         Get user by user name
-         
-         - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
-         - returns: Promise<User>
-         */
-        public class func getUserByName(username username: String) -> Promise<User> {
-            let deferred = Promise<User>.pendingPromise()
-            getUserByName(username: username) { data, error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill(data!)
-                }
-            }
-            return deferred.promise
+    /**
+     
+     Logs out current logged in user session
+     
+     - GET /user/logout
+     - 
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func logoutUserWithRequestBuilder() -> RequestBuilder<Void> {
+        let path = "/user/logout"
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Get user by user name
+     
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func getUserByName(username username: String, completion: ((data: User?, error: ErrorType?) -> Void)) {
+        getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
+            completion(data: response?.body, error: error);
         }
+    }
 
-        /**
-         
-         Get user by user name
-         
-         - GET /user/{username}
-         - 
-         - examples: [{example={
+    /**
+     
+     Get user by user name
+     
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
+     - returns: Promise<User>
+     */
+    public class func getUserByName(username username: String) -> Promise<User> {
+        let deferred = Promise<User>.pendingPromise()
+        getUserByName(username: username) { data, error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill(data!)
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Get user by user name
+     
+     - GET /user/{username}
+     - 
+     - examples: [{example={
   "id" : 1,
   "username" : "johnp",
   "firstName" : "John",
@@ -336,137 +335,136 @@ extension PetstoreClientAPI {
   "phone" : "0123456789",
   "userStatus" : 0
 }, contentType=application/json}]
-         
-         - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
+     
+     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
 
-         - returns: RequestBuilder<User> 
-         */
-        public class func getUserByNameWithRequestBuilder(username username: String) -> RequestBuilder<User> {
-            var path = "/user/{username}"
-            path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
+     - returns: RequestBuilder<User> 
+     */
+    public class func getUserByNameWithRequestBuilder(username username: String) -> RequestBuilder<User> {
+        var path = "/user/{username}"
+        path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
 
-            let requestBuilder: RequestBuilder<User>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+        let requestBuilder: RequestBuilder<User>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
-            return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Updated user
-         
-         - parameter username: (path) name that need to be deleted
-         - parameter body: (body) Updated user object
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func updateUser(username username: String, body: User?, completion: ((error: ErrorType?) -> Void)) {
-            updateUserWithRequestBuilder(username: username, body: body).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         Updated user
-         
-         - parameter username: (path) name that need to be deleted
-         - parameter body: (body) Updated user object
-         - returns: Promise<Void>
-         */
-        public class func updateUser(username username: String, body: User?) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            updateUser(username: username, body: body) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Updated user
-         
-         - PUT /user/{username}
-         - This can only be done by the logged in user.
-         
-         - parameter username: (path) name that need to be deleted
-         - parameter body: (body) Updated user object
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func updateUserWithRequestBuilder(username username: String, body: User?) -> RequestBuilder<Void> {
-            var path = "/user/{username}"
-            path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let parameters = body?.encodeToJSON() as? [String:AnyObject]
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "PUT", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
-        /**
-         
-         Delete user
-         
-         - parameter username: (path) The name that needs to be deleted
-         - parameter completion: completion handler to receive the data and the error objects
-         */
-        public class func deleteUser(username username: String, completion: ((error: ErrorType?) -> Void)) {
-            deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
-                completion(error: error);
-            }
-        }
-
-        /**
-         
-         Delete user
-         
-         - parameter username: (path) The name that needs to be deleted
-         - returns: Promise<Void>
-         */
-        public class func deleteUser(username username: String) -> Promise<Void> {
-            let deferred = Promise<Void>.pendingPromise()
-            deleteUser(username: username) { error in
-                if let error = error {
-                    deferred.reject(error)
-                } else {
-                    deferred.fulfill()
-                }
-            }
-            return deferred.promise
-        }
-
-        /**
-         
-         Delete user
-         
-         - DELETE /user/{username}
-         - This can only be done by the logged in user.
-         
-         - parameter username: (path) The name that needs to be deleted
-
-         - returns: RequestBuilder<Void> 
-         */
-        public class func deleteUserWithRequestBuilder(username username: String) -> RequestBuilder<Void> {
-            var path = "/user/{username}"
-            path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
-            let URLString = PetstoreClientAPI.basePath + path
-            
-            let nillableParameters: [String:AnyObject?] = [:]
-            let parameters = APIHelper.rejectNil(nillableParameters)
-
-            let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
-
-            return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: parameters, isBody: true)
-        }
-    
+        return requestBuilder.init(method: "GET", URLString: URLString, parameters: parameters, isBody: true)
     }
+
+    /**
+     
+     Updated user
+     
+     - parameter username: (path) name that need to be deleted
+     - parameter body: (body) Updated user object
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func updateUser(username username: String, body: User?, completion: ((error: ErrorType?) -> Void)) {
+        updateUserWithRequestBuilder(username: username, body: body).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     Updated user
+     
+     - parameter username: (path) name that need to be deleted
+     - parameter body: (body) Updated user object
+     - returns: Promise<Void>
+     */
+    public class func updateUser(username username: String, body: User?) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        updateUser(username: username, body: body) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Updated user
+     
+     - PUT /user/{username}
+     - This can only be done by the logged in user.
+     
+     - parameter username: (path) name that need to be deleted
+     - parameter body: (body) Updated user object
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func updateUserWithRequestBuilder(username username: String, body: User?) -> RequestBuilder<Void> {
+        var path = "/user/{username}"
+        path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let parameters = body?.encodeToJSON() as? [String:AnyObject]
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "PUT", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
+    /**
+     
+     Delete user
+     
+     - parameter username: (path) The name that needs to be deleted
+     - parameter completion: completion handler to receive the data and the error objects
+     */
+    public class func deleteUser(username username: String, completion: ((error: ErrorType?) -> Void)) {
+        deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
+            completion(error: error);
+        }
+    }
+
+    /**
+     
+     Delete user
+     
+     - parameter username: (path) The name that needs to be deleted
+     - returns: Promise<Void>
+     */
+    public class func deleteUser(username username: String) -> Promise<Void> {
+        let deferred = Promise<Void>.pendingPromise()
+        deleteUser(username: username) { error in
+            if let error = error {
+                deferred.reject(error)
+            } else {
+                deferred.fulfill()
+            }
+        }
+        return deferred.promise
+    }
+
+    /**
+     
+     Delete user
+     
+     - DELETE /user/{username}
+     - This can only be done by the logged in user.
+     
+     - parameter username: (path) The name that needs to be deleted
+
+     - returns: RequestBuilder<Void> 
+     */
+    public class func deleteUserWithRequestBuilder(username username: String) -> RequestBuilder<Void> {
+        var path = "/user/{username}"
+        path = path.stringByReplacingOccurrencesOfString("{username}", withString: "\(username)", options: .LiteralSearch, range: nil)
+        let URLString = PetstoreClientAPI.basePath + path
+        
+        let nillableParameters: [String:AnyObject?] = [:]
+        let parameters = APIHelper.rejectNil(nillableParameters)
+
+        let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
+
+        return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: parameters, isBody: true)
+    }
+
 }

--- a/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -35,7 +35,7 @@ class PetAPITests: XCTestCase {
         newPet.id = 1000
         newPet.name = "Fluffy"
         newPet.status = .Available
-        PetstoreClientAPI.PetAPI.addPet(body: newPet).execute().then { response -> Void in
+        PetstoreClientAPI.PetAPI.addPet(body: newPet).then {
                 expectation.fulfill()
             }.always {
                 // Noop for now
@@ -47,8 +47,7 @@ class PetAPITests: XCTestCase {
     
     func test2GetPet() {
         let expectation = self.expectationWithDescription("testGetPet")
-        PetstoreClientAPI.PetAPI.getPetById(petId: 1000).execute().then { response -> Void in
-                let pet = response.body
+        PetstoreClientAPI.PetAPI.getPetById(petId: 1000).then { pet -> Void in
                 XCTAssert(pet.id == 1000, "invalid id")
                 XCTAssert(pet.name == "Fluffy", "invalid name")
                 expectation.fulfill()
@@ -62,7 +61,7 @@ class PetAPITests: XCTestCase {
     
     func test3DeletePet() {
         let expectation = self.expectationWithDescription("testDeletePet")
-        PetstoreClientAPI.PetAPI.deletePet(petId: 1000).execute().always { response -> Void in
+        PetstoreClientAPI.PetAPI.deletePet(petId: 1000).always {
                 // expectation.fulfill()
             }.always {
                 // Noop for now

--- a/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
+++ b/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/PetAPITests.swift
@@ -35,7 +35,7 @@ class PetAPITests: XCTestCase {
         newPet.id = 1000
         newPet.name = "Fluffy"
         newPet.status = .Available
-        PetstoreClientAPI.PetAPI.addPet(body: newPet).then {
+        PetAPI.addPet(body: newPet).then {
                 expectation.fulfill()
             }.always {
                 // Noop for now
@@ -47,7 +47,7 @@ class PetAPITests: XCTestCase {
     
     func test2GetPet() {
         let expectation = self.expectationWithDescription("testGetPet")
-        PetstoreClientAPI.PetAPI.getPetById(petId: 1000).then { pet -> Void in
+        PetAPI.getPetById(petId: 1000).then { pet -> Void in
                 XCTAssert(pet.id == 1000, "invalid id")
                 XCTAssert(pet.name == "Fluffy", "invalid name")
                 expectation.fulfill()
@@ -61,7 +61,7 @@ class PetAPITests: XCTestCase {
     
     func test3DeletePet() {
         let expectation = self.expectationWithDescription("testDeletePet")
-        PetstoreClientAPI.PetAPI.deletePet(petId: 1000).always {
+        PetAPI.deletePet(petId: 1000).always {
                 // expectation.fulfill()
             }.always {
                 // Noop for now

--- a/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/StoreAPITests.swift
+++ b/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/StoreAPITests.swift
@@ -34,8 +34,7 @@ class StoreAPITests: XCTestCase {
         order.shipDate = NSDate()
         order.status = .Placed
         let expectation = self.expectationWithDescription("testPlaceOrder")
-        PetstoreClientAPI.StoreAPI.placeOrder(body: order).execute().then { response -> Void in
-                let order = response.body
+        PetstoreClientAPI.StoreAPI.placeOrder(body: order).then { order -> Void in
                 XCTAssert(order.id == 1000, "invalid id")
                 XCTAssert(order.quantity == 10, "invalid quantity")
                 XCTAssert(order.status == .Placed, "invalid status")
@@ -50,8 +49,7 @@ class StoreAPITests: XCTestCase {
     
     func test2GetOrder() {
         let expectation = self.expectationWithDescription("testGetOrder")
-        PetstoreClientAPI.StoreAPI.getOrderById(orderId: "1000").execute().then { response -> Void in
-            let order = response.body
+        PetstoreClientAPI.StoreAPI.getOrderById(orderId: "1000").then { order -> Void in
             XCTAssert(order.id == 1000, "invalid id")
             XCTAssert(order.quantity == 10, "invalid quantity")
             XCTAssert(order.status == .Placed, "invalid status")
@@ -66,7 +64,7 @@ class StoreAPITests: XCTestCase {
     
     func test3DeleteOrder() {
         let expectation = self.expectationWithDescription("testDeleteOrder")
-        PetstoreClientAPI.StoreAPI.deleteOrder(orderId: "1000").execute().then { response -> Void in
+        PetstoreClientAPI.StoreAPI.deleteOrder(orderId: "1000").then {
                 expectation.fulfill()
             }.always {
                 // Noop for now

--- a/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/StoreAPITests.swift
+++ b/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/StoreAPITests.swift
@@ -34,7 +34,7 @@ class StoreAPITests: XCTestCase {
         order.shipDate = NSDate()
         order.status = .Placed
         let expectation = self.expectationWithDescription("testPlaceOrder")
-        PetstoreClientAPI.StoreAPI.placeOrder(body: order).then { order -> Void in
+        StoreAPI.placeOrder(body: order).then { order -> Void in
                 XCTAssert(order.id == 1000, "invalid id")
                 XCTAssert(order.quantity == 10, "invalid quantity")
                 XCTAssert(order.status == .Placed, "invalid status")
@@ -49,7 +49,7 @@ class StoreAPITests: XCTestCase {
     
     func test2GetOrder() {
         let expectation = self.expectationWithDescription("testGetOrder")
-        PetstoreClientAPI.StoreAPI.getOrderById(orderId: "1000").then { order -> Void in
+        StoreAPI.getOrderById(orderId: "1000").then { order -> Void in
             XCTAssert(order.id == 1000, "invalid id")
             XCTAssert(order.quantity == 10, "invalid quantity")
             XCTAssert(order.status == .Placed, "invalid status")
@@ -64,7 +64,7 @@ class StoreAPITests: XCTestCase {
     
     func test3DeleteOrder() {
         let expectation = self.expectationWithDescription("testDeleteOrder")
-        PetstoreClientAPI.StoreAPI.deleteOrder(orderId: "1000").then {
+        StoreAPI.deleteOrder(orderId: "1000").then {
                 expectation.fulfill()
             }.always {
                 // Noop for now

--- a/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/UserAPITests.swift
+++ b/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/UserAPITests.swift
@@ -27,7 +27,7 @@ class UserAPITests: XCTestCase {
     
     func testLogin() {
         let expectation = self.expectationWithDescription("testLogin")
-        PetstoreClientAPI.UserAPI.loginUser(username: "swiftTester", password: "swift").execute().then { response -> Void in
+        PetstoreClientAPI.UserAPI.loginUser(username: "swiftTester", password: "swift").then { _ -> Void in
                 expectation.fulfill()
             }.always {
                 // Noop for now
@@ -48,7 +48,7 @@ class UserAPITests: XCTestCase {
     
     func testLogout() {
         let expectation = self.expectationWithDescription("testLogout")
-        PetstoreClientAPI.UserAPI.logoutUser().execute().then { response -> Void in
+        PetstoreClientAPI.UserAPI.logoutUser().then {
                 expectation.fulfill()
             }.always {
                 // Noop for now
@@ -79,7 +79,7 @@ class UserAPITests: XCTestCase {
         newUser.phone = "867-5309"
         newUser.username = "test@test.com"
         newUser.userStatus = 0
-        PetstoreClientAPI.UserAPI.createUser(body: newUser).execute().then { response -> Void in
+        PetstoreClientAPI.UserAPI.createUser(body: newUser).then {
                 expectation.fulfill()
             }.always {
                 // Noop for now
@@ -101,8 +101,7 @@ class UserAPITests: XCTestCase {
     
     func test2GetUser() {
         let expectation = self.expectationWithDescription("testGetUser")
-        PetstoreClientAPI.UserAPI.getUserByName(username: "test@test.com").execute().then { response -> Void in
-                let user = response.body
+        PetstoreClientAPI.UserAPI.getUserByName(username: "test@test.com").then {user -> Void in
                 XCTAssert(user.userStatus == 0, "invalid userStatus")
                 XCTAssert(user.email == "test@test.com", "invalid email")
                 XCTAssert(user.firstName == "Test", "invalid firstName")
@@ -120,7 +119,7 @@ class UserAPITests: XCTestCase {
     
     func test3DeleteUser() {
         let expectation = self.expectationWithDescription("testDeleteUser")
-        PetstoreClientAPI.UserAPI.deleteUser(username: "test@test.com").execute().then { response -> Void in
+        PetstoreClientAPI.UserAPI.deleteUser(username: "test@test.com").then {
                 expectation.fulfill()
             }.always {
                 // Noop for now

--- a/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/UserAPITests.swift
+++ b/samples/client/petstore/swift/SwaggerClientTests/SwaggerClientTests/UserAPITests.swift
@@ -27,7 +27,7 @@ class UserAPITests: XCTestCase {
     
     func testLogin() {
         let expectation = self.expectationWithDescription("testLogin")
-        PetstoreClientAPI.UserAPI.loginUser(username: "swiftTester", password: "swift").then { _ -> Void in
+        UserAPI.loginUser(username: "swiftTester", password: "swift").then { _ -> Void in
                 expectation.fulfill()
             }.always {
                 // Noop for now
@@ -48,7 +48,7 @@ class UserAPITests: XCTestCase {
     
     func testLogout() {
         let expectation = self.expectationWithDescription("testLogout")
-        PetstoreClientAPI.UserAPI.logoutUser().then {
+        UserAPI.logoutUser().then {
                 expectation.fulfill()
             }.always {
                 // Noop for now
@@ -79,7 +79,7 @@ class UserAPITests: XCTestCase {
         newUser.phone = "867-5309"
         newUser.username = "test@test.com"
         newUser.userStatus = 0
-        PetstoreClientAPI.UserAPI.createUser(body: newUser).then {
+        UserAPI.createUser(body: newUser).then {
                 expectation.fulfill()
             }.always {
                 // Noop for now
@@ -101,7 +101,7 @@ class UserAPITests: XCTestCase {
     
     func test2GetUser() {
         let expectation = self.expectationWithDescription("testGetUser")
-        PetstoreClientAPI.UserAPI.getUserByName(username: "test@test.com").then {user -> Void in
+        UserAPI.getUserByName(username: "test@test.com").then {user -> Void in
                 XCTAssert(user.userStatus == 0, "invalid userStatus")
                 XCTAssert(user.email == "test@test.com", "invalid email")
                 XCTAssert(user.firstName == "Test", "invalid firstName")
@@ -119,7 +119,7 @@ class UserAPITests: XCTestCase {
     
     func test3DeleteUser() {
         let expectation = self.expectationWithDescription("testDeleteUser")
-        PetstoreClientAPI.UserAPI.deleteUser(username: "test@test.com").then {
+        UserAPI.deleteUser(username: "test@test.com").then {
                 expectation.fulfill()
             }.always {
                 // Noop for now


### PR DESCRIPTION
Fix https://github.com/swagger-api/swagger-codegen/issues/2120, https://github.com/swagger-api/swagger-codegen/issues/2157  -- Note this is a Breaking Change.

The following illustrates the differences in the usage of generated SDK:

Before:
```swift
        PetstoreClientAPI.PetAPI.getPetById(petId: 1000).execute { response, error -> Void in
                let pet = response?.body
```
After:
```swift
        PetAPI.getPetById(petId: 1000) { pet, error -> Void in
```

PromiseKit ready version of simplified methods are also generated:

Before:
```swift
        PetstoreClientAPI.PetAPI.getPetById(petId: 1000).execute().then { response -> Void in
                let pet = response.body
```
After:
```swift
        PetAPI.getPetById(petId: 1000).then { pet -> Void in
```

The `{{projectName}}API` namespace for API classes (`PetstoreClientAPI` above) now became optional and can be turned on via a CLI option: `-D swiftUseApiNamespace=true` 

In order to allow developers to access the response object when needed, the old methods still exist with `WithRequestBuilder` added to the end of the method name:

Before:
```swift
public class func getPetById(petId petId: Int) -> RequestBuilder<Pet> {
```

After:
```swift
public class func getPetByIdWithRequestBuilder(petId petId: Int) -> RequestBuilder<Pet> {
```

I initially thought to provide an improved abstraction over these `WithRequestBuilder` methods (to make them look closer to C#'s `WithHttpInfo` methods), but it will involve more lines to add (esp. to provide PromiseKit ready version).  I thought it better be done in a separate PR.
