### PR TITLE
Fixes #3386: Allowed to configure HTTP port for generator container

### DIFF
--- a/modules/swagger-generator/Dockerfile
+++ b/modules/swagger-generator/Dockerfile
@@ -1,6 +1,8 @@
 FROM java:8-jdk
 
 WORKDIR /generator
+COPY src/main/docker/entry-point.sh /generator/entry-point.sh
+RUN chmod 555 /generator/entry-point.sh
 COPY target/lib/jetty-runner* /generator/jetty-runner.jar
 COPY target/*.war /generator/swagger-generator.war
 
@@ -8,5 +10,4 @@ ENV GENERATOR_HOST=https://generator.swaggerhub.com/api/swagger.json
 RUN apt-get update
 
 EXPOSE 8080
-CMD ["java", "-jar", "/generator/jetty-runner.jar", "/generator/swagger-generator.war"]
-
+ENTRYPOINT ["/generator/entry-point.sh"]

--- a/modules/swagger-generator/src/main/docker/entry-point.sh
+++ b/modules/swagger-generator/src/main/docker/entry-point.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+java -jar /generator/jetty-runner.jar --port ${HTTP_PORT-8080} /generator/swagger-generator.war


### PR DESCRIPTION
This PR allows to start the generator container on custom HTTP port:
`docker run -d -e HTTP_PORT=80 swagger-generator`
