### PR TITLE
Added long to primitive data types supported in Python codegen

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -180,7 +180,7 @@ class ApiClient(object):
         Builds a JSON POST object.
 
         If obj is None, return None.
-        If obj is str, int, float, bool, return directly.
+        If obj is str, int, long, float, bool, return directly.
         If obj is datetime.datetime, datetime.date
             convert to string in iso8601 format.
         If obj is list, sanitize each element in the list.
@@ -190,7 +190,7 @@ class ApiClient(object):
         :param obj: The data to serialize.
         :return: The serialized form of data.
         """
-        types = (str, int, float, bool, tuple)
+        types = (str, int, long, float, bool, tuple)
         if sys.version_info < (3, 0):
             types = types + (unicode,)
         if isinstance(obj, type(None)):
@@ -266,14 +266,14 @@ class ApiClient(object):
 
             # convert str to class
             # for native types
-            if klass in ['int', 'float', 'str', 'bool',
+            if klass in ['int', 'long', 'float', 'str', 'bool',
                          "date", 'datetime', "object"]:
                 klass = eval(klass)
             # for model types
             else:
                 klass = eval('models.' + klass)
 
-        if klass in [int, float, str, bool]:
+        if klass in [int, long, float, str, bool]:
             return self.__deserialize_primitive(data, klass)
         elif klass == object:
             return self.__deserialize_object(data)
@@ -501,7 +501,7 @@ class ApiClient(object):
         :param data: str.
         :param klass: class literal.
 
-        :return: int, float, str, bool.
+        :return: int, long, float, str, bool.
         """
         try:
             value = klass(data)


### PR DESCRIPTION
Added long to primitives along with int, float, str, date and tuple. Needed for Python 2.x