### PR TITLE
Unserialuse a Timestamp date passed from Server to PHP client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -239,6 +239,13 @@ class ObjectSerializer
             // be interpreted as a missing field/value. Let's handle
             // this graceful.
             if (!empty($data)) {
+                // In some cases the server can send us a valid data
+                // represented as a timestamp either in seconds, 10 digits,
+                // or in milliseconds, 14 digits. We need to transform it in
+                // in valid format before passing it back as DateTime object.
+                if (1 === preg_match('/\d{10,14}/', $data)) {
+                    $data = date(DATE_ISO8601, $data);
+                }
                 return new \DateTime($data);
             } else {
                 return null;


### PR DESCRIPTION
In some cases the server can return a date in timestamp format instead of ISO8601.

That is a valid date format that can be either 10 or 14 digits respectfully for
seconds or milliseconds time stamp.

Currently the code throws a runtime error as we try to instanciate a DateTime object
that can't make use of a timestamp format.