### PR TITLE
Raise Exception Instead of String in Python Test

### DIFF
--- a/samples/client/petstore/python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/tests/test_pet_api.py
@@ -200,7 +200,7 @@ class PetApiTests(unittest.TestCase):
 
         try:
             self.pet_api.get_pet_by_id(pet_id=self.pet.id)
-            raise "expected an error"
+            raise Exception("expected an error")
         except ApiException as e:
             self.assertEqual(404, e.status)
 


### PR DESCRIPTION
```
======================================================================
ERROR: test_delete_pet (tests.test_pet_api.PetApiTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/swagger-api/swagger-codegen/samples/client/petstore/python/tests/test_pet_api.py", line 203, in test_delete_pet
    raise "expected an error"
TypeError: exceptions must be old-style classes or derived from BaseException, not str
```
in https://travis-ci.org/swagger-api/swagger-codegen/jobs/143133869.

The test itself seems flaky. And that's not fixed in this PR.