### PR TITLE
[csharp] Add common IApiAccessor interface

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -218,6 +218,8 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         binRelativePath += "vendor";
         additionalProperties.put("binRelativePath", binRelativePath);
 
+        supportingFiles.add(new SupportingFile("IApiAccessor.mustache",
+                clientPackageDir, "IApiAccessor.cs"));
         supportingFiles.add(new SupportingFile("Configuration.mustache",
                 clientPackageDir, "Configuration.cs"));
         supportingFiles.add(new SupportingFile("ApiClient.mustache",

--- a/modules/swagger-codegen/src/main/resources/csharp/IApiAccessor.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/IApiAccessor.mustache
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using RestSharp;
+
+namespace {{packageName}}.Client
+{
+    /// <summary>
+    /// Represents configuration aspects required to interact with the API endpoints.
+    /// </summary>
+    public interface IApiAccessor
+    {
+        /// <summary>
+        /// Gets or sets the configuration object
+        /// </summary>
+        /// <value>An instance of the Configuration</value>
+        Configuration Configuration {get; set;}
+
+        /// <summary>
+        /// Gets the base path of the API client.
+        /// </summary>
+        /// <value>The base path</value>
+        String GetBasePath();
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -72,7 +72,7 @@ namespace {{packageName}}.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public class {{classname}} : I{{classname}}
+    public partial class {{classname}} : I{{classname}}
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}"/> class.
@@ -122,7 +122,7 @@ namespace {{packageName}}.Api
         /// Sets the base path of the API client.
         /// </summary>
         /// <value>The base path</value>
-        [Obsolete("SetBasePath is deprecated, please do 'Configuraiton.ApiClient = new ApiClient(\"http://new-path\")' instead.")]
+        [Obsolete("SetBasePath is deprecated, please do 'Configuration.ApiClient = new ApiClient(\"http://new-path\")' instead.")]
         public void SetBasePath(String basePath)
         {
             // do nothing

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -13,7 +13,7 @@ namespace {{packageName}}.Api
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public interface I{{classname}}
+    public interface I{{classname}} : IApiAccessor
     {
         #region Synchronous Operations
         {{#operation}}


### PR DESCRIPTION
This pull does two things: adds partial keyword to generated Api class. This allows developers to create additional methods in non-generated files.

This also adds `IApiAccessor` as a base interface for Api interfaces. This allows devs to access `Configuration` getter/setter and `GetBasePath` programmatically when the specific type name of the Api class is not known or not relevant.

see #2723