### PR TITLE
[csharp] map number/no format to Decimal

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
@@ -77,6 +77,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                         "string",
                         "bool?",
                         "double?",
+                        "decimal?",
                         "int?",
                         "long?",
                         "float?",
@@ -112,7 +113,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         typeMapping.put("float", "float?");
         typeMapping.put("long", "long?");
         typeMapping.put("double", "double?");
-        typeMapping.put("number", "double?");
+        typeMapping.put("number", "decimal?");
         typeMapping.put("datetime", "DateTime?");
         typeMapping.put("date", "DateTime?");
         typeMapping.put("file", "System.IO.Stream");


### PR DESCRIPTION
Changes the default primitive for `number` with no specified format from `double` to `decimal` in C#.

Other number/integer mappings remain unchanged:

| type | format | C# type |
|-------|----------|------------|
| number | float | System.Float |
| number | double | System.Double |
| number | ------ | System.Decimal |
| integer | int64 | System.Int64 | 
| integer | int32 | System.Int32 | 
| integer | ------ | System.Int32 | 

See #2967 and #2813.

@wing328 this seems like an extremely simple fix, and I feel like I've missed something. I generated the csharp client and verified that types looked fine and tests passed.