### PR TITLE
use {{name}} not {{classname}} in HTML section header/anchors

### DIFF
--- a/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
@@ -156,7 +156,7 @@
   <ol>
   {{#models}}
   {{#model}}
-    <li><a href="#{{classname}}"><code>{{classname}}</code></a></li>
+    <li><a href="#{{name}}"><code>{{name}}</code></a></li>
   {{/model}}
   {{/models}}
   </ol>
@@ -164,7 +164,7 @@
   {{#models}}
   {{#model}}
   <div class="model">
-    <h3 class="field-label"><a name="{{classname}}">{{classname}}</a> <a class="up" href="#__Models">Up</a></h3>
+    <h3 class="field-label"><a name="{{name}}">{{name}}</a> <a class="up" href="#__Models">Up</a></h3>
     <div class="field-items">
       {{#vars}}<div class="param">{{name}} {{^required}}(optional){{/required}}</div><div class="param-desc"><span class="param-type">{{^isPrimitiveType}}<a href="#{{complexType}}">{{datatype}}</a>{{/isPrimitiveType}}</span> {{description}}</div>
       {{#isEnum}}


### PR DESCRIPTION
Fixes #3012 