### PR TITLE
Fixed several issues with Qt5 generator and Qt5 PetStore tests

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -135,6 +135,9 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
 
         systemIncludes.add("QString");
         systemIncludes.add("QList");
+        systemIncludes.add("QMap");
+        systemIncludes.add("QDate");
+        systemIncludes.add("QDateTime");
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -87,7 +87,7 @@ void
     HttpRequestInput input(fullPath, "{{httpMethod}}");
 
     {{#formParams}}if ({{paramName}} != NULL) {
-        {{^isFile}}input.add_var("{{paramName}}", *{{paramName}});{{/isFile}}{{#isFile}}input.add_file("{{paramName}}", *{{paramName}}.local_filename, *{{paramName}}.request_filename, *{{paramName}}.mime_type);{{/isFile}}
+        {{^isFile}}input.add_var("{{paramName}}", *{{paramName}});{{/isFile}}{{#isFile}}input.add_file("{{paramName}}", (*{{paramName}}).local_filename, (*{{paramName}}).request_filename, (*{{paramName}}).mime_type);{{/isFile}}
     }
     {{/formParams}}
 

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -53,6 +53,46 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
             qDebug() << "Can't set value because the target pointer is NULL";
         }
     }
+    else if (QStringLiteral("QDateTime").compare(type) == 0) {
+        QDateTime **val = static_cast<QDateTime**>(value);
+
+        if(val != NULL) {
+            if(!obj.isNull()) {
+                // create a new value and return
+                delete *val;
+                *val = new QDateTime(QDateTime::fromString(obj.toString(), Qt::ISODate));
+                return;
+            }
+            else {
+                // set target to NULL
+                delete *val;
+                *val = NULL;
+            }
+        }
+        else {
+            qDebug() << "Can't set value because the target pointer is NULL";
+        }
+    }
+    else if (QStringLiteral("QDate").compare(type) == 0) {
+        QDate **val = static_cast<QDate**>(value);
+
+        if(val != NULL) {
+            if(!obj.isNull()) {
+                // create a new value and return
+                delete *val;
+                *val = new QDate(QDate::fromString(obj.toString(), Qt::ISODate));
+                return;
+            }
+            else {
+                // set target to NULL
+                delete *val;
+                *val = NULL;
+            }
+        }
+        else {
+            qDebug() << "Can't set value because the target pointer is NULL";
+        }
+    }
     else if(type.startsWith("SWG") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
@@ -104,6 +144,21 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                     setValue(&val, jval, QStringLiteral("double"), QStringLiteral(""));
                     output->append((void*)&val);
                 }
+                else if(QStringLiteral("QString").compare(complexType) == 0) {
+                    QString val;
+                    setValue(&val, jval, QStringLiteral("QString"), QStringLiteral(""));
+                    output->append((void*)&val);
+                }
+                else if(QStringLiteral("QDate").compare(complexType) == 0) {
+                    QDate val;
+                    setValue(&val, jval, QStringLiteral("QDate"), QStringLiteral(""));
+                    output->append((void*)&val);
+                }
+                else if(QStringLiteral("QDateTime").compare(complexType) == 0) {
+                    QDateTime val;
+                    setValue(&val, jval, QStringLiteral("QDateTime"), QStringLiteral(""));
+                    output->append((void*)&val);
+                }
             }
         }
         QList<void*> **val = static_cast<QList<void*>**>(value);
@@ -139,23 +194,31 @@ toJsonValue(QString name, void* value, QJsonObject* output, QString type) {
     }
     else if(QStringLiteral("qint32").compare(type) == 0) {
         qint32* str = static_cast<qint32*>(value);
-        output->insert(name, QJsonValue(*str));    
+        output->insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("qint64").compare(type) == 0) {
         qint64* str = static_cast<qint64*>(value);
-        output->insert(name, QJsonValue(*str));    
+        output->insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("bool").compare(type) == 0) {
         bool* str = static_cast<bool*>(value);
-        output->insert(name, QJsonValue(*str));    
+        output->insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("float").compare(type) == 0) {
         float* str = static_cast<float*>(value);
-        output->insert(name, QJsonValue((double)*str));    
+        output->insert(name, QJsonValue((double)*str));
     }
     else if(QStringLiteral("double").compare(type) == 0) {
         double* str = static_cast<double*>(value);
-        output->insert(name, QJsonValue(*str));    
+        output->insert(name, QJsonValue(*str));
+    }
+    else if(QStringLiteral("QDate").compare(type) == 0) {
+        QDate* date = static_cast<QDate*>(value);
+        output->insert(name, QJsonValue(date->toString(Qt::ISODate)));
+    }
+    else if(QStringLiteral("QDateTime").compare(type) == 0) {
+        QDateTime* datetime = static_cast<QDateTime*>(value);
+        output->insert(name, QJsonValue(datetime->toString(Qt::ISODate)));
     }
 }
 

