### PR TITLE
Add a test case that demonstrates how #1993 broke swagger-codegen.

### DIFF
--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -1294,6 +1294,13 @@
         "$special[property.name]": {
           "type": "integer",
           "format": "int64"
+        },
+        "type": {
+          "type":"string",
+          "enum": [
+            "Type1",
+            "Type2"
+          ]
         }
       },
       "xml": {

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -225,20 +225,20 @@ public class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -247,21 +247,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -270,7 +270,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter status: (query) Status values that need to be considered for query
 
@@ -331,20 +331,20 @@ public class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -353,21 +353,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -376,7 +376,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter tags: (query) Tags to filter by
 
@@ -434,26 +434,26 @@ public class PetAPI: APIBase {
      
      - GET /pet/{petId}
      - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -462,21 +462,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -485,7 +485,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter petId: (path) ID of pet that needs to be fetched
 
@@ -542,46 +542,46 @@ public class PetAPI: APIBase {
      
      - GET /pet/{petId}?response=inline_arbitrary_object
      - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example={
-  "id" : 123456789,
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
-  "category" : "{}",
-  "status" : "aeiou",
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<null>
+  "id" : 123456789,
+  "category" : "{}",
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<null>
+  <photoUrls>string</photoUrls>
+  <name>doggie</name>
   <id>123456</id>
   <category>not implemented io.swagger.models.properties.ObjectProperty@37ff6855</category>
   <status>string</status>
-  <name>doggie</name>
-  <photoUrls>string</photoUrls>
-</null>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
-  "category" : "{}",
-  "status" : "aeiou",
+</null>}]
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<null>
+  "id" : 123456789,
+  "category" : "{}",
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<null>
+  <photoUrls>string</photoUrls>
+  <name>doggie</name>
   <id>123456</id>
   <category>not implemented io.swagger.models.properties.ObjectProperty@37ff6855</category>
   <status>string</status>
-  <name>doggie</name>
-  <photoUrls>string</photoUrls>
-</null>, contentType=application/xml}]
+</null>}]
      
      - parameter petId: (path) ID of pet that needs to be fetched
 
@@ -638,14 +638,14 @@ public class PetAPI: APIBase {
      
      - GET /pet/{petId}?testing_byte_array=true
      - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example="", contentType=application/json}, {example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e, contentType=application/xml}]
-     - examples: [{example="", contentType=application/json}, {example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e, contentType=application/xml}]
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - examples: [{contentType=application/json, example=""}, {contentType=application/xml, example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e}]
+     - examples: [{contentType=application/json, example=""}, {contentType=application/xml, example=not implemented io.swagger.models.properties.BinaryProperty@55e6ae9e}]
      
      - parameter petId: (path) ID of pet that needs to be fetched
 

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -111,36 +111,36 @@ public class StoreAPI: APIBase {
      - API Key:
        - type: apiKey x-test_api_client_secret 
        - name: test_api_client_secret
-     - examples: [{example=[ {
-  "id" : 123456789,
+     - examples: [{contentType=application/json, example=[ {
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-} ], contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+0000",
+  "complete" : true,
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example=[ {
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example=[ {
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-} ], contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+0000",
+  "complete" : true,
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter status: (query) Status value that needs to be considered for query
 
@@ -199,12 +199,12 @@ public class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{example={
+     - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
-     - examples: [{example={
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
+     - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
 
      - returns: RequestBuilder<[String:Int]> 
      */
@@ -259,8 +259,8 @@ public class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{example="{}", contentType=application/json}, {example=not implemented io.swagger.models.properties.ObjectProperty@37aadb4f, contentType=application/xml}]
-     - examples: [{example="{}", contentType=application/json}, {example=not implemented io.swagger.models.properties.ObjectProperty@37aadb4f, contentType=application/xml}]
+     - examples: [{contentType=application/json, example="{}"}, {contentType=application/xml, example=not implemented io.swagger.models.properties.ObjectProperty@37aadb4f}]
+     - examples: [{contentType=application/json, example="{}"}, {contentType=application/xml, example=not implemented io.swagger.models.properties.ObjectProperty@37aadb4f}]
 
      - returns: RequestBuilder<AnyObject> 
      */
@@ -315,41 +315,41 @@ public class StoreAPI: APIBase {
      - GET /store/order/{orderId}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      - API Key:
-       - type: apiKey test_api_key_header 
-       - name: test_api_key_header
-     - API Key:
        - type: apiKey test_api_key_query (QUERY)
        - name: test_api_key_query
-     - examples: [{example={
-  "id" : 123456789,
+     - API Key:
+       - type: apiKey test_api_key_header 
+       - name: test_api_key_header
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+0000",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+0000",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched
 
@@ -412,36 +412,36 @@ public class StoreAPI: APIBase {
      - API Key:
        - type: apiKey x-test_api_client_secret 
        - name: test_api_client_secret
-     - examples: [{example={
-  "id" : 123456789,
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+0000",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+0000"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+0000",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter body: (body) order placed for purchasing the pet
 

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -211,6 +211,9 @@ public class UserAPI: APIBase {
      
      - DELETE /user/{username}
      - This can only be done by the logged in user.
+     - BASIC:
+       - type: basic
+       - name: test_http_basic
      
      - parameter username: (path) The name that needs to be deleted
 
@@ -267,7 +270,7 @@ public class UserAPI: APIBase {
      
      - GET /user/{username}
      - 
-     - examples: [{example={
+     - examples: [{contentType=application/json, example={
   "id" : 1,
   "username" : "johnp",
   "firstName" : "John",
@@ -276,7 +279,7 @@ public class UserAPI: APIBase {
   "password" : "-secret-",
   "phone" : "0123456789",
   "userStatus" : 0
-}, contentType=application/json}]
+}}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.
 
@@ -335,8 +338,8 @@ public class UserAPI: APIBase {
      
      - GET /user/login
      - 
-     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
-     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
+     - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
+     - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
      
      - parameter username: (query) The user name for login
      - parameter password: (query) The password for login in clear text

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -146,12 +146,12 @@ class Decoders {
             Decoders.addDecoder(clazz: InlineResponse200.self) { (source: AnyObject) -> InlineResponse200 in
                 let sourceDictionary = source as! [NSObject:AnyObject]
                 let instance = InlineResponse200()
-                instance.tags = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["tags"])
+                instance.photoUrls = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["photoUrls"])
+                instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"])
                 instance.id = Decoders.decodeOptional(clazz: Int.self, source: sourceDictionary["id"])
                 instance.category = Decoders.decodeOptional(clazz: AnyObject.self, source: sourceDictionary["category"])
+                instance.tags = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["tags"])
                 instance.status = InlineResponse200.Status(rawValue: (sourceDictionary["status"] as? String) ?? "") 
-                instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"])
-                instance.photoUrls = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["photoUrls"])
                 return instance
             }
 			
@@ -227,6 +227,7 @@ class Decoders {
                 let sourceDictionary = source as! [NSObject:AnyObject]
                 let instance = SpecialModelName()
                 instance.specialPropertyName = Decoders.decodeOptional(clazz: Int.self, source: sourceDictionary["specialPropertyName"])
+                instance._type = SpecialModelName._type(rawValue: (sourceDictionary["_type"] as? String) ?? "") 
                 return instance
             }
 			

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/InlineResponse200.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/InlineResponse200.swift
@@ -16,13 +16,13 @@ public class InlineResponse200: JSONEncodable {
         case Sold = "sold"
     }
     
-    public var tags: [Tag]?
+    public var photoUrls: [String]?
+    public var name: String?
     public var id: Int?
     public var category: AnyObject?
+    public var tags: [Tag]?
     /** pet status in the store */
     public var status: Status?
-    public var name: String?
-    public var photoUrls: [String]?
     
 
     public init() {}
@@ -30,12 +30,12 @@ public class InlineResponse200: JSONEncodable {
     // MARK: JSONEncodable
     func encodeToJSON() -> AnyObject {
         var nillableDictionary = [String:AnyObject?]()
-        nillableDictionary["tags"] = self.tags?.encodeToJSON()
+        nillableDictionary["photoUrls"] = self.photoUrls?.encodeToJSON()
+        nillableDictionary["name"] = self.name
         nillableDictionary["id"] = self.id
         nillableDictionary["category"] = self.category
+        nillableDictionary["tags"] = self.tags?.encodeToJSON()
         nillableDictionary["status"] = self.status?.rawValue
-        nillableDictionary["name"] = self.name
-        nillableDictionary["photoUrls"] = self.photoUrls?.encodeToJSON()
         let dictionary: [String:AnyObject] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -10,7 +10,13 @@ import Foundation
 
 public class SpecialModelName: JSONEncodable {
 
+    public enum _type: String { 
+        case Type1 = "Type1"
+        case Type2 = "Type2"
+    }
+    
     public var specialPropertyName: Int?
+    public var _type: _type?
     
 
     public init() {}
@@ -19,6 +25,7 @@ public class SpecialModelName: JSONEncodable {
     func encodeToJSON() -> AnyObject {
         var nillableDictionary = [String:AnyObject?]()
         nillableDictionary["specialPropertyName"] = self.specialPropertyName
+        nillableDictionary["_type"] = self._type?.rawValue
         let dictionary: [String:AnyObject] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift/SwaggerClientTests/Pods/Pods.xcodeproj/project.pbxproj
+++ b/samples/client/petstore/swift/SwaggerClientTests/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,105 +7,107 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01AF8B9D50B8538E720346ED302802B8 /* NSURLSession+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535DF88FC12304114DEF55E4003421B2 /* NSURLSession+Promise.swift */; };
 		03F494989CC1A8857B68A317D5D6860F /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF5FC3AF99846209C5FCE55A2E12D9A /* Response.swift */; };
-		043AACBEFC1A58B79AF6B81C8E7E117E /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1D1571AB15108DF6F9C4FE2064E3C43 /* Alamofire.framework */; };
+		04305D1BEF17E3A670D90AF5A3F19D9F /* UIViewController+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = AA24C5EC82CF437D8D1FFFAB68975408 /* UIViewController+AnyPromise.m */; };
 		0681ADC8BAE2C3185F13487BAAB4D9DD /* Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE38472832BBCC541E646DA6C18EF9C /* Upload.swift */; };
-		06FD19EDA263742E49199D15FF81FFAA /* dispatch_promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392FA21A33296B88F790D62A4FAA4E4E /* dispatch_promise.swift */; };
-		07AA794848F8E6615B1DFD30673CE4EE /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511325F77CCC682529E5D61A5AA0B381 /* Order.swift */; };
-		0AC8F78F69436E83746D56B1963C7321 /* PMKAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C731FBFCC690050C6C08E5AC9D9DC724 /* PMKAlertController.swift */; };
+		0AAE766A8E92B8EAA0D1DF2E170C4DC1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB15A61DB7ABCB74565286162157C5A0 /* Foundation.framework */; };
 		0B34EB4425C08BB021C2D09F75C9C146 /* OMGHTTPURLRQ.h in Headers */ = {isa = PBXBuildFile; fileRef = 450166FEA2155A5821D97744A0127DF8 /* OMGHTTPURLRQ.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0B94E66F8539BBA52E693DAE322DCBAA /* APIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A3BBCDB687E9609F39F4EFC404B045 /* APIHelper.swift */; };
-		0DB1CFFE7FEC5667D7CD14C580D8AB8F /* UIView+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F0F4EDC2236E1C270DC2014181D6506 /* UIView+AnyPromise.m */; };
-		0E84511CF3F1E8C48CCC75BA66EBE0BA /* UIViewController+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BA017E288BB42E06EBEE9C6E6993EAF /* UIViewController+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		11E1A6059DD32FBA0734660403713531 /* UIAlertView+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = F075F63EFE77F7B59FF77CBA95B9AADF /* UIAlertView+AnyPromise.m */; };
-		1478812AA43E16777600753CDF6ACE1F /* dispatch_promise.m in Sources */ = {isa = PBXBuildFile; fileRef = A92242715FB4C0608F8DCEBF8F3791E2 /* dispatch_promise.m */; };
-		1C8D5A3F181EE2797475BF8CD3D17FAB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB15A61DB7ABCB74565286162157C5A0 /* Foundation.framework */; };
-		21FB1E69B7CC6FCCA95B3B7531378D84 /* NSNotificationCenter+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93FB4BB16CFB41DCA35A8CFAD7A7FEF /* NSNotificationCenter+Promise.swift */; };
-		21FE4548D5605FFE12EFA269102C88E1 /* Promise+Properties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0DBDE561A6C2E7AC7A24160F8A5F28 /* Promise+Properties.swift */; };
-		23B39958BB2757E02093BEEFD900A50D /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE322C982813B48FD220881237FD90F /* Models.swift */; };
-		24D2C12AA4466F61F04FB7136AF497CA /* CALayer+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A22F2595054D39018E03961CA7283A /* CALayer+AnyPromise.m */; };
-		287EC582989EE65F605374D6908AA35C /* UIActionSheet+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD570E28B63274E742E7D1FBBD55BB41 /* UIActionSheet+Promise.swift */; };
-		293859B4A8F6053D41FC5A50FF268CFA /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E25EC84C24B3AB284A71E47CB032082 /* UserAPI.swift */; };
-		2B1CB7AD3BF6CCE951E9CA7080097081 /* PetAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04911F3B72D4F18187122A620682A84 /* PetAPI.swift */; };
+		0D761520A50B34A5601921D0EB2F7832 /* URLDataPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CE161ED0CF68954A63F30528ACAD9B /* URLDataPromise.swift */; };
+		11611AA162541D7F4F502D602E6C541C /* PetstoreClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F681D2C508D1BA8F62893120D9343A4 /* PetstoreClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		12836D804685C0B30EB6A689963FE3D6 /* PetAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FE4C094684D4C89D71B1C97DB4545B /* PetAPI.swift */; };
+		12C9F6C1F328683EA621071B8894143C /* UIView+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = BCDD82DB3E6D43BA9769FCA9B744CB5E /* UIView+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1365B07A306A080C0CE339C905202875 /* NSObject+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EB54C331FED437583A5F01EB2757D1 /* NSObject+Promise.swift */; };
+		159E4432157C043E55EC4BC078BD2B0E /* UIViewController+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D459D0AB2361B48F81C4D14C6D0DAA /* UIViewController+Promise.swift */; };
+		18DAF8340B205F8D0A79B7B2A33328C0 /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5973BC143AE488C12FFB1E83E71F0C45 /* AnyPromise.swift */; };
+		1E8369F4E856C0D36BE6724B0979DFD7 /* UIView+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CDA0958D6247505ECD9098D662EA74 /* UIView+Promise.swift */; };
+		2631F71E6E7452FA9960EEE1EFDB85A3 /* SpecialModelName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B3CAA64819C3DF5DCBAD5A21CA04D5 /* SpecialModelName.swift */; };
+		2A604AC39C85680112EC65338A6A5CF6 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558DFECE2C740177CA6357DA71A1DFBB /* Error.swift */; };
 		2C5450AC69398958CF6F7539EF7D99E5 /* Alamofire-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 30CE7341A995EF6812D71771E74CF7F7 /* Alamofire-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D5C3B34453DDCB27D66B3D5BF82E831 /* URLDataPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CE161ED0CF68954A63F30528ACAD9B /* URLDataPromise.swift */; };
