### PR TITLE
[PHP] Map number without format to float

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -96,6 +96,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping = new HashMap<String, String>();
         typeMapping.put("integer", "int");
         typeMapping.put("long", "int");
+        typeMapping.put("number", "float");
         typeMapping.put("float", "float");
         typeMapping.put("double", "double");
         typeMapping.put("string", "string");


### PR DESCRIPTION
Previously if you specified a property to be of type `number` and didn't
explicitly specify a format Codegen would map it into an (unknown) PHP
class `Number`.

We add a mapping from Swaggers `number` to PHPs `float`.