### PR TITLE
[generator] Individual options to exclude tests and docs for apis and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,26 @@ To control the specific files being generated, you can pass a CSV list of what y
 -Dmodels=User -DsupportingFiles=StringUtil.java
 ```
 
+To control generation of docs and tests for api and models, pass false to the option. For api, these options are  `-DapiTest=false` and `-DapiDocs=false`. For models, `-DmodelTest=false` and `-DmodelDocs=false`.
+These options default to true and don't limit the generation of the feature options listed above (like `-Dapi`):
+
+```
+# generate only models (with tests and documentation)
+java -Dmodels {opts}
+
+# generate only models (with tests but no documentation)
+java -Dmodels -DmodelDocs=false {opts}
+
+# generate only User and Pet models (no tests and no documentation)
+java -Dmodels=User,Pet -DmodelTests=false {opts}
+
+# generate only apis (without tests)
+java -Dapis -DapiTests=false {opts}
+
+# generate only apis (modelTests option is ignored)
+java -Dapis -DmodelTests=false {opts}
+```
+
 When using selective generation, _only_ the templates needed for the specific generation will be used.
 
 ### Customizing the generator

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -105,4 +105,14 @@ public class CodegenConstants {
 
     public static final String SUPPORTS_ES6 = "supportsES6";
     public static final String SUPPORTS_ES6_DESC = "Generate code that conforms to ES6.";
+
+    public static final String EXCLUDE_TESTS = "excludeTests";
+    public static final String EXCLUDE_TESTS_DESC = "Specifies that no tests are to be generated.";
+
+    public static final String GENERATE_API_TESTS = "generateApiTests";
+    public static final String GENERATE_API_TESTS_DESC = "Specifies that api tests are to be generated.";
+
+    public static final String GENERATE_MODEL_TESTS = "generateModelTests";
+    public static final String GENERATE_MODEL_TESTS_DESC = "Specifies that model tests are to be generated.";
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -137,6 +137,11 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     @Override
     public void processOpts() {
         super.processOpts();
+        Boolean excludeTests = false;
+
+        if(additionalProperties.containsKey(CodegenConstants.EXCLUDE_TESTS)) {
+            excludeTests = Boolean.valueOf(additionalProperties.get(CodegenConstants.EXCLUDE_TESTS).toString());
+        }
 
         apiPackage = "Api";
         modelPackage = "Model";
@@ -232,7 +237,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
         // copy package.config to nuget's standard location for project-level installs
         supportingFiles.add(new SupportingFile("packages.config.mustache", packageFolder + File.separator, "packages.config"));
-        supportingFiles.add(new SupportingFile("packages_test.config.mustache", testPackageFolder + File.separator, "packages.config"));
+
+        if(Boolean.FALSE.equals(excludeTests)) {
+            supportingFiles.add(new SupportingFile("packages_test.config.mustache", testPackageFolder + File.separator, "packages.config"));
+        }
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
@@ -245,11 +253,9 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
             supportingFiles.add(new SupportingFile("Solution.mustache", "", packageName + ".sln"));
             supportingFiles.add(new SupportingFile("Project.mustache", packageFolder, packageName + ".csproj"));
 
-            // TODO: Check if test project output is enabled, partially related to #2506. Should have options for:
-            //       1) No test project
-            //       2) No model tests
-            //       3) No api tests
-            supportingFiles.add(new SupportingFile("TestProject.mustache", testPackageFolder, testPackageName + ".csproj"));
+            if(Boolean.FALSE.equals(excludeTests)) {
+                supportingFiles.add(new SupportingFile("TestProject.mustache", testPackageFolder, testPackageName + ".csproj"));
+            }
         }
 
         additionalProperties.put("apiDocPath", apiDocPath);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -116,6 +116,11 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
     @Override
     public void processOpts() {
         super.processOpts();
+        Boolean excludeTests = false;
+
+        if(additionalProperties.containsKey(CodegenConstants.EXCLUDE_TESTS)) {
+            excludeTests = Boolean.valueOf(additionalProperties.get(CodegenConstants.EXCLUDE_TESTS).toString());
+        }
 
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
@@ -151,7 +156,10 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         supportingFiles.add(new SupportingFile("__init__package.mustache", swaggerFolder, "__init__.py"));
         supportingFiles.add(new SupportingFile("__init__model.mustache", modelPackage, "__init__.py"));
         supportingFiles.add(new SupportingFile("__init__api.mustache", apiPackage, "__init__.py"));
-        supportingFiles.add(new SupportingFile("__init__test.mustache", testFolder, "__init__.py"));
+
+        if(Boolean.FALSE.equals(excludeTests)) {
+            supportingFiles.add(new SupportingFile("__init__test.mustache", testFolder, "__init__.py"));
+        }
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
     }

--- a/modules/swagger-codegen/src/main/resources/csharp/Solution.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Solution.mustache
@@ -4,9 +4,9 @@ VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{packageName}}", "src\{{packageName}}\{{packageName}}.csproj", "{{packageGuid}}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{testPackageName}}", "src\{{testPackageName}}\{{testPackageName}}.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
+{{^excludeTests}}Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{testPackageName}}", "src\{{testPackageName}}\{{testPackageName}}.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
-Global
+{{/excludeTests}}Global
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
 Debug|Any CPU = Debug|Any CPU
 Release|Any CPU = Release|Any CPU


### PR DESCRIPTION
> Adds support for system properties `apiTests`, `modelTests`, `modelTests`, `modelDocs`.
> All accepting a boolean value to explicitly define whether or not these
> should be generated.
> 
> These properties aren't considered "features", so specifying
> `-DmodelTests=false` for example won't cause api or supportFiles to be ignored.
> 
> Includes additionalProperty excludeTests for when apiTests and modelTests are
> both set to false.
> 
> Also includes update to csharp client generator to prevent generation of
> the Test project or inclusion of the Test project when both api and
> model tests are excluded.

Also updates the Python generator to not output the test init script when all tests are excluded.

I did a search and only found C# and Python would be affected. Please let me know if I missed anything.

Example command:

```
java -DapiTests=false -DmodelTests=false $JAVA_OPTS \
    -jar "./modules/swagger-codegen-cli/target/swagger-codegen-cli.jar" \
    generate -i swagger.yaml \
    -l csharp -o targetDir
```

The above command explicitly requests not to generate tests for APIs or models. As a result in the C# client generator, additional project files shouldn't be created (project, package.json) and the test project shouldn't be referenced in the solution.

These options are applied in `DefaultGenerator.java`, so they should work consistently across all generators.

see #2506