### PR TITLE
[Swift] make sure to only escape an enum if the actual final variable name is…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -332,9 +332,9 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
             // the variable name doesn't match the generated enum type or the
             // Swift compiler will generate an error
             if (isReservedWord(codegenProperty.datatypeWithEnum) ||
-                    name.equals(codegenProperty.datatypeWithEnum)) {
+		toVarName(name).equals(codegenProperty.datatypeWithEnum)) {
                 codegenProperty.datatypeWithEnum = escapeReservedWord(codegenProperty.datatypeWithEnum);
-                    }
+            }
         }
         return codegenProperty;
     }


### PR DESCRIPTION
… going to match the enum name - now that we camelCase variable names this cuts down on the amount of enum escaping we have.