### PR TITLE
[PHP] Fixing bug with composer project path in generated sdk

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -120,7 +120,9 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(PACKAGE_PATH, "The main package name for classes. e.g. GeneratedPetstore"));
         cliOptions.add(new CliOption(SRC_BASE_PATH, "The directory under packagePath to serve as source root."));
         cliOptions.add(new CliOption(COMPOSER_VENDOR_NAME, "The vendor name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. yaypets. IMPORTANT NOTE (2016/03): composerVendorName will be deprecated and replaced by gitUserId in the next swagger-codegen release"));
+        cliOptions.add(new CliOption(CodegenConstants.GIT_USER_ID, CodegenConstants.GIT_USER_ID_DESC));
         cliOptions.add(new CliOption(COMPOSER_PROJECT_NAME, "The project name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client. IMPORTANT NOTE (2016/03): composerProjectName will be deprecated and replaced by gitRepoId in the next swagger-codegen release"));
+        cliOptions.add(new CliOption(CodegenConstants.GIT_REPO_ID, CodegenConstants.GIT_REPO_ID_DESC));
         cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_VERSION, "The version to use in the composer package version field. e.g. 1.2.3"));
     }
 
@@ -208,10 +210,22 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
             additionalProperties.put(COMPOSER_PROJECT_NAME, composerProjectName);
         }
 
+        if (additionalProperties.containsKey(CodegenConstants.GIT_USER_ID)) {
+            this.setGitUserId((String) additionalProperties.get(CodegenConstants.GIT_USER_ID));
+        } else {
+            additionalProperties.put(CodegenConstants.GIT_USER_ID, gitUserId);
+        }
+
         if (additionalProperties.containsKey(COMPOSER_VENDOR_NAME)) {
             this.setComposerVendorName((String) additionalProperties.get(COMPOSER_VENDOR_NAME));
         } else {
             additionalProperties.put(COMPOSER_VENDOR_NAME, composerVendorName);
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.GIT_REPO_ID)) {
+            this.setGitRepoId((String) additionalProperties.get(CodegenConstants.GIT_REPO_ID));
+        } else {
+            additionalProperties.put(CodegenConstants.GIT_REPO_ID, gitRepoId);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_VERSION)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -30,8 +30,8 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
     public static final String COMPOSER_VENDOR_NAME = "composerVendorName";
     public static final String COMPOSER_PROJECT_NAME = "composerProjectName";
     protected String invokerPackage = "Swagger\\Client";
-    protected String composerVendorName = "swagger";
-    protected String composerProjectName = "swagger-client";
+    protected String composerVendorName = null;
+    protected String composerProjectName = null;
     protected String packagePath = "SwaggerClient-php";
     protected String artifactVersion = "1.0.0";
     protected String srcBasePath = "lib";

--- a/modules/swagger-codegen/src/main/resources/php/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/README.mustache
@@ -27,11 +27,11 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}.git"
+      "url": "https://github.com/{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}.git"
     }
   ],
   "require": {
-    "{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}": "*@dev"
+    "{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}": "*@dev"
   }
 }
 ```

--- a/modules/swagger-codegen/src/main/resources/php/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/README.mustache
@@ -27,11 +27,11 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}.git"
+      "url": "https://github.com/{{composerVendorName}}/{{composerProjectName}}.git"
     }
   ],
   "require": {
-    "{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}": "*@dev"
+    "{{composerVendorName}}/{{composerProjectName}}": "*@dev"
   }
 }
 ```