-		2D9C89E698B7962248B91C84556B8521 /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B7E90A568681E000EF3CB0917584F3C /* AnyPromise.m */; };
-		3365F629B3DD2CC5092161DADB5B24BA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB15A61DB7ABCB74565286162157C5A0 /* Foundation.framework */; };
+		304FB800967DC336C7C1B61AAC1557E4 /* ModelReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C340998270315690E1FFB70343A8B4 /* ModelReturn.swift */; };
+		316C4405052019758E146DB3FA95FAD1 /* NSNotificationCenter+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93FB4BB16CFB41DCA35A8CFAD7A7FEF /* NSNotificationCenter+Promise.swift */; };
+		3197AFA938310557A94C7B2EE8B1B27B /* APIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729DF3BC8AE6F841794084E31E43FDF8 /* APIs.swift */; };
+		344A37F9B72CEAD747EF1BE892A4E60F /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F19945EE403F7B29D8B1939EA6D579A /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D72F02370DF0F99DF58728A2E64D27 /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = F4B6A98D6DAF474045210F5A74FF1C3C /* hang.m */; };
 		35F6B35131F89EA23246C6508199FB05 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB15A61DB7ABCB74565286162157C5A0 /* Foundation.framework */; };
-		36BC51A48A364E9D70DD4A12F1BFDC24 /* NSURLSession+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535DF88FC12304114DEF55E4003421B2 /* NSURLSession+Promise.swift */; };
+		36452068A6A705BE66FC426E7032FE84 /* UIAlertView+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = F075F63EFE77F7B59FF77CBA95B9AADF /* UIAlertView+AnyPromise.m */; };
 		3A8D316D4266A3309D0A98ED74F8A13A /* OMGUserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 87BC7910B8D7D31310A07C32438A8C67 /* OMGUserAgent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3BEC62AF9DDCF822F1865057CF1D50A2 /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5973BC143AE488C12FFB1E83E71F0C45 /* AnyPromise.swift */; };
-		3FC49DA692C9A42F947C9F561D3CAF1D /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275DA9A664C70DD40A4059090D1A00D4 /* after.swift */; };
-		422EB81C476A49349CBD929094E659BE /* Pet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C7F7995EC233B46050D81ABA34442C /* Pet.swift */; };
+		3BE4C9D6053FA221A8AA4EE551FE1EC5 /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 6AD59903FAA8315AD0036AC459FFB97F /* join.m */; };
+		3C7A51B6FDE0C1194AD8461285566978 /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = B868468092D7B2489B889A50981C9247 /* after.m */; };
+		3F7A0195CFB169B5FB86D5AC8AF94553 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0185D2A99819176B80E0B0DDCAE0886C /* Models.swift */; };
 		48CB8E7E16443CA771E4DCFB3E0709A2 /* OMGHTTPURLRQ.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D579267FC1F163C8F04B444DAEFED0D /* OMGHTTPURLRQ.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		4DE5FCC41D100B113B6645EA64410F16 /* ParameterEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBD351D007CF4095C98C9DFD9D83D61 /* ParameterEncoding.swift */; };
-		4FBA897D5492D0DD3CB07502E2596F6A /* PetstoreClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A8E0328DC896E0893B565FE8742167 /* PetstoreClient-dummy.m */; };
+		4F339AA0FB595AEB829BFA4DA37E00F7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52264308989BDCFCFCEA8C6B5E4B0BA8 /* User.swift */; };
 		5192A7466019F9B3D7F1E987124E96BC /* OMGHTTPURLRQ-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F7EBDD2EEED520E06ACB3538B3832049 /* OMGHTTPURLRQ-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		524CC219844C01E75355CACC63869C0D /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 6AD59903FAA8315AD0036AC459FFB97F /* join.m */; };
+		51D192188A3C93B037151A81E8B84ED8 /* dispatch_promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392FA21A33296B88F790D62A4FAA4E4E /* dispatch_promise.swift */; };
+		53B67EC16CDB25629E86C25BBB0AB363 /* NSNotificationCenter+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 4798BAC01B0E3F07E3BBBB07BA57F2D7 /* NSNotificationCenter+AnyPromise.m */; };
 		5480169E42C456C49BE59E273D7E0115 /* OMGFormURLEncode.h in Headers */ = {isa = PBXBuildFile; fileRef = 51ADA0B6B6B00CB0E818AA8CBC311677 /* OMGFormURLEncode.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		56E4DB673DB3EAE8F31C5854581C9239 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A1DC80A0773C5A569348DC442EAFD1D /* UIKit.framework */; };
-		61BB171AC3499F5339DEFFBB37E15E84 /* UIViewController+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D459D0AB2361B48F81C4D14C6D0DAA /* UIViewController+Promise.swift */; };
-		62F41914F8A9F9740EBBC8E412761EDB /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16730DAF3E51C161D8247E473F069E71 /* when.swift */; };
-		6756077354E35F7C661D714587C52F6B /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC4BF94DC4B3D8B88FC160B00931B0EC /* QuartzCore.framework */; };
-		6C0758FA1866AFC3B001BCCE294DF971 /* UIViewController+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = AA24C5EC82CF437D8D1FFFAB68975408 /* UIViewController+AnyPromise.m */; };
-		6C835D49402A31D15D3D53439F607525 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F19945EE403F7B29D8B1939EA6D579A /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5FBBFC6C720339FB8A32A743009316F4 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980FD13F87B44BFD90F8AC129BEB2E61 /* race.swift */; };
+		646412C35292AD2A6F963CC080F807F8 /* NSURLConnection+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = BAE48ACA10E8895BB8BF5CE8C0846B4B /* NSURLConnection+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		65CA6308EE66756E2E6F96C60B983868 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D0925E1F1CAB4577203530ABA563F3 /* Extensions.swift */; };
 		6CB84A616D7B4D189A4E94BD37621575 /* OMGUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = E11BFB27B43B742CB5D6086C4233A909 /* OMGUserAgent.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
 		6D264CCBD7DAC0A530076FB1A847EEC7 /* Pods-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 894E5DA93A9F359521A89826BE6DA777 /* Pods-dummy.m */; };
 		6F63943B0E954F701F32BC7A1F4C2FEC /* OMGFormURLEncode.m in Sources */ = {isa = PBXBuildFile; fileRef = 25614E715DDC170DAFB0DF50C5503E33 /* OMGFormURLEncode.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		6F676A66D92467D28EA52325927C5BC5 /* AlamofireImplementations.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F0EE7E4E76A7AC6932305A9A0A35A /* AlamofireImplementations.swift */; };
-		732A5A91563E46475A3FBE7D28C942E3 /* UIAlertView+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA854180C132DB5511D64C82535C5FDE /* UIAlertView+Promise.swift */; };
-		74E7435F4420251677F0494908757D56 /* UIActionSheet+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 6846D22C9F0CCBC48DF833E309A8E84F /* UIActionSheet+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		774EB2064BFD3266EEF2B07905D9B0CF /* NSNotificationCenter+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 3616971BAEF40302B7F2F8B1007C0B2B /* NSNotificationCenter+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73E8BA15FE5EB6DBD421C81FB1B7E9B6 /* Promise+Properties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0DBDE561A6C2E7AC7A24160F8A5F28 /* Promise+Properties.swift */; };
+		773B79EEB7C3D2B24E3E4BB0E7427BC5 /* PromiseKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9042667D08D783E45394FE8B97EE6468 /* PromiseKit-dummy.m */; };
+		785BC8D5C81A4E1BDE414BF809865748 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB15A61DB7ABCB74565286162157C5A0 /* Foundation.framework */; };
+		78EB600BF72978AE0C7F2CA2FA3E2A3D /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A112EF8BB3933C1C1E42F11B3DD3B02A /* PromiseKit.framework */; };
+		7996E39A4AC0202EDC641B1CC0D656D3 /* UIAlertView+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D340D66F03F31237B70F23FE9B00D0 /* UIAlertView+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		80F496237530D382A045A29654D8C11C /* ServerTrustPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A6910E83F606BCD67DC11FA706697 /* ServerTrustPolicy.swift */; };
+		81F12F28B1B768C021A5321105D1E807 /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD9D66ED521DD18E4F97AE9C02A0743 /* UserAPI.swift */; };
 		82971968CBDAB224212EEB4607C9FB8D /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F8B2513042BD6DB957E8063EF895BD /* Result.swift */; };
