### PR TITLE
non default java clients wont compile if description is empty in API json.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/model.mustache
@@ -13,7 +13,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * {{description}}
  **/{{/description}}
-@ApiModel(description = "{{{description}}}")
+{{#description}}@ApiModel(description = "{{{description}}}"){{/description}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
   {{#vars}}{{#isEnum}}
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/model.mustache
@@ -13,7 +13,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * {{description}}
  **/{{/description}}
-@ApiModel(description = "{{{description}}}")
+{{#description}}@ApiModel(description = "{{{description}}}"){{/description}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
   {{#vars}}{{#isEnum}}
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/model.mustache
@@ -13,7 +13,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * {{description}}
  **/{{/description}}
-@ApiModel(description = "{{{description}}}")
+{{#description}}@ApiModel(description = "{{{description}}}"){{/description}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
   {{#vars}}{{#isEnum}}
 


### PR DESCRIPTION
If the API definition contains something like

```
   "integer": {
    "id": "integer",
    "properties": {}
   },
```

with no description property, the generated code for all no default libraries will add a ApiModel annotation but no import. 

pull request appears to fix the compile time issue.