### PR TITLE
Fixes instructions for generating PHP Silex code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
 ```
 java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
   -i http://petstore.swagger.io/v2/swagger.json \
-  -l silex \
+  -l silex-PHP \
   -o samples/server/petstore/silex
 ```
 


### PR DESCRIPTION
The name of this generator was updated from `silex` to `silex-PHP` in @dc7c2a4b, but that change wasn't reflected in README.md.