+		831AD8EE90B0E7F8EA1D1F3A2BC08F98 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC63EB77B3791891517B98CAA115DE8 /* State.swift */; };
 		8399DBEE3E2D98EB1F466132E476F4D9 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F14E17B4D6BDF8BD3E384BE6528F744 /* MultipartFormData.swift */; };
-		874DC0CE734CE6E3F54200621F9BECE5 /* UIActionSheet+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 9774D31336C85248A115B569E7D95283 /* UIActionSheet+AnyPromise.m */; };
-		90E44B5F3E21A2420F481DB132E52684 /* PetstoreClient-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F681D2C508D1BA8F62893120D9343A4 /* PetstoreClient-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		920AD5E4875F89BE0B3413FA0946ACB4 /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BFFA6FD621E9ED341AA89AEAC1604D7 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		92D9F79E690C48BC3A1BE0C4D861E4B7 /* afterlife.swift in Sources */ = {isa = PBXBuildFile; fileRef = C476B916B763E55E4161F0B30760C4E8 /* afterlife.swift */; };
-		92DB5CB64170AA4B906B58018ADC9419 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D23C407A7CDBFD244D6115899F9D45D /* Promise.swift */; };
-		94E9D5A7158985FA79136143BCA8E66E /* join.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84319E048FE6DD89B905FA3A81005C5F /* join.swift */; };
-		95DFE0BD617B4C9A707D8D55CD2F6858 /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = F4B6A98D6DAF474045210F5A74FF1C3C /* hang.m */; };
+		83FC08E17B53087B838BE39E4F6129EB /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BFFA6FD621E9ED341AA89AEAC1604D7 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		847F2464DBD0EFCCC90D723A05304E86 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16730DAF3E51C161D8247E473F069E71 /* when.swift */; };
+		8590AC534037A664D8120B086B306916 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A76B6037FEDFB0B427CFCC4B5C7A031 /* Order.swift */; };
+		8786202BD1AF3C19468B8D51097F9FBD /* NSURLConnection+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412985229DA7A4DF9E129B7E8F0C09BB /* NSURLConnection+Promise.swift */; };
+		8D1C373EAE7BEB9A4237AE570558B9C5 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163409B7188B5DF06D5C42D9F850AECE /* Tag.swift */; };
+		92927FAC8B986CA7D90E6B413322D8D2 /* afterlife.swift in Sources */ = {isa = PBXBuildFile; fileRef = C476B916B763E55E4161F0B30760C4E8 /* afterlife.swift */; };
+		93676264F29F30EAFE0E3ECA51938BD5 /* InlineResponse200.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5E31A70EA28AAB923EF00AEC3F5547 /* InlineResponse200.swift */; };
+		945A2D7116117EAECC7699761AF3577D /* APIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008F792AD713099E0A6A852B3C8535AC /* APIHelper.swift */; };
 		96D99D0C2472535A169DED65CB231CD7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB15A61DB7ABCB74565286162157C5A0 /* Foundation.framework */; };
-		9D70DDC375D7119F81D3B5FA30F17D38 /* PromiseKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9042667D08D783E45394FE8B97EE6468 /* PromiseKit-dummy.m */; };
-		9E339448B1EFC5B2112D847A766F844A /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A112EF8BB3933C1C1E42F11B3DD3B02A /* PromiseKit.framework */; };
-		9FB7204EEC7DA5E6E0BB5826DAE8FA6F /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558DFECE2C740177CA6357DA71A1DFBB /* Error.swift */; };
+		9E137F7B793F61E8DEABCB71BA66D5DE /* UIActionSheet+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 9774D31336C85248A115B569E7D95283 /* UIActionSheet+AnyPromise.m */; };
 		A2C172FE407C0BC3478ADCA91A6C9CEC /* Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D51C929AC51E34493AA757180C09C3B /* Manager.swift */; };
 		A3505FA2FB3067D53847AD288AC04F03 /* Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04177B09D9596450D827FE49A36C4C4 /* Download.swift */; };
-		A4AE8E155661325CF82446A0FF242B07 /* Umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A8906F6D6920DF197965D1740A7E283 /* Umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9DF4EE19A7494F3A91CE23C261FDE13 /* NSError+Cancellation.h in Headers */ = {isa = PBXBuildFile; fileRef = 045C1F608ADE57757E6732D721779F22 /* NSError+Cancellation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AF3198275DBC570992BA895FB8FAF293 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60C1B336FDA263A9AB0025BF89FF7D6 /* Tag.swift */; };
+		A3FA077C7B09DAFBE9DCF0FCC0574796 /* UIActionSheet+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 6846D22C9F0CCBC48DF833E309A8E84F /* UIActionSheet+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A7BA92F8595C7A7A7CD1DA218981E22F /* PetstoreClient-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 46A8E0328DC896E0893B565FE8742167 /* PetstoreClient-dummy.m */; };
+		AB116488546ECF8C547EA889D8FF00AC /* NSError+Cancellation.h in Headers */ = {isa = PBXBuildFile; fileRef = 045C1F608ADE57757E6732D721779F22 /* NSError+Cancellation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AC423EEEF34342F639A628EF7AB3B542 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = 143BC30E5DDAF52A3D9578F507EC6A41 /* when.m */; };
+		AE384E44FBEDCB47FA71778B86E55EC3 /* OMGHTTPURLRQ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3530BF15E14D1F6D7134EE67377D5C8C /* OMGHTTPURLRQ.framework */; };
 		B0FB4B01682814B9E3D32F9DC4A5E762 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B476A57549D7994745E17A6DE5BE745 /* Alamofire.swift */; };
-		B1931E222F0FF379FE4B14FC99171BF9 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40980C10A3E4CD8F73FEF4585BC9B273 /* Extensions.swift */; };
-		B68C4829A81227CAC51BC61F43D91445 /* APIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C04A06028D1D93105B1F69EE2C7311 /* APIs.swift */; };
+		B3A90D838B7484DA7EE40B666E397E80 /* CALayer+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 04A22F2595054D39018E03961CA7283A /* CALayer+AnyPromise.m */; };
+		B4DD64A13A5B316A81BC1A9FBBE6FA14 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0B4AE35B1E2D98834FFD2ADA8D284E /* Category.swift */; };
 		B6D2DC3E3DA44CD382B9B425F40E11C1 /* Alamofire-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 139346EB669CBE2DE8FE506E14A2BA9C /* Alamofire-dummy.m */; };
-		BC5E262FDC0CD0C1803EB715E2C48F52 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2001DB27FE23C000ACF411B329BC099F /* User.swift */; };
-		C0FBBB8365C842ACBC9181264649DCC1 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC63EB77B3791891517B98CAA115DE8 /* State.swift */; };
-		C1AC5BBB1762E93B083317C5E8A939DE /* OMGHTTPURLRQ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3530BF15E14D1F6D7134EE67377D5C8C /* OMGHTTPURLRQ.framework */; };
-		C320DDEFFEED8D4BB9EF3954D6FC8DE2 /* NSObject+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6EB54C331FED437583A5F01EB2757D1 /* NSObject+Promise.swift */; };
+		BF5E319D3C6549236D4894B3B39E32AA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A1DC80A0773C5A569348DC442EAFD1D /* UIKit.framework */; };
+		C2558B49CEC04C35FA6A054C296B96D2 /* join.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84319E048FE6DD89B905FA3A81005C5F /* join.swift */; };
 		C75519F0450166A6F28126ECC7664E9C /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1AD92813B887E2D017D051B8C0E3D2 /* Validation.swift */; };
-		C7F1A5669CE3AAA90BF2B5CCA70F90F6 /* SpecialModelName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B043AFA6B4E018E9989ED2EBED883492 /* SpecialModelName.swift */; };
-		C8F3620654924A2D88756CDCC5CCFB11 /* StoreAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A581DA18EB8A9137C3A6FCB144D6EA /* StoreAPI.swift */; };
-		CDFEEA22781236F07F32D6B739517178 /* CALayer+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E0FE41D771BE8BE3F0D4F1DAD0B179 /* CALayer+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C8FF7FA51F203929EFADBFA8D1BF33FD /* Pet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78EBA6214B5B4A7E499BCF7E15F32BFE /* Pet.swift */; };
+		CA774CD374F66F65293250838FC6BA13 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1D1571AB15108DF6F9C4FE2064E3C43 /* Alamofire.framework */; };
+		CBE429FD5A24DBB57A1DBCD013940B35 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D23C407A7CDBFD244D6115899F9D45D /* Promise.swift */; };
+		D02026F81674F4C0B52834486C113515 /* CALayer+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E0FE41D771BE8BE3F0D4F1DAD0B179 /* CALayer+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D1E8B31EFCBDE00F108E739AD69425C0 /* Pods-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BCC458FDD5F692BBB2BFC64BB5701FC /* Pods-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D21B7325B3642887BFBE977E021F2D26 /* ResponseSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD558DDCDDA1B46951548B02C34277EF /* ResponseSerialization.swift */; };
-		D21F8EFE0A5E06F45D8C203FE583EF77 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980FD13F87B44BFD90F8AC129BEB2E61 /* race.swift */; };
 		D358A828E68E152D06FC8E35533BF00B /* OMGHTTPURLRQ-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F36B65CF990C57DC527824ED0BA1915 /* OMGHTTPURLRQ-dummy.m */; };
+		D39005E13E26282E9C7EDA64463866E8 /* NSURLConnection+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = A7F0DAACAC89A93B940BBE54E6A87E9F /* NSURLConnection+AnyPromise.m */; };
 		D75CA395D510E08C404E55F5BDAE55CE /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9CB35983E4859DFFBAD8840196A094 /* Error.swift */; };
-		DC5EC2239846C76B4CCC3EAD4B022B8D /* NSNotificationCenter+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 4798BAC01B0E3F07E3BBBB07BA57F2D7 /* NSNotificationCenter+AnyPromise.m */; };
-		DD324C55ECC625F8893C07BD52B67E99 /* UIView+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = BCDD82DB3E6D43BA9769FCA9B744CB5E /* UIView+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9E510357C0C787483EFE8D1474B3AE2 /* UIAlertView+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA854180C132DB5511D64C82535C5FDE /* UIAlertView+Promise.swift */; };
+		DA9B18EFE21EF506FF9DA744D45B06C0 /* PMKAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C731FBFCC690050C6C08E5AC9D9DC724 /* PMKAlertController.swift */; };
 		DD8D067A7F742F39B87FA04CE12DD118 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB15A61DB7ABCB74565286162157C5A0 /* Foundation.framework */; };
