### PR TITLE
let HTTP-GET also set Content-Type, so Java Spring Framework pass the…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -548,6 +548,10 @@ public class ApiClient {
       builder = httpClient.resource(url).accept(accept);
     }
 
+    if ("GET".equals(method) && contentType != null && contentType.length() > 0) {
+      headerParams.put("Content-Type", contentType);
+    }
+
     for (String key : headerParams.keySet()) {
       builder = builder.header(key, headerParams.get(key));
     }


### PR DESCRIPTION
… request type check. See bug https://github.com/swagger-api/swagger-codegen/issues/2254