### PR TITLE
[C#] add type object support to C# API client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -241,16 +241,10 @@ namespace {{packageName}}.Client
         /// <returns>Object representation of the JSON string.</returns>
         public object Deserialize(IRestResponse response, Type type)
         {
-            byte[] data = response.RawBytes;
-            string content = response.Content;
             IList<Parameter> headers = response.Headers;
-            if (type == typeof(Object)) // return an object
+            if (type == typeof(byte[])) // return byte array
             {
-                return content;
-            }
-            else if (type == typeof(byte[])) // return byte array
-            {
-                return data;
+                return response.RawBytes;
             }
 
             if (type == typeof(Stream))
@@ -267,29 +261,29 @@ namespace {{packageName}}.Client
                         if (match.Success)
                         {
                             string fileName = filePath + SanitizeFilename(match.Groups[1].Value.Replace("\"", "").Replace("'", ""));
-                            File.WriteAllBytes(fileName, data);
+                            File.WriteAllBytes(fileName, response.RawBytes);
                             return new FileStream(fileName, FileMode.Open);
                         }
                     }
                 }
-                var stream = new MemoryStream(data);
+                var stream = new MemoryStream(response.RawBytes);
                 return stream;
             }
 
             if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
             {
-                return DateTime.Parse(content,  null, System.Globalization.DateTimeStyles.RoundtripKind);
+                return DateTime.Parse(response.Content,  null, System.Globalization.DateTimeStyles.RoundtripKind);
             }
 
             if (type == typeof(String) || type.Name.StartsWith("System.Nullable")) // return primitive type
             {
-                return ConvertType(content, type); 
+                return ConvertType(response.Content, type); 
             }
     
             // at this point, it must be a model (json)
             try
             {
-                return JsonConvert.DeserializeObject(content, type);
+                return JsonConvert.DeserializeObject(response.Content, type);
             }
             catch (Exception e)
             {

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/ApiClient.cs
@@ -241,16 +241,10 @@ namespace IO.Swagger.Client
         /// <returns>Object representation of the JSON string.</returns>
         public object Deserialize(IRestResponse response, Type type)
         {
-            byte[] data = response.RawBytes;
-            string content = response.Content;
             IList<Parameter> headers = response.Headers;
-            if (type == typeof(Object)) // return an object
+            if (type == typeof(byte[])) // return byte array
             {
-                return content;
-            }
-            else if (type == typeof(byte[])) // return byte array
-            {
-                return data;
+                return response.RawBytes;
             }
 
             if (type == typeof(Stream))
@@ -267,29 +261,29 @@ namespace IO.Swagger.Client
                         if (match.Success)
                         {
                             string fileName = filePath + SanitizeFilename(match.Groups[1].Value.Replace("\"", "").Replace("'", ""));
-                            File.WriteAllBytes(fileName, data);
+                            File.WriteAllBytes(fileName, response.RawBytes);
                             return new FileStream(fileName, FileMode.Open);
                         }
                     }
                 }