-		E29B659D873F03F056C25D9B139CE225 /* NSURLConnection+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = BAE48ACA10E8895BB8BF5CE8C0846B4B /* NSURLConnection+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E3A8BAEE55DCBC8D16D9210A78D5A200 /* ObjectReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6DD0A2A0094280A4A78C9B772E3BAF /* ObjectReturn.swift */; };
-		EE2920251312E2F32C421CD05ACF4DA4 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = 143BC30E5DDAF52A3D9578F507EC6A41 /* when.m */; };
-		F0322283A43A3230AF9E1A363F5682AF /* InlineResponse200.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5559FBE62F3407535CE97AD320341ACC /* InlineResponse200.swift */; };
-		F2F841536DFF2E08BA87B09E1A62A15C /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876669E4CF92F0757A01F74D0325057C /* Category.swift */; };
-		F300CE6E3C784F5DEB89BC29C4895DBE /* NSURLConnection+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = A7F0DAACAC89A93B940BBE54E6A87E9F /* NSURLConnection+AnyPromise.m */; };
-		F4FE9A55D8791B871926069F21DCF818 /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = B868468092D7B2489B889A50981C9247 /* after.m */; };
-		F79E72246A63190A6B5E70F348E6670F /* UIAlertView+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 92D340D66F03F31237B70F23FE9B00D0 /* UIAlertView+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DF4272006B5C1E44DDCFBB47EE2E7803 /* UIActionSheet+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD570E28B63274E742E7D1FBBD55BB41 /* UIActionSheet+Promise.swift */; };
+		DFC90C62AC88EAA37AB7B861CA306F3D /* ObjectReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8185E452035CD0BF7C060F55F0B5F70A /* ObjectReturn.swift */; };
+		E0A9003301396FBC6A606B1BF2831B19 /* StoreAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3300C588B454777D34CF2746434D831C /* StoreAPI.swift */; };
+		E2D96BD179C73392E8567D7E4DD85F1F /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F41E1E46E1AA869B6EB76697DDE8C22 /* Name.swift */; };
+		E44FABF8A6A349BF6BBDBF5A85EAF2AD /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B7E90A568681E000EF3CB0917584F3C /* AnyPromise.m */; };
+		E4B4FE692923A3EEEA6E746C468130D0 /* Umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A8906F6D6920DF197965D1740A7E283 /* Umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E77FDF40A4F74F5B76C808F99DAFFAE3 /* dispatch_promise.m in Sources */ = {isa = PBXBuildFile; fileRef = A92242715FB4C0608F8DCEBF8F3791E2 /* dispatch_promise.m */; };
+		EA738E196BCD32AB9D155181B560C45F /* UIViewController+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BA017E288BB42E06EBEE9C6E6993EAF /* UIViewController+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB8361708EBAE300530139E12360E691 /* NSNotificationCenter+AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 3616971BAEF40302B7F2F8B1007C0B2B /* NSNotificationCenter+AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC1F2BC4EB0D75B825B5CD07AB03785B /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275DA9A664C70DD40A4059090D1A00D4 /* after.swift */; };
+		F3E994E1244780163ADAECFC1E57B9B9 /* AlamofireImplementations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119930426E00BF23E0F407F4E023D93A /* AlamofireImplementations.swift */; };
+		FA97B9777CCCBE575BA68891D5EC9F74 /* UIView+AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F0F4EDC2236E1C270DC2014181D6506 /* UIView+AnyPromise.m */; };
 		FC14480CECE872865A9C6E584F886DA3 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133C5287CFDCB3B67578A7B1221E132C /* Request.swift */; };
-		FC574F2027A58666D90BE40CF7716309 /* NSURLConnection+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412985229DA7A4DF9E129B7E8F0C09BB /* NSURLConnection+Promise.swift */; };
-		FD9BA35E0547A375AE7FCA49432C9C54 /* UIView+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CDA0958D6247505ECD9098D662EA74 /* UIView+Promise.swift */; };
+		FC20AAF674E10082FCC7509716BE989F /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC4BF94DC4B3D8B88FC160B00931B0EC /* QuartzCore.framework */; };
 		FEF0D7653948988B804226129471C1EC /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8F373B23E0F7FB68B0BA71D92D1C60 /* Stream.swift */; };
 /* End PBXBuildFile section */
 
@@ -114,22 +116,8 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9A0F758601B5E1ACBCB2624392B58BD1;
+			remoteGlobalIDString = 979DB2F3AD7D9465C00964E430EFFA1F;
 			remoteInfo = PetstoreClient;
-		};
-		085169F5A412617F5AA660FCA8662D05 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 190ACD3A51BC90B85EADB13E9CDD207B;
-			remoteInfo = OMGHTTPURLRQ;
-		};
-		3C56ED43C177CB987DA7685FD87B4736 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FB594EEBD21FB1EF5B7508805A6F5D02;
-			remoteInfo = PromiseKit;
 		};
 		769630CDAAA8C24AA5B4C81A85C45AC8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -138,7 +126,7 @@
 			remoteGlobalIDString = 432ECC54282C84882B482CCB4CF227FC;
 			remoteInfo = Alamofire;
 		};
