### PR TITLE
[Swift] #3036 Make APIHelper.convertBoolToString return nil for nil input

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIHelper.mustache
@@ -19,18 +19,19 @@ class APIHelper {
         return destination
     }
 
-    static func convertBoolToString(source: [String: AnyObject]?) -> [String:AnyObject] {
+    static func convertBoolToString(source: [String: AnyObject]?) -> [String:AnyObject]? {
+        guard let source = source else {
+            return nil
+        }
         var destination = [String:AnyObject]()
         let theTrue = NSNumber(bool: true)
         let theFalse = NSNumber(bool: false)
-        if (source != nil) {
-            for (key, value) in source! {
-                switch value {
-                    case let x where x === theTrue || x === theFalse:
-                        destination[key] = "\(value as! Bool)"
-                    default:
-                        destination[key] = value
-                }
+        for (key, value) in source {
+            switch value {
+            case let x where x === theTrue || x === theFalse:
+                destination[key] = "\(value as! Bool)"
+            default:
+                destination[key] = value
             }
         }
         return destination


### PR DESCRIPTION
This will prevent the creation of an empty body for GET requests.