### PR TITLE
Changed check for required parameter to check for null or undefined

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.mustache
@@ -50,9 +50,9 @@ namespace {{package}} {
 {{/hasFormParams}}
 {{#allParams}}
 {{#required}}
-            // verify required parameter '{{paramName}}' is set
-            if (!{{paramName}}) {
-                throw new Error('Missing required parameter {{paramName}} when calling {{nickname}}');
+            // verify required parameter '{{paramName}}' is not null or undefined
+            if ({{paramName}} === null || {{paramName}} === undefined) {
+                throw new Error('Required parameter {{paramName}} was null or undefined when calling {{nickname}}.');
             }
 {{/required}}
 {{/allParams}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -42,9 +42,9 @@ export class {{classname}} {
 {{/hasFormParams}}
 {{#allParams}}
 {{#required}}
-        // verify required parameter '{{paramName}}' is set
-        if (!{{paramName}}) {
-            throw new Error('Missing required parameter {{paramName}} when calling {{nickname}}');
+        // verify required parameter '{{paramName}}' is not null or undefined
+        if ({{paramName}} === null || {{paramName}} === undefined) {
+            throw new Error('Required parameter {{paramName}} was null or undefined when calling {{nickname}}.');
         }
 {{/required}}
 {{/allParams}}


### PR DESCRIPTION
The required parameter check in the api.mustache caused unexpected behaviour if the actual parameter value evaluates to false e.g "false", 0, -1, false

The code was changed to check for undefined or null instead

See issue #3096