-                var stream = new MemoryStream(data);
+                var stream = new MemoryStream(response.RawBytes);
                 return stream;
             }
 
             if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
             {
-                return DateTime.Parse(content,  null, System.Globalization.DateTimeStyles.RoundtripKind);
+                return DateTime.Parse(response.Content,  null, System.Globalization.DateTimeStyles.RoundtripKind);
             }
 
             if (type == typeof(String) || type.Name.StartsWith("System.Nullable")) // return primitive type
             {
-                return ConvertType(content, type); 
+                return ConvertType(response.Content, type); 
             }
     
             // at this point, it must be a model (json)
             try
             {
-                return JsonConvert.DeserializeObject(content, type);
+                return JsonConvert.DeserializeObject(response.Content, type);
             }
             catch (Exception e)
             {

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/InlineResponse200.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Model/InlineResponse200.cs
@@ -18,15 +18,38 @@ namespace IO.Swagger.Model
     public partial class InlineResponse200 :  IEquatable<InlineResponse200>
     { 
     
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum StatusEnum {
+            
+            [EnumMember(Value = "available")]
+            Available,
+            
+            [EnumMember(Value = "pending")]
+            Pending,
+            
+            [EnumMember(Value = "sold")]
+            Sold
+        }
+    
+        /// <summary>
+        /// pet status in the store
+        /// </summary>
+        /// <value>pet status in the store</value>
+        [DataMember(Name="status", EmitDefaultValue=false)]
+        public StatusEnum? Status { get; set; }
+    
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineResponse200" /> class.
         /// Initializes a new instance of the <see cref="InlineResponse200" />class.
         /// </summary>
+        /// <param name="Tags">Tags.</param>
         /// <param name="Id">Id (required).</param>
         /// <param name="Category">Category.</param>
+        /// <param name="Status">pet status in the store.</param>
         /// <param name="Name">Name.</param>
+        /// <param name="PhotoUrls">PhotoUrls.</param>
 
-        public InlineResponse200(long? Id = null, Object Category = null, string Name = null)
+        public InlineResponse200(List<Tag> Tags = null, long? Id = null, Object Category = null, StatusEnum? Status = null, string Name = null, List<string> PhotoUrls = null)
         {
             // to ensure "Id" is required (not null)
             if (Id == null)
@@ -37,11 +60,20 @@ namespace IO.Swagger.Model
             {
                 this.Id = Id;
             }
+            this.Tags = Tags;
             this.Category = Category;
+            this.Status = Status;
             this.Name = Name;
+            this.PhotoUrls = PhotoUrls;
             
         }
         
+    
+        /// <summary>
+        /// Gets or Sets Tags
+        /// </summary>
+        [DataMember(Name="tags", EmitDefaultValue=false)]
+        public List<Tag> Tags { get; set; }
     
         /// <summary>
         /// Gets or Sets Id
@@ -62,6 +94,12 @@ namespace IO.Swagger.Model
         public string Name { get; set; }
     
         /// <summary>
+        /// Gets or Sets PhotoUrls
+        /// </summary>
+        [DataMember(Name="photoUrls", EmitDefaultValue=false)]
+        public List<string> PhotoUrls { get; set; }
+    
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -69,9 +107,12 @@ namespace IO.Swagger.Model
         {
             var sb = new StringBuilder();
             sb.Append("class InlineResponse200 {\n");
+            sb.Append("  Tags: ").Append(Tags).Append("\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("  Category: ").Append(Category).Append("\n");
+            sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
+            sb.Append("  PhotoUrls: ").Append(PhotoUrls).Append("\n");
             
             sb.Append("}\n");
             return sb.ToString();
@@ -110,6 +151,11 @@ namespace IO.Swagger.Model
 
             return 
                 (
+                    this.Tags == other.Tags ||
+                    this.Tags != null &&
+                    this.Tags.SequenceEqual(other.Tags)
+                ) && 
+                (
                     this.Id == other.Id ||
                     this.Id != null &&
                     this.Id.Equals(other.Id)
@@ -120,9 +166,19 @@ namespace IO.Swagger.Model
                     this.Category.Equals(other.Category)
                 ) && 
                 (
+                    this.Status == other.Status ||
+                    this.Status != null &&
+                    this.Status.Equals(other.Status)
+                ) && 
+                (
                     this.Name == other.Name ||
                     this.Name != null &&
                     this.Name.Equals(other.Name)
+                ) && 
+                (
+                    this.PhotoUrls == other.PhotoUrls ||
+                    this.PhotoUrls != null &&
+                    this.PhotoUrls.SequenceEqual(other.PhotoUrls)
                 );
         }
 
@@ -138,14 +194,23 @@ namespace IO.Swagger.Model
                 int hash = 41;
                 // Suitable nullity checks etc, of course :)
                 
+                if (this.Tags != null)
+                    hash = hash * 59 + this.Tags.GetHashCode();
+                
                 if (this.Id != null)
                     hash = hash * 59 + this.Id.GetHashCode();
                 
                 if (this.Category != null)
                     hash = hash * 59 + this.Category.GetHashCode();
                 
+                if (this.Status != null)
+                    hash = hash * 59 + this.Status.GetHashCode();
+                
                 if (this.Name != null)
                     hash = hash * 59 + this.Name.GetHashCode();
+                
+                if (this.PhotoUrls != null)
+                    hash = hash * 59 + this.PhotoUrls.GetHashCode();
                 
                 return hash;
             }

--- a/samples/client/petstore/csharp/SwaggerClientTest/SwaggerClientTest.userprefs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/SwaggerClientTest.userprefs
@@ -1,11 +1,17 @@
 ﻿<Properties StartupItem="SwaggerClientTest.csproj">
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
-  <MonoDevelop.Ide.Workbench ActiveDocument="Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/PetApi.cs">
+  <MonoDevelop.Ide.Workbench ActiveDocument="TestPet.cs">
     <Files>
-      <File FileName="TestPet.cs" Line="1" Column="1" />
-      <File FileName="TestOrder.cs" Line="1" Column="1" />
-      <File FileName="Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/PetApi.cs" Line="18" Column="9" />
+      <File FileName="TestPet.cs" Line="189" Column="4" />
+      <File FileName="TestOrder.cs" Line="88" Column="47" />
     </Files>
+    <Pads>
+      <Pad Id="MonoDevelop.NUnit.TestPad">
+        <State name="__root__">
+          <Node name="SwaggerClientTest" expanded="True" />
+        </State>
+      </Pad>
+    </Pads>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
     <BreakpointStore />

--- a/samples/client/petstore/csharp/SwaggerClientTest/TestOrder.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/TestOrder.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Newtonsoft.Json;
 
 
-namespace SwaggerClientTest.TestORder
+namespace SwaggerClientTest.TestOrder
 {
 	[TestFixture ()]
 	public class TestOrder
@@ -53,6 +53,48 @@ namespace SwaggerClientTest.TestORder
 			Assert.AreEqual (true, o.Complete);
 
 		}
+
+		/// <summary>
+		/// Test GetInvetory
+		/// </summary>
+		[Test ()]
+		public void TestGetInventory ()
+		{
+			// set timeout to 10 seconds
+			Configuration c1 = new Configuration (timeout: 10000);
+
+			StoreApi storeApi = new StoreApi (c1);
+			Dictionary<String, int?> response = storeApi.GetInventory ();
+
+			foreach(KeyValuePair<string, int?> entry in response)
+			{
+				Assert.IsInstanceOf (typeof(int?), entry.Value);
+			}
+				
+		}
+
+		/// <summary>
+		/// Test GetInvetoryInObject
+		/// </summary>
+		[Test ()]
+		public void TestGetInventoryInObject ()
+		{
+			// set timeout to 10 seconds
+			Configuration c1 = new Configuration (timeout: 10000);
+
+			StoreApi storeApi = new StoreApi (c1);
+			Newtonsoft.Json.Linq.JObject response = (Newtonsoft.Json.Linq.JObject)storeApi.GetInventoryInObject ();
+
+			// should be a Newtonsoft.Json.Linq.JObject since type is object
+			Assert.IsInstanceOf (typeof(Newtonsoft.Json.Linq.JObject), response);
+
+			foreach(KeyValuePair<string, string> entry in response.ToObject<Dictionary<string, string>>())
+			{
+				Assert.IsInstanceOf (typeof(int?), Int32.Parse(entry.Value));
+			}
+
+		}
+
 	}
 }
 

