### PR TITLE
Missing multipart (form data) imports.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api.mustache
@@ -6,6 +6,8 @@ package {{package}};
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
+import org.apache.cxf.jaxrs.ext.multipart.*;
+
 @Path("/")
 public interface {{classname}}  {
 {{#operations}}


### PR DESCRIPTION
Swagger files that declare "in: formData" parameters will result in API class that cannot be compiled due to the usage of "@Multipart" annotations in method signatures.