### PR TITLE
typescript-angular2: Set Accept and Content-Type to application/json

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -17,7 +17,10 @@ import 'rxjs/Rx';
 @Injectable()
 export class {{classname}} {
     protected basePath = '{{basePath}}';
-    public defaultHeaders : Headers = new Headers();
+    public defaultHeaders : Headers = new Headers({
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    });
 
     constructor(protected http: Http, @Optional() basePath: string) {
         if (basePath) {


### PR DESCRIPTION
Set Accept and Content-Type to application/json as default for all requests.

See #3081 for a description of the problem.