### PR TITLE
[PHP] update deserializer to handle object type and add more test cases

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -241,6 +241,9 @@ class ObjectSerializer
                 $values[] = self::deserialize($value, $subClass);
             }
             $deserialized = $values;
+        } elseif ($class === 'object') {
+            settype($data, 'array');
+            $deserialized = $data;
         } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
         } elseif (in_array($class, array({{&primitives}}))) {

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -353,6 +353,35 @@
                 "name": {
                   "type": "string",
                   "example": "doggie"
+                },
+                "photoUrls": {
+                    "type": "array",
+                    "xml": {
+                        "name": "photoUrl",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "xml": {
+                        "name": "tag",
+                        "wrapped": true
+                    },
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                },
+                "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": [
+                        "available",
+                    "pending",
+                    "sold"
+                        ]
                 }
               }
             }

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/InlineResponse200.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/InlineResponse200.php
@@ -51,9 +51,12 @@ class InlineResponse200 implements ArrayAccess
       * @var string[]
       */
     static $swaggerTypes = array(
+        'tags' => '\Swagger\Client\Model\Tag[]',
         'id' => 'int',
         'category' => 'object',
-        'name' => 'string'
+        'status' => 'string',
+        'name' => 'string',
+        'photo_urls' => 'string[]'
     );
   
     /** 
@@ -61,9 +64,12 @@ class InlineResponse200 implements ArrayAccess
       * @var string[] 
       */
     static $attributeMap = array(
+        'tags' => 'tags',
         'id' => 'id',
         'category' => 'category',
-        'name' => 'name'
+        'status' => 'status',
+        'name' => 'name',
+        'photo_urls' => 'photoUrls'
     );
   
     /**
@@ -71,9 +77,12 @@ class InlineResponse200 implements ArrayAccess
       * @var string[]
       */
     static $setters = array(
+        'tags' => 'setTags',
         'id' => 'setId',
         'category' => 'setCategory',
-        'name' => 'setName'
+        'status' => 'setStatus',
+        'name' => 'setName',
+        'photo_urls' => 'setPhotoUrls'
     );
   
     /**
@@ -81,11 +90,20 @@ class InlineResponse200 implements ArrayAccess
       * @var string[]
       */
     static $getters = array(
+        'tags' => 'getTags',
         'id' => 'getId',
         'category' => 'getCategory',
-        'name' => 'getName'
+        'status' => 'getStatus',
+        'name' => 'getName',
+        'photo_urls' => 'getPhotoUrls'
     );
   
+    
+    /**
+      * $tags 
+      * @var \Swagger\Client\Model\Tag[]
+      */
+    protected $tags;
     
     /**
       * $id 
@@ -100,10 +118,22 @@ class InlineResponse200 implements ArrayAccess
     protected $category;
     
     /**
+      * $status pet status in the store
+      * @var string
+      */
+    protected $status;
+    
+    /**
       * $name 
       * @var string
       */
     protected $name;
+    
+    /**
+      * $photo_urls 
+      * @var string[]
+      */
+    protected $photo_urls;
     
 
     /**
@@ -113,10 +143,34 @@ class InlineResponse200 implements ArrayAccess
     public function __construct(array $data = null)
     {
         if ($data != null) {
+            $this->tags = $data["tags"];
             $this->id = $data["id"];
             $this->category = $data["category"];
+            $this->status = $data["status"];
             $this->name = $data["name"];
+            $this->photo_urls = $data["photo_urls"];
         }
+    }
+    
+    /**
+     * Gets tags
+     * @return \Swagger\Client\Model\Tag[]
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+  
+    /**
+     * Sets tags
+     * @param \Swagger\Client\Model\Tag[] $tags 
+     * @return $this
+     */
+    public function setTags($tags)
+    {
+        
+        $this->tags = $tags;
+        return $this;
     }
     
     /**
@@ -162,6 +216,30 @@ class InlineResponse200 implements ArrayAccess
     }
     
     /**
+     * Gets status
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+  
+    /**
+     * Sets status
+     * @param string $status pet status in the store
+     * @return $this
+     */
+    public function setStatus($status)
+    {
+        $allowed_values = array("available", "pending", "sold");
+        if (!in_array($status, $allowed_values)) {
+            throw new \InvalidArgumentException("Invalid value for 'status', must be one of 'available', 'pending', 'sold'");
+        }
+        $this->status = $status;
+        return $this;
+    }
+    
+    /**
      * Gets name
      * @return string
      */
@@ -179,6 +257,27 @@ class InlineResponse200 implements ArrayAccess
     {
         
         $this->name = $name;
+        return $this;
+    }
+    
+    /**
+     * Gets photo_urls
+     * @return string[]
+     */
+    public function getPhotoUrls()
+    {
+        return $this->photo_urls;
+    }
+  
+    /**
+     * Sets photo_urls
+     * @param string[] $photo_urls 
+     * @return $this
+     */
+    public function setPhotoUrls($photo_urls)
+    {
+        
+        $this->photo_urls = $photo_urls;
         return $this;
     }
     

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -241,6 +241,9 @@ class ObjectSerializer
                 $values[] = self::deserialize($value, $subClass);
             }
             $deserialized = $values;
+        } elseif ($class === 'object') {
+            settype($data, 'array');
+            $deserialized = $data;
         } elseif ($class === '\DateTime') {
             $deserialized = new \DateTime($data);
         } elseif (in_array($class, array('integer', 'int', 'void', 'number', 'object', 'double', 'float', 'byte', 'DateTime', 'string', 'mixed', 'boolean', 'bool'))) {

--- a/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/PetApiTest.php
@@ -110,8 +110,31 @@ class PetApiTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($response->getTags()[0]->getId(), $pet_id);
         $this->assertSame($response->getTags()[0]->getName(), 'test php tag');
     }
