### PR TITLE
Use UnsupportedOperationException.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
@@ -7,10 +7,8 @@ import io.swagger.models.properties.*;
 import io.swagger.models.Model;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.*;
-import java.io.File;
 
 public class HaskellServantCodegen extends DefaultCodegen implements CodegenConfig {
 
@@ -432,7 +430,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
             case "pipes": return "(QueryList 'PipeSeparated (" + type + "))";
             case "multi": return "(QueryList 'MultiParamArray (" + type + "))";
             default:
-                throw new NotImplementedException();
+                throw new UnsupportedOperationException();
         }
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/go/GoClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/go/GoClientOptionsTest.java
@@ -1,4 +1,4 @@
-package io.swagger.codegen.Go;
+package io.swagger.codegen.go;
 
 import io.swagger.codegen.AbstractOptionsTest;
 import io.swagger.codegen.CodegenConfig;
@@ -29,7 +29,7 @@ public class GoClientOptionsTest extends AbstractOptionsTest {
             clientCodegen.setPackageVersion(GoClientOptionsProvider.PACKAGE_VERSION_VALUE);
             times = 1;
             clientCodegen.setPackageName(GoClientOptionsProvider.PACKAGE_NAME_VALUE);
-            times = 1;                        
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/go/GoModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/go/GoModelTest.java
@@ -1,4 +1,4 @@
-package io.swagger.codegen.Go;
+package io.swagger.codegen.go;
 
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenProperty;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/lumen/LumenServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/lumen/LumenServerOptionsTest.java
@@ -1,4 +1,4 @@
-package io.swagger.codegen.slim;
+package io.swagger.codegen.lumen;
 
 import io.swagger.codegen.AbstractOptionsTest;
 import io.swagger.codegen.CodegenConfig;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/springboot/SpringBootServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/springboot/SpringBootServerOptionsTest.java
@@ -1,4 +1,4 @@
-package io.swagger.codegen.springBoot;
+package io.swagger.codegen.springboot;
 
 import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.java.JavaClientOptionsTest;
@@ -54,7 +54,7 @@ public class SpringBootServerOptionsTest extends JavaClientOptionsTest {
             times = 1;
             clientCodegen.setBasePackage(SpringBootServerOptionsProvider.BASE_PACKAGE_VALUE);
             times = 1;
- 
+
         }};
     }
 }


### PR DESCRIPTION
Replaced NotImplementedException with UnsupportedOperationException. See
bug #3011.

Eclipse was throwing some errors related to differences in package names
vs file path. I renamed the packages io.swagger.codegen.Go to
io.swagger.codegen.go, io.swagger.codegen.slim to package
io.swagger.codegen.lumen and io.swagger.codegen.springBoot to
io.swagger.codegen.springboot in some test files.