### PR TITLE
Update the injector static variable to contain all injected values.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.mustache
@@ -15,7 +15,7 @@ namespace {{package}} {
         protected basePath = '{{basePath}}';
         public defaultHeaders : any = {};
 
-        static $inject: string[] = ['$http', '$httpParamSerializer'];
+        static $inject: string[] = ['$http', '$httpParamSerializer', 'basePath'];
 
         constructor(protected $http: ng.IHttpService, protected $httpParamSerializer?: (d: any) => any, basePath?: string) {
             if (basePath) {

--- a/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
@@ -9,7 +9,7 @@ namespace API.Client {
         protected basePath = 'http://petstore.swagger.io/v2';
         public defaultHeaders : any = {};
 
-        static $inject: string[] = ['$http', '$httpParamSerializer'];
+        static $inject: string[] = ['$http', '$httpParamSerializer', 'basePath'];
 
         constructor(protected $http: ng.IHttpService, protected $httpParamSerializer?: (d: any) => any, basePath?: string) {
             if (basePath) {

--- a/samples/client/petstore/typescript-angular/API/Client/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/StoreApi.ts
@@ -9,7 +9,7 @@ namespace API.Client {
         protected basePath = 'http://petstore.swagger.io/v2';
         public defaultHeaders : any = {};
 
-        static $inject: string[] = ['$http', '$httpParamSerializer'];
+        static $inject: string[] = ['$http', '$httpParamSerializer', 'basePath'];
 
         constructor(protected $http: ng.IHttpService, protected $httpParamSerializer?: (d: any) => any, basePath?: string) {
             if (basePath) {

--- a/samples/client/petstore/typescript-angular/API/Client/UserApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/UserApi.ts
@@ -9,7 +9,7 @@ namespace API.Client {
         protected basePath = 'http://petstore.swagger.io/v2';
         public defaultHeaders : any = {};
 
-        static $inject: string[] = ['$http', '$httpParamSerializer'];
+        static $inject: string[] = ['$http', '$httpParamSerializer', 'basePath'];
 
         constructor(protected $http: ng.IHttpService, protected $httpParamSerializer?: (d: any) => any, basePath?: string) {
             if (basePath) {


### PR DESCRIPTION
In Angular.js, values are injected into service in one of two ways:

1) Inline (by name).
2) By a static injector variable.

The TypeScript generator uses the 2nd method. This method requires you
to explicitly enumerate all the values you would like to have injected.
If you fail to inject a value the Angular DI system will simply pass you
`undefined`. The constructor is expecting 3 values to be passed (the
final being basePath) but the injector static only defines 2 values.
This results in basePath always being undefined no matter what you
define it to be.

This change updates the injector variable to handle that properly.