### PR TITLE
Issue 2410: Suport HTTP body for DELETE operation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -371,7 +371,8 @@ class ApiClient(object):
         elif method == "DELETE":
             return self.rest_client.DELETE(url,
                                            query_params=query_params,
-                                           headers=headers)
+                                           headers=headers,
+                                           body=body)
         else:
             raise ValueError(
                 "http method must be `GET`, `HEAD`,"

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -133,8 +133,8 @@ class RESTClientObject(object):
             headers['Content-Type'] = 'application/json'
 
         try:
-            # For `POST`, `PUT`, `PATCH`, `OPTIONS`
-            if method in ['POST', 'PUT', 'PATCH', 'OPTIONS']:
+            # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
+            if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
                 if query_params:
                     url += '?' + urlencode(query_params)
                 if headers['Content-Type'] == 'application/json':
@@ -154,7 +154,7 @@ class RESTClientObject(object):
                                                   fields=post_params,
                                                   encode_multipart=True,
                                                   headers=headers)
-            # For `GET`, `HEAD`, `DELETE`
+            # For `GET`, `HEAD`
             else:
                 r = self.pool_manager.request(method, url,
                                               fields=query_params,
@@ -195,10 +195,11 @@ class RESTClientObject(object):
                             post_params=post_params,
                             body=body)
 
-    def DELETE(self, url, headers=None, query_params=None):
+    def DELETE(self, url, headers=None, query_params=None, body=None):
         return self.request("DELETE", url,
                             headers=headers,
-                            query_params=query_params)
+                            query_params=query_params,
+                            body=body)
 
     def POST(self, url, headers=None, query_params=None, post_params=None, body=None):
         return self.request("POST", url,

--- a/samples/client/petstore/python/swagger_client/api_client.py
+++ b/samples/client/petstore/python/swagger_client/api_client.py
@@ -371,7 +371,8 @@ class ApiClient(object):
         elif method == "DELETE":
             return self.rest_client.DELETE(url,
                                            query_params=query_params,
-                                           headers=headers)
+                                           headers=headers,
+                                           body=body)
         else:
             raise ValueError(
                 "http method must be `GET`, `HEAD`,"

--- a/samples/client/petstore/python/swagger_client/rest.py
+++ b/samples/client/petstore/python/swagger_client/rest.py
@@ -133,7 +133,6 @@ class RESTClientObject(object):
             headers['Content-Type'] = 'application/json'
 
         try:
-            print(method)
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
                 if query_params:

--- a/samples/client/petstore/python/swagger_client/rest.py
+++ b/samples/client/petstore/python/swagger_client/rest.py
@@ -133,8 +133,9 @@ class RESTClientObject(object):
             headers['Content-Type'] = 'application/json'
 
         try:
-            # For `POST`, `PUT`, `PATCH`, `OPTIONS`
-            if method in ['POST', 'PUT', 'PATCH', 'OPTIONS']:
+            print(method)
+            # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
+            if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
                 if query_params:
                     url += '?' + urlencode(query_params)
                 if headers['Content-Type'] == 'application/json':
@@ -154,7 +155,7 @@ class RESTClientObject(object):
                                                   fields=post_params,
                                                   encode_multipart=True,
                                                   headers=headers)
-            # For `GET`, `HEAD`, `DELETE`
+            # For `GET`, `HEAD`
             else:
                 r = self.pool_manager.request(method, url,
                                               fields=query_params,
@@ -195,10 +196,11 @@ class RESTClientObject(object):
                             post_params=post_params,
                             body=body)
 
-    def DELETE(self, url, headers=None, query_params=None):
+    def DELETE(self, url, headers=None, query_params=None, body=None):
         return self.request("DELETE", url,
                             headers=headers,
-                            query_params=query_params)
+                            query_params=query_params,
+                            body=body)
 
     def POST(self, url, headers=None, query_params=None, post_params=None, body=None):
         return self.request("POST", url,


### PR DESCRIPTION
Allow HTTP body to be used in DELETE operation for Python client. A fix for Issue #2410.