--- a/samples/client/petstore/qt5cpp/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/qt5cpp/PetStore/PetApiTests.cpp
@@ -228,7 +228,7 @@ void PetApiTests::updatePetWithFormTest() {
     connect(api, &SWGPetApi::updatePetWithFormSignal, this, [](){loop.quit();});
     connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
 
-    api->updatePetWithForm(new QString(QString::number(id)), new QString("gorilla"), NULL);
+    api->updatePetWithForm(id, new QString("gorilla"), NULL);
     timer.start();
     loop.exec();
     QVERIFY2(timer.isActive(), "didn't finish within timeout");

--- a/samples/client/petstore/qt5cpp/PetStore/PetStore.pro
+++ b/samples/client/petstore/qt5cpp/PetStore/PetStore.pro
@@ -28,6 +28,7 @@ SOURCES += main.cpp \
     ../client/SWGTag.cpp \
     ../client/SWGUser.cpp \
     ../client/SWGUserApi.cpp \
+    ../client/SWGApiResponse.cpp \
     PetApiTests.cpp
 
 HEADERS += \
@@ -43,4 +44,5 @@ HEADERS += \
     ../client/SWGUser.h \
     ../client/SWGUserApi.h \
     PetApiTests.h \
+    ../client/SWGApiResponse.h \
     ../client/SWGModelFactory.h

--- a/samples/client/petstore/qt5cpp/client/SWGHelpers.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGHelpers.cpp
@@ -53,6 +53,46 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
             qDebug() << "Can't set value because the target pointer is NULL";
         }
     }
+    else if (QStringLiteral("QDateTime").compare(type) == 0) {
+        QDateTime **val = static_cast<QDateTime**>(value);
+
+        if(val != NULL) {
+            if(!obj.isNull()) {
+                // create a new value and return
+                delete *val;
+                *val = new QDateTime(QDateTime::fromString(obj.toString(), Qt::ISODate));
+                return;
+            }
+            else {
+                // set target to NULL
+                delete *val;
+                *val = NULL;
+            }
+        }
+        else {
+            qDebug() << "Can't set value because the target pointer is NULL";
+        }
+    }
+    else if (QStringLiteral("QDate").compare(type) == 0) {
+        QDate **val = static_cast<QDate**>(value);
+
+        if(val != NULL) {
+            if(!obj.isNull()) {
+                // create a new value and return
+                delete *val;
+                *val = new QDate(QDate::fromString(obj.toString(), Qt::ISODate));
+                return;
+            }
+            else {
+                // set target to NULL
+                delete *val;
+                *val = NULL;
+            }
+        }
+        else {
+            qDebug() << "Can't set value because the target pointer is NULL";
+        }
+    }
     else if(type.startsWith("SWG") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
@@ -104,6 +144,21 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                     setValue(&val, jval, QStringLiteral("double"), QStringLiteral(""));
                     output->append((void*)&val);
                 }
