### PR TITLE
Append reserved swift enum type with "Enum"

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -337,7 +337,7 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
             // Swift compiler will generate an error
             if (isReservedWord(codegenProperty.datatypeWithEnum) ||
                     name.equals(codegenProperty.datatypeWithEnum)) {
-                codegenProperty.datatypeWithEnum = escapeReservedWord(codegenProperty.datatypeWithEnum);
+                codegenProperty.datatypeWithEnum = codegenProperty.datatypeWithEnum + "Enum";
                     }
         }
         return codegenProperty;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -335,10 +335,9 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
             // Ensure that the enum type doesn't match a reserved word or
             // the variable name doesn't match the generated enum type or the
             // Swift compiler will generate an error
-            if (isReservedWord(codegenProperty.datatypeWithEnum) ||
-                    name.equals(codegenProperty.datatypeWithEnum)) {
+            if (isReservedWord(codegenProperty.datatypeWithEnum) || name.equals(codegenProperty.datatypeWithEnum)) {
                 codegenProperty.datatypeWithEnum = codegenProperty.datatypeWithEnum + "Enum";
-                    }
+            }
         }
         return codegenProperty;
     }


### PR DESCRIPTION
This replaces something like `property:_Type` with `property:TypeEnum`, which is more idiomatic swift