### PR TITLE
Fix for the sourceFolder option when using the aspnet5 generator.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNet5ServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNet5ServerCodegen.java
@@ -11,13 +11,14 @@ import java.util.*;
 
 public class AspNet5ServerCodegen extends AbstractCSharpCodegen {
 
-    protected String sourceFolder = "src" + File.separator + packageName;
 
     @SuppressWarnings("hiding")
     protected Logger LOGGER = LoggerFactory.getLogger(AspNet5ServerCodegen.class);
 
     public AspNet5ServerCodegen() {
         super();
+
+        this.sourceFolder = "src" + File.separator + packageName;
 
         outputFolder = "generated-code" + File.separator + this.getName();
 


### PR DESCRIPTION
Fixes #3137 

The issue was the redefinition of the protected string sourceFolder in AspNet5ServerCodegen.java. This hides the previous definition of sourceFolder AbstractCSharpCodegen.java. Moving the initialization of sourceFolder to the constructor of the AspNet5ServerCodegen class seems to resolve the issue for me.
