### PR TITLE
[C#] fix base64encode issue in csharp

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -228,7 +228,7 @@ namespace {{packageName}}.Api
             // http basic authentication required
             if (!String.IsNullOrEmpty(Configuration.Username) || !String.IsNullOrEmpty(Configuration.Password))
             {
-                localVarHeaderParams["Authorization"] = "Basic " + Base64Encode(Configuration.Username + ":" + Configuration.Password);
+                localVarHeaderParams["Authorization"] = "Basic " + ApiClient.Base64Encode(Configuration.Username + ":" + Configuration.Password);
             }{{/isBasic}}{{#isOAuth}}
             // oauth required
             if (!String.IsNullOrEmpty(Configuration.AccessToken))
@@ -340,7 +340,7 @@ namespace {{packageName}}.Api
             // http basic authentication required
             if (!String.IsNullOrEmpty(Configuration.Username) || !String.IsNullOrEmpty(Configuration.Password))
             {
-                localVarHeaderParams["Authorization"] = "Basic " + Base64Encode(Configuration.Username + ":" + Configuration.Password);
+                localVarHeaderParams["Authorization"] = "Basic " + ApiClient.Base64Encode(Configuration.Username + ":" + Configuration.Password);
             }{{/isBasic}}{{#isOAuth}}
             // oauth required
             if (!String.IsNullOrEmpty(Configuration.AccessToken))

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore.json
@@ -1091,7 +1091,12 @@
           "400": {
             "description": "Invalid username supplied"
           }
-        }
+        },
+        "security": [
+          {
+            "test_http_basic": []
+          }
+        ]
       }
     }
   },
@@ -1129,6 +1134,9 @@
       "type": "apiKey",
       "name": "test_api_key_query",
       "in": "query"
+    },
+    "test_http_basic": {
+      "type": "basic"
     }
   },
   "definitions": {

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/UserApi.cs
@@ -1001,6 +1001,13 @@ namespace IO.Swagger.Api
             
             
 
+            // authentication (test_http_basic) required
+            
+            // http basic authentication required
+            if (!String.IsNullOrEmpty(Configuration.Username) || !String.IsNullOrEmpty(Configuration.Password))
+            {
+                localVarHeaderParams["Authorization"] = "Basic " + ApiClient.Base64Encode(Configuration.Username + ":" + Configuration.Password);
+            }
             
     
             // make the HTTP request
@@ -1079,6 +1086,14 @@ namespace IO.Swagger.Api
             
             
 
+            
+            // authentication (test_http_basic) required
+            
+            // http basic authentication required
+            if (!String.IsNullOrEmpty(Configuration.Username) || !String.IsNullOrEmpty(Configuration.Password))
+            {
+                localVarHeaderParams["Authorization"] = "Basic " + ApiClient.Base64Encode(Configuration.Username + ":" + Configuration.Password);
+            }
             
 
             // make the HTTP request


### PR DESCRIPTION
- fixed base64encode in C# API class
- added test case to cover http basic authentication moving forward

(to fix #2368)