### PR TITLE
[Java] Update Java version to 1.7 in generated pom

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pom.mustache
@@ -97,8 +97,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This fixes #2607 and brings the Java version in the generated pom to match the version in the generated build.gradle.

-

_Copy/pasted from #2607_

The `default.yaml` example spec available in the swagger editor is sufficient for reproducing this.

A minimalist spec would be any spec that has a `definitions` section:
```
swagger: '2.0'
info:
  version: 0.0.0
  title: Simple API
paths:
  /:
    get:
      responses:
        200:
          description: OK
definitions:
  Example:
    type: object
    properties:
      uuid:
        type: string
```

Every generated class under `io.swagger.client.model` has a reference to `java.util.Objects`, which was only added in JDK 1.7. The generated `build.gradle` specifies 1.7 as the target/source version, but the `pom.xml` specifies 1.6.