### PR TITLE
[ObjC] Fix various bugs in generated code.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -50,6 +50,7 @@ static NSString * {{classPrefix}}__fileNameForResponse(NSURLResponse *response) 
 - (instancetype)initWithBaseURL:(NSURL *)url {
     self = [super initWithBaseURL:url];
     if (self) {
+        self.timeoutInterval = 60;
         self.requestSerializer = [AFJSONRequestSerializer serializer];
         self.responseSerializer = [AFJSONResponseSerializer serializer];
         self.securityPolicy = [self customSecurityPolicy];
@@ -85,6 +86,11 @@ static NSString * {{classPrefix}}__fileNameForResponse(NSURLResponse *response) 
 
 - (void)setHeaderValue:(NSString*) value forKey:(NSString*) forKey {
     [self.requestSerializer setValue:value forHTTPHeaderField:forKey];
+}
+
+- (void)setRequestSerializer:(AFHTTPRequestSerializer<AFURLRequestSerialization> *)requestSerializer {
+    [super setRequestSerializer:requestSerializer];
+    requestSerializer.timeoutInterval = self.timeoutInterval;
 }
 
 #pragma mark - Cache Methods

--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <ISO8601/ISO8601.h>
-#import <AFNetworking.h>
+#import <AFNetworking/AFNetworking.h>
 #import "{{classPrefix}}JSONResponseSerializer.h"
 #import "{{classPrefix}}JSONRequestSerializer.h"
 #import "{{classPrefix}}QueryParamCollection.h"

--- a/modules/swagger-codegen/src/main/resources/objc/Sanitizer-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/Sanitizer-body.mustache
@@ -35,13 +35,13 @@ NSString * {{classPrefix}}PercentEscapedStringFromString(NSString *string) {
     return escaped;
 }
 
-@interface SWGSanitizer ()
+@interface {{classPrefix}}Sanitizer ()
 
 @property (nonatomic, strong) NSRegularExpression* jsonHeaderTypeExpression;
 
 @end
 
-@implementation SWGSanitizer
+@implementation {{classPrefix}}Sanitizer
 
 static NSString * kApplicationJSONType = @"application/json";
 


### PR DESCRIPTION
Fix a bug that's been around for a while where ApiClient.timeoutInterval didn't do anything. Every time `requestWithPath:...` is called, a new `requestSerializer` is set, which is why the timeout update needs to happen in `setRequestSerializer:`. `60` is the default timeout interval for `NSURLRequest`. I couldn't find a way to get that value programmatically.

Also, when I updated my clone of `swagger-codegen`, my generated code failed to compile for a number of reasons. I had to fix these bugs to get the compile working again. All of these were introduced in the past month or so, it seems like I'm just cleaning up after someone else's mess here.
- Change `#import <AFNetworking.h>` back to `#import <AFNetworking/AFNetworking.h>`. XCode can't locate the header with a normal CocoaPod dependency when it's just `<AFNetworking.h>`.
- Fix usages of `SWG` instead of `{{classPrefix}}` which make the compile break whenever a `classPrefix` is configured.