### PR TITLE
[Java] Optional Parcelable models for okhttp-gson

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -14,12 +14,14 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaClientCodegen.class);
 
     public static final String USE_RX_JAVA = "useRxJava";
+    public static final String PARCELABLE_MODEL = "parcelableModel";
 
     public static final String RETROFIT_1 = "retrofit";
     public static final String RETROFIT_2 = "retrofit2";
 
     protected String gradleWrapperPackage = "gradle.wrapper";
     protected boolean useRxJava = false;
+    protected boolean parcelableModel = false;
 
     public JavaClientCodegen() {
         super();
@@ -31,11 +33,12 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
         modelPackage = "io.swagger.client.model";
 
         cliOptions.add(CliOption.newBoolean(USE_RX_JAVA, "Whether to use the RxJava adapter with the retrofit2 library."));
+        cliOptions.add(CliOption.newBoolean(PARCELABLE_MODEL, "Whether to generate models for Android that implement Parcelable with the okhttp-gson library."));
 
         supportedLibraries.put("jersey1", "HTTP client: Jersey client 1.19.1. JSON processing: Jackson 2.7.0");
         supportedLibraries.put("feign", "HTTP client: Netflix Feign 8.16.0. JSON processing: Jackson 2.7.0");
         supportedLibraries.put("jersey2", "HTTP client: Jersey client 2.22.2. JSON processing: Jackson 2.7.0");
-        supportedLibraries.put("okhttp-gson", "HTTP client: OkHttp 2.7.5. JSON processing: Gson 2.6.2");
+        supportedLibraries.put("okhttp-gson", "HTTP client: OkHttp 2.7.5. JSON processing: Gson 2.6.2. Enable Parcelable modles on Android using '-DparcelableModel=true'");
         supportedLibraries.put(RETROFIT_1, "HTTP client: OkHttp 2.7.5. JSON processing: Gson 2.3.1 (Retrofit 1.9.0). IMPORTANT NOTE: retrofit1.x is no longer actively maintained so please upgrade to 'retrofit2' instead.");
         supportedLibraries.put(RETROFIT_2, "HTTP client: OkHttp 3.2.0. JSON processing: Gson 2.6.1 (Retrofit 2.0.2). Enable the RxJava adapter using '-DuseRxJava=true'. (RxJava 1.1.3)");
 
@@ -69,6 +72,9 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
 
         if (additionalProperties.containsKey(USE_RX_JAVA)) {
             this.setUseRxJava(Boolean.valueOf(additionalProperties.get(USE_RX_JAVA).toString()));
+        }
+        if (additionalProperties.containsKey(PARCELABLE_MODEL)) {
+            this.setParcelableModels(Boolean.valueOf(additionalProperties.get(PARCELABLE_MODEL).toString()));
         }
 
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
@@ -212,4 +218,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
         this.useRxJava = useRxJava;
     }
 
+    public void setParcelableModels(boolean parcelableModel) {
+        this.parcelableModel = parcelableModel;
+    }
 }

--- a/modules/swagger-codegen/src/main/resources/Java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/model.mustache
@@ -8,6 +8,8 @@ import {{import}};
 {{/imports}}
 
 {{#serializableModel}}import java.io.Serializable;{{/serializableModel}}
+{{#parcelableModel}}import android.os.Parcelable;
+import android.os.Parcel;{{/parcelableModel}}
 {{#models}}
 {{#model}}
 {{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>pojo}}{{/isEnum}}

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -3,7 +3,7 @@
  */{{#description}}
 @ApiModel(description = "{{{description}}}"){{/description}}
 {{>generatedAnnotation}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#parcelableModel}}implements Parcelable{{#serializableModel}}, Serializable{{/serializableModel}}{{/parcelableModel}}{{#serializableModel}}implements Serializable{{/serializableModel}} {
+public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#parcelableModel}}implements Parcelable{{#serializableModel}}, Serializable{{/serializableModel}}{{/parcelableModel}}{{^parcelableModel}}{{#serializableModel}}implements Serializable{{/serializableModel}}{{/parcelableModel}} {
   {{#vars}}
     {{#isEnum}}
     {{^isContainer}}

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -3,7 +3,7 @@
  */{{#description}}
 @ApiModel(description = "{{{description}}}"){{/description}}
 {{>generatedAnnotation}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#parcelableModel}}implements Parcelable{{#serializableModel}}, Serializable{{/serializableModel}}{{/parcelableModel}}{{#serializableModel}}implements Serializable{{/serializableModel}} {
   {{#vars}}
     {{#isEnum}}
     {{^isContainer}}
@@ -105,4 +105,46 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     }
     return o.toString().replace("\n", "\n    ");
   }
+  
+  {{#parcelableModel}}
+  public void writeToParcel(Parcel out, int flags) {
+    {{#parent}} super.writeToParcel(out, flags); {{/parent}} {{#vars}}
+    out.writeValue({{name}});
+    {{/vars}}
+  }
+
+  public {{classname}}() {
+    super();
+  }
+
+  {{classname}}(Parcel in) {
+    {{#parent}} super(in); {{/parent}}
+    {{#vars}}
+    {{#isContainer}}
+    {{#complexType}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue({{complexType}}.class.getClassLoader());
+    {{/complexType}}
+    {{^complexType}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue(null);
+    {{/complexType}}
+    {{/isContainer}}
+    {{^isContainer}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue(null);
+    {{/isContainer}}
+    {{/vars}}
+  }
+  
+  public int describeContents() {
+    return 0;
+  }
+
+  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<{{classname}}>() {
+    public {{classname}} createFromParcel(Parcel in) {
+      return new {{classname}}(in);
+    }
+    public {{classname}}[] newArray(int size) {
+      return new {{classname}}[size];
+    }
+  };
+  {{/parcelableModel}}
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaClientOptionsProvider.java
@@ -16,6 +16,7 @@ public class JavaClientOptionsProvider extends JavaOptionsProvider {
         Map<String, String> options = new HashMap<String, String>(super.createOptions());
         options.put(CodegenConstants.LIBRARY, DEFAULT_LIBRARY_VALUE);
         options.put(JavaClientCodegen.USE_RX_JAVA, "false");
+        options.put(JavaClientCodegen.PARCELABLE_MODEL, "false");
 
         return options;
     }


### PR DESCRIPTION
As discussed in https://github.com/swagger-api/swagger-codegen/issues/3302.

When generating with `-l java --library=okhttp-gson -DparcelableModel=true`, generated model classes will now implement Android's `Parcelable` interface.

I essentially just copied how `useRxJava` works to add the command line option and make the tests pass. Let me know if I should do anything differently and I'll be happy to make the change 👍.
