### PR TITLE
Fix handling optional fields in asyncscala client model

### DIFF
--- a/modules/swagger-codegen/src/main/resources/asyncscala/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/asyncscala/model.mustache
@@ -7,7 +7,7 @@ import java.util.UUID
 
 {{#model}}
 case class {{classname}} (
-  {{#vars}}{{name}}: {{#isNotRequired}}Option[{{/isNotRequired}}{{datatype}}{{#isNotRequired}}]{{/isNotRequired}}{{#hasMore}},{{/hasMore}}{{#description}}  // {{description}}{{/description}}
+  {{#vars}}{{name}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}]{{/required}}{{#hasMore}},{{/hasMore}}{{#description}}  // {{description}}{{/description}}
   {{/vars}}
 )
 {{/model}}


### PR DESCRIPTION
Small fix to generate Option fields correctly in the model of the scalaasync client. 

When displaying the mustache scope with the option -DdebugModels I was not able to 
find the variable "isNotRequired" so I replaced it with the negated version of "required". Now
the model.mustache generates Option fields correctly. 
