### PR TITLE
Use PHP's DateTime::ATOM for true ISO-8601 support

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -57,7 +57,7 @@ class ObjectSerializer
         if (is_scalar($data) || null === $data) {
             $sanitized = $data;
         } elseif ($data instanceof \DateTime) {
-            $sanitized = $data->format(\DateTime::ISO8601);
+            $sanitized = $data->format(\DateTime::ATOM);
         } elseif (is_array($data)) {
             foreach ($data as $property => $value) {
                 $data[$property] = self::sanitizeForSerialization($value);
@@ -172,7 +172,7 @@ class ObjectSerializer
     public function toString($value)
     {
         if ($value instanceof \DateTime) { // datetime in ISO8601 format
-            return $value->format(\DateTime::ISO8601);
+            return $value->format(\DateTime::ATOM);
         } else {
             return $value;
         }

--- a/samples/client/petstore/php/SwaggerClient-php/README.md
+++ b/samples/client/petstore/php/SwaggerClient-php/README.md
@@ -89,10 +89,25 @@ Class | Method | HTTP request | Description
 ## Documentation For Authorization
 
 
-## test_api_key_header
+## petstore_auth
+
+- **Type**: OAuth
+- **Flow**: implicit
+- **Authorizatoin URL**: http://petstore.swagger.io/api/oauth/dialog
+- **Scopes**: 
+ - **write:pets**: modify pets in your account
+ - **read:pets**: read your pets
+
+## test_api_client_id
 
 - **Type**: API key 
-- **API key parameter name**: test_api_key_header
+- **API key parameter name**: x-test_api_client_id
+- **Location**: HTTP header
+
+## test_api_client_secret
+
+- **Type**: API key 
+- **API key parameter name**: x-test_api_client_secret
 - **Location**: HTTP header
 
 ## api_key
@@ -105,32 +120,17 @@ Class | Method | HTTP request | Description
 
 - **Type**: HTTP basic authentication
 
-## test_api_client_secret
-
-- **Type**: API key 
-- **API key parameter name**: x-test_api_client_secret
-- **Location**: HTTP header
-
-## test_api_client_id
-
-- **Type**: API key 
-- **API key parameter name**: x-test_api_client_id
-- **Location**: HTTP header
-
 ## test_api_key_query
 
 - **Type**: API key 
 - **API key parameter name**: test_api_key_query
 - **Location**: URL query string
 
-## petstore_auth
+## test_api_key_header
 
-- **Type**: OAuth
-- **Flow**: implicit
-- **Authorizatoin URL**: http://petstore.swagger.io/api/oauth/dialog
-- **Scopes**: 
- - **write:pets**: modify pets in your account
- - **read:pets**: read your pets
+- **Type**: API key 
+- **API key parameter name**: test_api_key_header
+- **Location**: HTTP header
 
 
 ## Author

--- a/samples/client/petstore/php/SwaggerClient-php/docs/InlineResponse200.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/InlineResponse200.md
@@ -3,12 +3,12 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**tags** | [**\Swagger\Client\Model\Tag[]**](Tag.md) |  | [optional] 
+**photo_urls** | **string[]** |  | [optional] 
+**name** | **string** |  | [optional] 
 **id** | **int** |  | 
 **category** | **object** |  | [optional] 
+**tags** | [**\Swagger\Client\Model\Tag[]**](Tag.md) |  | [optional] 
 **status** | **string** | pet status in the store | [optional] 
-**name** | **string** |  | [optional] 
-**photo_urls** | **string[]** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/php/SwaggerClient-php/docs/PetApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/PetApi.md
@@ -268,12 +268,12 @@ Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error cond
 <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
+// Configure OAuth2 access token for authorization: petstore_auth
+Swagger\Client::getDefaultConfiguration->setAccessToken('YOUR_ACCESS_TOKEN');
 // Configure API key authorization: api_key
 Swagger\Client::getDefaultConfiguration->setApiKey('api_key', 'YOUR_API_KEY');
 // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
 // Swagger\Client::getDefaultConfiguration->setApiKeyPrefix('api_key', 'BEARER');
-// Configure OAuth2 access token for authorization: petstore_auth
-Swagger\Client::getDefaultConfiguration->setAccessToken('YOUR_ACCESS_TOKEN');
 
 $api_instance = new Swagger\Client\PetApi();
 $pet_id = 789; // int | ID of pet that needs to be fetched
@@ -299,7 +299,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api_key](../README.md#api_key), [petstore_auth](../README.md#petstore_auth)
+[petstore_auth](../README.md#petstore_auth), [api_key](../README.md#api_key)
 
 ### HTTP reuqest headers
 
@@ -320,12 +320,12 @@ Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error cond
 <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
+// Configure OAuth2 access token for authorization: petstore_auth
+Swagger\Client::getDefaultConfiguration->setAccessToken('YOUR_ACCESS_TOKEN');
 // Configure API key authorization: api_key
 Swagger\Client::getDefaultConfiguration->setApiKey('api_key', 'YOUR_API_KEY');
 // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
 // Swagger\Client::getDefaultConfiguration->setApiKeyPrefix('api_key', 'BEARER');
-// Configure OAuth2 access token for authorization: petstore_auth
-Swagger\Client::getDefaultConfiguration->setAccessToken('YOUR_ACCESS_TOKEN');
 
 $api_instance = new Swagger\Client\PetApi();
 $pet_id = 789; // int | ID of pet that needs to be fetched
@@ -351,7 +351,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api_key](../README.md#api_key), [petstore_auth](../README.md#petstore_auth)
+[petstore_auth](../README.md#petstore_auth), [api_key](../README.md#api_key)
 
 ### HTTP reuqest headers
 
@@ -372,12 +372,12 @@ Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error cond
 <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
+// Configure OAuth2 access token for authorization: petstore_auth
+Swagger\Client::getDefaultConfiguration->setAccessToken('YOUR_ACCESS_TOKEN');
 // Configure API key authorization: api_key
 Swagger\Client::getDefaultConfiguration->setApiKey('api_key', 'YOUR_API_KEY');
 // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
 // Swagger\Client::getDefaultConfiguration->setApiKeyPrefix('api_key', 'BEARER');
-// Configure OAuth2 access token for authorization: petstore_auth
-Swagger\Client::getDefaultConfiguration->setAccessToken('YOUR_ACCESS_TOKEN');
 
 $api_instance = new Swagger\Client\PetApi();
 $pet_id = 789; // int | ID of pet that needs to be fetched
@@ -403,7 +403,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api_key](../README.md#api_key), [petstore_auth](../README.md#petstore_auth)
+[petstore_auth](../README.md#petstore_auth), [api_key](../README.md#api_key)
 
 ### HTTP reuqest headers
 

--- a/samples/client/petstore/php/SwaggerClient-php/docs/StoreApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/StoreApi.md
@@ -214,14 +214,14 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
-// Configure API key authorization: test_api_key_header
-Swagger\Client::getDefaultConfiguration->setApiKey('test_api_key_header', 'YOUR_API_KEY');
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-// Swagger\Client::getDefaultConfiguration->setApiKeyPrefix('test_api_key_header', 'BEARER');
 // Configure API key authorization: test_api_key_query
 Swagger\Client::getDefaultConfiguration->setApiKey('test_api_key_query', 'YOUR_API_KEY');
 // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
 // Swagger\Client::getDefaultConfiguration->setApiKeyPrefix('test_api_key_query', 'BEARER');
+// Configure API key authorization: test_api_key_header
+Swagger\Client::getDefaultConfiguration->setApiKey('test_api_key_header', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
+// Swagger\Client::getDefaultConfiguration->setApiKeyPrefix('test_api_key_header', 'BEARER');
 
 $api_instance = new Swagger\Client\StoreApi();
 $order_id = "order_id_example"; // string | ID of pet that needs to be fetched
@@ -247,7 +247,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[test_api_key_header](../README.md#test_api_key_header), [test_api_key_query](../README.md#test_api_key_query)
+[test_api_key_query](../README.md#test_api_key_query), [test_api_key_header](../README.md#test_api_key_header)
 
 ### HTTP reuqest headers
 

--- a/samples/client/petstore/php/SwaggerClient-php/git_push.sh
+++ b/samples/client/petstore/php/SwaggerClient-php/git_push.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# ref: https://help.github.com/articles/adding-an-existing-project-to-github-using-the-command-line/
+#
+# Usage example: /bin/sh ./git_push.sh wing328 swagger-petstore-perl "minor update"
+
+git_user_id=$1
+git_repo_id=$2
+release_note=$3
+
+if [ "$git_user_id" = "" ]; then
+    git_user_id="YOUR_GIT_USR_ID"
+    echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
+fi
+
+if [ "$git_repo_id" = "" ]; then
+    git_repo_id="YOUR_GIT_REPO_ID"
+    echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
+fi
+
+if [ "$release_note" = "" ]; then
+    release_note="Minor update"
+    echo "[INFO] No command line input provided. Set \$release_note to $release_note"
+fi
+
+# Initialize the local directory as a Git repository
+git init
+
+# Adds the files in the local repository and stages them for commit.
+git add .
+
+# Commits the tracked changes and prepares them to be pushed to a remote repository. 
+git commit -m "$release_note"
+
+# Sets the new remote
+git_remote=`git remote`
+if [ "$git_remote" = "" ]; then # git remote not defined
+
+    if [ "$GIT_TOKEN" = "" ]; then
+        echo "[INFO] \$GIT_TOKEN (environment variable) is not set. Using the git crediential in your environment."
+        git remote add origin https://github.com/${git_user_id}/${git_repo_id}.git
+    else
+        git remote add origin https://${git_user_id}:${GIT_TOKEN}@github.com/${git_user_id}/${git_repo_id}.git
+    fi
+
+fi
+
+git pull origin master
+
+# Pushes (Forces) the changes in the local repository up to the remote repository
+echo "Git pushing to https://github.com/${git_user_id}/${git_repo_id}.git"
+git push origin master 2>&1 | grep -v 'To https'
+

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -618,17 +618,17 @@ class PetApi
             $httpBody = $formParams; // for HTTP post (form)
         }
         
+        // this endpoint requires OAuth (access token)
+        if (strlen($this->apiClient->getConfig()->getAccessToken()) !== 0) {
+            $headerParams['Authorization'] = 'Bearer ' . $this->apiClient->getConfig()->getAccessToken();
+        }
+        
         // this endpoint requires API key authentication
         $apiKey = $this->apiClient->getApiKeyWithPrefix('api_key');
         if (strlen($apiKey) !== 0) {
             $headerParams['api_key'] = $apiKey;
         }
         
-        
-        // this endpoint requires OAuth (access token)
-        if (strlen($this->apiClient->getConfig()->getAccessToken()) !== 0) {
-            $headerParams['Authorization'] = 'Bearer ' . $this->apiClient->getConfig()->getAccessToken();
-        }
         
         // make the API Call
         try {
@@ -725,17 +725,17 @@ class PetApi
             $httpBody = $formParams; // for HTTP post (form)
         }
         
+        // this endpoint requires OAuth (access token)
+        if (strlen($this->apiClient->getConfig()->getAccessToken()) !== 0) {
+            $headerParams['Authorization'] = 'Bearer ' . $this->apiClient->getConfig()->getAccessToken();
+        }
+        
         // this endpoint requires API key authentication
         $apiKey = $this->apiClient->getApiKeyWithPrefix('api_key');
         if (strlen($apiKey) !== 0) {
             $headerParams['api_key'] = $apiKey;
         }
         
-        
-        // this endpoint requires OAuth (access token)
-        if (strlen($this->apiClient->getConfig()->getAccessToken()) !== 0) {
-            $headerParams['Authorization'] = 'Bearer ' . $this->apiClient->getConfig()->getAccessToken();
-        }
         
         // make the API Call
         try {
@@ -832,17 +832,17 @@ class PetApi
             $httpBody = $formParams; // for HTTP post (form)
         }
         
+        // this endpoint requires OAuth (access token)
+        if (strlen($this->apiClient->getConfig()->getAccessToken()) !== 0) {
+            $headerParams['Authorization'] = 'Bearer ' . $this->apiClient->getConfig()->getAccessToken();
+        }
+        
         // this endpoint requires API key authentication
         $apiKey = $this->apiClient->getApiKeyWithPrefix('api_key');
         if (strlen($apiKey) !== 0) {
             $headerParams['api_key'] = $apiKey;
         }
         
-        
-        // this endpoint requires OAuth (access token)
-        if (strlen($this->apiClient->getConfig()->getAccessToken()) !== 0) {
-            $headerParams['Authorization'] = 'Bearer ' . $this->apiClient->getConfig()->getAccessToken();
-        }
         
         // make the API Call
         try {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -525,16 +525,16 @@ class StoreApi
         }
         
         // this endpoint requires API key authentication
-        $apiKey = $this->apiClient->getApiKeyWithPrefix('test_api_key_header');
+        $apiKey = $this->apiClient->getApiKeyWithPrefix('test_api_key_query');
         if (strlen($apiKey) !== 0) {
-            $headerParams['test_api_key_header'] = $apiKey;
+            $queryParams['test_api_key_query'] = $apiKey;
         }
         
         
         // this endpoint requires API key authentication
-        $apiKey = $this->apiClient->getApiKeyWithPrefix('test_api_key_query');
+        $apiKey = $this->apiClient->getApiKeyWithPrefix('test_api_key_header');
         if (strlen($apiKey) !== 0) {
-            $queryParams['test_api_key_query'] = $apiKey;
+            $headerParams['test_api_key_header'] = $apiKey;
         }
         
         

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/InlineResponse200.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/InlineResponse200.php
@@ -51,12 +51,12 @@ class InlineResponse200 implements ArrayAccess
       * @var string[]
       */
     static $swaggerTypes = array(
-        'tags' => '\Swagger\Client\Model\Tag[]',
+        'photo_urls' => 'string[]',
+        'name' => 'string',
         'id' => 'int',
         'category' => 'object',
-        'status' => 'string',
-        'name' => 'string',
-        'photo_urls' => 'string[]'
+        'tags' => '\Swagger\Client\Model\Tag[]',
+        'status' => 'string'
     );
   
     /** 
@@ -64,12 +64,12 @@ class InlineResponse200 implements ArrayAccess
       * @var string[] 
       */
     static $attributeMap = array(
-        'tags' => 'tags',
+        'photo_urls' => 'photoUrls',
+        'name' => 'name',
         'id' => 'id',
         'category' => 'category',
-        'status' => 'status',
-        'name' => 'name',
-        'photo_urls' => 'photoUrls'
+        'tags' => 'tags',
+        'status' => 'status'
     );
   
     /**
@@ -77,12 +77,12 @@ class InlineResponse200 implements ArrayAccess
       * @var string[]
       */
     static $setters = array(
-        'tags' => 'setTags',
+        'photo_urls' => 'setPhotoUrls',
+        'name' => 'setName',
         'id' => 'setId',
         'category' => 'setCategory',
-        'status' => 'setStatus',
-        'name' => 'setName',
-        'photo_urls' => 'setPhotoUrls'
+        'tags' => 'setTags',
+        'status' => 'setStatus'
     );
   
     /**
@@ -90,20 +90,26 @@ class InlineResponse200 implements ArrayAccess
       * @var string[]
       */
     static $getters = array(
-        'tags' => 'getTags',
+        'photo_urls' => 'getPhotoUrls',
+        'name' => 'getName',
         'id' => 'getId',
         'category' => 'getCategory',
-        'status' => 'getStatus',
-        'name' => 'getName',
-        'photo_urls' => 'getPhotoUrls'
+        'tags' => 'getTags',
+        'status' => 'getStatus'
     );
   
     
     /**
-      * $tags 
-      * @var \Swagger\Client\Model\Tag[]
+      * $photo_urls 
+      * @var string[]
       */
-    protected $tags;
+    protected $photo_urls;
+    
+    /**
+      * $name 
+      * @var string
+      */
+    protected $name;
     
     /**
       * $id 
@@ -118,22 +124,16 @@ class InlineResponse200 implements ArrayAccess
     protected $category;
     
     /**
+      * $tags 
+      * @var \Swagger\Client\Model\Tag[]
+      */
+    protected $tags;
+    
+    /**
       * $status pet status in the store
       * @var string
       */
     protected $status;
-    
-    /**
-      * $name 
-      * @var string
-      */
-    protected $name;
-    
-    /**
-      * $photo_urls 
-      * @var string[]
-      */
-    protected $photo_urls;
     
 
     /**
@@ -143,33 +143,54 @@ class InlineResponse200 implements ArrayAccess
     public function __construct(array $data = null)
     {
         if ($data != null) {
-            $this->tags = $data["tags"];
+            $this->photo_urls = $data["photo_urls"];
+            $this->name = $data["name"];
             $this->id = $data["id"];
             $this->category = $data["category"];
+            $this->tags = $data["tags"];
             $this->status = $data["status"];
-            $this->name = $data["name"];
-            $this->photo_urls = $data["photo_urls"];
         }
     }
     
     /**
-     * Gets tags
-     * @return \Swagger\Client\Model\Tag[]
+     * Gets photo_urls
+     * @return string[]
      */
-    public function getTags()
+    public function getPhotoUrls()
     {
-        return $this->tags;
+        return $this->photo_urls;
     }
   
     /**
-     * Sets tags
-     * @param \Swagger\Client\Model\Tag[] $tags 
+     * Sets photo_urls
+     * @param string[] $photo_urls 
      * @return $this
      */
-    public function setTags($tags)
+    public function setPhotoUrls($photo_urls)
     {
         
-        $this->tags = $tags;
+        $this->photo_urls = $photo_urls;
+        return $this;
+    }
+    
+    /**
+     * Gets name
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+  
+    /**
+     * Sets name
+     * @param string $name 
+     * @return $this
+     */
+    public function setName($name)
+    {
+        
+        $this->name = $name;
         return $this;
     }
     
@@ -216,6 +237,27 @@ class InlineResponse200 implements ArrayAccess
     }
     
     /**
+     * Gets tags
+     * @return \Swagger\Client\Model\Tag[]
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+  
+    /**
+     * Sets tags
+     * @param \Swagger\Client\Model\Tag[] $tags 
+     * @return $this
+     */
+    public function setTags($tags)
+    {
+        
+        $this->tags = $tags;
+        return $this;
+    }
+    
+    /**
      * Gets status
      * @return string
      */
@@ -236,48 +278,6 @@ class InlineResponse200 implements ArrayAccess
             throw new \InvalidArgumentException("Invalid value for 'status', must be one of 'available', 'pending', 'sold'");
         }
         $this->status = $status;
-        return $this;
-    }
-    
-    /**
-     * Gets name
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-  
-    /**
-     * Sets name
-     * @param string $name 
-     * @return $this
-     */
-    public function setName($name)
-    {
-        
-        $this->name = $name;
-        return $this;
-    }
-    
-    /**
-     * Gets photo_urls
-     * @return string[]
-     */
-    public function getPhotoUrls()
-    {
-        return $this->photo_urls;
-    }
-  
-    /**
-     * Sets photo_urls
-     * @param string[] $photo_urls 
-     * @return $this
-     */
-    public function setPhotoUrls($photo_urls)
-    {
-        
-        $this->photo_urls = $photo_urls;
         return $this;
     }
     

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -57,7 +57,7 @@ class ObjectSerializer
         if (is_scalar($data) || null === $data) {
             $sanitized = $data;
         } elseif ($data instanceof \DateTime) {
-            $sanitized = $data->format(\DateTime::ISO8601);
+            $sanitized = $data->format(\DateTime::ATOM);
         } elseif (is_array($data)) {
             foreach ($data as $property => $value) {
                 $data[$property] = self::sanitizeForSerialization($value);
@@ -172,7 +172,7 @@ class ObjectSerializer
     public function toString($value)
     {
         if ($value instanceof \DateTime) { // datetime in ISO8601 format
-            return $value->format(\DateTime::ISO8601);
+            return $value->format(\DateTime::ATOM);
         } else {
             return $value;
         }
@@ -256,7 +256,7 @@ class ObjectSerializer
             } else {
                 $deserialized = null;
             }
-        } elseif (in_array($class, array('integer', 'int', 'void', 'number', 'object', 'double', 'float', 'byte', 'DateTime', 'string', 'mixed', 'boolean', 'bool'))) {
+        } elseif (in_array($class, array('void', 'bool', 'string', 'double', 'byte', 'mixed', 'integer', 'float', 'int', 'DateTime', 'number', 'boolean', 'object'))) {
             settype($data, $class);
             $deserialized = $data;
         } elseif ($class === '\SplFileObject') {


### PR DESCRIPTION
Currently we use PHP's `DateTime::ISO8601` for the date-time properties but according to http://php.net/manual/en/class.datetime.php#datetime.constants.iso8601 it is actually not compatible with ISO-8601.

Instead we should use `DateTime::ATOM`.