-		94CC4862E0BF723067DDE7ABACFC5AF0 /* PBXContainerItemProxy */ = {
+		984DCCB3B51465C0D88D84E572BEA151 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
@@ -156,58 +144,76 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = FB594EEBD21FB1EF5B7508805A6F5D02;
+			remoteGlobalIDString = 4D88D9ED4DC4A6B8EF35E557375BD620;
+			remoteInfo = PromiseKit;
+		};
+		C504ACE6EDC632581A19C2453DE9E6DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 190ACD3A51BC90B85EADB13E9CDD207B;
+			remoteInfo = OMGHTTPURLRQ;
+		};
+		FD89F55B413E450305523C416F6AC5EC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4D88D9ED4DC4A6B8EF35E557375BD620;
 			remoteInfo = PromiseKit;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		008F792AD713099E0A6A852B3C8535AC /* APIHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIHelper.swift; sourceTree = "<group>"; };
+		0185D2A99819176B80E0B0DDCAE0886C /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		01D0925E1F1CAB4577203530ABA563F3 /* Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		045C1F608ADE57757E6732D721779F22 /* NSError+Cancellation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError+Cancellation.h"; path = "Sources/NSError+Cancellation.h"; sourceTree = "<group>"; };
 		04A22F2595054D39018E03961CA7283A /* CALayer+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CALayer+AnyPromise.m"; path = "Categories/QuartzCore/CALayer+AnyPromise.m"; sourceTree = "<group>"; };
-		0A6DD0A2A0094280A4A78C9B772E3BAF /* ObjectReturn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ObjectReturn.swift; sourceTree = "<group>"; };
 		0A8906F6D6920DF197965D1740A7E283 /* Umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Umbrella.h; path = Sources/Umbrella.h; sourceTree = "<group>"; };
 		0BA017E288BB42E06EBEE9C6E6993EAF /* UIViewController+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+AnyPromise.h"; path = "Categories/UIKit/UIViewController+AnyPromise.h"; sourceTree = "<group>"; };
 		0F36B65CF990C57DC527824ED0BA1915 /* OMGHTTPURLRQ-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "OMGHTTPURLRQ-dummy.m"; sourceTree = "<group>"; };
+		0F41E1E46E1AA869B6EB76697DDE8C22 /* Name.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
+		119930426E00BF23E0F407F4E023D93A /* AlamofireImplementations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlamofireImplementations.swift; sourceTree = "<group>"; };
 		122D5005A81832479161CD1D223C573A /* PromiseKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PromiseKit-prefix.pch"; sourceTree = "<group>"; };
 		133C5287CFDCB3B67578A7B1221E132C /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Request.swift; path = Source/Request.swift; sourceTree = "<group>"; };
 		139346EB669CBE2DE8FE506E14A2BA9C /* Alamofire-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Alamofire-dummy.m"; sourceTree = "<group>"; };
 		141F0B43C42CE92856BBA8F8D98481DB /* Alamofire.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Alamofire.xcconfig; sourceTree = "<group>"; };
 		143BC30E5DDAF52A3D9578F507EC6A41 /* when.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = when.m; path = Sources/when.m; sourceTree = "<group>"; };
+		163409B7188B5DF06D5C42D9F850AECE /* Tag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
 		16730DAF3E51C161D8247E473F069E71 /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = when.swift; path = Sources/when.swift; sourceTree = "<group>"; };
 		16D7C901D915C251DEBA27AC1EF57E34 /* OMGHTTPURLRQ.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = OMGHTTPURLRQ.xcconfig; sourceTree = "<group>"; };
 		1B7E90A568681E000EF3CB0917584F3C /* AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AnyPromise.m; path = Sources/AnyPromise.m; sourceTree = "<group>"; };
 		1F19945EE403F7B29D8B1939EA6D579A /* AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AnyPromise.h; path = Sources/AnyPromise.h; sourceTree = "<group>"; };
 		1FBD351D007CF4095C98C9DFD9D83D61 /* ParameterEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParameterEncoding.swift; path = Source/ParameterEncoding.swift; sourceTree = "<group>"; };
-		1FE322C982813B48FD220881237FD90F /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
-		2001DB27FE23C000ACF411B329BC099F /* User.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		24C79ED4B5226F263307B22E96E88F9F /* OMGHTTPURLRQ.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = OMGHTTPURLRQ.modulemap; sourceTree = "<group>"; };
 		25614E715DDC170DAFB0DF50C5503E33 /* OMGFormURLEncode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OMGFormURLEncode.m; path = Sources/OMGFormURLEncode.m; sourceTree = "<group>"; };
 		275DA9A664C70DD40A4059090D1A00D4 /* after.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = after.swift; path = Sources/after.swift; sourceTree = "<group>"; };
 		27E0FE41D771BE8BE3F0D4F1DAD0B179 /* CALayer+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CALayer+AnyPromise.h"; path = "Categories/QuartzCore/CALayer+AnyPromise.h"; sourceTree = "<group>"; };
-		28A3BBCDB687E9609F39F4EFC404B045 /* APIHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIHelper.swift; sourceTree = "<group>"; };
+		2A76B6037FEDFB0B427CFCC4B5C7A031 /* Order.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
 		2BCC458FDD5F692BBB2BFC64BB5701FC /* Pods-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-umbrella.h"; sourceTree = "<group>"; };
 		2D51C929AC51E34493AA757180C09C3B /* Manager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Manager.swift; path = Source/Manager.swift; sourceTree = "<group>"; };
 		2F0F4EDC2236E1C270DC2014181D6506 /* UIView+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+AnyPromise.m"; path = "Categories/UIKit/UIView+AnyPromise.m"; sourceTree = "<group>"; };
 		30CE7341A995EF6812D71771E74CF7F7 /* Alamofire-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Alamofire-umbrella.h"; sourceTree = "<group>"; };
+		3300C588B454777D34CF2746434D831C /* StoreAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreAPI.swift; sourceTree = "<group>"; };
 		3530BF15E14D1F6D7134EE67377D5C8C /* OMGHTTPURLRQ.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OMGHTTPURLRQ.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3616971BAEF40302B7F2F8B1007C0B2B /* NSNotificationCenter+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNotificationCenter+AnyPromise.h"; path = "Categories/Foundation/NSNotificationCenter+AnyPromise.h"; sourceTree = "<group>"; };
+		38B3CAA64819C3DF5DCBAD5A21CA04D5 /* SpecialModelName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpecialModelName.swift; sourceTree = "<group>"; };
 		392FA21A33296B88F790D62A4FAA4E4E /* dispatch_promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = dispatch_promise.swift; path = Sources/dispatch_promise.swift; sourceTree = "<group>"; };
 		3950B63B8EB1B9CD8FC31CDA8CC2E7C7 /* Alamofire-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Alamofire-prefix.pch"; sourceTree = "<group>"; };
 		3BFFA6FD621E9ED341AA89AEAC1604D7 /* PromiseKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PromiseKit.h; path = Sources/PromiseKit.h; sourceTree = "<group>"; };
 		3CE589B7B1FE57084403D25DC49528B5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3D23C407A7CDBFD244D6115899F9D45D /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Promise.swift; path = Sources/Promise.swift; sourceTree = "<group>"; };
 		400A6910E83F606BCD67DC11FA706697 /* ServerTrustPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServerTrustPolicy.swift; path = Source/ServerTrustPolicy.swift; sourceTree = "<group>"; };
-		40980C10A3E4CD8F73FEF4585BC9B273 /* Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		412985229DA7A4DF9E129B7E8F0C09BB /* NSURLConnection+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLConnection+Promise.swift"; path = "Categories/Foundation/NSURLConnection+Promise.swift"; sourceTree = "<group>"; };
 		450166FEA2155A5821D97744A0127DF8 /* OMGHTTPURLRQ.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OMGHTTPURLRQ.h; path = Sources/OMGHTTPURLRQ.h; sourceTree = "<group>"; };
+		45C340998270315690E1FFB70343A8B4 /* ModelReturn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelReturn.swift; sourceTree = "<group>"; };
 		46A8E0328DC896E0893B565FE8742167 /* PetstoreClient-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PetstoreClient-dummy.m"; sourceTree = "<group>"; };
 		4798BAC01B0E3F07E3BBBB07BA57F2D7 /* NSNotificationCenter+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNotificationCenter+AnyPromise.m"; path = "Categories/Foundation/NSNotificationCenter+AnyPromise.m"; sourceTree = "<group>"; };
-		511325F77CCC682529E5D61A5AA0B381 /* Order.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
+		4F0B4AE35B1E2D98834FFD2ADA8D284E /* Category.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		51ADA0B6B6B00CB0E818AA8CBC311677 /* OMGFormURLEncode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OMGFormURLEncode.h; path = Sources/OMGFormURLEncode.h; sourceTree = "<group>"; };
+		52264308989BDCFCFCEA8C6B5E4B0BA8 /* User.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		535DF88FC12304114DEF55E4003421B2 /* NSURLSession+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSURLSession+Promise.swift"; path = "Categories/Foundation/NSURLSession+Promise.swift"; sourceTree = "<group>"; };
 		53F8B2513042BD6DB957E8063EF895BD /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Result.swift; path = Source/Result.swift; sourceTree = "<group>"; };
-		54C7F7995EC233B46050D81ABA34442C /* Pet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Pet.swift; sourceTree = "<group>"; };
-		5559FBE62F3407535CE97AD320341ACC /* InlineResponse200.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InlineResponse200.swift; sourceTree = "<group>"; };
 		558DFECE2C740177CA6357DA71A1DFBB /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = Sources/Error.swift; sourceTree = "<group>"; };
 		5973BC143AE488C12FFB1E83E71F0C45 /* AnyPromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnyPromise.swift; path = Sources/AnyPromise.swift; sourceTree = "<group>"; };
 		5A1DC80A0773C5A569348DC442EAFD1D /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -216,14 +222,14 @@
 		5F14E17B4D6BDF8BD3E384BE6528F744 /* MultipartFormData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultipartFormData.swift; path = Source/MultipartFormData.swift; sourceTree = "<group>"; };
 		6846D22C9F0CCBC48DF833E309A8E84F /* UIActionSheet+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActionSheet+AnyPromise.h"; path = "Categories/UIKit/UIActionSheet+AnyPromise.h"; sourceTree = "<group>"; };
 		6AD59903FAA8315AD0036AC459FFB97F /* join.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = join.m; path = Sources/join.m; sourceTree = "<group>"; };
-		6E25EC84C24B3AB284A71E47CB032082 /* UserAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserAPI.swift; sourceTree = "<group>"; };
-		75A581DA18EB8A9137C3A6FCB144D6EA /* StoreAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreAPI.swift; sourceTree = "<group>"; };
+		729DF3BC8AE6F841794084E31E43FDF8 /* APIs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIs.swift; sourceTree = "<group>"; };
+		78EBA6214B5B4A7E499BCF7E15F32BFE /* Pet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Pet.swift; sourceTree = "<group>"; };
 		792D14AC86CD98AA9C31373287E0F353 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		79A9DEDC89FE8336BF5FEDAAF75BF7FC /* Pods.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Pods.modulemap; sourceTree = "<group>"; };
 		7E0DBDE561A6C2E7AC7A24160F8A5F28 /* Promise+Properties.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Promise+Properties.swift"; path = "Sources/Promise+Properties.swift"; sourceTree = "<group>"; };
+		8185E452035CD0BF7C060F55F0B5F70A /* ObjectReturn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ObjectReturn.swift; sourceTree = "<group>"; };
 		84319E048FE6DD89B905FA3A81005C5F /* join.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = join.swift; path = Sources/join.swift; sourceTree = "<group>"; };
 		8749F40CC17CE0C26C36B0F431A9C8F0 /* Alamofire.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Alamofire.modulemap; sourceTree = "<group>"; };
-		876669E4CF92F0757A01F74D0325057C /* Category.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		87B213035BAC5F75386F62D3C75D2342 /* Pods-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-acknowledgements.plist"; sourceTree = "<group>"; };
 		87BC7910B8D7D31310A07C32438A8C67 /* OMGUserAgent.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OMGUserAgent.h; path = Sources/OMGUserAgent.h; sourceTree = "<group>"; };
 		894E5DA93A9F359521A89826BE6DA777 /* Pods-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-dummy.m"; sourceTree = "<group>"; };
@@ -233,6 +239,7 @@
 		8DC63EB77B3791891517B98CAA115DE8 /* State.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = State.swift; path = Sources/State.swift; sourceTree = "<group>"; };
 		9042667D08D783E45394FE8B97EE6468 /* PromiseKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PromiseKit-dummy.m"; sourceTree = "<group>"; };
 		92D340D66F03F31237B70F23FE9B00D0 /* UIAlertView+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+AnyPromise.h"; path = "Categories/UIKit/UIAlertView+AnyPromise.h"; sourceTree = "<group>"; };
+		96FE4C094684D4C89D71B1C97DB4545B /* PetAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetAPI.swift; sourceTree = "<group>"; };
 		9774D31336C85248A115B569E7D95283 /* UIActionSheet+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActionSheet+AnyPromise.m"; path = "Categories/UIKit/UIActionSheet+AnyPromise.m"; sourceTree = "<group>"; };
 		977577C045EDA9D9D1F46E2598D19FC7 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Pods.debug.xcconfig; sourceTree = "<group>"; };
 		980FD13F87B44BFD90F8AC129BEB2E61 /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = race.swift; path = Sources/race.swift; sourceTree = "<group>"; };
@@ -241,13 +248,10 @@
 		A04177B09D9596450D827FE49A36C4C4 /* Download.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Download.swift; path = Source/Download.swift; sourceTree = "<group>"; };
 		A112EF8BB3933C1C1E42F11B3DD3B02A /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1D1571AB15108DF6F9C4FE2064E3C43 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A60C1B336FDA263A9AB0025BF89FF7D6 /* Tag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
 		A7F0DAACAC89A93B940BBE54E6A87E9F /* NSURLConnection+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLConnection+AnyPromise.m"; path = "Categories/Foundation/NSURLConnection+AnyPromise.m"; sourceTree = "<group>"; };
 		A92242715FB4C0608F8DCEBF8F3791E2 /* dispatch_promise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = dispatch_promise.m; path = Sources/dispatch_promise.m; sourceTree = "<group>"; };
 		AA24C5EC82CF437D8D1FFFAB68975408 /* UIViewController+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+AnyPromise.m"; path = "Categories/UIKit/UIViewController+AnyPromise.m"; sourceTree = "<group>"; };
 		AB4DA378490493502B34B20D4B12325B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B043AFA6B4E018E9989ED2EBED883492 /* SpecialModelName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpecialModelName.swift; sourceTree = "<group>"; };
-		B0C04A06028D1D93105B1F69EE2C7311 /* APIs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = APIs.swift; sourceTree = "<group>"; };
 		B3A144887C8B13FD888B76AB096B0CA1 /* PetstoreClient-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PetstoreClient-prefix.pch"; sourceTree = "<group>"; };
 		B868468092D7B2489B889A50981C9247 /* after.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = after.m; path = Sources/after.m; sourceTree = "<group>"; };
 		B93FB4BB16CFB41DCA35A8CFAD7A7FEF /* NSNotificationCenter+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSNotificationCenter+Promise.swift"; path = "Categories/Foundation/NSNotificationCenter+Promise.swift"; sourceTree = "<group>"; };
@@ -255,7 +259,6 @@
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		BAE48ACA10E8895BB8BF5CE8C0846B4B /* NSURLConnection+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLConnection+AnyPromise.h"; path = "Categories/Foundation/NSURLConnection+AnyPromise.h"; sourceTree = "<group>"; };
 		BCDD82DB3E6D43BA9769FCA9B744CB5E /* UIView+AnyPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+AnyPromise.h"; path = "Categories/UIKit/UIView+AnyPromise.h"; sourceTree = "<group>"; };
-		BE4F0EE7E4E76A7AC6932305A9A0A35A /* AlamofireImplementations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlamofireImplementations.swift; sourceTree = "<group>"; };
 		C476B916B763E55E4161F0B30760C4E8 /* afterlife.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = afterlife.swift; path = Categories/Foundation/afterlife.swift; sourceTree = "<group>"; };
 		C731FBFCC690050C6C08E5AC9D9DC724 /* PMKAlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PMKAlertController.swift; path = Categories/UIKit/PMKAlertController.swift; sourceTree = "<group>"; };
 		CA1AD92813B887E2D017D051B8C0E3D2 /* Validation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Validation.swift; path = Source/Validation.swift; sourceTree = "<group>"; };
@@ -265,7 +268,6 @@
 		CCE38472832BBCC541E646DA6C18EF9C /* Upload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Upload.swift; path = Source/Upload.swift; sourceTree = "<group>"; };
 		CDC4DD7DB9F4C34A288BECA73BC13B57 /* PromiseKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = PromiseKit.modulemap; sourceTree = "<group>"; };
 		D0405803033A2A777B8E4DFA0C1800ED /* Pods-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-acknowledgements.markdown"; sourceTree = "<group>"; };
-		D04911F3B72D4F18187122A620682A84 /* PetAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PetAPI.swift; sourceTree = "<group>"; };
 		D4248CF20178C57CEFEFAAF453C0DC75 /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6D459D0AB2361B48F81C4D14C6D0DAA /* UIViewController+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIViewController+Promise.swift"; path = "Categories/UIKit/UIViewController+Promise.swift"; sourceTree = "<group>"; };
 		D6EB54C331FED437583A5F01EB2757D1 /* NSObject+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSObject+Promise.swift"; path = "Categories/Foundation/NSObject+Promise.swift"; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 		E7CE161ED0CF68954A63F30528ACAD9B /* URLDataPromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = URLDataPromise.swift; path = Sources/URLDataPromise.swift; sourceTree = "<group>"; };
 		E7F21354943D9F42A70697D5A5EF72E9 /* Pods-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-frameworks.sh"; sourceTree = "<group>"; };
 		E8446514FBAD26C0E18F24A5715AEF67 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EAD9D66ED521DD18E4F97AE9C02A0743 /* UserAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserAPI.swift; sourceTree = "<group>"; };
 		EBC4140FCBB5B4D3A955B1608C165C04 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F075F63EFE77F7B59FF77CBA95B9AADF /* UIAlertView+AnyPromise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+AnyPromise.m"; path = "Categories/UIKit/UIAlertView+AnyPromise.m"; sourceTree = "<group>"; };
 		F0D4E00A8974E74325E9E53D456F9AD4 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -286,29 +289,19 @@
 		F7EBDD2EEED520E06ACB3538B3832049 /* OMGHTTPURLRQ-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OMGHTTPURLRQ-umbrella.h"; sourceTree = "<group>"; };
 		FB15A61DB7ABCB74565286162157C5A0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		FC4BF94DC4B3D8B88FC160B00931B0EC /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
+		FC5E31A70EA28AAB923EF00AEC3F5547 /* InlineResponse200.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InlineResponse200.swift; sourceTree = "<group>"; };
 		FD558DDCDDA1B46951548B02C34277EF /* ResponseSerialization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResponseSerialization.swift; path = Source/ResponseSerialization.swift; sourceTree = "<group>"; };
 		FD570E28B63274E742E7D1FBBD55BB41 /* UIActionSheet+Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIActionSheet+Promise.swift"; path = "Categories/UIKit/UIActionSheet+Promise.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		38849761E5F4A894893A402F6D564927 /* Frameworks */ = {
+		55DFB9B3654647DE72E6EE1FCD7B7655 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C8D5A3F181EE2797475BF8CD3D17FAB /* Foundation.framework in Frameworks */,
-				C1AC5BBB1762E93B083317C5E8A939DE /* OMGHTTPURLRQ.framework in Frameworks */,
-				6756077354E35F7C661D714587C52F6B /* QuartzCore.framework in Frameworks */,
-				56E4DB673DB3EAE8F31C5854581C9239 /* UIKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7404DE837DAB14F44B0D18F88690804A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				043AACBEFC1A58B79AF6B81C8E7E117E /* Alamofire.framework in Frameworks */,
-				3365F629B3DD2CC5092161DADB5B24BA /* Foundation.framework in Frameworks */,
-				9E339448B1EFC5B2112D847A766F844A /* PromiseKit.framework in Frameworks */,
+				CA774CD374F66F65293250838FC6BA13 /* Alamofire.framework in Frameworks */,
+				0AAE766A8E92B8EAA0D1DF2E170C4DC1 /* Foundation.framework in Frameworks */,
+				78EB600BF72978AE0C7F2CA2FA3E2A3D /* PromiseKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -325,6 +318,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				96D99D0C2472535A169DED65CB231CD7 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B652D3B636B5A57EECFD1D2202EF9791 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				785BC8D5C81A4E1BDE414BF809865748 /* Foundation.framework in Frameworks */,
+				AE384E44FBEDCB47FA71778B86E55EC3 /* OMGHTTPURLRQ.framework in Frameworks */,
+				FC20AAF674E10082FCC7509716BE989F /* QuartzCore.framework in Frameworks */,
+				BF5E319D3C6549236D4894B3B39E32AA /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -370,6 +374,20 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
+		4B2B2118F6D9E8F52DC35450A0E17208 /* Swaggers */ = {
+			isa = PBXGroup;
+			children = (
+				119930426E00BF23E0F407F4E023D93A /* AlamofireImplementations.swift */,
+				008F792AD713099E0A6A852B3C8535AC /* APIHelper.swift */,
+				729DF3BC8AE6F841794084E31E43FDF8 /* APIs.swift */,
+				01D0925E1F1CAB4577203530ABA563F3 /* Extensions.swift */,
+				0185D2A99819176B80E0B0DDCAE0886C /* Models.swift */,
+				B6EB4B6CD57EC53C4EFFA0684F4349E3 /* APIs */,
+				78C1E3267AD72EF53448FB09EC677A77 /* Models */,
+			);
+			path = Swaggers;
+			sourceTree = "<group>";
+		};
 		75D98FF52E597A11900E131B6C4E1ADA /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -404,17 +422,19 @@
 			name = Foundation;
 			sourceTree = "<group>";
 		};
