### PR TITLE
Fix wget command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 If you're looking for the latest stable version, you can grab it directly from maven central (you'll need java 7 runtime at a minimum):
 
 ```
-wget http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.1.5/swagger-codegen-cli-2.1.5.jar -o swagger-codegen-cli.jar
+wget http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.1.5/swagger-codegen-cli-2.1.5.jar -O swagger-codegen-cli.jar
 
 java -jar swagger-codegen-cli.jar help
 ```


### PR DESCRIPTION
The parameter being used was outputting a log file instead of changing downloading the file.