-  
+
     // test getPetById with a Pet object (id 10005)
+    public function testGetPetByIdInObject()
+    {
+        // initialize the API client without host
+        $pet_id = 10005;  // ID of pet that needs to be fetched
+        $pet_api = new Swagger\Client\Api\PetAPI();
+        $pet_api->getApiClient()->getConfig()->setApiKey('api_key', '111222333444555');
+        // return Pet (inline model)
+        $response = $pet_api->getPetByIdInObject($pet_id);
+        $this->assertInstanceOf('Swagger\Client\Model\InlineResponse200', $response);
+        $this->assertSame($response->getId(), $pet_id);
+        $this->assertSame($response->getName(), 'PHP Unit Test');
+        $this->assertSame($response->getPhotoUrls()[0], 'http://test_php_unit_test.com');
+
+        // category is type "object"
+        $this->assertInternalType('array', $response->getCategory());
+        $this->assertSame($response->getCategory()['id'], $pet_id);
+        $this->assertSame($response->getCategory()['name'], 'test php category');
+
+        $this->assertSame($response->getTags()[0]->getId(), $pet_id);
+        $this->assertSame($response->getTags()[0]->getName(), 'test php tag');
+    }
+  
+    // test getPetByIdWithHttpInfo with a Pet object (id 10005)
     public function testGetPetByIdWithHttpInfo()
     {
         // initialize the API client without host

--- a/samples/client/petstore/php/SwaggerClient-php/tests/StoreApiTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/StoreApiTest.php
@@ -5,47 +5,61 @@ require_once('autoload.php');
 class StoreApiTest extends \PHPUnit_Framework_TestCase
 {
 
-  // add a new pet (id 10005) to ensure the pet object is available for all the tests
-  public static function setUpBeforeClass() {
-    // for error reporting (need to run with php5.3 to get no warning)
-    //ini_set('display_errors', 1);
-    //error_reporting(~0);
-    // new pet
-    $new_pet_id = 10005;
-    $new_pet = new Swagger\Client\Model\Pet;
-    $new_pet->setId($new_pet_id);
-    $new_pet->setName("PHP Unit Test");
-    $new_pet->setStatus("available");
-    // new tag
-    $tag= new Swagger\Client\Model\Tag;
-    $tag->setId($new_pet_id); // use the same id as pet
-    $tag->setName("test php tag");
-    // new category
-    $category = new Swagger\Client\Model\Category;
-    $category->setId($new_pet_id); // use the same id as pet
-    $category->setName("test php category");
+    // add a new pet (id 10005) to ensure the pet object is available for all the tests
+    public static function setUpBeforeClass() {
+        // for error reporting (need to run with php5.3 to get no warning)
+        //ini_set('display_errors', 1);
+        //error_reporting(~0);
+        // new pet
+        $new_pet_id = 10005;
+        $new_pet = new Swagger\Client\Model\Pet;
+        $new_pet->setId($new_pet_id);
+        $new_pet->setName("PHP Unit Test");
+        $new_pet->setStatus("available");
+        // new tag
+        $tag= new Swagger\Client\Model\Tag;
+        $tag->setId($new_pet_id); // use the same id as pet
+        $tag->setName("test php tag");
+        // new category
+        $category = new Swagger\Client\Model\Category;
+        $category->setId($new_pet_id); // use the same id as pet
+        $category->setName("test php category");
 
-    $new_pet->setTags(array($tag));
-    $new_pet->setCategory($category);
+        $new_pet->setTags(array($tag));
+        $new_pet->setCategory($category);
 
-    $pet_api = new Swagger\Client\Api\PetAPI();
-    // add a new pet (model)
-    $add_response = $pet_api->addPet($new_pet);
-  }
+        $pet_api = new Swagger\Client\Api\PetAPI();
+        // add a new pet (model)
+        $add_response = $pet_api->addPet($new_pet);
+    }
 
-  // test get inventory
-  public function testGetInventory()
-  {
-    // initialize the API client
-    $config = (new Swagger\Client\Configuration())->setHost('http://petstore.swagger.io/v2');
-    $api_client = new Swagger\Client\ApiClient($config);
-    $store_api = new Swagger\Client\Api\StoreAPI($api_client);
-    // get inventory
-    $get_response = $store_api->getInventory();
+    // test get inventory
+    public function testGetInventory()
+    {
+        // initialize the API client
+        $config = (new Swagger\Client\Configuration())->setHost('http://petstore.swagger.io/v2');
+        $api_client = new Swagger\Client\ApiClient($config);
+        $store_api = new Swagger\Client\Api\StoreAPI($api_client);
+        // get inventory
+        $get_response = $store_api->getInventory();
 
-    $this->assertInternalType("int", $get_response['available']);
+        $this->assertInternalType("array", $get_response);
+        $this->assertInternalType("int", $get_response['available']);
+    }
 
-  }
+    // test get inventory
+    public function testGetInventoryInObject()
+    {
+        // initialize the API client
+        //$config = (new Swagger\Client\Configuration())->setHost('http://petstore.swagger.io/v2');
+        $api_client = new Swagger\Client\ApiClient();
+        $store_api = new Swagger\Client\Api\StoreAPI($api_client);
+        // get inventory
+        $get_response = $store_api->getInventoryInObject();
+
+        $this->assertInternalType("array", $get_response);
+        $this->assertInternalType("int", $get_response['available']);
+    }
 
 }
 


### PR DESCRIPTION
To deserialize `type: object` properly, we need to update the deserializer: set data type to `array` (associative array in PHP)

We also add more test cases to cover `type: object`