-		788DC9779BF60419FE26A13FA7F62348 /* Models */ = {
+		78C1E3267AD72EF53448FB09EC677A77 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				876669E4CF92F0757A01F74D0325057C /* Category.swift */,
-				5559FBE62F3407535CE97AD320341ACC /* InlineResponse200.swift */,
-				0A6DD0A2A0094280A4A78C9B772E3BAF /* ObjectReturn.swift */,
-				511325F77CCC682529E5D61A5AA0B381 /* Order.swift */,
-				54C7F7995EC233B46050D81ABA34442C /* Pet.swift */,
-				B043AFA6B4E018E9989ED2EBED883492 /* SpecialModelName.swift */,
-				A60C1B336FDA263A9AB0025BF89FF7D6 /* Tag.swift */,
-				2001DB27FE23C000ACF411B329BC099F /* User.swift */,
+				4F0B4AE35B1E2D98834FFD2ADA8D284E /* Category.swift */,
+				FC5E31A70EA28AAB923EF00AEC3F5547 /* InlineResponse200.swift */,
+				45C340998270315690E1FFB70343A8B4 /* ModelReturn.swift */,
+				0F41E1E46E1AA869B6EB76697DDE8C22 /* Name.swift */,
+				8185E452035CD0BF7C060F55F0B5F70A /* ObjectReturn.swift */,
+				2A76B6037FEDFB0B427CFCC4B5C7A031 /* Order.swift */,
+				78EBA6214B5B4A7E499BCF7E15F32BFE /* Pet.swift */,
+				38B3CAA64819C3DF5DCBAD5A21CA04D5 /* SpecialModelName.swift */,
+				163409B7188B5DF06D5C42D9F850AECE /* Tag.swift */,
+				52264308989BDCFCFCEA8C6B5E4B0BA8 /* User.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -462,30 +482,6 @@
 				04A22F2595054D39018E03961CA7283A /* CALayer+AnyPromise.m */,
 			);
 			name = QuartzCore;
-			sourceTree = "<group>";
-		};
-		8598DF5E36C16045F5598501B66C2CCB /* APIs */ = {
-			isa = PBXGroup;
-			children = (
-				D04911F3B72D4F18187122A620682A84 /* PetAPI.swift */,
-				75A581DA18EB8A9137C3A6FCB144D6EA /* StoreAPI.swift */,
-				6E25EC84C24B3AB284A71E47CB032082 /* UserAPI.swift */,
-			);
-			path = APIs;
-			sourceTree = "<group>";
-		};
-		86A31D6593E5DF6FFDE3D3802AAAA862 /* Swaggers */ = {
-			isa = PBXGroup;
-			children = (
-				BE4F0EE7E4E76A7AC6932305A9A0A35A /* AlamofireImplementations.swift */,
-				28A3BBCDB687E9609F39F4EFC404B045 /* APIHelper.swift */,
-				B0C04A06028D1D93105B1F69EE2C7311 /* APIs.swift */,
-				40980C10A3E4CD8F73FEF4585BC9B273 /* Extensions.swift */,
-				1FE322C982813B48FD220881237FD90F /* Models.swift */,
-				8598DF5E36C16045F5598501B66C2CCB /* APIs */,
-				788DC9779BF60419FE26A13FA7F62348 /* Models */,
-			);
-			path = Swaggers;
 			sourceTree = "<group>";
 		};
 		8EA2A359F1831ACBB15BAAEA04D6FB95 /* UIKit */ = {
@@ -579,9 +575,19 @@
 		AD94092456F8ABCB18F74CAC75AD85DE /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				86A31D6593E5DF6FFDE3D3802AAAA862 /* Swaggers */,
+				4B2B2118F6D9E8F52DC35450A0E17208 /* Swaggers */,
 			);
 			path = Classes;
