### PR TITLE
Handle empty date-time gracefully

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -245,7 +245,17 @@ class ObjectSerializer
             settype($data, 'array');
             $deserialized = $data;
         } elseif ($class === '\DateTime') {
-            $deserialized = new \DateTime($data);
+            // Some API's return an invalid, empty string as a
+            // date-time property. DateTime::__construct() will return
+            // the current time for empty input which is probably not
+            // what is meant. The invalid empty string is probably to
+            // be interpreted as a missing field/value. Let's handle
+            // this graceful.
+            if (!empty($data)) {
+                $deserialized = new \DateTime($data);
+            } else {
+                $deserialized = null;
+            }
         } elseif (in_array($class, array({{&primitives}}))) {
             settype($data, $class);
             $deserialized = $data;


### PR DESCRIPTION
Some API's return an invalid, empty string as a date-time property.

DateTime::__construct() will return the current time for empty input which is probably not what is meant.

The invalid empty string is probably to be interpreted as a missing field/value.

Let's handle this graceful.