### PR TITLE
typescript-angular2 query string fix

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -35,7 +35,7 @@ export class {{classname}} {
         const path = this.basePath + '{{path}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
 
-        let queryParameters: any = ""; // This should probably be an object in the future
+        let queryParameters = new URLSearchParams();
         let headerParams = this.defaultHeaders;
 {{#hasFormParams}}
         let formParams = new URLSearchParams();
@@ -51,7 +51,7 @@ export class {{classname}} {
 {{/allParams}}
 {{#queryParams}}
         if ({{paramName}} !== undefined) {
-            queryParameters['{{baseName}}'] = {{paramName}};
+            queryParameters.set('{{baseName}}', {{paramName}});
         }
 
 {{/queryParams}}


### PR DESCRIPTION
This should fix the following problems, I ran into:
1) typescript complaining: "Cannot create property 'xxx' on string '' " (string treated as map)
2) I have a subclass of RequestOptions which will call merge, which behind the scenes calls clone which isn't implemented on string
