### PR TITLE
Update APIHelper.mustache so that it can handle real boolean to string conversion

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
@@ -18,4 +18,22 @@ class APIHelper {
         }
         return destination
     }
+    static func convertBoolToString(source: [String: AnyObject]) -> [String:AnyObject]? {
+        var destination = [String:AnyObject]()
+        let theTrue = NSNumber(bool: true)
+        let theFalse = NSNumber(bool: false)
+        for (key, value) in source {
+            switch value {
+                case let x where x === theTrue || x === theFalse:
+                    destination[key] = "\(value as! Bool)"
+                default:
+                    destination[key] = "not a bool"
+            }
+        }
+
+        if destination.isEmpty {
+            return nil
+        }
+        return destination
+    }
 }

--- a/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
@@ -27,7 +27,7 @@ class APIHelper {
                 case let x where x === theTrue || x === theFalse:
                     destination[key] = "\(value as! Bool)"
                 default:
-                    destination[key] = "not a bool"
+                    destination[key] = value
             }
         }
 

--- a/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
@@ -18,7 +18,7 @@ class APIHelper {
         }
         return destination
     }
-    static func convertBoolToString(source: [String: AnyObject]) -> [String:AnyObject]? {
+    static func convertBoolToString(source: [String: AnyObject]) -> [String:AnyObject] {
         var destination = [String:AnyObject]()
         let theTrue = NSNumber(bool: true)
         let theFalse = NSNumber(bool: false)
@@ -29,10 +29,6 @@ class APIHelper {
                 default:
                     destination[key] = value
             }
-        }
-
-        if destination.isEmpty {
-            return nil
         }
         return destination
     }


### PR DESCRIPTION
This is a fix attempt for : [Swift] Bool value conversion #2446 
It is copied from http://stackoverflow.com/questions/36185530/how-to-check-dictionary-value-to-be-exactly-a-bool/36186159#36186159