### PR TITLE
[C#] add httpUserAgent option, add configurable user-agent support to C#

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -117,6 +117,9 @@ public class Generate implements Runnable {
 
     @Option(name = {"--release-version"}, title = "release version", description = CodegenConstants.RELEASE_VERSION_DESC)
     private String releaseVersion;
+    
+    @Option(name = {"--http-user-agent"}, title = "http user agent", description = CodegenConstants.HTTP_USER_AGENT)
+    private String httpUserAgent;
 
     @Override
     public void run() {
@@ -209,6 +212,10 @@ public class Generate implements Runnable {
 
         if (isNotEmpty(releaseVersion)) {
             configurator.setReleaseVersion(releaseVersion);
+        }
+        
+        if (isNotEmpty(httpUserAgent)) {
+            configurator.setHttpUserAgent(httpUserAgent);
         }
 
         applySystemPropertiesKvp(systemProperties, configurator);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -184,4 +184,8 @@ public interface CodegenConfig {
 
     String getReleaseVersion();
 
+    void setHttpUserAgent(String httpUserAgent);
+
+    String getHttpUserAgent();
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -103,4 +103,7 @@ public class CodegenConstants {
     public static final String RELEASE_VERSION = "releaseVersion";
     public static final String RELEASE_VERSION_DESC= "Release version, e.g. 1.2.5, default to 0.1.0.";
 
+    public static final String HTTP_USER_AGENT = "httpUserAgent";
+    public static final String HTTP_USER_AGENT_DESC = "HTTP user agent, e.g. codegen_csharp_api_client, default to 'Swagger-Codegen/{releaseVersion}}/{language}'";
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -84,6 +84,7 @@ public class DefaultCodegen {
     protected Boolean sortParamsByRequiredFlag = true;
     protected Boolean ensureUniqueParams = true;
     protected String gitUserId, gitRepoId, releaseNote, releaseVersion;
+    protected String httpUserAgent;
 
     public List<CliOption> cliOptions() {
         return cliOptions;
@@ -2429,6 +2430,24 @@ public class DefaultCodegen {
      */
     public String getReleaseVersion() {
         return releaseVersion;
+    }
+
+    /**
+     * Set HTTP user agent.
+     *
+     * @param httpUserAgent HTTP user agent
+     */
+    public void setHttpUserAgent(String httpUserAgent) {
+        this.httpUserAgent = httpUserAgent;
+    }
+
+    /**
+     * HTTP user agent 
+     *
+     * @return HTTP user agent
+     */
+    public String getHttpUserAgent() {
+        return httpUserAgent;
     }
 
     @SuppressWarnings("static-method")

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -64,6 +64,7 @@ public class CodegenConfigurator {
     private String gitRepoId="YOUR_GIT_REPO_ID";
     private String releaseNote="Minor update";
     private String releaseVersion="0.1.0";
+    private String httpUserAgent;
 
     private final Map<String, String> dynamicProperties = new HashMap<String, String>(); //the map that holds the JsonAnySetter/JsonAnyGetter values
 
@@ -334,6 +335,15 @@ public class CodegenConfigurator {
         this.releaseVersion = releaseVersion;
         return this;
     }
+    
+    public String getHttpUserAgent() {
+        return httpUserAgent;
+    }
+
+    public CodegenConfigurator setHttpUserAgent(String httpUserAgent) {
+        this.httpUserAgent= httpUserAgent;
+        return this;
+    }
 
     public ClientOptInput toClientOptInput() {
 
@@ -366,6 +376,7 @@ public class CodegenConfigurator {
         checkAndSetAdditionalProperty(gitRepoId, CodegenConstants.GIT_REPO_ID);
         checkAndSetAdditionalProperty(releaseVersion, CodegenConstants.RELEASE_VERSION);
         checkAndSetAdditionalProperty(releaseNote, CodegenConstants.RELEASE_NOTE);
+        checkAndSetAdditionalProperty(httpUserAgent, CodegenConstants.HTTP_USER_AGENT);
 
         handleDynamicProperties(config);
 

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -84,6 +84,9 @@ namespace {{packageName}}.Client
             String contentType)
         {
             var request = new RestRequest(path, method);
+
+            // add user agent header
+            request.AddHeader("User-Agent", Configuration.HttpUserAgent);
    
             // add path parameter, if any
             foreach(var param in pathParams)

--- a/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
@@ -34,7 +34,8 @@ namespace {{packageName}}.Client
                              Dictionary<String, String> apiKeyPrefix = null,
                              string tempFolderPath = null,
                              string dateTimeFormat = null,
-                             int timeout = 100000
+                             int timeout = 100000,
+                             string httpUserAgent = "{{#httpUserAgent}}{{.}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{packageVersion}}/csharp{{/httpUserAgent}}"
                             )
         {
             setApiClientUsingDefault(apiClient);
@@ -42,6 +43,7 @@ namespace {{packageName}}.Client
             Username = username;
             Password = password;
             AccessToken = accessToken;
+            HttpUserAgent = httpUserAgent;
 
             if (defaultHeader != null)
                 DefaultHeader = defaultHeader;
@@ -145,6 +147,12 @@ namespace {{packageName}}.Client
         {
             _defaultHeaderMap.Add(key, value);
         }
+
+        /// <summary>
+        /// Gets or sets the HTTP user agent.
+        /// </summary>
+        /// <value>Http user agent.</value>
+        public String HttpUserAgent { get; set; }
 
         /// <summary>
         /// Gets or sets the username (HTTP basic authentication).

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -82,6 +82,12 @@ namespace {{packageName}}.Api
         public {{classname}}(String basePath)
         {
             this.Configuration = new Configuration(new ApiClient(basePath));
+
+            // ensure API client has configuration ready
+            if (Configuration.ApiClient.Configuration == null)
+            {
+                this.Configuration.ApiClient.Configuration = this.Configuration;
+            }
         }
     
         /// <summary>
@@ -96,6 +102,12 @@ namespace {{packageName}}.Api
                 this.Configuration = Configuration.Default; 
             else
                 this.Configuration = configuration;
+
+            // ensure API client has configuration ready
+            if (Configuration.ApiClient.Configuration == null)
+            {
+                this.Configuration.ApiClient.Configuration = this.Configuration;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/PetApi.cs
@@ -541,6 +541,12 @@ namespace IO.Swagger.Api
         public PetApi(String basePath)
         {
             this.Configuration = new Configuration(new ApiClient(basePath));
+
+            // ensure API client has configuration ready
+            if (Configuration.ApiClient.Configuration == null)
+            {
+                this.Configuration.ApiClient.Configuration = this.Configuration;
+            }
         }
     
         /// <summary>
@@ -555,6 +561,12 @@ namespace IO.Swagger.Api
                 this.Configuration = Configuration.Default; 
             else
                 this.Configuration = configuration;
+
+            // ensure API client has configuration ready
+            if (Configuration.ApiClient.Configuration == null)
+            {
+                this.Configuration.ApiClient.Configuration = this.Configuration;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/StoreApi.cs
@@ -293,6 +293,12 @@ namespace IO.Swagger.Api
         public StoreApi(String basePath)
         {
             this.Configuration = new Configuration(new ApiClient(basePath));
+
+            // ensure API client has configuration ready
+            if (Configuration.ApiClient.Configuration == null)
+            {
+                this.Configuration.ApiClient.Configuration = this.Configuration;
+            }
         }
     
         /// <summary>
@@ -307,6 +313,12 @@ namespace IO.Swagger.Api
                 this.Configuration = Configuration.Default; 
             else
                 this.Configuration = configuration;
+
+            // ensure API client has configuration ready
+            if (Configuration.ApiClient.Configuration == null)
+            {
+                this.Configuration.ApiClient.Configuration = this.Configuration;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Api/UserApi.cs
@@ -393,6 +393,12 @@ namespace IO.Swagger.Api
         public UserApi(String basePath)
         {
             this.Configuration = new Configuration(new ApiClient(basePath));
+
+            // ensure API client has configuration ready
+            if (Configuration.ApiClient.Configuration == null)
+            {
+                this.Configuration.ApiClient.Configuration = this.Configuration;
+            }
         }
     
         /// <summary>
@@ -407,6 +413,12 @@ namespace IO.Swagger.Api
                 this.Configuration = Configuration.Default; 
             else
                 this.Configuration = configuration;
+
+            // ensure API client has configuration ready
+            if (Configuration.ApiClient.Configuration == null)
+            {
+                this.Configuration.ApiClient.Configuration = this.Configuration;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/ApiClient.cs
@@ -84,6 +84,9 @@ namespace IO.Swagger.Client
             String contentType)
         {
             var request = new RestRequest(path, method);
+
+            // add user agent header
+            request.AddHeader("User-Agent", Configuration.HttpUserAgent);
    
             // add path parameter, if any
             foreach(var param in pathParams)

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/Configuration.cs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/src/main/csharp/IO/Swagger/Client/Configuration.cs
@@ -34,7 +34,8 @@ namespace IO.Swagger.Client
                              Dictionary<String, String> apiKeyPrefix = null,
                              string tempFolderPath = null,
                              string dateTimeFormat = null,
-                             int timeout = 100000
+                             int timeout = 100000,
+                             string httpUserAgent = "Swagger-Codegen/1.0.0/csharp"
                             )
         {
             setApiClientUsingDefault(apiClient);
@@ -42,6 +43,7 @@ namespace IO.Swagger.Client
             Username = username;
             Password = password;
             AccessToken = accessToken;
+            HttpUserAgent = httpUserAgent;
 
             if (defaultHeader != null)
                 DefaultHeader = defaultHeader;
@@ -145,6 +147,12 @@ namespace IO.Swagger.Client
         {
             _defaultHeaderMap.Add(key, value);
         }
+
+        /// <summary>
+        /// Gets or sets the HTTP user agent.
+        /// </summary>
+        /// <value>Http user agent.</value>
+        public String HttpUserAgent { get; set; }
 
         /// <summary>
         /// Gets or sets the username (HTTP basic authentication).

--- a/samples/client/petstore/csharp/SwaggerClientTest/SwaggerClientTest.userprefs
+++ b/samples/client/petstore/csharp/SwaggerClientTest/SwaggerClientTest.userprefs
@@ -2,9 +2,16 @@
   <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
   <MonoDevelop.Ide.Workbench ActiveDocument="TestPet.cs">
     <Files>
-      <File FileName="TestPet.cs" Line="189" Column="4" />
+      <File FileName="TestPet.cs" Line="69" Column="32" />
       <File FileName="TestOrder.cs" Line="1" Column="1" />
     </Files>
+    <Pads>
+      <Pad Id="MonoDevelop.NUnit.TestPad">
+        <State name="__root__">
+          <Node name="SwaggerClientTest" expanded="True" />
+        </State>
+      </Pad>
+    </Pads>
   </MonoDevelop.Ide.Workbench>
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
     <BreakpointStore />


### PR DESCRIPTION
Tested on both Windows and Mac. All test cases passed.

We'll roll out the feature (configurable user-agent) to other language one by one.

The feature is broken at the moment due to RestSharp: https://github.com/restsharp/RestSharp/issues/787

(for https://github.com/swagger-api/swagger-codegen/issues/2367)