### PR TITLE
Fix typo in wget arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Swagger Codegen Version    | Release Date | OpenAPI Spec compatibility | Notes
 If you're looking for the latest stable version, you can grab it directly from maven central (you'll need java 7 runtime at a minimum):
 
 ```
-wget http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.1.5/swagger-codegen-cli-2.1.6.jar -O swagger-codegen-cli.jar
+wget http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.1.6/swagger-codegen-cli-2.1.6.jar -O swagger-codegen-cli.jar
 
 java -jar swagger-codegen-cli.jar help
 ```


### PR DESCRIPTION
The first URL (from the doc) does not work (at least for me) whereas the second does .

- **Previously** wget http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.1.**5**/...
- **Now** wget http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.1.**6**/...