+			sourceTree = "<group>";
+		};
+		B6EB4B6CD57EC53C4EFFA0684F4349E3 /* APIs */ = {
+			isa = PBXGroup;
+			children = (
+				96FE4C094684D4C89D71B1C97DB4545B /* PetAPI.swift */,
+				3300C588B454777D34CF2746434D831C /* StoreAPI.swift */,
+				EAD9D66ED521DD18E4F97AE9C02A0743 /* UserAPI.swift */,
+			);
+			path = APIs;
 			sourceTree = "<group>";
 		};
 		B7B80995527643776607AFFA75B91E24 /* Targets Support Files */ = {
@@ -696,6 +702,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		0E64CBD424B5CDDD3F8BDD0DAB0D77C9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11611AA162541D7F4F502D602E6C541C /* PetstoreClient-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5F7B61281F714E2A64A51E80A2C9C062 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -712,24 +726,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8D247574BE8EE44D7F586F5EE3E64A71 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6C835D49402A31D15D3D53439F607525 /* AnyPromise.h in Headers */,
-				CDFEEA22781236F07F32D6B739517178 /* CALayer+AnyPromise.h in Headers */,
-				A9DF4EE19A7494F3A91CE23C261FDE13 /* NSError+Cancellation.h in Headers */,
-				774EB2064BFD3266EEF2B07905D9B0CF /* NSNotificationCenter+AnyPromise.h in Headers */,
-				E29B659D873F03F056C25D9B139CE225 /* NSURLConnection+AnyPromise.h in Headers */,
-				920AD5E4875F89BE0B3413FA0946ACB4 /* PromiseKit.h in Headers */,
-				74E7435F4420251677F0494908757D56 /* UIActionSheet+AnyPromise.h in Headers */,
-				F79E72246A63190A6B5E70F348E6670F /* UIAlertView+AnyPromise.h in Headers */,
-				DD324C55ECC625F8893C07BD52B67E99 /* UIView+AnyPromise.h in Headers */,
-				0E84511CF3F1E8C48CCC75BA66EBE0BA /* UIViewController+AnyPromise.h in Headers */,
-				A4AE8E155661325CF82446A0FF242B07 /* Umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8EC2461DE4442A7991319873E6012164 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -741,11 +737,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DB92AC3A884C820A686DDA31CFC1C325 /* Headers */ = {
+		E0918703FA0C8DBA4CCE042E64FA5815 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				90E44B5F3E21A2420F481DB132E52684 /* PetstoreClient-umbrella.h in Headers */,
+				344A37F9B72CEAD747EF1BE892A4E60F /* AnyPromise.h in Headers */,
+				D02026F81674F4C0B52834486C113515 /* CALayer+AnyPromise.h in Headers */,
+				AB116488546ECF8C547EA889D8FF00AC /* NSError+Cancellation.h in Headers */,
+				EB8361708EBAE300530139E12360E691 /* NSNotificationCenter+AnyPromise.h in Headers */,
+				646412C35292AD2A6F963CC080F807F8 /* NSURLConnection+AnyPromise.h in Headers */,
+				83FC08E17B53087B838BE39E4F6129EB /* PromiseKit.h in Headers */,
+				A3FA077C7B09DAFBE9DCF0FCC0574796 /* UIActionSheet+AnyPromise.h in Headers */,
+				7996E39A4AC0202EDC641B1CC0D656D3 /* UIAlertView+AnyPromise.h in Headers */,
+				12C9F6C1F328683EA621071B8894143C /* UIView+AnyPromise.h in Headers */,
+				EA738E196BCD32AB9D155181B560C45F /* UIViewController+AnyPromise.h in Headers */,
+				E4B4FE692923A3EEEA6E746C468130D0 /* Umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -786,6 +792,24 @@
 			productReference = EBC4140FCBB5B4D3A955B1608C165C04 /* Alamofire.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		4D88D9ED4DC4A6B8EF35E557375BD620 /* PromiseKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 08663B0D9373BDC5C957FD20C9854C47 /* Build configuration list for PBXNativeTarget "PromiseKit" */;
+			buildPhases = (
+				FB4836AFB2F7262D45CD0FC339EE67BF /* Sources */,
+				B652D3B636B5A57EECFD1D2202EF9791 /* Frameworks */,
+				E0918703FA0C8DBA4CCE042E64FA5815 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2DD8156E827B0502CCF0D8C12B2F3F2F /* PBXTargetDependency */,
+			);
+			name = PromiseKit;
+			productName = PromiseKit;
+			productReference = D4248CF20178C57CEFEFAAF453C0DC75 /* PromiseKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		7A5DBD588D2CC1C0CB1C42D4ED613FE4 /* Pods */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8CB3C5DF3F4B6413A6F2D003B58CCF32 /* Build configuration list for PBXNativeTarget "Pods" */;
@@ -807,41 +831,23 @@
 			productReference = D931A99C6B5A8E0F69C818C6ECC3C44F /* Pods.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		9A0F758601B5E1ACBCB2624392B58BD1 /* PetstoreClient */ = {
+		979DB2F3AD7D9465C00964E430EFFA1F /* PetstoreClient */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0481A4393EA0CC504EB6542154C8F7AE /* Build configuration list for PBXNativeTarget "PetstoreClient" */;
+			buildConfigurationList = 5764D52D7BBF1EBF5FE0684F90F03BDA /* Build configuration list for PBXNativeTarget "PetstoreClient" */;
 			buildPhases = (
-				44D324C6406A51269508FD8F254CF846 /* Sources */,
-				7404DE837DAB14F44B0D18F88690804A /* Frameworks */,
-				DB92AC3A884C820A686DDA31CFC1C325 /* Headers */,
+				FBB88BC7ECAFC27A96F5747F401600D0 /* Sources */,
+				55DFB9B3654647DE72E6EE1FCD7B7655 /* Frameworks */,
+				0E64CBD424B5CDDD3F8BDD0DAB0D77C9 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				0791AE80538B89D74023D1648662A746 /* PBXTargetDependency */,
-				6D5049EB7DC059D4D2A0236320915EE8 /* PBXTargetDependency */,
+				92766EE7AEB0ABB3BFA67559A621AA90 /* PBXTargetDependency */,
+				6196E2F6FB1435188D0239A1A3CC4599 /* PBXTargetDependency */,
 			);
 			name = PetstoreClient;
 			productName = PetstoreClient;
 			productReference = E160B50E4D11692AA38E74C897D69C61 /* PetstoreClient.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		FB594EEBD21FB1EF5B7508805A6F5D02 /* PromiseKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F48703966D7224FCD529288B421CB38B /* Build configuration list for PBXNativeTarget "PromiseKit" */;
-			buildPhases = (
-				3F8ED5287F9952B5D94F0569303CB691 /* Sources */,
-				38849761E5F4A894893A402F6D564927 /* Frameworks */,
-				8D247574BE8EE44D7F586F5EE3E64A71 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				BBE09C7A178207CA23DF95EC1E858E78 /* PBXTargetDependency */,
-			);
-			name = PromiseKit;
-			productName = PromiseKit;
-			productReference = D4248CF20178C57CEFEFAAF453C0DC75 /* PromiseKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -867,56 +873,14 @@
 			targets = (
 				432ECC54282C84882B482CCB4CF227FC /* Alamofire */,
 				190ACD3A51BC90B85EADB13E9CDD207B /* OMGHTTPURLRQ */,
-				9A0F758601B5E1ACBCB2624392B58BD1 /* PetstoreClient */,
+				979DB2F3AD7D9465C00964E430EFFA1F /* PetstoreClient */,
 				7A5DBD588D2CC1C0CB1C42D4ED613FE4 /* Pods */,
-				FB594EEBD21FB1EF5B7508805A6F5D02 /* PromiseKit */,
+				4D88D9ED4DC4A6B8EF35E557375BD620 /* PromiseKit */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		3F8ED5287F9952B5D94F0569303CB691 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F4FE9A55D8791B871926069F21DCF818 /* after.m in Sources */,
-				3FC49DA692C9A42F947C9F561D3CAF1D /* after.swift in Sources */,
-				92D9F79E690C48BC3A1BE0C4D861E4B7 /* afterlife.swift in Sources */,
-				2D9C89E698B7962248B91C84556B8521 /* AnyPromise.m in Sources */,
-				3BEC62AF9DDCF822F1865057CF1D50A2 /* AnyPromise.swift in Sources */,
-				24D2C12AA4466F61F04FB7136AF497CA /* CALayer+AnyPromise.m in Sources */,
-				1478812AA43E16777600753CDF6ACE1F /* dispatch_promise.m in Sources */,
-				06FD19EDA263742E49199D15FF81FFAA /* dispatch_promise.swift in Sources */,
-				9FB7204EEC7DA5E6E0BB5826DAE8FA6F /* Error.swift in Sources */,
-				95DFE0BD617B4C9A707D8D55CD2F6858 /* hang.m in Sources */,
-				524CC219844C01E75355CACC63869C0D /* join.m in Sources */,
-				94E9D5A7158985FA79136143BCA8E66E /* join.swift in Sources */,
-				DC5EC2239846C76B4CCC3EAD4B022B8D /* NSNotificationCenter+AnyPromise.m in Sources */,
-				21FB1E69B7CC6FCCA95B3B7531378D84 /* NSNotificationCenter+Promise.swift in Sources */,
-				C320DDEFFEED8D4BB9EF3954D6FC8DE2 /* NSObject+Promise.swift in Sources */,
-				F300CE6E3C784F5DEB89BC29C4895DBE /* NSURLConnection+AnyPromise.m in Sources */,
-				FC574F2027A58666D90BE40CF7716309 /* NSURLConnection+Promise.swift in Sources */,
-				36BC51A48A364E9D70DD4A12F1BFDC24 /* NSURLSession+Promise.swift in Sources */,
-				0AC8F78F69436E83746D56B1963C7321 /* PMKAlertController.swift in Sources */,
-				21FE4548D5605FFE12EFA269102C88E1 /* Promise+Properties.swift in Sources */,
-				92DB5CB64170AA4B906B58018ADC9419 /* Promise.swift in Sources */,
-				9D70DDC375D7119F81D3B5FA30F17D38 /* PromiseKit-dummy.m in Sources */,
-				D21F8EFE0A5E06F45D8C203FE583EF77 /* race.swift in Sources */,
-				C0FBBB8365C842ACBC9181264649DCC1 /* State.swift in Sources */,
-				874DC0CE734CE6E3F54200621F9BECE5 /* UIActionSheet+AnyPromise.m in Sources */,
-				287EC582989EE65F605374D6908AA35C /* UIActionSheet+Promise.swift in Sources */,
-				11E1A6059DD32FBA0734660403713531 /* UIAlertView+AnyPromise.m in Sources */,
-				732A5A91563E46475A3FBE7D28C942E3 /* UIAlertView+Promise.swift in Sources */,
-				0DB1CFFE7FEC5667D7CD14C580D8AB8F /* UIView+AnyPromise.m in Sources */,
-				FD9BA35E0547A375AE7FCA49432C9C54 /* UIView+Promise.swift in Sources */,
-				6C0758FA1866AFC3B001BCCE294DF971 /* UIViewController+AnyPromise.m in Sources */,
-				61BB171AC3499F5339DEFFBB37E15E84 /* UIViewController+Promise.swift in Sources */,
-				2D5C3B34453DDCB27D66B3D5BF82E831 /* URLDataPromise.swift in Sources */,
-				EE2920251312E2F32C421CD05ACF4DA4 /* when.m in Sources */,
-				62F41914F8A9F9740EBBC8E412761EDB /* when.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		44321F32F148EB47FF23494889576DF5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -925,30 +889,6 @@
 				D358A828E68E152D06FC8E35533BF00B /* OMGHTTPURLRQ-dummy.m in Sources */,
 				48CB8E7E16443CA771E4DCFB3E0709A2 /* OMGHTTPURLRQ.m in Sources */,
 				6CB84A616D7B4D189A4E94BD37621575 /* OMGUserAgent.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		44D324C6406A51269508FD8F254CF846 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6F676A66D92467D28EA52325927C5BC5 /* AlamofireImplementations.swift in Sources */,
-				0B94E66F8539BBA52E693DAE322DCBAA /* APIHelper.swift in Sources */,
-				B68C4829A81227CAC51BC61F43D91445 /* APIs.swift in Sources */,
-				F2F841536DFF2E08BA87B09E1A62A15C /* Category.swift in Sources */,
-				B1931E222F0FF379FE4B14FC99171BF9 /* Extensions.swift in Sources */,
-				F0322283A43A3230AF9E1A363F5682AF /* InlineResponse200.swift in Sources */,
-				23B39958BB2757E02093BEEFD900A50D /* Models.swift in Sources */,
-				E3A8BAEE55DCBC8D16D9210A78D5A200 /* ObjectReturn.swift in Sources */,
-				07AA794848F8E6615B1DFD30673CE4EE /* Order.swift in Sources */,
-				422EB81C476A49349CBD929094E659BE /* Pet.swift in Sources */,
-				2B1CB7AD3BF6CCE951E9CA7080097081 /* PetAPI.swift in Sources */,
-				4FBA897D5492D0DD3CB07502E2596F6A /* PetstoreClient-dummy.m in Sources */,
-				C7F1A5669CE3AAA90BF2B5CCA70F90F6 /* SpecialModelName.swift in Sources */,
-				C8F3620654924A2D88756CDCC5CCFB11 /* StoreAPI.swift in Sources */,
-				AF3198275DBC570992BA895FB8FAF293 /* Tag.swift in Sources */,
-				BC5E262FDC0CD0C1803EB715E2C48F52 /* User.swift in Sources */,
-				293859B4A8F6053D41FC5A50FF268CFA /* UserAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -982,26 +922,100 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FB4836AFB2F7262D45CD0FC339EE67BF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C7A51B6FDE0C1194AD8461285566978 /* after.m in Sources */,
+				EC1F2BC4EB0D75B825B5CD07AB03785B /* after.swift in Sources */,
+				92927FAC8B986CA7D90E6B413322D8D2 /* afterlife.swift in Sources */,
+				E44FABF8A6A349BF6BBDBF5A85EAF2AD /* AnyPromise.m in Sources */,
+				18DAF8340B205F8D0A79B7B2A33328C0 /* AnyPromise.swift in Sources */,
+				B3A90D838B7484DA7EE40B666E397E80 /* CALayer+AnyPromise.m in Sources */,
+				E77FDF40A4F74F5B76C808F99DAFFAE3 /* dispatch_promise.m in Sources */,
+				51D192188A3C93B037151A81E8B84ED8 /* dispatch_promise.swift in Sources */,
+				2A604AC39C85680112EC65338A6A5CF6 /* Error.swift in Sources */,
+				34D72F02370DF0F99DF58728A2E64D27 /* hang.m in Sources */,
+				3BE4C9D6053FA221A8AA4EE551FE1EC5 /* join.m in Sources */,
+				C2558B49CEC04C35FA6A054C296B96D2 /* join.swift in Sources */,
+				53B67EC16CDB25629E86C25BBB0AB363 /* NSNotificationCenter+AnyPromise.m in Sources */,
+				316C4405052019758E146DB3FA95FAD1 /* NSNotificationCenter+Promise.swift in Sources */,
+				1365B07A306A080C0CE339C905202875 /* NSObject+Promise.swift in Sources */,
+				D39005E13E26282E9C7EDA64463866E8 /* NSURLConnection+AnyPromise.m in Sources */,
+				8786202BD1AF3C19468B8D51097F9FBD /* NSURLConnection+Promise.swift in Sources */,
+				01AF8B9D50B8538E720346ED302802B8 /* NSURLSession+Promise.swift in Sources */,
+				DA9B18EFE21EF506FF9DA744D45B06C0 /* PMKAlertController.swift in Sources */,
+				73E8BA15FE5EB6DBD421C81FB1B7E9B6 /* Promise+Properties.swift in Sources */,
+				CBE429FD5A24DBB57A1DBCD013940B35 /* Promise.swift in Sources */,
+				773B79EEB7C3D2B24E3E4BB0E7427BC5 /* PromiseKit-dummy.m in Sources */,
+				5FBBFC6C720339FB8A32A743009316F4 /* race.swift in Sources */,
+				831AD8EE90B0E7F8EA1D1F3A2BC08F98 /* State.swift in Sources */,
+				9E137F7B793F61E8DEABCB71BA66D5DE /* UIActionSheet+AnyPromise.m in Sources */,
+				DF4272006B5C1E44DDCFBB47EE2E7803 /* UIActionSheet+Promise.swift in Sources */,
+				36452068A6A705BE66FC426E7032FE84 /* UIAlertView+AnyPromise.m in Sources */,
+				D9E510357C0C787483EFE8D1474B3AE2 /* UIAlertView+Promise.swift in Sources */,
+				FA97B9777CCCBE575BA68891D5EC9F74 /* UIView+AnyPromise.m in Sources */,
+				1E8369F4E856C0D36BE6724B0979DFD7 /* UIView+Promise.swift in Sources */,
+				04305D1BEF17E3A670D90AF5A3F19D9F /* UIViewController+AnyPromise.m in Sources */,
+				159E4432157C043E55EC4BC078BD2B0E /* UIViewController+Promise.swift in Sources */,
+				0D761520A50B34A5601921D0EB2F7832 /* URLDataPromise.swift in Sources */,
+				AC423EEEF34342F639A628EF7AB3B542 /* when.m in Sources */,
+				847F2464DBD0EFCCC90D723A05304E86 /* when.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FBB88BC7ECAFC27A96F5747F401600D0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F3E994E1244780163ADAECFC1E57B9B9 /* AlamofireImplementations.swift in Sources */,
+				945A2D7116117EAECC7699761AF3577D /* APIHelper.swift in Sources */,
+				3197AFA938310557A94C7B2EE8B1B27B /* APIs.swift in Sources */,
+				B4DD64A13A5B316A81BC1A9FBBE6FA14 /* Category.swift in Sources */,
+				65CA6308EE66756E2E6F96C60B983868 /* Extensions.swift in Sources */,
+				93676264F29F30EAFE0E3ECA51938BD5 /* InlineResponse200.swift in Sources */,
+				304FB800967DC336C7C1B61AAC1557E4 /* ModelReturn.swift in Sources */,
+				3F7A0195CFB169B5FB86D5AC8AF94553 /* Models.swift in Sources */,
+				E2D96BD179C73392E8567D7E4DD85F1F /* Name.swift in Sources */,
+				DFC90C62AC88EAA37AB7B861CA306F3D /* ObjectReturn.swift in Sources */,
+				8590AC534037A664D8120B086B306916 /* Order.swift in Sources */,
+				C8FF7FA51F203929EFADBFA8D1BF33FD /* Pet.swift in Sources */,
+				12836D804685C0B30EB6A689963FE3D6 /* PetAPI.swift in Sources */,
+				A7BA92F8595C7A7A7CD1DA218981E22F /* PetstoreClient-dummy.m in Sources */,
+				2631F71E6E7452FA9960EEE1EFDB85A3 /* SpecialModelName.swift in Sources */,
+				E0A9003301396FBC6A606B1BF2831B19 /* StoreAPI.swift in Sources */,
+				8D1C373EAE7BEB9A4237AE570558B9C5 /* Tag.swift in Sources */,
+				4F339AA0FB595AEB829BFA4DA37E00F7 /* User.swift in Sources */,
+				81F12F28B1B768C021A5321105D1E807 /* UserAPI.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0791AE80538B89D74023D1648662A746 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Alamofire;
-			target = 432ECC54282C84882B482CCB4CF227FC /* Alamofire */;
-			targetProxy = 94CC4862E0BF723067DDE7ABACFC5AF0 /* PBXContainerItemProxy */;
-		};
 		2673248EF608AB8375FABCFDA8141072 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PetstoreClient;
-			target = 9A0F758601B5E1ACBCB2624392B58BD1 /* PetstoreClient */;
+			target = 979DB2F3AD7D9465C00964E430EFFA1F /* PetstoreClient */;
 			targetProxy = 014385BD85FA83B60A03ADE9E8844F33 /* PBXContainerItemProxy */;
+		};
+		2DD8156E827B0502CCF0D8C12B2F3F2F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = OMGHTTPURLRQ;
+			target = 190ACD3A51BC90B85EADB13E9CDD207B /* OMGHTTPURLRQ */;
+			targetProxy = C504ACE6EDC632581A19C2453DE9E6DF /* PBXContainerItemProxy */;
 		};
 		5433AD51A3DC696530C96B8A7D78ED7D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PromiseKit;
