### PR TITLE
Update typings for typescript-fetch

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -24,11 +24,10 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     @Override
     public void processOpts() {
         super.processOpts();
-        final String defaultFolder = apiPackage().replace('.', File.separatorChar);
-
-        supportingFiles.add(new SupportingFile("api.mustache", null, "api.ts"));
+        supportingFiles.add(new SupportingFile("api.mustache", "", "api.ts"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
-        supportingFiles.add(new SupportingFile("assign.ts", defaultFolder, "assign.ts"));
+        supportingFiles.add(new SupportingFile("assign.ts", "", "assign.ts"));
+        supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
         supportingFiles.add(new SupportingFile("package.json.mustache", "", "package.json"));
         supportingFiles.add(new SupportingFile("typings.json.mustache", "", "typings.json"));
         supportingFiles.add(new SupportingFile("tsconfig.json.mustache", "", "tsconfig.json"));

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/README.md
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/README.md
@@ -1,0 +1,44 @@
+# TypeScript-Fetch
+
+This generator creates TypeScript/JavaScript client that utilizes [Fetch API](https://fetch.spec.whatwg.org/). The codegen Node module can be used in the following environments: 
+
+* Node.JS
+* Webpack
+* Browserify
+
+It is usable in both TypeScript and JavaScript. In TypeScript, the definition should be automatically resolved via `typings` in `package.json`. ([Reference](http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html))
+
+### Installation ###
+
+`swagger-codegen` does not generate JavaScript directly. The codegen Node module comes with `package.json` that bundles `typescript` and `typings` so it can self-compile. The self-compile is normally run automatically via the `npm` `postinstall` script of `npm install`. 
+
+CAVEAT: Due to [privilege implications](https://docs.npmjs.com/misc/scripts#user), `npm` may skip `postinstall` script if the user is `root`. You would need to manually invoke `npm install` or `npm run postinstall` for the codegen module if that's the case. 
+
+#### NPM repository ###
+If you remove `"private": true` from `package.json`, you may publish the module to NPM. In which case, you would be able to install the module as any other NPM module. 
+
+It maybe useful to use [scoped packages](https://docs.npmjs.com/misc/scope).
+
+#### NPM install local file ###
+You should be able to directly install the module using `npm install file:///codegen_path`. 
+
+NOTES: If you do `npm install file:///codegen_path --save` NPM might convert your path to relative path, maybe have adverse affect. `npm install` and `npm shrinkwrap` may misbehave if the installation path is not absolute.
+
+#### direct copy/symlink ###
+You may also simply copy or symlink the codegen into a directly under your project. The syntax of the usage would differ if you take this route. (See below)
+
+### Usage ###
+With ES6 module syntax, the following syntaxes are supported: 
+```
+import * as localName from 'npmName';
+import {operationId} from 'npmName';
+
+import * as localName from './symlinkDir';
+import {operationId} from './symlinkDir';
+```
+With CommonJS, the following syntaxes are supported: 
+```
+import localName = require('npmName');
+
+import localName = require('./symlinkDir')';
+```

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/package.json.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/package.json.mustache
@@ -2,8 +2,9 @@
   "name": "{{#npmName}}{{{npmName}}}{{/npmName}}{{^npmName}}typescript-fetch-api{{/npmName}}",
   "version": "{{#npmVersion}}{{{npmVersion}}}{{/npmVersion}}{{^npmVersion}}0.0.0{{/npmVersion}}",
   "private": true,
-  "main": "dist/api.js",
-  "browser": "dist/api.js",
+  "main": "./dist/api.js",
+  "browser": "./dist/api.js",
+  "typings": "./dist/api.d.ts",
   "dependencies": {
     "isomorphic-fetch": "^2.2.1"
   },

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/tsconfig.json.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/tsconfig.json.mustache
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
+    "declaration": true,
     "target": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}es5{{/supportsES6}}",
     "module": "commonjs",
     "noImplicitAny": true,
     "outDir": "dist"
   },
   "exclude": [
+    "dist",
     "node_modules",
     "typings/browser",
     "typings/main",

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/typings.json.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/typings.json.mustache
@@ -4,6 +4,6 @@
   "ambientDependencies": {
 {{^supportsES6}}    "es6-promise": "registry:dt/es6-promise#0.0.0+20160423074304",
 {{/supportsES6}}    "node": "registry:dt/node#4.0.0+20160423143914",
-    "isomorphic-fetch": "github:leonyu/DefinitelyTyped/isomorphic-fetch/isomorphic-fetch.d.ts#isomorphic-fetch-fix-module"
+    "isomorphic-fetch": "registry:dt/isomorphic-fetch#0.0.0+20160505171433"
   }
 }


### PR DESCRIPTION
### What's done ###
* build `declaration` and expose it via `typings` in `package.json`
* Update `typings.json` to point to DefinitelyTyped for `isomorphic-fetch`. (Previously the definition in DefinitelyTyped had an issue with ES6 usage that was fixed by my [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/9144))
* Add README.md
