### PR TITLE
use Title attribute as model name

### DIFF
--- a/modules/swagger-codegen/.gitignore
+++ b/modules/swagger-codegen/.gitignore
@@ -1,1 +1,2 @@
 /.settings/
+/test-output/

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -50,7 +50,7 @@ public class InlineModelResolver {
                                         if (obj.getType() == null || "object".equals(obj.getType())) {
                                             if (obj.getProperties() != null && obj.getProperties().size() > 0) {
                                                 flattenProperties(obj.getProperties(), pathname);
-                                                String modelName = uniqueName(bp.getName());
+                                                String modelName = resolveModelName( obj.getTitle(), bp.getName());
                                                 bp.setSchema(new RefModel(modelName));
                                                 addGenerated(modelName, model);
                                                 swagger.addDefinition(modelName, model);
@@ -65,7 +65,7 @@ public class InlineModelResolver {
                                             ObjectProperty op = (ObjectProperty) inner;
                                             if (op.getProperties() != null && op.getProperties().size() > 0) {
                                                 flattenProperties(op.getProperties(), pathname);
-                                                String modelName = uniqueName(bp.getName());
+                                                String modelName = resolveModelName( op.getTitle(), bp.getName());
                                                 Model innerModel = modelFromProperty(op, modelName);
                                                 String existing = matchGenerated(innerModel);
                                                 if (existing != null) {
@@ -91,7 +91,7 @@ public class InlineModelResolver {
                                 if (property instanceof ObjectProperty) {
                                     ObjectProperty op = (ObjectProperty) property;
                                     if (op.getProperties() != null && op.getProperties().size() > 0) {
-                                        String modelName = uniqueName("inline_response_" + key);
+					String modelName = resolveModelName( op.getTitle(),"inline_response_" + key);
                                         Model model = modelFromProperty(op, modelName);
                                         String existing = matchGenerated(model);
                                         if (existing != null) {
@@ -108,18 +108,18 @@ public class InlineModelResolver {
 
                                     if(inner instanceof ObjectProperty) {
                                         ObjectProperty op = (ObjectProperty) inner;
-                                        if (op.getProperties() != null && op.getProperties().size() > 0) {
-                                            flattenProperties(op.getProperties(), pathname);
-                                            String modelName = uniqueName("inline_response_" + key);
-                                            Model innerModel = modelFromProperty(op, modelName);
-                                            String existing = matchGenerated(innerModel);
-                                            if (existing != null) {
-                                                ap.setItems(new RefProperty(existing));
-                                            } else {
+					if (op.getProperties() != null && op.getProperties().size() > 0) {
+					flattenProperties(op.getProperties(), pathname);
+					String modelName = resolveModelName( op.getTitle(),"inline_response_" + key);
+					Model innerModel = modelFromProperty(op, modelName);
+					String existing = matchGenerated(innerModel);
+                                        if (existing != null) {
+                                            	ap.setItems(new RefProperty(existing));
+                                        } else {
                                                 ap.setItems(new RefProperty(modelName));
                                                 addGenerated(modelName, innerModel);
                                                 swagger.addDefinition(modelName, innerModel);
-                                            }
+                                        	}
                                         }
                                     }
                                 } else if (property instanceof MapProperty) {
@@ -129,18 +129,18 @@ public class InlineModelResolver {
                                     if(innerProperty instanceof ObjectProperty) {
                                         ObjectProperty op = (ObjectProperty) innerProperty;
                                         if (op.getProperties() != null && op.getProperties().size() > 0) {
-                                            flattenProperties(op.getProperties(), pathname);
-                                            String modelName = uniqueName("inline_response_" + key);
-                                            Model innerModel = modelFromProperty(op, modelName);
-                                            String existing = matchGenerated(innerModel);
-                                            if (existing != null) {
-                                                mp.setAdditionalProperties(new RefProperty(existing));
-                                            } else {
-                                                mp.setAdditionalProperties(new RefProperty(modelName));
-                                                addGenerated(modelName, innerModel);
-                                                swagger.addDefinition(modelName, innerModel);
-                                            }
-                                        }
+					flattenProperties(op.getProperties(), pathname);
+					String modelName = resolveModelName( op.getTitle(),"inline_response_" + key);
+					Model innerModel = modelFromProperty(op, modelName);
+					String existing = matchGenerated(innerModel);
+	                                if (existing != null) {
+	                                    mp.setAdditionalProperties(new RefProperty(existing));
+	                                } else {
+	                                    mp.setAdditionalProperties(new RefProperty(modelName));
+	                                    addGenerated(modelName, innerModel);
+	                                    swagger.addDefinition(modelName, innerModel);
+	                                  }
+					}
                                     }
                                 }
                             }
@@ -182,6 +182,15 @@ public class InlineModelResolver {
                 }
             }
         }
+    }
+
+    private String resolveModelName(String title, String key ) {
+	if (title == null) {
+	    return uniqueName(key);
+	}
+	else {
+	    return uniqueName(title);
+	}
     }
 
     public String matchGenerated(Model model) {


### PR DESCRIPTION
[Use "Title" as model name if provided in swagger definition](https://github.com/swagger-api/swagger-codegen/issues/2868)

this allows to use names defined by user in Response model instead of
"inline_response". Also user could use title to have specific name for
request model instead of parameter name