--- a/modules/swagger-codegen/src/main/resources/php/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/README.mustache
@@ -27,11 +27,11 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/{{composerVendorName}}/{{composerProjectName}}.git"
+      "url": "https://github.com/{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}.git"
     }
   ],
   "require": {
-    "{{composerVendorName}}/{{composerProjectName}}": "*@dev"
+    "{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}": "*@dev"
   }
 }
 ```

--- a/modules/swagger-codegen/src/main/resources/php/composer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/composer.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "{{composerVendorName}}/{{composerProjectName}}",{{#artifactVersion}}
+    "name": "{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}",{{#artifactVersion}}
     "version": "{{artifactVersion}}",{{/artifactVersion}}
     "description": "{{description}}",
     "keywords": [

--- a/modules/swagger-codegen/src/main/resources/php/composer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/composer.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}",{{#artifactVersion}}
+    "name": "{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}",{{#artifactVersion}}
     "version": "{{artifactVersion}}",{{/artifactVersion}}
     "description": "{{description}}",
     "keywords": [

--- a/modules/swagger-codegen/src/main/resources/php/composer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/composer.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "{{#gitUserId}}{{.}}{{/gitUserId}}{{^gitUserId}}{{composerVendorName}}{{/gitUserId}}/{{#gitRepoId}}{{.}}{{/gitRepoId}}{{^gitRepoId}}{{composerProjectName}}{{/gitRepoId}}",{{#artifactVersion}}
+    "name": "{{composerVendorName}}/{{composerProjectName}}",{{#artifactVersion}}
     "version": "{{artifactVersion}}",{{/artifactVersion}}
     "description": "{{description}}",
     "keywords": [

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/PhpClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/PhpClientOptionsProvider.java
@@ -18,6 +18,8 @@ public class PhpClientOptionsProvider implements OptionsProvider {
     public static final String SRC_BASE_PATH_VALUE = "libPhp";
     public static final String COMPOSER_VENDOR_NAME_VALUE = "swaggerPhp";
     public static final String COMPOSER_PROJECT_NAME_VALUE = "swagger-client-php";
+    public static final String GIT_USER_ID_VALUE = "gitSwaggerPhp";
+    public static final String GIT_REPO_ID_VALUE = "git-swagger-client-php";
     public static final String ARTIFACT_VERSION_VALUE = "1.0.0-SNAPSHOT";
 
     @Override
@@ -37,7 +39,9 @@ public class PhpClientOptionsProvider implements OptionsProvider {
                 .put(PhpClientCodegen.PACKAGE_PATH, PACKAGE_PATH_VALUE)
                 .put(PhpClientCodegen.SRC_BASE_PATH, SRC_BASE_PATH_VALUE)
                 .put(PhpClientCodegen.COMPOSER_VENDOR_NAME, COMPOSER_VENDOR_NAME_VALUE)
+                .put(CodegenConstants.GIT_USER_ID, GIT_USER_ID_VALUE)
                 .put(PhpClientCodegen.COMPOSER_PROJECT_NAME, COMPOSER_PROJECT_NAME_VALUE)
+                .put(CodegenConstants.GIT_REPO_ID, GIT_REPO_ID_VALUE)
                 .put(CodegenConstants.ARTIFACT_VERSION, ARTIFACT_VERSION_VALUE)
                 .build();
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpClientOptionsTest.java
@@ -42,7 +42,11 @@ public class PhpClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setComposerVendorName(PhpClientOptionsProvider.COMPOSER_VENDOR_NAME_VALUE);
             times = 1;
+            clientCodegen.setGitUserId(PhpClientOptionsProvider.GIT_USER_ID_VALUE);
+            times = 1;
             clientCodegen.setComposerProjectName(PhpClientOptionsProvider.COMPOSER_PROJECT_NAME_VALUE);
+            times = 1;
+            clientCodegen.setGitRepoId(PhpClientOptionsProvider.GIT_REPO_ID_VALUE);
             times = 1;
             clientCodegen.setArtifactVersion(PhpClientOptionsProvider.ARTIFACT_VERSION_VALUE);
             times = 1;


### PR DESCRIPTION
There couple of issues with the current version:
* CliOptions `composerVendorName` and `composerProjectName` have no effect, because `gitUserId` and `gitRepoId` have default values so the inverted condition will never work.
* Further more CliOptions `gitUserId` and `gitRepoId` eventhough they would work they are not documented when running `java -jar swagger-codegen-cli.jar config-help -l php` or anywhere else.