--- a/samples/client/petstore/csharp/SwaggerClientTest/TestPet.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/TestPet.cs
@@ -159,6 +159,37 @@ namespace SwaggerClientTest.TestPet
 		}
 
 		/// <summary>
+		/// Test GetPetByIdInObject
+		/// </summary>
+		[Test ()]
+		public void TestGetPetByIdInObject ()
+		{
+			// set timeout to 10 seconds
+			Configuration c1 = new Configuration (timeout: 10000);
+
+			PetApi petApi = new PetApi (c1);
+			InlineResponse200 response = petApi.GetPetByIdInObject (petId);
+			Assert.IsInstanceOf<InlineResponse200> (response, "Response is a Pet");
+
+			Assert.AreEqual ("Csharp test", response.Name);
+			Assert.AreEqual (InlineResponse200.StatusEnum.Available, response.Status);
+
+			Assert.IsInstanceOf<List<Tag>> (response.Tags, "Response.Tags is a Array");
+			Assert.AreEqual (petId, response.Tags [0].Id);
+			Assert.AreEqual ("csharp sample tag name1", response.Tags [0].Name);
+
+			Assert.IsInstanceOf<List<String>> (response.PhotoUrls, "Response.PhotoUrls is a Array");
+			Assert.AreEqual ("sample photoUrls", response.PhotoUrls [0]);
+
+			Assert.IsInstanceOf<Newtonsoft.Json.Linq.JObject> (response.Category, "Response.Category is a Newtonsoft.Json.Linq.JObject");
+
+			Newtonsoft.Json.Linq.JObject category = (Newtonsoft.Json.Linq.JObject)response.Category;
+			Assert.AreEqual (56, (int)category ["id"]);
+			Assert.AreEqual ("sample category name2", (string) category["name"]);
+
+		}
+
+		/// <summary>
 		/// Test GetPetByIdWithByteArray
 		/// </summary>
 		[Test ()]


### PR DESCRIPTION
Update deserialisation to return `type:obejct` as `Newtonsoft.Json.Linq.JObject`

Added more test cases