### PR TITLE
Updates to objc api to address issue #2422

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -53,6 +53,10 @@ static void (^reachabilityChangeBlock)(int);
     cacheEnabled = enabled;
 }
 
++(void) setReachabilityStatus:(AFNetworkReachabilityStatus)status {
+    reachabilityStatus = status;
+}
+
 - (void)setHeaderValue:(NSString*) value
                 forKey:(NSString*) forKey {
     [self.requestSerializer setValue:value forHTTPHeaderField:forKey];
@@ -236,6 +240,10 @@ static void (^reachabilityChangeBlock)(int);
 
 +(AFNetworkReachabilityStatus) getReachabilityStatus {
     return reachabilityStatus;
+}
+
++(bool) getOfflineState {
+    return offlineState;
 }
 
 +(void) setReachabilityChangeBlock:(void(^)(int))changeBlock {

--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
@@ -65,6 +65,20 @@ extern NSString *const {{classPrefix}}ResponseObjectErrorKey;
 +(void) setOfflineState:(BOOL) state;
 
 /**
+ * Gets if the client is unreachable
+ *
+ * @return The client offline state
+ */
++(bool) getOfflineState;
+
+/**
+ * Sets the client reachability, this may be override by the reachability manager if reachability changes
+ *
+ * @param The client reachability.
+ */
++(void) setReachabilityStatus:(AFNetworkReachabilityStatus) status;
+
+/**
  * Gets the client reachability
  *
  * @return The client reachability.

--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
@@ -72,7 +72,7 @@ extern NSString *const {{classPrefix}}ResponseObjectErrorKey;
 +(bool) getOfflineState;
 
 /**
- * Sets the client reachability, this may be override by the reachability manager if reachability changes
+ * Sets the client reachability, this may be overridden by the reachability manager if reachability changes
  *
  * @param The client reachability.
  */

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.h
@@ -74,6 +74,20 @@ extern NSString *const SWGResponseObjectErrorKey;
 +(void) setOfflineState:(BOOL) state;
 
 /**
+ * Gets if the client is unreachable
+ *
+ * @return The client offline state
+ */
++(bool) getOfflineState;
+
+/**
+ * Sets the client reachability, this may be override by the reachability manager if reachability changes
+ *
+ * @param The client reachability.
+ */
++(void) setReachabilityStatus:(AFNetworkReachabilityStatus) status;
+
+/**
  * Gets the client reachability
  *
  * @return The client reachability.

--- a/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGApiClient.m
@@ -53,6 +53,10 @@ static void (^reachabilityChangeBlock)(int);
     cacheEnabled = enabled;
 }
 
++(void) setReachabilityStatus:(AFNetworkReachabilityStatus)status {
+    reachabilityStatus = status;
+}
+
 - (void)setHeaderValue:(NSString*) value
                 forKey:(NSString*) forKey {
     [self.requestSerializer setValue:value forHTTPHeaderField:forKey];
@@ -236,6 +240,10 @@ static void (^reachabilityChangeBlock)(int);
 
 +(AFNetworkReachabilityStatus) getReachabilityStatus {
     return reachabilityStatus;
+}
+
++(bool) getOfflineState {
+    return offlineState;
 }
 
 +(void) setReachabilityChangeBlock:(void(^)(int))changeBlock {

--- a/samples/client/petstore/objc/SwaggerClient/SWGName.h
+++ b/samples/client/petstore/objc/SwaggerClient/SWGName.h
@@ -17,4 +17,6 @@
 
 @property(nonatomic) NSNumber* name;
 
+@property(nonatomic) NSNumber* snakeCase;
+
 @end

--- a/samples/client/petstore/objc/SwaggerClient/SWGName.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGName.m
@@ -20,7 +20,7 @@
  */
 + (JSONKeyMapper *)keyMapper
 {
-  return [[JSONKeyMapper alloc] initWithDictionary:@{ @"name": @"name" }];
+  return [[JSONKeyMapper alloc] initWithDictionary:@{ @"name": @"name", @"snake_case": @"snakeCase" }];
 }
 
 /**
@@ -30,7 +30,7 @@
  */
 + (BOOL)propertyIsOptional:(NSString *)propertyName
 {
-  NSArray *optionalProperties = @[@"name"];
+  NSArray *optionalProperties = @[@"name", @"snakeCase"];
 
   if ([optionalProperties containsObject:propertyName]) {
     return YES;


### PR DESCRIPTION
Added getter for offline state this lets the app check if and ApiClient is going to attempt the network request or just force cache.

Added setter for AFNetworkReachabilityStatus, this is useful for two reason first to set the default before it has been set by the reachability manager. 

Also as the ApiClient uses a shared instance of the reachability manager it is possible for another class to setReachabilityStatusChangeBlock stopping the ApiClient getting reachability change callbacks internally. By adding a setter it would be possible to pass the changes along.


Note: on changes to SWGName, these changes must be because the last person to edit the swagger spec did not regenerate the objc code.