### PR TITLE
Update swagger-codegen-maven-plugin example to use current dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 
 script:
   - mvn verify -Psamples
+  - cd modules/swagger-codegen-maven-plugin/examples && mvn -f java-client.xml swagger-codegen:generate
   - if [ $DOCKER_HUB_USERNAME ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD && docker build -t $DOCKER_IMAGE_NAME ./modules/swagger-generator && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_IMAGE_NAME:latest $DOCKER_IMAGE_NAME:$TRAVIS_TAG; fi && docker push $DOCKER_IMAGE_NAME; fi
 
 env:

--- a/modules/swagger-codegen-maven-plugin/examples/java-client.xml
+++ b/modules/swagger-codegen-maven-plugin/examples/java-client.xml
@@ -12,27 +12,27 @@
             <plugin>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>2.1.5-SNAPSHOT</version>
+                <version>2.2.0-SNAPSHOT</version>
+                <configuration>
+                    <!-- specify the swagger yaml -->
+                    <inputSpec>swagger.yaml</inputSpec>
+
+                    <!-- target to generate -->
+                    <language>java</language>
+
+                    <!-- pass any necessary config options -->
+                    <configOptions>
+                        <dateLibrary>java8</dateLibrary>
+                    </configOptions>
+
+                    <!-- override the default library to jersey2 -->
+                    <library>jersey2</library>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>generate</goal>
                         </goals>
-                        <configuration>
-                            <!-- specify the swagger yaml -->
-                            <inputSpec>swagger.yaml</inputSpec>
-
-                            <!-- target to generate -->
-                            <language>java</language>
-
-                            <!-- pass any necessary config options -->
-                            <configOptions>
-                                <dateLibrary>java8</dateLibrary>
-                            </configOptions>
-
-                            <!-- override the default library to jersey2 -->
-                            <library>jersey2</library>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -81,13 +81,8 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-            <version>2.1.5</version>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>${jodatime-version}</version>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.4.0</version>
         </dependency>
 
         <!-- Base64 encoding that works in both JVM and Android -->
@@ -101,15 +96,16 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>
-            <scope>test</scope>
+            <!--<scope>test</scope>-->
         </dependency>
     </dependencies>
     <properties>
         <swagger-annotations-version>1.5.0</swagger-annotations-version>
-        <jersey-version>2.12</jersey-version>
-        <jackson-version>2.4.2</jackson-version>
-        <jodatime-version>2.3</jodatime-version>
+        <swagger-core-version>1.5.8</swagger-core-version>
+        <jersey-version>2.22.2</jersey-version>
+        <jackson-version>2.7.0</jackson-version>
+        <jodatime-version>2.9.3</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <junit-version>4.8.1</junit-version>
+        <junit-version>4.12</junit-version>
     </properties>
 </project>


### PR DESCRIPTION
@wing328 I did a little dance and added a step in the travis build to verify. I had to remove the test scope from the junit dependency because `mvn swagger-codegen:generate` would complain about `Test` not being found. Same thing for moving `<configuration>` out of `<executions>` and into the main plugin block.

Java isn't my strong suit so feel free to tear it apart.

Fixes #3261 