### PR TITLE
Feign: disable FAIL_ON_UNKNOWN_PROPERTIES by default

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -22,7 +22,7 @@ import {{invokerPackage}}.auth.OAuth.AccessTokenListener;
 public class ApiClient {
   public interface Api {}
 
-  private ObjectMapper objectMapper;
+  protected ObjectMapper objectMapper;
   private String basePath = "{{basePath}}";
   private Map<String, RequestInterceptor> apiAuthorizations;
   private Feign.Builder feignBuilder;
@@ -128,6 +128,11 @@ public class ApiClient {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+    objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    return objectMapper;
+  }
+
+  public ObjectMapper getObjectMapper(){
     return objectMapper;
   }
 

--- a/samples/client/petstore/java/feign/LICENSE
+++ b/samples/client/petstore/java/feign/LICENSE
@@ -174,3 +174,28 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/FormAwareEncoder.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/FormAwareEncoder.java
@@ -14,7 +14,7 @@ import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import feign.RequestTemplate;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class FormAwareEncoder implements Encoder {
   public static final String UTF_8 = "utf-8";
   private static final String LINE_FEED = "\r\n";

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/StringUtil.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/StringUtil.java
@@ -1,6 +1,6 @@
 package io.swagger.client;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 import feign.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public interface FakeApi extends ApiClient.Api {
 
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 import feign.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public interface PetApi extends ApiClient.Api {
 
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/StoreApi.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 import feign.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public interface StoreApi extends ApiClient.Api {
 
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/UserApi.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 import feign.*;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public interface UserApi extends ApiClient.Api {
 
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
@@ -13,7 +13,7 @@ import java.util.Map;
 /**
  * AdditionalPropertiesClass
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class AdditionalPropertiesClass   {
   
   private Map<String, String> mapProperty = new HashMap<String, String>();

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Animal.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Animal   {
   
   private String className = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/AnimalFarm.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/AnimalFarm.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * AnimalFarm
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class AnimalFarm extends ArrayList<Animal>  {
   
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ArrayTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * ArrayTest
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class ArrayTest   {
   
   private List<String> arrayOfString = new ArrayList<String>();

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Cat.java
@@ -11,7 +11,7 @@ import io.swagger.client.model.Animal;
 /**
  * Cat
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Cat extends Animal  {
   
   private String className = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Category.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Category
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Category   {
   
   private Long id = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Dog.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Dog.java
@@ -11,7 +11,7 @@ import io.swagger.client.model.Animal;
 /**
  * Dog
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Dog extends Animal  {
   
   private String className = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
@@ -11,7 +11,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * EnumTest
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class EnumTest   {
   
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/FormatTest.java
@@ -12,7 +12,7 @@ import java.util.Date;
 /**
  * FormatTest
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class FormatTest   {
   
   private Integer integer = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,7 +15,7 @@ import java.util.Map;
 /**
  * MixedPropertiesAndAdditionalPropertiesClass
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   
   private String uuid = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Model200Response.java
@@ -11,7 +11,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Model for testing model name starting with number
  */
 @ApiModel(description = "Model for testing model name starting with number")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Model200Response   {
   
   private Integer name = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ModelApiResponse.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ModelApiResponse
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class ModelApiResponse   {
   
   private Integer code = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ModelReturn.java
@@ -11,7 +11,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Model for testing reserved words
  */
 @ApiModel(description = "Model for testing reserved words")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class ModelReturn   {
   
   private Integer _return = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Name.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Name.java
@@ -11,7 +11,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Model for testing model name same as property name
  */
 @ApiModel(description = "Model for testing model name same as property name")
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Name   {
   
   private Integer name = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
@@ -12,7 +12,7 @@ import java.util.Date;
 /**
  * Order
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Order   {
   
   private Long id = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
@@ -15,7 +15,7 @@ import java.util.List;
 /**
  * Pet
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Pet   {
   
   private Long id = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ReadOnlyFirst.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ReadOnlyFirst
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class ReadOnlyFirst   {
   
   private String bar = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/SpecialModelName.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * SpecialModelName
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class SpecialModelName   {
   
   private Long specialPropertyName = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Tag.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Tag
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class Tag   {
   
   private Long id = null;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/User.java
@@ -10,7 +10,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * User
  */
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-29T21:13:47.191+01:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaClientCodegen", date = "2016-05-31T18:50:49.249+02:00")
 public class User   {
   
   private Long id = null;


### PR DESCRIPTION
By default, the feign jackson decoder doesn't fail on unknown properties.
I think the swagger feign generated code should follow the same behaviour.