### PR TITLE
Add build folder under java sample clients into gitignore in sample.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,11 @@ samples/client/petstore/java/jersey2/.gradle/
 samples/client/petstore/java/jersey2/build/
 samples/client/petstore/java/okhttp-gson/.gradle/
 samples/client/petstore/java/okhttp-gson/build/
+samples/client/petstore/java/feign/build/
+samples/client/petstore/java/retrofit/build/
+samples/client/petstore/java/retrofit2/build/
+samples/client/petstore/java/retrofit2rx/build/
+samples/client/petstore/java/default/build/
 
 #PHP
 samples/client/petstore/php/SwaggerClient-php/composer.lock


### PR DESCRIPTION
As they all support gradle now, the build folder that contains the artifacts and test reports should be added into gitignore.