### PR TITLE
[Typescript-Node] Verify required parameter is not undefined instead of falsey.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -192,7 +192,7 @@ export class {{classname}} {
 {{#allParams}}{{#required}}
         // verify required parameter '{{paramName}}' is not null or undefined
         if ({{paramName}} == null) {
-            throw new Error('Missing required parameter {{paramName}} when calling {{nickname}}');
+            throw new Error('Required parameter {{paramName}} was null or undefined when calling {{nickname}}.');
         }
 {{/required}}{{/allParams}}
 {{#queryParams}}

--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -190,8 +190,8 @@ export class {{classname}} {
         let formParams: any = {};
 
 {{#allParams}}{{#required}}
-        // verify required parameter '{{paramName}}' is set
-        if ({{paramName}} === undefined) {
+        // verify required parameter '{{paramName}}' is not null or undefined
+        if ({{paramName}} == null) {
             throw new Error('Missing required parameter {{paramName}} when calling {{nickname}}');
         }
 {{/required}}{{/allParams}}

--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -191,7 +191,7 @@ export class {{classname}} {
 
 {{#allParams}}{{#required}}
         // verify required parameter '{{paramName}}' is set
-        if (!{{paramName}}) {
+        if ({{paramName}} === undefined) {
             throw new Error('Missing required parameter {{paramName}} when calling {{nickname}}');
         }
 {{/required}}{{/allParams}}

--- a/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-node/api.mustache
@@ -191,7 +191,7 @@ export class {{classname}} {
 
 {{#allParams}}{{#required}}
         // verify required parameter '{{paramName}}' is not null or undefined
-        if ({{paramName}} == null) {
+        if ({{paramName}} === null || {{paramName}} === undefined) {
             throw new Error('Required parameter {{paramName}} was null or undefined when calling {{nickname}}.');
         }
 {{/required}}{{/allParams}}

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -355,7 +355,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is not null or undefined
-        if (petId == null) {
+        if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
 
@@ -521,7 +521,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is not null or undefined
-        if (petId == null) {
+        if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
@@ -579,7 +579,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is not null or undefined
-        if (petId == null) {
+        if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling getPetByIdInObject.');
         }
 
@@ -637,7 +637,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is not null or undefined
-        if (petId == null) {
+        if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling petPetIdtestingByteArraytrueGet.');
         }
 
@@ -748,7 +748,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is not null or undefined
-        if (petId == null) {
+        if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
 
@@ -814,7 +814,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is not null or undefined
-        if (petId == null) {
+        if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
 
@@ -942,7 +942,7 @@ export class StoreApi {
 
 
         // verify required parameter 'orderId' is not null or undefined
-        if (orderId == null) {
+        if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
@@ -1150,7 +1150,7 @@ export class StoreApi {
 
 
         // verify required parameter 'orderId' is not null or undefined
-        if (orderId == null) {
+        if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
@@ -1471,7 +1471,7 @@ export class UserApi {
 
 
         // verify required parameter 'username' is not null or undefined
-        if (username == null) {
+        if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
@@ -1527,7 +1527,7 @@ export class UserApi {
 
 
         // verify required parameter 'username' is not null or undefined
-        if (username == null) {
+        if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
@@ -1686,7 +1686,7 @@ export class UserApi {
 
 
         // verify required parameter 'username' is not null or undefined
-        if (username == null) {
+        if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling updateUser.');
         }
 

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -25,6 +25,20 @@ export class Dog extends Animal {
     "breed": string;
 }
 
+export class FormatTest {
+    "integer": number;
+    "int32": number;
+    "int64": number;
+    "number": number;
+    "float": number;
+    "double": number;
+    "string": string;
+    "byte": ByteArray;
+    "binary": string;
+    "date": Date;
+    "dateTime": string;
+}
+
 export class InlineResponse200 {
     "photoUrls": Array<string>;
     "name": string;
@@ -295,7 +309,7 @@ export class PetApi {
      * @param body Pet object in the form of byte array
      */
     public addPetUsingByteArray (body?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
-        const localVarPath = this.basePath + '/pet?testing_byte_array=true';
+        const localVarPath = this.basePath + '/pet?testing_byte_array&#x3D;true';
         let queryParameters: any = {};
         let headerParams: any = this.extendObj({}, this.defaultHeaders);
         let formParams: any = {};
@@ -355,7 +369,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is set
-        if (!petId) {
+        if (petId === undefined) {
             throw new Error('Missing required parameter petId when calling deletePet');
         }
 
@@ -521,7 +535,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is set
-        if (!petId) {
+        if (petId === undefined) {
             throw new Error('Missing required parameter petId when calling getPetById');
         }
 
@@ -571,7 +585,7 @@ export class PetApi {
      * @param petId ID of pet that needs to be fetched
      */
     public getPetByIdInObject (petId: number) : Promise<{ response: http.ClientResponse; body: InlineResponse200;  }> {
-        const localVarPath = this.basePath + '/pet/{petId}?response=inline_arbitrary_object'
+        const localVarPath = this.basePath + '/pet/{petId}?response&#x3D;inline_arbitrary_object'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
         let headerParams: any = this.extendObj({}, this.defaultHeaders);
@@ -579,7 +593,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is set
-        if (!petId) {
+        if (petId === undefined) {
             throw new Error('Missing required parameter petId when calling getPetByIdInObject');
         }
 
@@ -629,7 +643,7 @@ export class PetApi {
      * @param petId ID of pet that needs to be fetched
      */
     public petPetIdtestingByteArraytrueGet (petId: number) : Promise<{ response: http.ClientResponse; body: string;  }> {
-        const localVarPath = this.basePath + '/pet/{petId}?testing_byte_array=true'
+        const localVarPath = this.basePath + '/pet/{petId}?testing_byte_array&#x3D;true'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
         let headerParams: any = this.extendObj({}, this.defaultHeaders);
@@ -637,7 +651,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is set
-        if (!petId) {
+        if (petId === undefined) {
             throw new Error('Missing required parameter petId when calling petPetIdtestingByteArraytrueGet');
         }
 
@@ -748,7 +762,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is set
-        if (!petId) {
+        if (petId === undefined) {
             throw new Error('Missing required parameter petId when calling updatePetWithForm');
         }
 
@@ -814,7 +828,7 @@ export class PetApi {
 
 
         // verify required parameter 'petId' is set
-        if (!petId) {
+        if (petId === undefined) {
             throw new Error('Missing required parameter petId when calling uploadFile');
         }
 
@@ -942,7 +956,7 @@ export class StoreApi {
 
 
         // verify required parameter 'orderId' is set
-        if (!orderId) {
+        if (orderId === undefined) {
             throw new Error('Missing required parameter orderId when calling deleteOrder');
         }
 
@@ -1092,7 +1106,7 @@ export class StoreApi {
      * Returns an arbitrary object which is actually a map of status codes to quantities
      */
     public getInventoryInObject () : Promise<{ response: http.ClientResponse; body: any;  }> {
-        const localVarPath = this.basePath + '/store/inventory?response=arbitrary_object';
+        const localVarPath = this.basePath + '/store/inventory?response&#x3D;arbitrary_object';
         let queryParameters: any = {};
         let headerParams: any = this.extendObj({}, this.defaultHeaders);
         let formParams: any = {};
@@ -1138,7 +1152,7 @@ export class StoreApi {
     }
     /**
      * Find purchase order by ID
-     * For valid response try integer IDs with value &lt;= 5 or &gt; 10. Other values will generated exceptions
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderById (orderId: string) : Promise<{ response: http.ClientResponse; body: Order;  }> {
@@ -1150,7 +1164,7 @@ export class StoreApi {
 
 
         // verify required parameter 'orderId' is set
-        if (!orderId) {
+        if (orderId === undefined) {
             throw new Error('Missing required parameter orderId when calling getOrderById');
         }
 
@@ -1471,7 +1485,7 @@ export class UserApi {
 
 
         // verify required parameter 'username' is set
-        if (!username) {
+        if (username === undefined) {
             throw new Error('Missing required parameter username when calling deleteUser');
         }
 
@@ -1527,7 +1541,7 @@ export class UserApi {
 
 
         // verify required parameter 'username' is set
-        if (!username) {
+        if (username === undefined) {
             throw new Error('Missing required parameter username when calling getUserByName');
         }
 
@@ -1686,7 +1700,7 @@ export class UserApi {
 
 
         // verify required parameter 'username' is set
-        if (!username) {
+        if (username === undefined) {
             throw new Error('Missing required parameter username when calling updateUser');
         }
 

--- a/samples/client/petstore/typescript-node/api.ts
+++ b/samples/client/petstore/typescript-node/api.ts
@@ -25,20 +25,6 @@ export class Dog extends Animal {
     "breed": string;
 }
 
-export class FormatTest {
-    "integer": number;
-    "int32": number;
-    "int64": number;
-    "number": number;
-    "float": number;
-    "double": number;
-    "string": string;
-    "byte": ByteArray;
-    "binary": string;
-    "date": Date;
-    "dateTime": string;
-}
-
 export class InlineResponse200 {
     "photoUrls": Array<string>;
     "name": string;
@@ -368,9 +354,9 @@ export class PetApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'petId' is set
-        if (petId === undefined) {
-            throw new Error('Missing required parameter petId when calling deletePet');
+        // verify required parameter 'petId' is not null or undefined
+        if (petId == null) {
+            throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
 
         headerParams['api_key'] = apiKey;
@@ -534,9 +520,9 @@ export class PetApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'petId' is set
-        if (petId === undefined) {
-            throw new Error('Missing required parameter petId when calling getPetById');
+        // verify required parameter 'petId' is not null or undefined
+        if (petId == null) {
+            throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
         let useFormData = false;
@@ -592,9 +578,9 @@ export class PetApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'petId' is set
-        if (petId === undefined) {
-            throw new Error('Missing required parameter petId when calling getPetByIdInObject');
+        // verify required parameter 'petId' is not null or undefined
+        if (petId == null) {
+            throw new Error('Required parameter petId was null or undefined when calling getPetByIdInObject.');
         }
 
         let useFormData = false;
@@ -650,9 +636,9 @@ export class PetApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'petId' is set
-        if (petId === undefined) {
-            throw new Error('Missing required parameter petId when calling petPetIdtestingByteArraytrueGet');
+        // verify required parameter 'petId' is not null or undefined
+        if (petId == null) {
+            throw new Error('Required parameter petId was null or undefined when calling petPetIdtestingByteArraytrueGet.');
         }
 
         let useFormData = false;
@@ -761,9 +747,9 @@ export class PetApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'petId' is set
-        if (petId === undefined) {
-            throw new Error('Missing required parameter petId when calling updatePetWithForm');
+        // verify required parameter 'petId' is not null or undefined
+        if (petId == null) {
+            throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
 
         let useFormData = false;
@@ -827,9 +813,9 @@ export class PetApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'petId' is set
-        if (petId === undefined) {
-            throw new Error('Missing required parameter petId when calling uploadFile');
+        // verify required parameter 'petId' is not null or undefined
+        if (petId == null) {
+            throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
 
         let useFormData = false;
@@ -955,9 +941,9 @@ export class StoreApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'orderId' is set
-        if (orderId === undefined) {
-            throw new Error('Missing required parameter orderId when calling deleteOrder');
+        // verify required parameter 'orderId' is not null or undefined
+        if (orderId == null) {
+            throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
         let useFormData = false;
@@ -1163,9 +1149,9 @@ export class StoreApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'orderId' is set
-        if (orderId === undefined) {
-            throw new Error('Missing required parameter orderId when calling getOrderById');
+        // verify required parameter 'orderId' is not null or undefined
+        if (orderId == null) {
+            throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
         let useFormData = false;
@@ -1484,9 +1470,9 @@ export class UserApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'username' is set
-        if (username === undefined) {
-            throw new Error('Missing required parameter username when calling deleteUser');
+        // verify required parameter 'username' is not null or undefined
+        if (username == null) {
+            throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
         let useFormData = false;
@@ -1540,9 +1526,9 @@ export class UserApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'username' is set
-        if (username === undefined) {
-            throw new Error('Missing required parameter username when calling getUserByName');
+        // verify required parameter 'username' is not null or undefined
+        if (username == null) {
+            throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
         let useFormData = false;
@@ -1699,9 +1685,9 @@ export class UserApi {
         let formParams: any = {};
 
 
-        // verify required parameter 'username' is set
-        if (username === undefined) {
-            throw new Error('Missing required parameter username when calling updateUser');
+        // verify required parameter 'username' is not null or undefined
+        if (username == null) {
+            throw new Error('Required parameter username was null or undefined when calling updateUser.');
         }
 
         let useFormData = false;


### PR DESCRIPTION
This came up when needing to pass a bool as a param. If the bool was false, the API would throw saying it wasn't supplied, but false is a valid value for the input.