### PR TITLE
Keep sort order of APIs

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -560,7 +560,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     }
 
     public Map<String, List<CodegenOperation>> processPaths(Map<String, Path> paths) {
-        Map<String, List<CodegenOperation>> ops = new HashMap<String, List<CodegenOperation>>();
+        Map<String, List<CodegenOperation>> ops = new TreeMap<String, List<CodegenOperation>>();
 
         for (String resourcePath : paths.keySet()) {
             Path path = paths.get(resourcePath);


### PR DESCRIPTION
When generating static documentation, the sort order is important. This pull request keeps the sort order from swagger.getPaths()

Might be related to #1847