### PR TITLE
SwiftCodegen : change typeMapping for 'long' (Int64 instead of Int).

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -74,6 +74,7 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
         languageSpecificPrimitives = new HashSet<String>(
                 Arrays.asList(
                     "Int",
+                    "Int64",
                     "Float",
                     "Double",
                     "Bool",
@@ -116,7 +117,7 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("char", "Character");
         typeMapping.put("short", "Int");
         typeMapping.put("int", "Int");
-        typeMapping.put("long", "Int");
+        typeMapping.put("long", "Int64");
         typeMapping.put("integer", "Int");
         typeMapping.put("Integer", "Int");
         typeMapping.put("float", "Float");


### PR DESCRIPTION
`long` should be mapped to Int64 instead of Int, because `long` will have a range of signed 64 bits.

Following the recommendation of the [Swift Doc](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/TheBasics.html), fixing only the mapping for `long` is necessary and sufficient.

```
Int

In most cases, you don’t need to pick a specific size of integer to use in your code. Swift provides an additional integer type, Int, which has the same size as the current platform’s native word size:

On a 32-bit platform, Int is the same size as Int32.
On a 64-bit platform, Int is the same size as Int64.
Unless you need to work with a specific size of integer, always use Int for integer values in your code. This aids code consistency and interoperability. Even on 32-bit platforms, Int can store any value between -2,147,483,648 and 2,147,483,647, and is large enough for many integer ranges.
```