### PR TITLE
[csharp] Intercept hooks for req/res and ExceptionFactory

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -233,6 +233,8 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 clientPackageDir, "ApiException.cs"));
         supportingFiles.add(new SupportingFile("ApiResponse.mustache",
                 clientPackageDir, "ApiResponse.cs"));
+        supportingFiles.add(new SupportingFile("ExceptionFactory.mustache",
+                clientPackageDir, "ExceptionFactory.cs"));
 
         supportingFiles.add(new SupportingFile("compile.mustache", "", "build.bat"));
         supportingFiles.add(new SupportingFile("compile-mono.sh.mustache", "", "build.sh"));

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -17,14 +17,27 @@ using RestSharp;
 namespace {{packageName}}.Client
 {
     /// <summary>
-    /// API client is mainly responible for making the HTTP call to the API backend.
+    /// API client is mainly responsible for making the HTTP call to the API backend.
     /// </summary>
-    public class ApiClient
+    public partial class ApiClient
     {
         private JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
         };
+
+        /// <summary>
+        /// Allows for extending request processing for <see cref="ApiClient"/> generated code.
+        /// </summary>
+        /// <param name="request">The RestSharp request object</param>
+        partial void InterceptRequest(IRestRequest request);
+
+        /// <summary>
+        /// Allows for extending response processing for <see cref="ApiClient"/> generated code.
+        /// </summary>
+        /// <param name="request">The RestSharp request object</param>
+        /// <param name="response">The RestSharp response object</param>
+        partial void InterceptResponse(IRestRequest request, IRestResponse response);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class
@@ -165,6 +178,7 @@ namespace {{packageName}}.Client
             // set user agent
             RestClient.UserAgent = Configuration.UserAgent;
 
+            InterceptRequest(request);
             {{^supportsUWP}}
             var response = RestClient.Execute(request);
             {{/supportsUWP}}
@@ -172,6 +186,8 @@ namespace {{packageName}}.Client
             // Using async method to perform sync call (uwp-only)
             var response = RestClient.ExecuteTaskAsync(request).Result;
             {{/supportsUWP}}
+            InterceptResponse(request, response);
+
             return (Object) response;
         }
         {{#supportsAsync}}
@@ -197,7 +213,9 @@ namespace {{packageName}}.Client
             var request = PrepareRequest(
                 path, method, queryParams, postBody, headerParams, formParams, fileParams,
                 pathParams, contentType);
+            InterceptRequest(request);
             var response = await RestClient.ExecuteTaskAsync(request);
+            InterceptResponse(request, response);
             return (Object)response;
         }{{/supportsAsync}}
 

--- a/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
@@ -81,6 +81,17 @@ namespace {{packageName}}.Client
         public static Configuration Default = new Configuration();
 
         /// <summary>
+        /// Default creation of exceptions for a given method name and response object
+        /// </summary>
+        public static readonly ExceptionFactory DefaultExceptionFactory = (methodName, response) =>
+        {
+            int status = (int) response.StatusCode;
+            if (status >= 400) return new ApiException(status, String.Format("Error calling {0}: {1}", methodName, response.Content), response.Content);
+            if (status == 0) return new ApiException(status, String.Format("Error calling {0}: {1}", methodName, response.ErrorMessage), response.ErrorMessage);
+            return null;
+        };
+
+        /// <summary>
         /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 100000 milliseconds.
         /// </summary>
         /// <value>Timeout.</value>

--- a/modules/swagger-codegen/src/main/resources/csharp/ExceptionFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ExceptionFactory.mustache
@@ -1,0 +1,7 @@
+using System;
+using RestSharp;
+
+namespace {{packageName}}.Client
+{
+    public delegate Exception ExceptionFactory(string methodName, IRestResponse response);
+}

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -75,6 +75,8 @@ namespace {{packageName}}.Api
     /// </summary>
     public partial class {{classname}} : I{{classname}}
     {
+        private {{packageName}}.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}"/> class.
         /// </summary>
@@ -82,6 +84,8 @@ namespace {{packageName}}.Api
         public {{classname}}(String basePath)
         {
             this.Configuration = new Configuration(new ApiClient(basePath));
+
+            ExceptionFactory = {{packageName}}.Client.Configuration.DefaultExceptionFactory;
 
             // ensure API client has configuration ready
             if (Configuration.ApiClient.Configuration == null)
@@ -102,6 +106,8 @@ namespace {{packageName}}.Api
                 this.Configuration = Configuration.Default;
             else
                 this.Configuration = configuration;
+
+            ExceptionFactory = {{packageName}}.Client.Configuration.DefaultExceptionFactory;
 
             // ensure API client has configuration ready
             if (Configuration.ApiClient.Configuration == null)
@@ -134,6 +140,22 @@ namespace {{packageName}}.Api
         /// </summary>
         /// <value>An instance of the Configuration</value>
         public Configuration Configuration {get; set;}
+
+        /// <summary>
+        /// Provides a factory method hook for the creation of exceptions.
+        /// </summary>
+        public {{packageName}}.Client.ExceptionFactory ExceptionFactory
+        {
+            get
+            {
+                if (_exceptionFactory != null && _exceptionFactory.GetInvocationList().Length > 1)
+                {
+                    throw new InvalidOperationException("Multicast delegate for ExceptionFactory is unsupported.");
+                }
+                return _exceptionFactory;
+            }
+            set { _exceptionFactory = value; }
+        }
 
         /// <summary>
         /// Gets the default header.
@@ -276,10 +298,11 @@ namespace {{packageName}}.Api
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
-            if (localVarStatusCode >= 400)
-                throw new ApiException (localVarStatusCode, "Error calling {{operationId}}: " + localVarResponse.Content, localVarResponse.Content);
-            else if (localVarStatusCode == 0)
-                throw new ApiException (localVarStatusCode, "Error calling {{operationId}}: " + localVarResponse.ErrorMessage, localVarResponse.ErrorMessage);
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("{{operationId}}", localVarResponse);
+                if (exception != null) throw exception;
+            }
 
             {{#returnType}}return new ApiResponse<{{{returnType}}}>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
@@ -410,10 +433,11 @@ namespace {{packageName}}.Api
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
-            if (localVarStatusCode >= 400)
-                throw new ApiException (localVarStatusCode, "Error calling {{operationId}}: " + localVarResponse.Content, localVarResponse.Content);
-            else if (localVarStatusCode == 0)
-                throw new ApiException (localVarStatusCode, "Error calling {{operationId}}: " + localVarResponse.ErrorMessage, localVarResponse.ErrorMessage);
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("{{operationId}}", localVarResponse);
+                if (exception != null) throw exception;
+            }
 
             {{#returnType}}return new ApiResponse<{{{returnType}}}>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),


### PR DESCRIPTION
See #2724 

This implements a delegate `ExceptionFactory` which can be applied to an instance of `Configuration`. Defaults to previous exception handling logic.

Also converts `ApiClient` to a partial class, with partial methods to intercept requests and responses. These could be used to do any number of things that hook into the `CallApi` methods.

Users can now implement their own logic in partial classes and prevent future overwrites using .swagger-codegen-ignore. For example:

```
// in src/IO.Swagger/Client/ApiClientRequestInterceptor.cs
//…
public partial class ApiClient 
{
    partial void InterceptRequest(IRestRequest request)
    {
        Debug.WriteLine("Request made: {0}", request.Path);
    }
}

// in .swagger-codegen-ignore, prevents any possible file overwrites.
//…
src/IO.Swagger/Client/ApiClientRequestInterceptor.cs
```