### PR TITLE
Update TypeScript to do a better check for empty on basePath.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.mustache
@@ -18,7 +18,7 @@ namespace {{package}} {
         static $inject: string[] = ['$http', '$httpParamSerializer'];
 
         constructor(protected $http: ng.IHttpService, protected $httpParamSerializer?: (d: any) => any, basePath?: string) {
-            if (basePath) {
+            if (basePath !== undefined) {
                 this.basePath = basePath;
             }
         }

--- a/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
@@ -12,7 +12,7 @@ namespace API.Client {
         static $inject: string[] = ['$http', '$httpParamSerializer'];
 
         constructor(protected $http: ng.IHttpService, protected $httpParamSerializer?: (d: any) => any, basePath?: string) {
-            if (basePath) {
+            if (basePath !== undefined) {
                 this.basePath = basePath;
             }
         }

--- a/samples/client/petstore/typescript-angular/API/Client/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/StoreApi.ts
@@ -12,7 +12,7 @@ namespace API.Client {
         static $inject: string[] = ['$http', '$httpParamSerializer'];
 
         constructor(protected $http: ng.IHttpService, protected $httpParamSerializer?: (d: any) => any, basePath?: string) {
-            if (basePath) {
+            if (basePath !== undefined) {
                 this.basePath = basePath;
             }
         }

--- a/samples/client/petstore/typescript-angular/API/Client/UserApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/UserApi.ts
@@ -12,7 +12,7 @@ namespace API.Client {
         static $inject: string[] = ['$http', '$httpParamSerializer'];
 
         constructor(protected $http: ng.IHttpService, protected $httpParamSerializer?: (d: any) => any, basePath?: string) {
-            if (basePath) {
+            if (basePath !== undefined) {
                 this.basePath = basePath;
             }
         }


### PR DESCRIPTION
In Angular if a value is not defined for injection it is passed as
undefined. That means that most of the time `if (value) {` is a
reasonable test. Unfortunately since `""` (empty string) is also falsey
by nature, an empty string will not trigger the if properly.

Instead you should check `if (value !== undefined) {`.