### PR TITLE
Update typescript-angular2 client to adapt to rc (#2770)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -2,6 +2,7 @@ import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@ang
 import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
 

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -1,5 +1,5 @@
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from 'angular2/http';
-import {Injectable} from 'angular2/core';
+import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -18,10 +18,10 @@ export class {{classname}} {
     protected basePath = '{{basePath}}';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, basePath: string) {
-        if (basePath) {
-            this.basePath = basePath;
-        }
+    constructor(protected http: Http) {}
+
+    setBasePath(basePath: string) {
+        this.basePath = basePath;
     }
 
 {{#operation}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -1,5 +1,5 @@
 import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -18,10 +18,10 @@ export class {{classname}} {
     protected basePath = '{{basePath}}';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http) {}
-
-    setBasePath(basePath: string) {
-        this.basePath = basePath;
+    constructor(protected http: Http, @Optional() basePath: string) {
+        if (basePath) {
+            this.basePath = basePath;
+        }
     }
 
 {{#operation}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
@@ -22,11 +22,20 @@
     "@angular/http": "^2.0.0-rc.1",
     "@angular/platform-browser": "^2.0.0-rc.1",
     "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
-    "core-js": "^2.3.0"
+    "core-js": "^2.3.0",
     "rxjs": "^5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },
   "devDependencies": {
+    "@angular/common": "^2.0.0-rc.1",
+    "@angular/compiler": "^2.0.0-rc.1",
+    "@angular/core": "^2.0.0-rc.1",
+    "@angular/http": "^2.0.0-rc.1",
+    "@angular/platform-browser": "^2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
+    "core-js": "^2.3.0",
+    "rxjs": "^5.0.0-beta.6",
+    "zone.js": "^0.6.12",
     "typescript": "^1.8.10",
     "typings": "^0.8.1",
     "es6-shim": "^0.35.0",

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "typings install && tsc"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@angular/common": "^2.0.0-rc.1",
     "@angular/compiler": "^2.0.0-rc.1",
     "@angular/core": "^2.0.0-rc.1",
@@ -23,8 +23,6 @@
     "@angular/platform-browser": "^2.0.0-rc.1",
     "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
     "core-js": "^2.3.0"
-  },
-  "peerDependencies": {
     "rxjs": "^5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
@@ -15,18 +15,24 @@
   "scripts": {
     "build": "typings install && tsc"
   },
+  "dependencies": {
+    "@angular/common": "^2.0.0-rc.1",
+    "@angular/compiler": "^2.0.0-rc.1",
+    "@angular/core": "^2.0.0-rc.1",
+    "@angular/http": "^2.0.0-rc.1",
+    "@angular/platform-browser": "^2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
+    "core-js": "^2.3.0"
+  },
   "peerDependencies": {
-    "angular2": "^2.0.0-beta.15",
-    "rxjs": "^5.0.0-beta.2"
+    "rxjs": "^5.0.0-beta.6",
+    "zone.js": "^0.6.12"
   },
   "devDependencies": {
     "typescript": "^1.8.10",
     "typings": "^0.8.1",
-    "angular2": "^2.0.0-beta.15",
     "es6-shim": "^0.35.0",
-    "es7-reflect-metadata": "^1.6.0",
-    "rxjs": "5.0.0-beta.2",
-    "zone.js": "^0.6.10"
+    "es7-reflect-metadata": "^1.6.0"
   }{{#npmRepository}},
   "publishConfig":{
     "registry":"{{npmRepository}}"

--- a/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
@@ -2,6 +2,7 @@ import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@ang
 import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
 

--- a/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
@@ -1,5 +1,5 @@
 import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class PetApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http) {}
-
-    setBasePath(basePath: string) {
-        this.basePath = basePath;
+    constructor(protected http: Http, @Optional() basePath: string) {
+        if (basePath) {
+            this.basePath = basePath;
+        }
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
@@ -1,5 +1,5 @@
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from 'angular2/http';
-import {Injectable} from 'angular2/core';
+import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class PetApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, basePath: string) {
-        if (basePath) {
-            this.basePath = basePath;
-        }
+    constructor(protected http: Http) {}
+
+    setBasePath(basePath: string) {
+        this.basePath = basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
@@ -2,6 +2,7 @@ import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@ang
 import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
 

--- a/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
@@ -1,5 +1,5 @@
 import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class StoreApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http) {}
-
-    setBasePath(basePath: string) {
-        this.basePath = basePath;
+    constructor(protected http: Http, @Optional() basePath: string) {
+        if (basePath) {
+            this.basePath = basePath;
+        }
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
@@ -1,5 +1,5 @@
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from 'angular2/http';
-import {Injectable} from 'angular2/core';
+import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class StoreApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, basePath: string) {
-        if (basePath) {
-            this.basePath = basePath;
-        }
+    constructor(protected http: Http) {}
+
+    setBasePath(basePath: string) {
+        this.basePath = basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
@@ -2,6 +2,7 @@ import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@ang
 import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
 

--- a/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
@@ -1,5 +1,5 @@
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from 'angular2/http';
-import {Injectable} from 'angular2/core';
+import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class UserApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, basePath: string) {
-        if (basePath) {
-            this.basePath = basePath;
-        }
+    constructor(protected http: Http) {}
+
+    setBasePath(basePath: string) {
+        this.basePath = basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
@@ -1,5 +1,5 @@
 import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class UserApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http) {}
-
-    setBasePath(basePath: string) {
-        this.basePath = basePath;
+    constructor(protected http: Http, @Optional() basePath: string) {
+        if (basePath) {
+            this.basePath = basePath;
+        }
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605061603
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605120027
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605061603 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605120027 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201604282253
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605041712
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201604282253 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605041712 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605041838
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605061603
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605041838 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605061603 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605041712
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605041838
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605041712 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201605041838 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
@@ -2,6 +2,7 @@ import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@ang
 import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
 

--- a/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
@@ -1,5 +1,5 @@
 import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class PetApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http) {}
-
-    setBasePath(basePath: string) {
-        this.basePath = basePath;
+    constructor(protected http: Http, @Optional() basePath: string) {
+        if (basePath) {
+            this.basePath = basePath;
+        }
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
@@ -1,5 +1,5 @@
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from 'angular2/http';
-import {Injectable} from 'angular2/core';
+import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class PetApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, basePath: string) {
-        if (basePath) {
-            this.basePath = basePath;
-        }
+    constructor(protected http: Http) {}
+
+    setBasePath(basePath: string) {
+        this.basePath = basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
@@ -2,6 +2,7 @@ import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@ang
 import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
 

--- a/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
@@ -1,5 +1,5 @@
 import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class StoreApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http) {}
-
-    setBasePath(basePath: string) {
-        this.basePath = basePath;
+    constructor(protected http: Http, @Optional() basePath: string) {
+        if (basePath) {
+            this.basePath = basePath;
+        }
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
@@ -1,5 +1,5 @@
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from 'angular2/http';
-import {Injectable} from 'angular2/core';
+import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class StoreApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, basePath: string) {
-        if (basePath) {
-            this.basePath = basePath;
-        }
+    constructor(protected http: Http) {}
+
+    setBasePath(basePath: string) {
+        this.basePath = basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
@@ -2,6 +2,7 @@ import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@ang
 import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
 

--- a/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
@@ -1,5 +1,5 @@
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from 'angular2/http';
-import {Injectable} from 'angular2/core';
+import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class UserApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, basePath: string) {
-        if (basePath) {
-            this.basePath = basePath;
-        }
+    constructor(protected http: Http) {}
+
+    setBasePath(basePath: string) {
+        this.basePath = basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
@@ -1,5 +1,5 @@
 import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
 
@@ -12,10 +12,10 @@ export class UserApi {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http) {}
-
-    setBasePath(basePath: string) {
-        this.basePath = basePath;
+    constructor(protected http: Http, @Optional() basePath: string) {
+        if (basePath) {
+            this.basePath = basePath;
+        }
     }
 
     /**

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201605041712",
+  "version": "0.0.1-SNAPSHOT.201605041838",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201605041838",
+  "version": "0.0.1-SNAPSHOT.201605061603",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "typings install && tsc"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@angular/common": "^2.0.0-rc.1",
     "@angular/compiler": "^2.0.0-rc.1",
     "@angular/core": "^2.0.0-rc.1",
@@ -23,8 +23,6 @@
     "@angular/platform-browser": "^2.0.0-rc.1",
     "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
     "core-js": "^2.3.0"
-  },
-  "peerDependencies": {
     "rxjs": "^5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201605061603",
+  "version": "0.0.1-SNAPSHOT.201605120027",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [
@@ -22,11 +22,20 @@
     "@angular/http": "^2.0.0-rc.1",
     "@angular/platform-browser": "^2.0.0-rc.1",
     "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
-    "core-js": "^2.3.0"
+    "core-js": "^2.3.0",
     "rxjs": "^5.0.0-beta.6",
     "zone.js": "^0.6.12"
   },
   "devDependencies": {
+    "@angular/common": "^2.0.0-rc.1",
+    "@angular/compiler": "^2.0.0-rc.1",
+    "@angular/core": "^2.0.0-rc.1",
+    "@angular/http": "^2.0.0-rc.1",
+    "@angular/platform-browser": "^2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
+    "core-js": "^2.3.0",
+    "rxjs": "^5.0.0-beta.6",
+    "zone.js": "^0.6.12",
     "typescript": "^1.8.10",
     "typings": "^0.8.1",
     "es6-shim": "^0.35.0",

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201604282253",
+  "version": "0.0.1-SNAPSHOT.201605041712",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [
@@ -15,18 +15,24 @@
   "scripts": {
     "build": "typings install && tsc"
   },
+  "dependencies": {
+    "@angular/common": "^2.0.0-rc.1",
+    "@angular/compiler": "^2.0.0-rc.1",
+    "@angular/core": "^2.0.0-rc.1",
+    "@angular/http": "^2.0.0-rc.1",
+    "@angular/platform-browser": "^2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
+    "core-js": "^2.3.0"
+  },
   "peerDependencies": {
-    "angular2": "^2.0.0-beta.15",
-    "rxjs": "^5.0.0-beta.2"
+    "rxjs": "^5.0.0-beta.6",
+    "zone.js": "^0.6.12"
   },
   "devDependencies": {
     "typescript": "^1.8.10",
     "typings": "^0.8.1",
-    "angular2": "^2.0.0-beta.15",
     "es6-shim": "^0.35.0",
-    "es7-reflect-metadata": "^1.6.0",
-    "rxjs": "5.0.0-beta.2",
-    "zone.js": "^0.6.10"
+    "es7-reflect-metadata": "^1.6.0"
   },
   "publishConfig":{
     "registry":"https://skimdb.npmjs.com/registry"


### PR DESCRIPTION
Updated typescript-anuglar2 clients so that generated code can be used in anuglar2 rc.

- What I've done
   - Update npm package name
   - Refactor generated code (Constructor of angular2 injector should not have any unnecessary argument)