-			target = FB594EEBD21FB1EF5B7508805A6F5D02 /* PromiseKit */;
+			target = 4D88D9ED4DC4A6B8EF35E557375BD620 /* PromiseKit */;
 			targetProxy = B5FB8931CDF8801206EDD2FEF94793BF /* PBXContainerItemProxy */;
+		};
+		6196E2F6FB1435188D0239A1A3CC4599 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PromiseKit;
+			target = 4D88D9ED4DC4A6B8EF35E557375BD620 /* PromiseKit */;
+			targetProxy = FD89F55B413E450305523C416F6AC5EC /* PBXContainerItemProxy */;
 		};
 		64142DAEC5D96F7E876BBE00917C0E9D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1009,17 +1023,11 @@
 			target = 432ECC54282C84882B482CCB4CF227FC /* Alamofire */;
 			targetProxy = 769630CDAAA8C24AA5B4C81A85C45AC8 /* PBXContainerItemProxy */;
 		};
-		6D5049EB7DC059D4D2A0236320915EE8 /* PBXTargetDependency */ = {
+		92766EE7AEB0ABB3BFA67559A621AA90 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = PromiseKit;
-			target = FB594EEBD21FB1EF5B7508805A6F5D02 /* PromiseKit */;
-			targetProxy = 3C56ED43C177CB987DA7685FD87B4736 /* PBXContainerItemProxy */;
-		};
-		BBE09C7A178207CA23DF95EC1E858E78 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = OMGHTTPURLRQ;
-			target = 190ACD3A51BC90B85EADB13E9CDD207B /* OMGHTTPURLRQ */;
-			targetProxy = 085169F5A412617F5AA660FCA8662D05 /* PBXContainerItemProxy */;
+			name = Alamofire;
+			target = 432ECC54282C84882B482CCB4CF227FC /* Alamofire */;
+			targetProxy = 984DCCB3B51465C0D88D84E572BEA151 /* PBXContainerItemProxy */;
 		};
 		F74DEE1C89F05CC835997330B0E3B7C1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1030,9 +1038,9 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		03999803391289FE0834D6CBC3E2921D /* Release */ = {
+		02AEEDCF1C490925CFCC69B930546D42 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CC49FF2A84C0E0E9349747D94036B728 /* PromiseKit.xcconfig */;
+			baseConfigurationReference = DADAB10704E49D6B9E18F59F995BB88F /* PetstoreClient.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1041,21 +1049,22 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PromiseKit/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/PetstoreClient/PetstoreClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PetstoreClient/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = PromiseKit;
+				MODULEMAP_FILE = "Target Support Files/PetstoreClient/PetstoreClient.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = PetstoreClient;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		0D12EBEB35AC8FA740B275C8105F9152 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1143,33 +1152,6 @@
 			};
 			name = Debug;
 		};
-		331BDA95D137A77409EE2678EFFC5790 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DADAB10704E49D6B9E18F59F995BB88F /* PetstoreClient.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/PetstoreClient/PetstoreClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PetstoreClient/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/PetstoreClient/PetstoreClient.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = PetstoreClient;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		4D5CD4E08FD8D405881C59A5535E6CE8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 16D7C901D915C251DEBA27AC1EF57E34 /* OMGHTTPURLRQ.xcconfig */;
@@ -1196,6 +1178,34 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		54F03AD27535DF41A77F66B103232B76 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CC49FF2A84C0E0E9349747D94036B728 /* PromiseKit.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/PromiseKit/PromiseKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PromiseKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = PromiseKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		819D3D3D508154D9CFF3CE30C13E000E /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1263,35 +1273,7 @@
 			};
 			name = Debug;
 		};
-		A290B7D0BE49A98C009A6FC59BDF65F1 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DADAB10704E49D6B9E18F59F995BB88F /* PetstoreClient.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/PetstoreClient/PetstoreClient-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PetstoreClient/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/PetstoreClient/PetstoreClient.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = PetstoreClient;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		C47FA3DFC99B853D3A46E60927179D9A /* Debug */ = {
+		914B75C4139F38B8685E2BBCD6F8B0CB /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CC49FF2A84C0E0E9349747D94036B728 /* PromiseKit.xcconfig */;
 			buildSettings = {
@@ -1308,16 +1290,15 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/PromiseKit/PromiseKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = PromiseKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
 		C5A18280E9321A9268D1C80B7DA43967 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1383,14 +1364,41 @@
 			};
 			name = Release;
 		};
+		E2BE2B3C3285894DE7E720341DA2FF41 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DADAB10704E49D6B9E18F59F995BB88F /* PetstoreClient.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/PetstoreClient/PetstoreClient-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PetstoreClient/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/PetstoreClient/PetstoreClient.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = PetstoreClient;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		0481A4393EA0CC504EB6542154C8F7AE /* Build configuration list for PBXNativeTarget "PetstoreClient" */ = {
+		08663B0D9373BDC5C957FD20C9854C47 /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A290B7D0BE49A98C009A6FC59BDF65F1 /* Debug */,
-				331BDA95D137A77409EE2678EFFC5790 /* Release */,
+				54F03AD27535DF41A77F66B103232B76 /* Debug */,
+				914B75C4139F38B8685E2BBCD6F8B0CB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1400,6 +1408,15 @@
 			buildConfigurations = (
 				8D1534490D941DCA47C62AC4314182AF /* Debug */,
 				C5A18280E9321A9268D1C80B7DA43967 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5764D52D7BBF1EBF5FE0684F90F03BDA /* Build configuration list for PBXNativeTarget "PetstoreClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				02AEEDCF1C490925CFCC69B930546D42 /* Debug */,
+				E2BE2B3C3285894DE7E720341DA2FF41 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1427,15 +1444,6 @@
 			buildConfigurations = (
 				1361791756A3908370041AE99E5CF772 /* Debug */,
 				D3F110D6C2483BBC023DA8D6DFC525C3 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		F48703966D7224FCD529288B421CB38B /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C47FA3DFC99B853D3A46E60927179D9A /* Debug */,
-				03999803391289FE0834D6CBC3E2921D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Demonstrates issue #2362.
cd samples/client/petstore/swift/SwaggerClientTests/
mvn verify
[...]
Testing failed:
    '_type' used within its own type
*\* TEST FAILED **

The following build commands failed:
    CompileSwift normal x86_64 /Users/cristi/Developer/swagger-codegen/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models.swift
    CompileSwift normal x86_64 /Users/cristi/Developer/swagger-codegen/samples/client/petstore/swift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
    CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
(3 failures)
