### PR TITLE
Upgrade swagger core to 1.5.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -562,7 +562,7 @@
         <swagger-parser-version>1.0.19</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>2.3.4</felix-version>
-        <swagger-core-version>1.5.8</swagger-core-version>
+        <swagger-core-version>1.5.9</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.8.1</junit-version>


### PR DESCRIPTION
release note: https://github.com/swagger-api/swagger-core/releases/tag/v1.5.9