### PR TITLE
[scala] Add SBT buid support for scala client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
@@ -87,6 +87,8 @@ public class ScalaClientCodegen extends DefaultCodegen implements CodegenConfig 
         supportingFiles.add(new SupportingFile( "gradle-wrapper.jar",
                 gradleWrapperPackage.replace( ".", File.separator ), "gradle-wrapper.jar") );
 
+        supportingFiles.add(new SupportingFile("build.sbt.mustache", "", "build.sbt"));
+
         importMapping.remove("List");
         importMapping.remove("Set");
         importMapping.remove("Map");

--- a/modules/swagger-codegen/src/main/resources/scala/build.sbt.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/build.sbt.mustache
@@ -1,0 +1,33 @@
+lazy val root = (project in file(".")).
+    settings(
+        version       := "{{artifactVersion}}",
+        name          := "{{artifactId}}",
+        organization  := "{{groupId}}",
+        scalaVersion  := "2.11.8",
+
+        libraryDependencies ++= Seq(
+            "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2",
+            "com.sun.jersey" % "jersey-core" % "1.19",
+            "com.sun.jersey" % "jersey-client" % "1.19",
+            "com.sun.jersey.contribs" % "jersey-multipart" % "1.19",
+            "org.jfarcand" % "jersey-ahc-client" % "1.0.5",
+            "io.swagger" % "swagger-core" % "1.5.8",
+            "joda-time" % "joda-time" % "2.2",
+            "org.joda" % "joda-convert" % "1.2",
+            "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+            "junit" % "junit" % "4.8.1" % "test"
+        ),
+
+        resolvers ++= Seq(
+            Resolver.jcenterRepo,
+            Resolver.mavenLocal
+        ),
+
+        scalacOptions := Seq(
+          "-unchecked",
+          "-deprecation",
+          "-feature"
+        ),
+
+        publishArtifact in (Compile, packageDoc) := false
+    )

--- a/samples/client/petstore/scala/build.sbt
+++ b/samples/client/petstore/scala/build.sbt
@@ -1,0 +1,33 @@
+lazy val root = (project in file(".")).
+    settings(
+        version       := "1.0.0",
+        name          := "swagger-scala-client",
+        organization  := "io.swagger",
+        scalaVersion  := "2.11.8",
+
+        libraryDependencies ++= Seq(
+            "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2",
+            "com.sun.jersey" % "jersey-core" % "1.19",
+            "com.sun.jersey" % "jersey-client" % "1.19",
+            "com.sun.jersey.contribs" % "jersey-multipart" % "1.19",
+            "org.jfarcand" % "jersey-ahc-client" % "1.0.5",
+            "io.swagger" % "swagger-core" % "1.5.8",
+            "joda-time" % "joda-time" % "2.2",
+            "org.joda" % "joda-convert" % "1.2",
+            "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+            "junit" % "junit" % "4.8.1" % "test"
+        ),
+
+        resolvers ++= Seq(
+            Resolver.jcenterRepo,
+            Resolver.mavenLocal
+        ),
+
+        scalacOptions := Seq(
+          "-unchecked",
+          "-deprecation",
+          "-feature"
+        ),
+
+        publishArtifact in (Compile, packageDoc) := false
+    )


### PR DESCRIPTION
See #241 and #3006

Adds build.sbt to scala client. Removed previous option-based functionality.

~~This adds a configuration option to support sbt (`-DbuildTool=sbt`) or gradle (`-DbuildTool=gradle`) to the scala client.~~

~~I've made the option value generic enough not to cause clutter. Unlike some of the java implementations like `JavaClientCodegen`, this will generate files for the selected build tool and not all files for both.~~

~~Also, unlike other sbt support which creates `build.sbt` this creates a `ProjectBuild.scala`. It's my understanding that some plugins don't work correctly when scalaVersion with binary version 2.11 is defined in `build.sbt` and a plugin requires 2.10. If this is incorrect, let me know and I'll change to build.sbt. However, both the .sbt and .scala build files can live side by side.~~