### PR TITLE
fix sync call for uwp

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -165,7 +165,7 @@ namespace {{packageName}}.Client
             {{#supportsUWP}}
             // Using async method to perform sync call (uwp-only)
             var response = RestClient.ExecuteTaskAsync(request).Result;
-			{{/supportsUWP}}
+            {{/supportsUWP}}
             return (Object) response;
         }
         {{#supportsAsync}}

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -163,11 +163,9 @@ namespace {{packageName}}.Client
             var response = RestClient.Execute(request);
             {{/supportsUWP}}
             {{#supportsUWP}}
-            // TODO: This is obviously not a valid response, but it prevents compiling-errors
-            // 'RestClient.CallApiAsync(..)' is used instead, because 'RestClient.ExecuteAsync(...)' 
-            // is available for Windows UWP, while 'RestClient.CallApi(...)' is not
-            var response = new object(); 
-            {{/supportsUWP}}
+            // Using async method to perform sync call (uwp-only)
+            var response = RestClient.ExecuteTaskAsync(request).Result;
+			{{/supportsUWP}}
             return (Object) response;
         }
         {{#supportsAsync}}


### PR DESCRIPTION
Workaround for unavailable sync HTTP-request in RestSharp, waiting for async HTTP-request now.
(this issue is/was UWP-only)