### PR TITLE
Disable path HTML-escaping in Ruby api template

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -176,7 +176,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 config.additionalProperties().put("termsOfService", config.escapeText(info.getTermsOfService()));
             }
         }
-        
+
         if(swagger.getVendorExtensions() != null) {
         	config.vendorExtensions().putAll(swagger.getVendorExtensions());
         }
@@ -279,21 +279,21 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         Map<String, Object> models = processModels(config, modelMap, definitions);
                         models.put("classname", config.toModelName(name));
                         models.putAll(config.additionalProperties());
-                        
+
                         allProcessedModels.put(name, models);
 
                     } catch (Exception e) {
                         throw new RuntimeException("Could not process model '" + name + "'", e);
                     }
                 }
-                
+
                 // post process all processed models
                 allProcessedModels = config.postProcessAllModels(allProcessedModels);
-                
+
                 // generate files based on processed models
                 for (String name: allProcessedModels.keySet()) {
                 	Map<String, Object> models = (Map<String, Object>)allProcessedModels.get(name);
-                
+
                 	try {
                         //don't generate models that have an import mapping
                         if(config.importMapping().containsKey(name)) {
@@ -393,7 +393,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     operation.put("classname", config.toApiName(tag));
                     operation.put("classVarName", config.toApiVarName(tag));
                     operation.put("importPath", config.toApiImport(tag));
-                    
+
                     if(!config.vendorExtensions().isEmpty()) {
                     	operation.put("vendorExtensions", config.vendorExtensions());
                     }
@@ -631,6 +631,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             String templateFile = getFullTemplateFile(config, templateName);
             String template = readTemplate(templateFile);
             Template tmpl = Mustache.compiler()
+                    .escapeHTML(false)
                     .withLoader(new Mustache.TemplateLoader() {
                         @Override
                         public Reader getTemplate(String name) {
@@ -704,7 +705,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 tags = new ArrayList<String>();
                 tags.add("default");
             }
-            
+
             /*
              build up a set of parameter "ids" defined at the operation level
              per the swagger 2.0 spec "A unique parameter is defined by a combination of a name and location"

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -631,7 +631,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             String templateFile = getFullTemplateFile(config, templateName);
             String template = readTemplate(templateFile);
             Template tmpl = Mustache.compiler()
-                    .escapeHTML(false)
                     .withLoader(new Mustache.TemplateLoader() {
                         @Override
                         public Reader getTemplate(String name) {

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -89,7 +89,7 @@ module {{moduleName}}
       {{/hasValidation}}
       {{/allParams}}
       # resource path
-      local_var_path = "{{path}}".sub('{format}','json'){{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
+      local_var_path = "{{{path}}}".sub('{format}','json'){{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
 
       # query parameters
       query_params = {}

--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -199,7 +199,7 @@ module {{moduleName}}
     # @return [Tempfile] the file downloaded
     def download_file(response)
       content_disposition = response.headers['Content-Disposition']
-      if content_disposition
+      if content_disposition and content_disposition =~ /filename=/i
         filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]
         prefix = sanitize_filename(filename)
       else

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
@@ -1,6 +1,7 @@
 package io.swagger.codegen;
 
 import io.swagger.codegen.languages.JavaClientCodegen;
+import io.swagger.codegen.languages.RubyClientCodegen;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import org.apache.commons.io.FileUtils;
@@ -218,6 +219,31 @@ public class DefaultGeneratorTest {
                 assertFalse(opIds.contains(op.operationId));
                 opIds.add(op.operationId);
             }
+        }
+    }
+
+    @Test
+    public void testGenerateWithHtmlEntity() throws Exception {
+        final File output = folder.getRoot();
+
+        final Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/pathWithHtmlEntity.yaml");
+        CodegenConfig codegenConfig = new RubyClientCodegen();
+        codegenConfig.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(clientOptInput);
+        List<File> files = generator.generate();
+        boolean apiFileGenerated = false;
+        for (File file : files) {
+          if (file.getName().equals("default_api.rb")) {
+            apiFileGenerated = true;
+            assertTrue(FileUtils.readFileToString(file, StandardCharsets.UTF_8).contains("local_var_path = \"/foo=bar\""));
+          }
+        }
+        if (!apiFileGenerated) {
+          fail("Default api file is not generated!");
         }
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
@@ -1,7 +1,6 @@
 package io.swagger.codegen;
 
 import io.swagger.codegen.languages.JavaClientCodegen;
-import io.swagger.codegen.languages.RubyClientCodegen;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import org.apache.commons.io.FileUtils;
@@ -219,32 +218,6 @@ public class DefaultGeneratorTest {
                 assertFalse(opIds.contains(op.operationId));
                 opIds.add(op.operationId);
             }
-        }
-    }
-
-    @Test
-    public void testGenerateRubyClientWithHtmlEntity() throws Exception {
-        final File output = folder.getRoot();
-
-        final Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/pathWithHtmlEntity.yaml");
-        CodegenConfig codegenConfig = new RubyClientCodegen();
-        codegenConfig.setOutputDir(output.getAbsolutePath());
-
-        ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
-
-        DefaultGenerator generator = new DefaultGenerator();
-        generator.opts(clientOptInput);
-        List<File> files = generator.generate();
-        boolean apiFileGenerated = false;
-        for (File file : files) {
-          if (file.getName().equals("default_api.rb")) {
-            apiFileGenerated = true;
-            // Ruby client should set the path unescaped in the api file
-            assertTrue(FileUtils.readFileToString(file, StandardCharsets.UTF_8).contains("local_var_path = \"/foo=bar\""));
-          }
-        }
-        if (!apiFileGenerated) {
-          fail("Default api file is not generated!");
         }
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/DefaultGeneratorTest.java
@@ -223,7 +223,7 @@ public class DefaultGeneratorTest {
     }
 
     @Test
-    public void testGenerateWithHtmlEntity() throws Exception {
+    public void testGenerateRubyClientWithHtmlEntity() throws Exception {
         final File output = folder.getRoot();
 
         final Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/pathWithHtmlEntity.yaml");
@@ -239,6 +239,7 @@ public class DefaultGeneratorTest {
         for (File file : files) {
           if (file.getName().equals("default_api.rb")) {
             apiFileGenerated = true;
+            // Ruby client should set the path unescaped in the api file
             assertTrue(FileUtils.readFileToString(file, StandardCharsets.UTF_8).contains("local_var_path = \"/foo=bar\""));
           }
         }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/ruby/RubyClientCodegenTest.java
@@ -1,0 +1,67 @@
+package io.swagger.codegen.ruby;
+
+import io.swagger.codegen.ClientOpts;
+import io.swagger.codegen.ClientOptInput;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.DefaultGenerator;
+import io.swagger.codegen.languages.RubyClientCodegen;
+import io.swagger.models.Swagger;
+import io.swagger.parser.SwaggerParser;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.rules.TemporaryFolder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.fail;
+import static org.testng.Assert.*;
+
+/**
+ * Tests for RubyClientCodegen-generated templates
+ */
+public class RubyClientCodegenTest {
+
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+      folder.create();
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+      folder.delete();
+  }
+
+  @Test
+  public void testGenerateRubyClientWithHtmlEntity() throws Exception {
+      final File output = folder.getRoot();
+
+      final Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/pathWithHtmlEntity.yaml");
+      CodegenConfig codegenConfig = new RubyClientCodegen();
+      codegenConfig.setOutputDir(output.getAbsolutePath());
+
+      ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
+
+      DefaultGenerator generator = new DefaultGenerator();
+      generator.opts(clientOptInput);
+      List<File> files = generator.generate();
+      boolean apiFileGenerated = false;
+      for (File file : files) {
+        if (file.getName().equals("default_api.rb")) {
+          apiFileGenerated = true;
+          // Ruby client should set the path unescaped in the api file
+          assertTrue(FileUtils.readFileToString(file, StandardCharsets.UTF_8).contains("local_var_path = \"/foo=bar\""));
+        }
+      }
+      if (!apiFileGenerated) {
+        fail("Default api file is not generated!");
+      }
+  }
+
+}

--- a/modules/swagger-codegen/src/test/resources/2_0/pathWithHtmlEntity.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/pathWithHtmlEntity.yaml
@@ -1,0 +1,10 @@
+---
+swagger: "2.0"
+basePath: "/"
+paths:
+  /foo=bar:
+    get:
+      parameters: []
+      responses:
+        200:
+          description: "success"


### PR DESCRIPTION
Prior to this PR, the default generator HTML-escapes the variables passed to Mustache, which breaks specification with a path that contains a HTML entity.

In my use case, the path contains an equal sign (e.g. /foo=bar), which gets escaped to &#x3D; by Mustache's Escaper (into /foo&#x3D;bar).
This obviously breaks the API client because it sends a request to /foo&#x3D;bar instead of /foo=bar .

This PR ensures that the path stays AS-IS in the generated client code.