### PR TITLE
Issue #3300 Modified JavaJaxrs resources to fix duplicated variable names

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
@@ -48,7 +48,7 @@ public class {{classname}}  {
         {{/hasMore}}{{/responses}} })
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},{{/allParams}}@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.{{nickname}}({{#allParams}}{{#isFile}}inputStream, fileDetail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}},{{/allParams}}securityContext);
+        return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}},{{/allParams}}securityContext);
     }
 {{/operation}}
 }

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/formParams.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/formParams.mustache
@@ -1,3 +1,3 @@
 {{#isFormParam}}{{#notFile}}@ApiParam(value = "{{{description}}}"{{#required}}, required=true{{/required}}{{#allowableValues}}, {{> allowableValues }}{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}){{#vendorExtensions.x-multipart}}@FormDataParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/vendorExtensions.x-multipart}}{{^vendorExtensions.x-multipart}}@FormParam("{{paramName}}")  {{{dataType}}} {{paramName}}{{/vendorExtensions.x-multipart}}{{/notFile}}{{#isFile}}
-            @FormDataParam("file") InputStream inputStream,
-            @FormDataParam("file") FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+            @FormDataParam("{{paramName}}") InputStream {{paramName}}InputStream,
+            @FormDataParam("{{paramName}}") FormDataContentDisposition {{paramName}}Detail{{/isFile}}{{/isFormParam}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/serviceFormParams.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/serviceFormParams.mustache
@@ -1,1 +1,1 @@
-{{#isFormParam}}{{#notFile}}{{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}InputStream inputStream, FormDataContentDisposition fileDetail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{#notFile}}{{{dataType}}} {{paramName}}{{/notFile}}{{#isFile}}InputStream {{paramName}}InputStream, FormDataContentDisposition {{paramName}}Detail{{/isFile}}{{/isFormParam}}


### PR DESCRIPTION
Fixed issue where the JAX-RS code generator creates variables with duplicate names when more than one file is included in the API call which results in a compilation error by modifying the api.mustache file, formParams.mustache file, and serviceFormParams.mustache file.