### PR TITLE
[Go] ParameterToString can panic

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api_client.mustache
@@ -94,7 +94,7 @@ func (c *APIClient) ParameterToString(obj interface{},collectionFormat string) s
 		}
 	}
 
-	return obj.(string)
+	return fmt.Sprintf("%v", obj)
 }
 
 func prepareRequest(postBody interface{},


### PR DESCRIPTION
Let the fmt package help convert the obj to a string.  Previously this could panic if the obj was an int.