### PR TITLE
[ObjC] Fix casing of 'Bearer' in Authorization header.

### DIFF
--- a/samples/client/petstore/objc/SwaggerClient/SWGConfiguration.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGConfiguration.m
@@ -72,7 +72,7 @@
         return @"";
     }
     else {
-        return [NSString stringWithFormat:@"BEARER %@", self.accessToken];
+        return [NSString stringWithFormat:@"Bearer %@", self.accessToken];
     }
 }
 


### PR DESCRIPTION
The [OAuth spec](https://tools.ietf.org/html/rfc6750#section-2.1) says that the correct format is `Bearer <token>`, not `BEARER <token>`. My server using [node-oauth2-server](https://github.com/oauthjs/node-oauth2-server) was rejecting my request without this fix.