### PR TITLE
Support multiple file type parameters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/jersey2/api.mustache
@@ -48,7 +48,7 @@ public class {{classname}}  {
         {{/hasMore}}{{/responses}} })
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},{{/allParams}}@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.{{nickname}}({{#allParams}}{{#isFile}}inputStream, fileDetail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}},{{/allParams}}securityContext);
+        return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}Stream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}},{{/allParams}}securityContext);
     }
 {{/operation}}
 }

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/jersey2/formParams.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/jersey2/formParams.mustache
@@ -1,3 +1,3 @@
 {{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, {{> allowableValues }}{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}){{#vendorExtensions.x-multipart}}@FormDataParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/vendorExtensions.x-multipart}}{{^vendorExtensions.x-multipart}}@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/vendorExtensions.x-multipart}}{{/notFile}}{{#isFile}}
-            @FormDataParam("file") InputStream inputStream,
-            @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+            @FormDataParam("{{paramName}}") InputStream {{paramName}}Stream,
+            @FormDataParam("{{paramName}}") FormDataContentDisposition {{paramName}}Detail{{/isFile}}{{/isFormParam}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/jersey2/serviceFormParams.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/jersey2/serviceFormParams.mustache
@@ -1,1 +1,1 @@
-{{#isFormParam}}{{#notFile}}{{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}InputStream inputStream, FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}{{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}InputStream {{paramName}}Stream, FormDataContentDisposition {{paramName}}Detail{{/isFile}}{{/isFormParam}}


### PR DESCRIPTION
I found that every parameter with a type of file added two method parameters with the name of inputStream and fileDetail. When two or more more file type parameters are used with an operation the names conflict. The provided patch uses the convention of {{paramName}}Stream and {{paramName}}Detail for the variables avoiding the name collision. I only made the fix for jersey2. I assume the same issue occurs with jersey 1, but I don't use those templates.
