### PR TITLE
Update api.mustache and APIHelper.mustache so that they can handle real boolean to string conversion

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
@@ -18,4 +18,20 @@ class APIHelper {
         }
         return destination
     }
+
+    static func convertBoolToString(source: [String: AnyObject]) -> [String:AnyObject] {
+        var destination = [String:AnyObject]()
+        let theTrue = NSNumber(bool: true)
+        let theFalse = NSNumber(bool: false)
+        for (key, value) in source {
+            switch value {
+                case let x where x === theTrue || x === theFalse:
+                    destination[key] = "\(value as! Bool)"
+                default:
+                    destination[key] = value
+            }
+        }
+        return destination
+    }
+
 }

--- a/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
@@ -19,16 +19,18 @@ class APIHelper {
         return destination
     }
 
-    static func convertBoolToString(source: [String: AnyObject]) -> [String:AnyObject] {
+    static func convertBoolToString(source: [String: AnyObject]?) -> [String:AnyObject] {
         var destination = [String:AnyObject]()
         let theTrue = NSNumber(bool: true)
         let theFalse = NSNumber(bool: false)
-        for (key, value) in source {
-            switch value {
-                case let x where x === theTrue || x === theFalse:
-                    destination[key] = "\(value as! Bool)"
-                default:
-                    destination[key] = value
+        if (source != nil) {
+            for (key, value) in source! {
+                switch value {
+                    case let x where x === theTrue || x === theFalse:
+                        destination[key] = "\(value as! Bool)"
+                    default:
+                        destination[key] = value
+                }
             }
         }
         return destination

--- a/modules/swagger-codegen/src/main/resources/swift/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/api.mustache
@@ -80,11 +80,14 @@ public class {{classname}}: APIBase {
         ]{{/hasMore}}{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}[{{/secondaryParam}}
             "{{baseName}}": {{paramName}}{{#isInteger}}{{^required}}?{{/required}}.encodeToJSON(){{/isInteger}}{{#isLong}}{{^required}}?{{/required}}.encodeToJSON(){{/isLong}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
         ]{{/hasMore}}{{/queryParams}}
-        let parameters = APIHelper.rejectNil(nillableParameters){{/bodyParam}}
-
+ 
+        let parameters = APIHelper.rejectNil(nillableParameters)
+ 
+        let convertedParameters = APIHelper.convertBoolToString(parameters!){{/bodyParam}}
+ 
         let requestBuilder: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = {{projectName}}API.requestBuilderFactory.getBuilder()
 
-        return requestBuilder.init(method: "{{httpMethod}}", URLString: URLString, parameters: parameters, isBody: {{^queryParams}}{{^formParams}}true{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/queryParams}}{{#formParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/formParams}})
+        return requestBuilder.init(method: "{{httpMethod}}", URLString: URLString, parameters: convertedParameters, isBody: {{^queryParams}}{{^formParams}}true{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/queryParams}}{{#formParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/formParams}})
     }
 
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/swift/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/api.mustache
@@ -83,7 +83,7 @@ public class {{classname}}: APIBase {
  
         let parameters = APIHelper.rejectNil(nillableParameters)
  
-        let convertedParameters = APIHelper.convertBoolToString(parameters!){{/bodyParam}}
+        let convertedParameters = APIHelper.convertBoolToString(parameters){{/bodyParam}}
  
         let requestBuilder: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = {{projectName}}API.requestBuilderFactory.getBuilder()
 

--- a/modules/swagger-codegen/src/main/resources/swift/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/api.mustache
@@ -81,9 +81,9 @@ public class {{classname}}: APIBase {
             "{{baseName}}": {{paramName}}{{#isInteger}}{{^required}}?{{/required}}.encodeToJSON(){{/isInteger}}{{#isLong}}{{^required}}?{{/required}}.encodeToJSON(){{/isLong}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
         ]{{/hasMore}}{{/queryParams}}
  
-        let parameters = APIHelper.rejectNil(nillableParameters)
+        let parameters = APIHelper.rejectNil(nillableParameters){{/bodyParam}}
  
-        let convertedParameters = APIHelper.convertBoolToString(parameters){{/bodyParam}}
+        let convertedParameters = APIHelper.convertBoolToString(parameters)
  
         let requestBuilder: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = {{projectName}}API.requestBuilderFactory.getBuilder()
 


### PR DESCRIPTION
This is a fix attempt for : [Swift] Bool value conversion #2446
It implements the usage of APIHelpers boolean to strings conversion for request parameters.