### PR TITLE
Make typescript-angular2 generated client code customizable

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -67,6 +67,7 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
         super.processOpts();
         supportingFiles.add(new SupportingFile("models.mustache", modelPackage().replace('.', File.separatorChar), "models.ts"));
         supportingFiles.add(new SupportingFile("apis.mustache", apiPackage().replace('.', File.separatorChar), "api.ts"));
+        supportingFiles.add(new SupportingFile("apiservice.mustache", apiPackage().replace('.', File.separatorChar), "ApiService.ts"));
         supportingFiles.add(new SupportingFile("index.mustache", getIndexDirectory(), "index.ts"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -1,8 +1,9 @@
 {{>licenseInfo}}
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable, Optional} from '@angular/core';
+import {Http, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import {ApiService} from './ApiService';
 import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
@@ -17,13 +18,8 @@ import 'rxjs/Rx';
 {{/description}}
 @Injectable()
 export class {{classname}} {
-    protected basePath = '{{basePath}}';
-    public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, @Optional() basePath: string) {
-        if (basePath) {
-            this.basePath = basePath;
-        }
+    constructor(protected http: Http, protected apiService: ApiService) {
     }
 
 {{#operation}}
@@ -32,12 +28,12 @@ export class {{classname}} {
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any ) : Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
-        const path = this.basePath + '{{path}}'{{#pathParams}}
+    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestOptions?: RequestOptionsArgs ) : Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+        const path = this.apiService.getBasePath() + '{{path}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
 
         let queryParameters = new URLSearchParams();
-        let headerParams = this.defaultHeaders;
+        let headerParams = this.apiService.getHeaders();
 {{#hasFormParams}}
         let formParams = new URLSearchParams();
 
@@ -79,6 +75,10 @@ export class {{classname}} {
         {{#hasFormParams}}
         requestOptions.body = formParams.toString();
         {{/hasFormParams}}
+
+        if (extraHttpRequestOptions) {
+           requestOptions = Object.assign(requestOptions, extraHttpRequestOptions);
+        }
 
         return this.http.request(path, requestOptions)
             .map((response: Response) => {

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/apiservice.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/apiservice.mustache
@@ -1,0 +1,27 @@
+{{>licenseInfo}}
+import {Headers} from '@angular/http';
+import {Injectable, Optional} from '@angular/core';
+
+/* tslint:disable:no-unused-variable member-ordering */
+
+'use strict';
+
+@Injectable()
+export class ApiService {
+    protected basePath = '{{basePath}}';
+    public defaultHeaders : Headers = new Headers();
+
+    constructor(@Optional() basePath: string) {
+        if (basePath) {
+            this.basePath = basePath;
+        }
+    }
+    
+    public getBasePath() : string {
+        return this.basePath;
+    }
+
+    public getHeaders() : Headers {
+        return this.defaultHeaders;
+    }
+}


### PR DESCRIPTION
This will enable clients to customize API parameters like basePath, headers, maybe response processing.

I'm not sure if this is the best approach but we found it difficult to implement a header based auth mechanism and to customize the base path use by the API.

Base path customization is necessary to run the same code on different endpoints (instances) while header based auth is also requested in #2938.
