### PR TITLE
Fix for clojure API filenames 

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ClojureClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ClojureClientCodegen.java
@@ -161,6 +161,11 @@ public class ClojureClientCodegen extends DefaultCodegen implements CodegenConfi
     }
 
     @Override
+    public String toApiFilename(String name) {
+        return underscore(toApiName(name));
+    }
+
+    @Override
     public String toApiName(String name) {
         return dashize(name);
     }


### PR DESCRIPTION
When the API name is more than one word (e.g., `UsersAPI` in a `users-service`), then the API namespace name will become `users-service.api.users-api`.

Prior to this fix, the API filename would include a dash, as it is solvely based on the API name (i.e., it currently is `users_service/api/users-api.clj`), which breaks clojure's conventions and leads to compilation errors.

With this fix, the API filename will be correctly converted to have underscores in place of dashes (i.e., the API file will be generated as `users_service/api/users_api.clj`).
