### PR TITLE
Issue-3168: [csharp] Allow additional-properties to set Assembly Info #3168

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -54,11 +54,17 @@ public class CodegenConstants {
 
     public static final String PACKAGE_NAME = "packageName";
     public static final String PACKAGE_VERSION = "packageVersion";
+    
     public static final String PACKAGE_TITLE = "packageTitle";
+    public static final String PACKAGE_TITLE_DESC = "Specifies an AssemblyTitle for the .NET Framework global assembly attributes stored in the AssemblyInfo file.";
     public static final String PACKAGE_PRODUCTNAME = "packageProductName";
+    public static final String PACKAGE_PRODUCTNAME_DESC = "Specifies an AssemblyProduct for the .NET Framework global assembly attributes stored in the AssemblyInfo file.";
     public static final String PACKAGE_DESCRIPTION = "packageDescription";
+    public static final String PACKAGE_DESCRIPTION_DESC = "Specifies a AssemblyDescription for the .NET Framework global assembly attributes stored in the AssemblyInfo file.";
     public static final String PACKAGE_COMPANY = "packageCompany";
+    public static final String PACKAGE_COMPANY_DESC = "Specifies an AssemblyCompany for the .NET Framework global assembly attributes stored in the AssemblyInfo file.";
     public static final String PACKAGE_COPYRIGHT = "packageCopyright";
+    public static final String PACKAGE_COPYRIGHT_DESC = "Specifies an AssemblyCopyright for the .NET Framework global assembly attributes stored in the AssemblyInfo file.";
     
     public static final String POD_VERSION = "podVersion";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -54,6 +54,12 @@ public class CodegenConstants {
 
     public static final String PACKAGE_NAME = "packageName";
     public static final String PACKAGE_VERSION = "packageVersion";
+    public static final String PACKAGE_TITLE = "packageTitle";
+    public static final String PACKAGE_PRODUCTNAME = "packageProductName";
+    public static final String PACKAGE_DESCRIPTION = "packageDescription";
+    public static final String PACKAGE_COMPANY = "packageCompany";
+    public static final String PACKAGE_COPYRIGHT = "packageCopyright";
+    
     public static final String POD_VERSION = "podVersion";
 
     public static final String OPTIONAL_METHOD_ARGUMENT = "optionalMethodArgument";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
@@ -21,6 +21,11 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
     protected String packageVersion = "1.0.0";
     protected String packageName = "IO.Swagger";
+    protected String packageTitle = "Swagger Library";
+    protected String packageProductName = "SwaggerLibrary";
+    protected String packageDescription = "A library generated from a Swagger doc";
+    protected String packageCompany = "Swagger";
+    protected String packageCopyright = "No Copyright";
 
     protected String sourceFolder = "src";
 
@@ -189,7 +194,42 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         } else {
             additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         }
+        
+        // {{packageTitle}}
+        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_TITLE)) {
+            setPackageTitle((String) additionalProperties.get(CodegenConstants.PACKAGE_TITLE));
+        } else {
+            additionalProperties.put(CodegenConstants.PACKAGE_TITLE, packageTitle);
+        }
+        
+        // {{packageProductName}}
+        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_PRODUCTNAME)) {
+            setPackageProductName((String) additionalProperties.get(CodegenConstants.PACKAGE_PRODUCTNAME));
+        } else {
+            additionalProperties.put(CodegenConstants.PACKAGE_PRODUCTNAME, packageProductName);
+        }
 
+        // {{packageDescription}}
+        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_DESCRIPTION)) {
+            setPackageDescription((String) additionalProperties.get(CodegenConstants.PACKAGE_DESCRIPTION));
+        } else {
+            additionalProperties.put(CodegenConstants.PACKAGE_DESCRIPTION, packageDescription);
+        }
+        
+        // {{packageCompany}}
+        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_COMPANY)) {
+            setPackageCompany((String) additionalProperties.get(CodegenConstants.PACKAGE_COMPANY));
+        } else {
+            additionalProperties.put(CodegenConstants.PACKAGE_COMPANY, packageCompany);
+        }
+        
+        // {{packageCopyright}}
+        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_COPYRIGHT)) {
+            setPackageCopyright((String) additionalProperties.get(CodegenConstants.PACKAGE_COPYRIGHT));
+        } else {
+            additionalProperties.put(CodegenConstants.PACKAGE_COPYRIGHT, packageCopyright);
+        }
+        
         // {{useDateTimeOffset}}
         if (additionalProperties.containsKey(CodegenConstants.USE_DATETIME_OFFSET)) {
             useDateTimeOffset(Boolean.valueOf(additionalProperties.get(CodegenConstants.USE_DATETIME_OFFSET).toString()));
@@ -541,7 +581,27 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
     public void setPackageVersion(String packageVersion) {
         this.packageVersion = packageVersion;
     }
+    
+    public void setPackageTitle(String packageTitle) {
+		this.packageTitle = packageTitle;
+	}
+    
+    public void setPackageProductName(String packageProductName) {
+		this.packageProductName = packageProductName;
+	}
 
+	public void setPackageDescription(String packageDescription) {
+		this.packageDescription = packageDescription;
+	}
+	
+    public void setPackageCompany(String packageCompany) {
+		this.packageCompany = packageCompany;
+	}
+    
+    public void setPackageCopyright(String packageCopyright) {
+		this.packageCopyright = packageCopyright;
+	}
+    
     public void setSourceFolder(String sourceFolder) {
         this.sourceFolder = sourceFolder;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -39,11 +39,6 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     private static final String DATA_TYPE_WITH_ENUM_EXTENSION = "plainDatatypeWithEnum";
 
     protected String packageGuid = "{" + java.util.UUID.randomUUID().toString().toUpperCase() + "}";
-    protected String packageTitle = "Swagger Library";
-    protected String packageProductName = "SwaggerLibrary";
-    protected String packageDescription = "A library generated from a Swagger doc";
-    protected String packageCompany = "Swagger";
-    protected String packageCopyright = "No Copyright";
     protected String clientPackage = "IO.Swagger.Client";
     protected String localVariablePrefix = "";
     protected String apiDocPath = "docs/";
@@ -149,12 +144,6 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
         additionalProperties.put("clientPackage", clientPackage);
 
-        // Add properties used by AssemblyInfo.mustache
-        additionalProperties.put("packageTitle", packageTitle);
-        additionalProperties.put("packageProductName", packageProductName);
-        additionalProperties.put("packageDescription", packageDescription);
-        additionalProperties.put("packageCompany", packageCompany);
-        additionalProperties.put("packageCopyright", packageCopyright);
         additionalProperties.put("emitDefaultValue", optionalEmitDefaultValue);
 
         if (additionalProperties.containsKey(CodegenConstants.DOTNET_FRAMEWORK)) {


### PR DESCRIPTION
[csharp] Enabling Assembly Info to be set by the following command line's additional-properties:
- packageTitle
- packageProductName
- packageDescription
- packageCompany
- packageCopyright