### PR TITLE
Fix Java CXF on parameter names containing '_' or '-'

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -18,6 +18,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
 
 {{>enumClass}}{{/items}}{{/items.isEnum}}
 
+  @XmlElement(name="{{baseName}}")
   private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/vars}}
 
   {{#vars}}

--- a/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/Category.java
@@ -19,8 +19,10 @@ import javax.xml.bind.annotation.XmlEnum;
 public class Category  {
   
 
+  @XmlElement(name="id")
   private Long id = null;
 
+  @XmlElement(name="name")
   private String name = null;
 
   /**

--- a/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/Order.java
@@ -19,19 +19,23 @@ import javax.xml.bind.annotation.XmlEnum;
 public class Order  {
   
 
+  @XmlElement(name="id")
   private Long id = null;
 
+  @XmlElement(name="petId")
   private Long petId = null;
 
+  @XmlElement(name="quantity")
   private Integer quantity = null;
 
+  @XmlElement(name="shipDate")
   private javax.xml.datatype.XMLGregorianCalendar shipDate = null;
 
 @XmlType(name="StatusEnum")
 @XmlEnum
 public enum StatusEnum {
 
-    PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
+    PLACED(String.valueOf("&quot;placed&quot;")), APPROVED(String.valueOf("&quot;approved&quot;")), DELIVERED(String.valueOf("&quot;delivered&quot;"));
 
 
     private String value;
@@ -49,8 +53,10 @@ public enum StatusEnum {
     }
 }
 
+  @XmlElement(name="status")
   private StatusEnum status = null;
 
+  @XmlElement(name="complete")
   private Boolean complete = false;
 
   /**

--- a/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/Pet.java
@@ -23,21 +23,26 @@ import javax.xml.bind.annotation.XmlEnum;
 public class Pet  {
   
 
+  @XmlElement(name="id")
   private Long id = null;
 
+  @XmlElement(name="category")
   private Category category = null;
 
+  @XmlElement(name="name")
   private String name = null;
 
+  @XmlElement(name="photoUrls")
   private List<String> photoUrls = new ArrayList<String>();
 
+  @XmlElement(name="tags")
   private List<Tag> tags = new ArrayList<Tag>();
 
 @XmlType(name="StatusEnum")
 @XmlEnum
 public enum StatusEnum {
 
-    AVAILABLE(String.valueOf("available")), PENDING(String.valueOf("pending")), SOLD(String.valueOf("sold"));
+    AVAILABLE(String.valueOf("&quot;available&quot;")), PENDING(String.valueOf("&quot;pending&quot;")), SOLD(String.valueOf("&quot;sold&quot;"));
 
 
     private String value;
@@ -55,6 +60,7 @@ public enum StatusEnum {
     }
 }
 
+  @XmlElement(name="status")
   private StatusEnum status = null;
 
   /**

--- a/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/Tag.java
@@ -19,8 +19,10 @@ import javax.xml.bind.annotation.XmlEnum;
 public class Tag  {
   
 
+  @XmlElement(name="id")
   private Long id = null;
 
+  @XmlElement(name="name")
   private String name = null;
 
   /**

--- a/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf/gen/java/io/swagger/model/User.java
@@ -19,20 +19,28 @@ import javax.xml.bind.annotation.XmlEnum;
 public class User  {
   
 
+  @XmlElement(name="id")
   private Long id = null;
 
+  @XmlElement(name="username")
   private String username = null;
 
+  @XmlElement(name="firstName")
   private String firstName = null;
 
+  @XmlElement(name="lastName")
   private String lastName = null;
 
+  @XmlElement(name="email")
   private String email = null;
 
+  @XmlElement(name="password")
   private String password = null;
 
+  @XmlElement(name="phone")
   private String phone = null;
 
+  @XmlElement(name="userStatus")
   private Integer userStatus = null;
 
   /**


### PR DESCRIPTION
[java-cxf] 	Fix Java CXF on parameter names containing '_' or '-'. The template uses only the parameter name which result on misnaming parameters.