### PR TITLE
[Swift] Expose NSProgress to RequestBuilder

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/APIs.mustache
@@ -37,6 +37,9 @@ public class RequestBuilder<T> {
     let method: String
     let URLString: String
     
+    /// Optional block to obtain a reference to the request's progress instance when available.
+    public var onProgressReady: ((NSProgress) -> ())?
+
     required public init(method: String, URLString: String, parameters: [String:AnyObject]?, isBody: Bool) {
         self.method = method
         self.URLString = URLString

--- a/modules/swagger-codegen/src/main/resources/swift/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/AlamofireImplementations.mustache
@@ -57,15 +57,22 @@ class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 encodingMemoryThreshold: Manager.MultipartFormDataEncodingMemoryThreshold,
                 encodingCompletion: { encodingResult in
                     switch encodingResult {
-                    case .Success(let upload, _, _):
-                        self.processRequest(upload, managerId, completion)
+                    case .Success(let uploadRequest, _, _):
+                        if let onProgressReady = self.onProgressReady {
+                            onProgressReady(uploadRequest.progress)
+                        }
+                        self.processRequest(uploadRequest, managerId, completion)
                     case .Failure(let encodingError):
                         completion(response: nil, error: encodingError)
                     }
                 }
             )
         } else {
-            processRequest(manager.request(xMethod!, URLString, parameters: parameters, encoding: encoding), managerId, completion)
+            let request = manager.request(xMethod!, URLString, parameters: parameters, encoding: encoding)
+            if let onProgressReady = self.onProgressReady {
+                onProgressReady(request.progress)
+            }
+            processRequest(request, managerId, completion)
         }
 
     }

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -37,6 +37,9 @@ public class RequestBuilder<T> {
     let method: String
     let URLString: String
     
+    /// Optional block to obtain a reference to the request's progress instance when available.
+    public var onProgressReady: ((NSProgress) -> ())?
+
     required public init(method: String, URLString: String, parameters: [String:AnyObject]?, isBody: Bool) {
         self.method = method
         self.URLString = URLString

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -57,15 +57,22 @@ class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 encodingMemoryThreshold: Manager.MultipartFormDataEncodingMemoryThreshold,
                 encodingCompletion: { encodingResult in
                     switch encodingResult {
-                    case .Success(let upload, _, _):
-                        self.processRequest(upload, managerId, completion)
+                    case .Success(let uploadRequest, _, _):
+                        if let onProgressReady = self.onProgressReady {
+                            onProgressReady(uploadRequest.progress)
+                        }
+                        self.processRequest(uploadRequest, managerId, completion)
                     case .Failure(let encodingError):
                         completion(response: nil, error: encodingError)
                     }
                 }
             )
         } else {
-            processRequest(manager.request(xMethod!, URLString, parameters: parameters, encoding: encoding), managerId, completion)
+            let request = manager.request(xMethod!, URLString, parameters: parameters, encoding: encoding)
+            if let onProgressReady = self.onProgressReady {
+                onProgressReady(request.progress)
+            }
+            processRequest(request, managerId, completion)
         }
 
     }

--- a/samples/client/petstore/swift/default/SwaggerClientTests/SwaggerClientTests/StoreAPITests.swift
+++ b/samples/client/petstore/swift/default/SwaggerClientTests/SwaggerClientTests/StoreAPITests.swift
@@ -90,6 +90,22 @@ class StoreAPITests: XCTestCase {
         self.waitForExpectationsWithTimeout(testTimeout, handler: nil)
     }
 
+    func testDownloadProgress() {
+        let responseExpectation = self.expectationWithDescription("obtain response")
+        let progressExpectation = self.expectationWithDescription("obtain progress")
+        let requestBuilder = StoreAPI.getOrderByIdWithRequestBuilder(orderId: "1000")
+
+        requestBuilder.onProgressReady = { (progress) in
+            progressExpectation.fulfill()
+        }
+
+        requestBuilder.execute { (response, error) in
+            responseExpectation.fulfill()
+        }
+
+        self.waitForExpectationsWithTimeout(testTimeout, handler: nil)
+    }
+
 }
 
 private extension NSDate {


### PR DESCRIPTION
By injecting `onProgressReady` into a `RequestBuilder` instance, you can now get a reference to the request's `NSProgress` instance.

```swift
requestBuilder.onProgressReady = { (requestProgress) in
    let disposable = requestProgress
        .rx_observeWeakly(CGFloat.self, "fractionCompleted")
        .subscribeNext({ (fractionCompleted) in
            guard let fractionCompleted = fractionCompleted else { return }
            progress(Float(fractionCompleted))
        })
    self.disposeBag.addDisposable(disposable)
}
```