### PR TITLE
Fix missing json import in go client template

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"errors"
 	"net/url"
+	"encoding/json"
 	{{#imports}}"{{import}}"
 {{/imports}}
 )


### PR DESCRIPTION
I used the last source code of swagger-codegen to generate proper go client code but compilation failed with the following error:

    undefined: json in json.Unmarshal

This commit intents to fix this.