### PR TITLE
fix date format in example generator

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -93,9 +93,9 @@ public class ExampleGenerator {
                 };
             }
         } else if (property instanceof DateProperty) {
-            return "2000-01-23T04:56:07.000+0000";
+            return "2000-01-23T04:56:07.000+00:00";
         } else if (property instanceof DateTimeProperty) {
-            return "2000-01-23T04:56:07.000+0000";
+            return "2000-01-23T04:56:07.000+00:00";
         } else if (property instanceof DecimalProperty) {
             return new BigDecimal(1.3579);
         } else if (property instanceof DoubleProperty) {


### PR DESCRIPTION
As stated on http://swagger.io/specification/#dataTypes the date-time format defined by RFC3339 requires a colon in the time-offset.

I think #2236 introduced that one.

The z-schema and the javascript swagger-tools validators even don't validate the date format without the colon. e.g. If you enable the output validation in the nodejs sample app, the request to http://localhost:8080/v2/store/order/1 failes with an `Error: Response validation failed: failed schema validation`