### PR TITLE
Remove unnecessary 2nd call to SwaggerParser.

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -163,8 +163,6 @@ public class CodeGenMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException {
 
-        Swagger swagger = new SwaggerParser().read(inputSpec);
-
         //attempt to read from config file
         CodegenConfigurator configurator = CodegenConfigurator.fromFile(configurationFile);
 


### PR DESCRIPTION
Both CodeGenMojo and CodegenConfigurator where parsing the swagger input.
The result in CodeGenMojo was discarded. I simply removed the line in
CodeGenMojo.