### PR TITLE
[Clojure] Improve api name for the Clojure client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -105,6 +105,8 @@ public interface CodegenConfig {
 
     void processSwagger(Swagger swagger);
 
+    String sanitizeTag(String tag);
+
     String toApiFilename(String name);
 
     String toModelFilename(String name);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2293,6 +2293,19 @@ public class DefaultCodegen {
         return name.replaceAll("[^a-zA-Z0-9_]", "");
     }
 
+    @SuppressWarnings("static-method")
+    public String sanitizeTag(String tag) {
+        // remove spaces and make strong case
+        String[] parts = tag.split(" ");
+        StringBuilder buf = new StringBuilder();
+        for (String part : parts) {
+            if (StringUtils.isNotEmpty(part)) {
+                buf.append(StringUtils.capitalize(part));
+            }
+        }
+        return buf.toString().replaceAll("[^a-zA-Z ]", "");
+    }
+
     /**
      * Only write if the file doesn't exist
      *

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.util.*;
 
-import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class DefaultGenerator extends AbstractGenerator implements Generator {
@@ -623,8 +622,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 try {
                     co = config.fromOperation(resourcePath, httpMethod, operation, swagger.getDefinitions(), swagger);
                     co.tags = new ArrayList<String>();
-                    co.tags.add(sanitizeTag(tag));
-                    config.addOperationToGroup(sanitizeTag(tag), resourcePath, operation, co, operations);
+                    co.tags.add(config.sanitizeTag(tag));
+                    config.addOperationToGroup(config.sanitizeTag(tag), resourcePath, operation, co, operations);
 
                     List<Map<String, List<String>>> securities = operation.getSecurity();
                     if (securities == null && swagger.getSecurity() != null) {
@@ -681,19 +680,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
     private static String generateParameterId(Parameter parameter) {
         return parameter.getName() + ":" + parameter.getIn();
-    }
-
-    @SuppressWarnings("static-method")
-    protected String sanitizeTag(String tag) {
-        // remove spaces and make strong case
-        String[] parts = tag.split(" ");
-        StringBuilder buf = new StringBuilder();
-        for (String part : parts) {
-            if (isNotEmpty(part)) {
-                buf.append(capitalize(part));
-            }
-        }
-        return buf.toString().replaceAll("[^a-zA-Z ]", "");
     }
 
     @SuppressWarnings("static-method")

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ClojureClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ClojureClientCodegen.java
@@ -146,6 +146,11 @@ public class ClojureClientCodegen extends DefaultCodegen implements CodegenConfi
     }
 
     @Override
+    public String sanitizeTag(String tag) {
+        return tag.replaceAll("[^a-zA-Z_]+", "_");
+    }
+
+    @Override
     public String apiFileFolder() {
         return outputFolder + File.separator + sourceFolder + File.separator + namespaceToFolder(apiPackage);
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/ClojureClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/ClojureClientCodegenTest.java
@@ -1,0 +1,38 @@
+package io.swagger.codegen.languages;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ClojureClientCodegenTest {
+    ClojureClientCodegen codegen = new ClojureClientCodegen();
+
+    @Test
+    public void testSanitizeTag() throws Exception {
+        Assert.assertEquals(codegen.sanitizeTag("users-api"), "users_api");
+        Assert.assertEquals(codegen.sanitizeTag("users_api"), "users_api");
+        Assert.assertEquals(codegen.sanitizeTag("users api"), "users_api");
+        Assert.assertEquals(codegen.sanitizeTag("users.api"), "users_api");
+        Assert.assertEquals(codegen.sanitizeTag("Users Api"), "Users_Api");
+        Assert.assertEquals(codegen.sanitizeTag("UsersApi"), "UsersApi");
+        Assert.assertEquals(codegen.sanitizeTag("usersapi"), "usersapi");
+        Assert.assertEquals(codegen.sanitizeTag("Usersapi"), "Usersapi");
+    }
+
+    @Test
+    public void testToApiName() throws Exception {
+        Assert.assertEquals(codegen.toApiName("users_api"), "users-api");
+        Assert.assertEquals(codegen.toApiName("Users_Api"), "users-api");
+        Assert.assertEquals(codegen.toApiName("UsersApi"), "users-api");
+        Assert.assertEquals(codegen.toApiName("usersapi"), "usersapi");
+        Assert.assertEquals(codegen.toApiName("Usersapi"), "usersapi");
+    }
+
+    @Test
+    public void testToApiFilename() throws Exception {
+        Assert.assertEquals(codegen.toApiFilename("users_api"), "users_api");
+        Assert.assertEquals(codegen.toApiFilename("Users_Api"), "users_api");
+        Assert.assertEquals(codegen.toApiFilename("UsersApi"), "users_api");
+        Assert.assertEquals(codegen.toApiFilename("usersapi"), "usersapi");
+        Assert.assertEquals(codegen.toApiFilename("Usersapi"), "usersapi");
+    }
+}


### PR DESCRIPTION
For example, when an operation's tag is `users-api`, `users_api` or `UsersApi`, generate the api file named `users_api.clj` and `users-api` as the namespace (it was `usersapi.clj` and `usersapi` before).

To implement this, I have to move the `sanitizeTag` method from DefaultGenerator.java to DefaultCodegen.java so that its behaviour can be overridden in ClojureClientCodegen.java, which is needed as the default implementation would sanitize `users-api` to `usersapi` before the tag is passed to `toApiName` and `toApiFilename`.