### PR TITLE
Remove security test from petstore-with-fake-endpoints-models-for-testing

### DIFF
--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -561,26 +561,6 @@ paths:
           description: User not found
 
   /fake:
-    put:
-      tags:
-        - fake
-      summary: To test code injection */ =end
-      descriptions:  To test code injection */ =end
-      operationId: testCodeInject */ =end
-      consumes:
-        - application/json
-        - "*/ =end'));(phpinfo('"
-      produces:
-        - application/json
-        - '*/ end'
-      parameters:
-        - name: test code inject */ =end
-          type: string
-          in: formData 
-          description: To test code injection */ =end
-      responses:
-        '400':
-          description: To test code injection */ =end
     get:
       tags:
         - fake

--- a/samples/server/petstore/lumen/app/Http/controllers/FakeApi.php
+++ b/samples/server/petstore/lumen/app/Http/controllers/FakeApi.php
@@ -2,7 +2,7 @@
 
 /**
  * Swagger Petstore
- * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\ 
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io
@@ -128,5 +128,30 @@ class FakeApi extends Controller
 
 
         return response('How about implementing testEndpointParameters as a POST method ?');
+    }
+    /**
+     * Operation testEnumQueryParameters
+     *
+     * To test enum query parameters.
+     *
+     *
+     * @return Http response
+     */
+    public function testEnumQueryParameters()
+    {
+        $input = Request::all();
+
+        //path params validation
+
+
+        //not path params validation
+        $enumQueryString = $input['enumQueryString'];
+
+        $enumQueryInteger = $input['enumQueryInteger'];
+
+        $enumQueryDouble = $input['enumQueryDouble'];
+
+
+        return response('How about implementing testEnumQueryParameters as a GET method ?');
     }
 }

--- a/samples/server/petstore/lumen/app/Http/controllers/PetApi.php
+++ b/samples/server/petstore/lumen/app/Http/controllers/PetApi.php
@@ -2,7 +2,7 @@
 
 /**
  * Swagger Petstore
- * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\ 
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io

--- a/samples/server/petstore/lumen/app/Http/controllers/StoreApi.php
+++ b/samples/server/petstore/lumen/app/Http/controllers/StoreApi.php
@@ -2,7 +2,7 @@
 
 /**
  * Swagger Petstore
- * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\ 
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io

--- a/samples/server/petstore/lumen/app/Http/controllers/UserApi.php
+++ b/samples/server/petstore/lumen/app/Http/controllers/UserApi.php
@@ -2,7 +2,7 @@
 
 /**
  * Swagger Petstore
- * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\ 
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io

--- a/samples/server/petstore/lumen/app/Http/routes.php
+++ b/samples/server/petstore/lumen/app/Http/routes.php
@@ -2,7 +2,7 @@
 
 /**
  * Swagger Petstore
- * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\ 
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io
@@ -40,6 +40,13 @@ $app->get('/', function () use ($app) {
  * Output-Formats: [application/xml; charset=utf-8, application/json; charset=utf-8]
  */
 $app->POST('/fake', 'FakeApi@testEndpointParameters');
+/**
+ * GET testEnumQueryParameters
+ * Summary: To test enum query parameters
+ * Notes: 
+ * Output-Formats: [application/json]
+ */
+$app->GET('/fake', 'FakeApi@testEnumQueryParameters');
 /**
  * POST addPet
  * Summary: Add a new pet to the store


### PR DESCRIPTION
The security tests have been moved to petstore-security-test.yaml