### PR TITLE
add variable for listContainerType

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
@@ -14,7 +14,7 @@ public class CodegenOperation {
             returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMapContainer,
             isListContainer, isMultipart, hasMore = Boolean.TRUE,
             isResponseBinary = Boolean.FALSE, hasReference = Boolean.FALSE;
-    public String path, operationId, returnType, httpMethod, returnBaseType,
+    public String path, operationId, returnType, returnContainerType, httpMethod, returnBaseType,
             returnContainer, summary, notes, baseName, defaultResponse, discriminator;
     public List<Map<String, String>> consumes, produces;
     public CodegenParameter bodyParam;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 public class CodegenProperty {
-    public String baseName, complexType, getter, setter, description, datatype, datatypeWithEnum,
+    public String baseName, complexType, getter, setter, description, datatype, datatypeWithEnum, listDatatype,
             name, min, max, defaultValue, defaultValueWithParam, baseType, containerType;
 
     public String unescapedDescription;
@@ -97,6 +97,7 @@ public class CodegenProperty {
         result = prime * result + ((isDateTime == null) ? 0 : isDateTime.hashCode());
         result = prime * result + ((isMapContainer == null) ? 0 : isMapContainer.hashCode());
         result = prime * result + ((isListContainer == null) ? 0 : isListContainer.hashCode());
+        result = prime * result + ((listDatatype == null) ? 0 : listDatatype.hashCode());
         return result;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -84,17 +84,17 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 
 	@Override
 	public String escapeReservedWord(String name) {
-		return "_" + name;
+        return "_" + name;
 	}
 
 	@Override
 	public String apiFileFolder() {
-		return outputFolder + "/" + apiPackage().replace('.', File.separatorChar);
+        return outputFolder + "/" + apiPackage().replace('.', File.separatorChar);
 	}
 
 	@Override
 	public String modelFileFolder() {
-		return outputFolder + "/" + modelPackage().replace('.', File.separatorChar);
+        return outputFolder + "/" + modelPackage().replace('.', File.separatorChar);
 	}
 
 	@Override
@@ -189,78 +189,78 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 		return toModelName(type);
 	}
 
-  @Override
-  public String toOperationId(String operationId) {
-    // throw exception if method name is empty
-    if (StringUtils.isEmpty(operationId)) {
-      throw new RuntimeException("Empty method name (operationId) not allowed");
+    @Override
+    public String toOperationId(String operationId) {
+        // throw exception if method name is empty
+        if (StringUtils.isEmpty(operationId)) {
+            throw new RuntimeException("Empty method name (operationId) not allowed");
+        }
+
+        // method name cannot use reserved keyword, e.g. return
+        // append _ at the beginning, e.g. _return
+        if (isReservedWord(operationId)) {
+            return escapeReservedWord(camelize(sanitizeName(operationId), true));
+        }
+
+        return camelize(sanitizeName(operationId), true);
     }
 
-    // method name cannot use reserved keyword, e.g. return
-    // append _ at the beginning, e.g. _return
-    if (isReservedWord(operationId)) {
-      return escapeReservedWord(camelize(sanitizeName(operationId), true));
+    @Override
+    public CodegenProperty fromProperty(String name, Property p) {
+        CodegenProperty property = super.fromProperty(name, p);
+        if (p instanceof ArrayProperty) {
+            property.listDatatype = getListDatatype(p);
+        }
+        return property;
     }
 
-    return camelize(sanitizeName(operationId), true);
-  }
-
-  @Override
-  public CodegenProperty fromProperty(String name, Property p) {
-    CodegenProperty property = super.fromProperty(name, p);
-    if (p instanceof ArrayProperty) {
-      property.listDatatype = getListDatatype(p);
-    }
-    return property;
-  }
-
-  @Override
-  public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, Map<String, Model> definitions, Swagger swagger) {
-    CodegenOperation op = super.fromOperation(path, httpMethod, operation, definitions, swagger);
-    Response methodResponse = findMethodResponse(operation.getResponses());
-    if (methodResponse != null) {
-      if (methodResponse.getSchema() != null) {
-        CodegenProperty cm = fromProperty("response", methodResponse.getSchema());
-        op.returnContainerType = cm.baseType;
-      }
-    }
-    return op;
-  }
-
-  public String getListDatatype(Property p) {
-    if (p instanceof ArrayProperty) {
-      ArrayProperty ap = (ArrayProperty) p;
-      Property inner = ap.getItems();
-      return getTypeDeclaration(inner);
-    }
-    return "";
-  }
-
-  public void setModelPropertyNaming(String naming) {
-    if ("original".equals(naming) || "camelCase".equals(naming) ||
-      "PascalCase".equals(naming) || "snake_case".equals(naming)) {
-      this.modelPropertyNaming = naming;
-    } else {
-      throw new IllegalArgumentException("Invalid model property naming '" +
-        naming + "'. Must be 'original', 'camelCase', " +
-        "'PascalCase' or 'snake_case'");
-    }
-  }
-
-  public String getModelPropertyNaming() {
-    return this.modelPropertyNaming;
-  }
-
-  public String getNameUsingModelPropertyNaming(String name) {
-    switch (CodegenConstants.MODEL_PROPERTY_NAMING_TYPE.valueOf(getModelPropertyNaming())) {
-      case original:    return name;
-      case camelCase:   return camelize(name, true);
-      case PascalCase:  return camelize(name);
-      case snake_case:  return underscore(name);
-      default:            throw new IllegalArgumentException("Invalid model property naming '" +
-                              name + "'. Must be 'original', 'camelCase', " +
-                              "'PascalCase' or 'snake_case'");
+    @Override
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, Map<String, Model> definitions, Swagger swagger) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, definitions, swagger);
+        Response methodResponse = findMethodResponse(operation.getResponses());
+        if (methodResponse != null) {
+            if (methodResponse.getSchema() != null) {
+                CodegenProperty cm = fromProperty("response", methodResponse.getSchema());
+                op.returnContainerType = cm.baseType;
+            }
+        }
+        return op;
     }
 
-  }
+    public String getListDatatype(Property p) {
+        if (p instanceof ArrayProperty) {
+            ArrayProperty ap = (ArrayProperty) p;
+            Property inner = ap.getItems();
+            return getTypeDeclaration(inner);
+        }
+        return "";
+    }
+
+    public void setModelPropertyNaming(String naming) {
+        if ("original".equals(naming) || "camelCase".equals(naming) ||
+            "PascalCase".equals(naming) || "snake_case".equals(naming)) {
+            this.modelPropertyNaming = naming;
+        } else {
+            throw new IllegalArgumentException("Invalid model property naming '" +
+            naming + "'. Must be 'original', 'camelCase', " +
+            "'PascalCase' or 'snake_case'");
+        }
+    }
+
+    public String getModelPropertyNaming() {
+        return this.modelPropertyNaming;
+    }
+
+    public String getNameUsingModelPropertyNaming(String name) {
+        switch (CodegenConstants.MODEL_PROPERTY_NAMING_TYPE.valueOf(getModelPropertyNaming())) {
+            case original:    return name;
+            case camelCase:   return camelize(name, true);
+            case PascalCase:  return camelize(name);
+            case snake_case:  return underscore(name);
+            default:          throw new IllegalArgumentException("Invalid model property naming '" +
+                                name + "'. Must be 'original', 'camelCase', " +
+                                "'PascalCase' or 'snake_case'");
+        }
+
+    }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -14,17 +14,17 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 	public String getHelp() {
 		return "Generates a TypeScript AngularJS client library.";
 	}
-	
+
 	@Override
     public void processOpts() {
         super.processOpts();
-	    supportingFiles.add(new SupportingFile("api.d.mustache", apiPackage().replace('.', File.separatorChar), "api.d.ts"));
+	    supportingFiles.add(new SupportingFile("lib.mustache", apiPackage().replace('.', File.separatorChar), "lib.ts"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         //supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
 
 
 	}
-	
+
 	public TypeScriptAngularClientCodegen() {
 	    super();
 	    outputFolder = "generated-code/typescript-angular";


### PR DESCRIPTION
Add two variables called returnContainerType and listDatatype.
Also fixed inconsistent indentation near the bottom of _AbstractTypeScriptClientCodegen.java_.

This is required because `import * from "library"` does not work in TypeScript. The required format is to import a library into a namespace, e.g. `import * as lib from "library"`.

The conflict occurs when dealing with containers and custom datatypes. Using the `datatype` and `returnType` variables return something along the lines of `Array<MyClass>` when `Array<lib.MyClass>` is required.

This commit allows TypeScript templates to be created with the proper format.
