### PR TITLE
Feign: disable FAIL_ON_UNKNOWN_PROPERTIES by default

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -128,6 +128,7 @@ public class ApiClient {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+    objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     return objectMapper;
   }
 


### PR DESCRIPTION
By default, the feign jackson decoder doesn't fail on unknown properties.
I think the generated feign generated code should follow the same behaviour.