### PR TITLE
Replace 'BEARER' with 'Bearer' everywhere for RFC6750 compliance.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/README.mustache
@@ -72,8 +72,8 @@ namespace Example
             Configuration.Default.Password = 'YOUR_PASSWORD';{{/isBasic}}{{#isApiKey}}
             // Configure API key authorization: {{{name}}}
             Configuration.Default.ApiKey.Add('{{{keyParamName}}}', 'YOUR_API_KEY');
-            // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add('{{{keyParamName}}}', 'BEARER');{{/isApiKey}}{{#isOAuth}}
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add('{{{keyParamName}}}', 'Bearer');{{/isApiKey}}{{#isOAuth}}
             // Configure OAuth2 access token for authorization: {{{name}}}
             Configuration.Default.AccessToken = 'YOUR_ACCESS_TOKEN';{{/isOAuth}}{{/authMethods}}
             {{/hasAuthMethods}}

--- a/modules/swagger-codegen/src/main/resources/csharp/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api_doc.mustache
@@ -37,8 +37,8 @@ namespace Example
             Configuration.Default.Password = 'YOUR_PASSWORD';{{/isBasic}}{{#isApiKey}}
             // Configure API key authorization: {{{name}}}
             Configuration.Default.ApiKey.Add('{{{keyParamName}}}', 'YOUR_API_KEY');
-            // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add('{{{keyParamName}}}', 'BEARER');{{/isApiKey}}{{#isOAuth}}
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add('{{{keyParamName}}}', 'Bearer');{{/isApiKey}}{{#isOAuth}}
             // Configure OAuth2 access token for authorization: {{{name}}}
             Configuration.Default.AccessToken = 'YOUR_ACCESS_TOKEN';{{/isOAuth}}{{/authMethods}}
             {{/hasAuthMethods}}

--- a/modules/swagger-codegen/src/main/resources/objc/Configuration-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/Configuration-body.mustache
@@ -72,7 +72,7 @@
         return @"";
     }
     else {
-        return [NSString stringWithFormat:@"BEARER %@", self.accessToken];
+        return [NSString stringWithFormat:@"Bearer %@", self.accessToken];
     }
 }
 

--- a/modules/swagger-codegen/src/main/resources/objc/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/README.mustache
@@ -70,8 +70,8 @@ Please follow the [installation procedure](#installation--usage) and then run th
 {{/isBasic}}{{#isApiKey}}
 // Configure API key authorization: (authentication scheme: {{{name}}})
 [apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"{{{keyParamName}}}"];
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-//[apiConfig setApiKeyPrefix:@"BEARER" forApiKeyIdentifier:@"{{{keyParamName}}}"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"{{{keyParamName}}}"];
 {{/isApiKey}}{{#isOAuth}}
 // Configure OAuth2 access token for authorization: (authentication scheme: {{{name}}})
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];

--- a/modules/swagger-codegen/src/main/resources/objc/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api_doc.mustache
@@ -31,8 +31,8 @@ Method | HTTP request | Description
 {{/isBasic}}{{#isApiKey}}
 // Configure API key authorization: (authentication scheme: {{{name}}})
 [apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"{{{keyParamName}}}"];
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-//[apiConfig setApiKeyPrefix:@"BEARER" forApiKeyIdentifier:@"{{{keyParamName}}}"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"{{{keyParamName}}}"];
 {{/isApiKey}}{{#isOAuth}}
 // Configure OAuth2 access token for authorization: (authentication scheme: {{{name}}})
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];

--- a/modules/swagger-codegen/src/main/resources/perl/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/README.mustache
@@ -257,8 +257,8 @@ ${{{moduleName}}}::Configuration::username = 'YOUR_USERNAME';
 ${{{moduleName}}}::Configuration::password = 'YOUR_PASSWORD';{{/isBasic}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}
 ${{{moduleName}}}::Configuration::api_key->{'{{{keyParamName}}}'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#${{{moduleName}}}::Configuration::api_key_prefix->{'{{{keyParamName}}}'} = 'BEARER';{{/isApiKey}}{{#isOAuth}}
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#${{{moduleName}}}::Configuration::api_key_prefix->{'{{{keyParamName}}}'} = 'Bearer';{{/isApiKey}}{{#isOAuth}}
 # Configure OAuth2 access token for authorization: {{{name}}}
 ${{{moduleName}}}::Configuration::access_token = 'YOUR_ACCESS_TOKEN';{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}

--- a/modules/swagger-codegen/src/main/resources/perl/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/api_doc.mustache
@@ -31,8 +31,8 @@ ${{{moduleName}}}::Configuration::username = 'YOUR_USERNAME';
 ${{{moduleName}}}::Configuration::password = 'YOUR_PASSWORD';{{/isBasic}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}
 ${{{moduleName}}}::Configuration::api_key->{'{{{keyParamName}}}'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#${{{moduleName}}}::Configuration::api_key_prefix->{'{{{keyParamName}}}'} = "BEARER";{{/isApiKey}}{{#isOAuth}}
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#${{{moduleName}}}::Configuration::api_key_prefix->{'{{{keyParamName}}}'} = "Bearer";{{/isApiKey}}{{#isOAuth}}
 # Configure OAuth2 access token for authorization: {{{name}}}
 ${{{moduleName}}}::Configuration::access_token = 'YOUR_ACCESS_TOKEN';{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}

--- a/modules/swagger-codegen/src/main/resources/php/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/README.mustache
@@ -68,8 +68,8 @@ require_once(__DIR__ . '/vendor/autoload.php');
 {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setPassword('YOUR_PASSWORD');{{/isBasic}}{{#isApiKey}}
 // Configure API key authorization: {{{name}}}
 {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setApiKey('{{{keyParamName}}}', 'YOUR_API_KEY');
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-// {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setApiKeyPrefix('{{{keyParamName}}}', 'BEARER');{{/isApiKey}}{{#isOAuth}}
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setApiKeyPrefix('{{{keyParamName}}}', 'Bearer');{{/isApiKey}}{{#isOAuth}}
 // Configure OAuth2 access token for authorization: {{{name}}}
 {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setAccessToken('YOUR_ACCESS_TOKEN');{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}

--- a/modules/swagger-codegen/src/main/resources/php/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api_doc.mustache
@@ -27,8 +27,8 @@ require_once(__DIR__ . '/vendor/autoload.php');
 {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setPassword('YOUR_PASSWORD');{{/isBasic}}{{#isApiKey}}
 // Configure API key authorization: {{{name}}}
 {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setApiKey('{{{keyParamName}}}', 'YOUR_API_KEY');
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-// {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setApiKeyPrefix('{{{keyParamName}}}', 'BEARER');{{/isApiKey}}{{#isOAuth}}
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setApiKeyPrefix('{{{keyParamName}}}', 'Bearer');{{/isApiKey}}{{#isOAuth}}
 // Configure OAuth2 access token for authorization: {{{name}}}
 {{{invokerPackage}}}\Configuration::getDefaultConfiguration()->setAccessToken('YOUR_ACCESS_TOKEN');{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}

--- a/modules/swagger-codegen/src/main/resources/python/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/README.mustache
@@ -61,8 +61,8 @@ from pprint import pprint
 {{{packageName}}}.configuration.password = 'YOUR_PASSWORD'{{/isBasic}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}
 {{{packageName}}}.configuration.api_key['{{{keyParamName}}}'] = 'YOUR_API_KEY'
-# Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-# {{{packageName}}}.configuration.api_key_prefix['{{{keyParamName}}}'] = 'BEARER'{{/isApiKey}}{{#isOAuth}}
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# {{{packageName}}}.configuration.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
 # Configure OAuth2 access token for authorization: {{{name}}}
 {{{packageName}}}.configuration.access_token = 'YOUR_ACCESS_TOKEN'{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}

--- a/modules/swagger-codegen/src/main/resources/python/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_doc.mustache
@@ -29,8 +29,8 @@ from pprint import pprint
 {{{packageName}}}.configuration.password = 'YOUR_PASSWORD'{{/isBasic}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}
 {{{packageName}}}.configuration.api_key['{{{keyParamName}}}'] = 'YOUR_API_KEY'
-# Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-# {{{packageName}}}.configuration.api_key_prefix['{{{keyParamName}}}'] = 'BEARER'{{/isApiKey}}{{#isOAuth}}
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# {{{packageName}}}.configuration.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
 # Configure OAuth2 access token for authorization: {{{name}}}
 {{{packageName}}}.configuration.access_token = 'YOUR_ACCESS_TOKEN'{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}

--- a/modules/swagger-codegen/src/main/resources/ruby/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/README.mustache
@@ -67,8 +67,8 @@ require '{{{gemName}}}'
   config.password = 'YOUR PASSWORD'{{/isBasic}}{{#isApiKey}}
   # Configure API key authorization: {{{name}}}
   config.api_key['{{{keyParamName}}}'] = 'YOUR API KEY'
-  # Uncomment the following line to set a prefix for the API key, e.g. 'BEARER' (defaults to nil)
-  #config.api_key_prefix['{{{keyParamName}}}'] = 'BEARER'{{/isApiKey}}{{#isOAuth}}
+  # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
+  #config.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
   # Configure OAuth2 access token for authorization: {{{name}}}
   config.access_token = 'YOUR ACCESS TOKEN'{{/isOAuth}}
 {{/authMethods}}end

--- a/modules/swagger-codegen/src/main/resources/ruby/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_doc.mustache
@@ -29,8 +29,8 @@ require '{{{gemName}}}'
   config.password = 'YOUR PASSWORD'{{/isBasic}}{{#isApiKey}}
   # Configure API key authorization: {{{name}}}
   config.api_key['{{{keyParamName}}}'] = 'YOUR API KEY'
-  # Uncomment the following line to set a prefix for the API key, e.g. 'BEARER' (defaults to nil)
-  #config.api_key_prefix['{{{keyParamName}}}'] = 'BEARER'{{/isApiKey}}{{#isOAuth}}
+  # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
+  #config.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
   # Configure OAuth2 access token for authorization: {{{name}}}
   config.access_token = 'YOUR ACCESS TOKEN'{{/isOAuth}}
 {{/authMethods}}end

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/README.mustache
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/README.mustache
@@ -50,27 +50,27 @@ public void main(){
     Configuration.Default.AccessToken = 'YOUR_ACCESS_TOKEN';
     // Configure API key authorization: test_api_client_id
     Configuration.Default.ApiKey.Add('x-test_api_client_id', 'YOUR_API_KEY');
-    // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-    // Configuration.Default.ApiKeyPrefix.Add('x-test_api_client_id', 'BEARER');
+    // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    // Configuration.Default.ApiKeyPrefix.Add('x-test_api_client_id', 'Bearer');
     // Configure API key authorization: test_api_client_secret
     Configuration.Default.ApiKey.Add('x-test_api_client_secret', 'YOUR_API_KEY');
-    // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-    // Configuration.Default.ApiKeyPrefix.Add('x-test_api_client_secret', 'BEARER');
+    // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    // Configuration.Default.ApiKeyPrefix.Add('x-test_api_client_secret', 'Bearer');
     // Configure API key authorization: api_key
     Configuration.Default.ApiKey.Add('api_key', 'YOUR_API_KEY');
-    // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-    // Configuration.Default.ApiKeyPrefix.Add('api_key', 'BEARER');
+    // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    // Configuration.Default.ApiKeyPrefix.Add('api_key', 'Bearer');
     // Configure HTTP basic authorization: test_http_basic
     Configuration.Default.Username = 'YOUR_USERNAME';
     Configuration.Default.Password = 'YOUR_PASSWORD';
     // Configure API key authorization: test_api_key_query
     Configuration.Default.ApiKey.Add('test_api_key_query', 'YOUR_API_KEY');
-    // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-    // Configuration.Default.ApiKeyPrefix.Add('test_api_key_query', 'BEARER');
+    // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    // Configuration.Default.ApiKeyPrefix.Add('test_api_key_query', 'Bearer');
     // Configure API key authorization: test_api_key_header
     Configuration.Default.ApiKey.Add('test_api_key_header', 'YOUR_API_KEY');
-    // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-    // Configuration.Default.ApiKeyPrefix.Add('test_api_key_header', 'BEARER');
+    // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    // Configuration.Default.ApiKeyPrefix.Add('test_api_key_header', 'Bearer');
 
 var apiInstance = new ();
 

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/docs/PetApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/docs/PetApi.md
@@ -294,8 +294,8 @@ namespace Example
             
             // Configure API key authorization: api_key
             Configuration.Default.ApiKey.Add('api_key', 'YOUR_API_KEY');
-            // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add('api_key', 'BEARER');
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add('api_key', 'Bearer');
 
             var apiInstance = new PetApi();
             var petId = 789;  // long? | ID of pet to return

--- a/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientTest/Lib/SwaggerClient/docs/StoreApi.md
@@ -94,8 +94,8 @@ namespace Example
             
             // Configure API key authorization: api_key
             Configuration.Default.ApiKey.Add('api_key', 'YOUR_API_KEY');
-            // Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add('api_key', 'BEARER');
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add('api_key', 'Bearer');
 
             var apiInstance = new StoreApi();
 

--- a/samples/client/petstore/objc/SwaggerClient/SWGConfiguration.m
+++ b/samples/client/petstore/objc/SwaggerClient/SWGConfiguration.m
@@ -72,7 +72,7 @@
         return @"";
     }
     else {
-        return [NSString stringWithFormat:@"BEARER %@", self.accessToken];
+        return [NSString stringWithFormat:@"Bearer %@", self.accessToken];
     }
 }
 

--- a/samples/client/petstore/objc/docs/SWGPetApi.md
+++ b/samples/client/petstore/objc/docs/SWGPetApi.md
@@ -283,8 +283,8 @@ SWGConfiguration *apiConfig = [SWGConfiguration sharedConfig];
 
 // Configure API key authorization: (authentication scheme: api_key)
 [apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"api_key"];
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-//[apiConfig setApiKeyPrefix:@"BEARER" forApiKeyIdentifier:@"api_key"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"api_key"];
 
 
 NSNumber* petId = @789; // ID of pet that needs to be fetched

--- a/samples/client/petstore/objc/docs/SWGStoreApi.md
+++ b/samples/client/petstore/objc/docs/SWGStoreApi.md
@@ -81,8 +81,8 @@ SWGConfiguration *apiConfig = [SWGConfiguration sharedConfig];
 
 // Configure API key authorization: (authentication scheme: api_key)
 [apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"api_key"];
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-//[apiConfig setApiKeyPrefix:@"BEARER" forApiKeyIdentifier:@"api_key"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"api_key"];
 
 
 

--- a/samples/client/petstore/perl/docs/PetApi.md
+++ b/samples/client/petstore/perl/docs/PetApi.md
@@ -269,8 +269,8 @@ use Data::Dumper;
 
 # Configure API key authorization: api_key
 $WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "Bearer";
 # Configure OAuth2 access token for authorization: petstore_auth
 $WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
 
@@ -320,8 +320,8 @@ use Data::Dumper;
 
 # Configure API key authorization: api_key
 $WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "Bearer";
 # Configure OAuth2 access token for authorization: petstore_auth
 $WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
 
@@ -371,8 +371,8 @@ use Data::Dumper;
 
 # Configure API key authorization: api_key
 $WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "Bearer";
 # Configure OAuth2 access token for authorization: petstore_auth
 $WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
 

--- a/samples/client/petstore/perl/docs/StoreApi.md
+++ b/samples/client/petstore/perl/docs/StoreApi.md
@@ -73,12 +73,12 @@ use Data::Dumper;
 
 # Configure API key authorization: test_api_client_id
 $WWW::SwaggerClient::Configuration::api_key->{'x-test_api_client_id'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'x-test_api_client_id'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'x-test_api_client_id'} = "Bearer";
 # Configure API key authorization: test_api_client_secret
 $WWW::SwaggerClient::Configuration::api_key->{'x-test_api_client_secret'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'x-test_api_client_secret'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'x-test_api_client_secret'} = "Bearer";
 
 my $api_instance = WWW::SwaggerClient::StoreApi->new();
 my $status = 'status_example'; # string | Status value that needs to be considered for query
@@ -126,8 +126,8 @@ use Data::Dumper;
 
 # Configure API key authorization: api_key
 $WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "Bearer";
 
 my $api_instance = WWW::SwaggerClient::StoreApi->new();
 
@@ -171,8 +171,8 @@ use Data::Dumper;
 
 # Configure API key authorization: api_key
 $WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "Bearer";
 
 my $api_instance = WWW::SwaggerClient::StoreApi->new();
 
@@ -216,12 +216,12 @@ use Data::Dumper;
 
 # Configure API key authorization: test_api_key_header
 $WWW::SwaggerClient::Configuration::api_key->{'test_api_key_header'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'test_api_key_header'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'test_api_key_header'} = "Bearer";
 # Configure API key authorization: test_api_key_query
 $WWW::SwaggerClient::Configuration::api_key->{'test_api_key_query'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'test_api_key_query'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'test_api_key_query'} = "Bearer";
 
 my $api_instance = WWW::SwaggerClient::StoreApi->new();
 my $order_id = 'order_id_example'; # string | ID of pet that needs to be fetched
@@ -269,12 +269,12 @@ use Data::Dumper;
 
 # Configure API key authorization: test_api_client_id
 $WWW::SwaggerClient::Configuration::api_key->{'x-test_api_client_id'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'x-test_api_client_id'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'x-test_api_client_id'} = "Bearer";
 # Configure API key authorization: test_api_client_secret
 $WWW::SwaggerClient::Configuration::api_key->{'x-test_api_client_secret'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'x-test_api_client_secret'} = "BEARER";
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::SwaggerClient::Configuration::api_key_prefix->{'x-test_api_client_secret'} = "Bearer";
 
 my $api_instance = WWW::SwaggerClient::StoreApi->new();
 my $body = WWW::SwaggerClient::Object::Order->new(); # Order | order placed for purchasing the pet

--- a/samples/client/petstore/perl/test.pl
+++ b/samples/client/petstore/perl/test.pl
@@ -17,7 +17,7 @@ use DateTime;
 
 $WWW::SwaggerClient::Configuration::http_user_agent = 'Perl-Swagger-Test';
 $WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'ZZZZZZZZZZZZZZ';
-$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = 'BEARER';
+$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = 'Bearer';
 
 $WWW::SwaggerClient::Configuration::username = 'username';
 $WWW::SwaggerClient::Configuration::password = 'password';

--- a/samples/client/petstore/php/SwaggerClient-php/docs/PetApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/PetApi.md
@@ -220,8 +220,8 @@ require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure API key authorization: api_key
 Swagger\Client\Configuration::getDefaultConfiguration()->setApiKey('api_key', 'YOUR_API_KEY');
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-// Swagger\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api_key', 'BEARER');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// Swagger\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api_key', 'Bearer');
 
 $api_instance = new Swagger\Client\Api\PetApi();
 $pet_id = 789; // int | ID of pet to return

--- a/samples/client/petstore/php/SwaggerClient-php/docs/StoreApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/StoreApi.md
@@ -68,8 +68,8 @@ require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure API key authorization: api_key
 Swagger\Client\Configuration::getDefaultConfiguration()->setApiKey('api_key', 'YOUR_API_KEY');
-// Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-// Swagger\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api_key', 'BEARER');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// Swagger\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('api_key', 'Bearer');
 
 $api_instance = new Swagger\Client\Api\StoreApi();
 

--- a/samples/client/petstore/python/docs/PetApi.md
+++ b/samples/client/petstore/python/docs/PetApi.md
@@ -230,8 +230,8 @@ from pprint import pprint
 
 # Configure API key authorization: api_key
 swagger_client.configuration.api_key['api_key'] = 'YOUR_API_KEY'
-# Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-# swagger_client.configuration.api_key_prefix['api_key'] = 'BEARER'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# swagger_client.configuration.api_key_prefix['api_key'] = 'Bearer'
 
 # create an instance of the API class
 api_instance = swagger_client.PetApi()

--- a/samples/client/petstore/python/docs/StoreApi.md
+++ b/samples/client/petstore/python/docs/StoreApi.md
@@ -72,8 +72,8 @@ from pprint import pprint
 
 # Configure API key authorization: api_key
 swagger_client.configuration.api_key['api_key'] = 'YOUR_API_KEY'
-# Uncomment below to setup prefix (e.g. BEARER) for API key, if needed
-# swagger_client.configuration.api_key_prefix['api_key'] = 'BEARER'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# swagger_client.configuration.api_key_prefix['api_key'] = 'Bearer'
 
 # create an instance of the API class
 api_instance = swagger_client.StoreApi()

--- a/samples/client/petstore/ruby/docs/PetApi.md
+++ b/samples/client/petstore/ruby/docs/PetApi.md
@@ -239,8 +239,8 @@ require 'petstore'
 Petstore.configure do |config|
   # Configure API key authorization: api_key
   config.api_key['api_key'] = 'YOUR API KEY'
-  # Uncomment the following line to set a prefix for the API key, e.g. 'BEARER' (defaults to nil)
-  #config.api_key_prefix['api_key'] = 'BEARER'
+  # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
+  #config.api_key_prefix['api_key'] = 'Bearer'
 end
 
 api_instance = Petstore::PetApi.new

--- a/samples/client/petstore/ruby/docs/StoreApi.md
+++ b/samples/client/petstore/ruby/docs/StoreApi.md
@@ -71,8 +71,8 @@ require 'petstore'
 Petstore.configure do |config|
   # Configure API key authorization: api_key
   config.api_key['api_key'] = 'YOUR API KEY'
-  # Uncomment the following line to set a prefix for the API key, e.g. 'BEARER' (defaults to nil)
-  #config.api_key_prefix['api_key'] = 'BEARER'
+  # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
+  #config.api_key_prefix['api_key'] = 'Bearer'
 end
 
 api_instance = Petstore::StoreApi.new


### PR DESCRIPTION
The [OAuth spec](https://tools.ietf.org/html/rfc6750#section-2.1) says that the correct format is `Bearer <token>`, not `BEARER <token>`. My server using [node-oauth2-server](https://github.com/oauthjs/node-oauth2-server) was rejecting my request without this fix.

It looks like the only place `BEARER` was in actual code was `modules/swagger-codegen/src/main/resources/objc/Configuration-body.mustache`. I experienced the issue in ObjC.

This pullreq was created by running
```bash
find . -type f -exec sed -i "" "s/BEARER/Bearer/g" {} \;
```
and then ignoring all the whitespace-only changes that generates.