+                else if(QStringLiteral("QString").compare(complexType) == 0) {
+                    QString val;
+                    setValue(&val, jval, QStringLiteral("QString"), QStringLiteral(""));
+                    output->append((void*)&val);
+                }
+                else if(QStringLiteral("QDate").compare(complexType) == 0) {
+                    QDate val;
+                    setValue(&val, jval, QStringLiteral("QDate"), QStringLiteral(""));
+                    output->append((void*)&val);
+                }
+                else if(QStringLiteral("QDateTime").compare(complexType) == 0) {
+                    QDateTime val;
+                    setValue(&val, jval, QStringLiteral("QDateTime"), QStringLiteral(""));
+                    output->append((void*)&val);
+                }
             }
         }
         QList<void*> **val = static_cast<QList<void*>**>(value);
@@ -139,23 +194,31 @@ toJsonValue(QString name, void* value, QJsonObject* output, QString type) {
     }
     else if(QStringLiteral("qint32").compare(type) == 0) {
         qint32* str = static_cast<qint32*>(value);
-        output->insert(name, QJsonValue(*str));    
+        output->insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("qint64").compare(type) == 0) {
         qint64* str = static_cast<qint64*>(value);
-        output->insert(name, QJsonValue(*str));    
+        output->insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("bool").compare(type) == 0) {
         bool* str = static_cast<bool*>(value);
-        output->insert(name, QJsonValue(*str));    
+        output->insert(name, QJsonValue(*str));
     }
     else if(QStringLiteral("float").compare(type) == 0) {
         float* str = static_cast<float*>(value);
-        output->insert(name, QJsonValue((double)*str));    
+        output->insert(name, QJsonValue((double)*str));
     }
     else if(QStringLiteral("double").compare(type) == 0) {
         double* str = static_cast<double*>(value);
-        output->insert(name, QJsonValue(*str));    
+        output->insert(name, QJsonValue(*str));
+    }
+    else if(QStringLiteral("QDate").compare(type) == 0) {
+        QDate* date = static_cast<QDate*>(value);
+        output->insert(name, QJsonValue(date->toString(Qt::ISODate)));
+    }
+    else if(QStringLiteral("QDateTime").compare(type) == 0) {
+        QDateTime* datetime = static_cast<QDateTime*>(value);
+        output->insert(name, QJsonValue(datetime->toString(Qt::ISODate)));
     }
 }
 

--- a/samples/client/petstore/qt5cpp/client/SWGOrder.h
+++ b/samples/client/petstore/qt5cpp/client/SWGOrder.h
@@ -10,7 +10,7 @@
 #include <QJsonObject>
 
 
-#include "QDateTime.h"
+#include <QDateTime>
 #include <QString>
 
 #include "SWGObject.h"

--- a/samples/client/petstore/qt5cpp/client/SWGPetApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGPetApi.cpp
@@ -438,7 +438,7 @@ SWGPetApi::uploadFile(qint64 petId, QString* additionalMetadata, SWGHttpRequestI
         input.add_var("additionalMetadata", *additionalMetadata);
     }
 if (file != NULL) {
-        input.add_file("file", *file.local_filename, *file.request_filename, *file.mime_type);
+        input.add_file("file", (*file).local_filename, (*file).request_filename, (*file).mime_type);
     }
 
 

--- a/samples/client/petstore/qt5cpp/client/SWGStoreApi.h
+++ b/samples/client/petstore/qt5cpp/client/SWGStoreApi.h
@@ -4,7 +4,7 @@
 #include "SWGHttpRequest.h"
 
 #include <QString>
-#include "QMap.h"
+#include <QMap>
 #include "SWGOrder.h"
 
 #include <QObject>


### PR DESCRIPTION
@wing328 as announced in my email, here is the fix for the missing data-type handlers in the template thats rendered into SWGHelpers.cpp

QDate and QDateTime handling was missing entirely. I also found QString handling to be missing in arrays.

PS: There are four overloaded `QString stringValue(..)` functions which are unused and never called as it seems. By logic, they would be missing overloaded funcs for float, double, QDate and QDateTime. I didnt add those tho as they are never called and SDK is working still fine.