### PR TITLE
Run petstore.swagger.io locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,11 @@ before_install:
   - gem install bundler
   - npm install -g typescript
   - sudo pip install virtualenv
-  # to run petstore server locally
+  # to run petstore server locally via docker
   - docker pull swaggerapi/petstore
   - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
   - docker ps -a
-  # update host table
-  #- sudo echo "127.0.0.1    petstore.swagger.io" >> /etc/hosts
+  # show host table to confirm petstore.swagger.io is mapped to localhost
   - cat /etc/hosts
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
   - npm install -g typescript
   - sudo pip install virtualenv
   # to run petstore server locally
-  - docker pull swaggerapi/swagger-petstore
-  - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/swagger-petstore
+  - docker pull swaggerapi/petstore
+  - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
   - docker ps -a
   # update host table
   - sudo echo "127.0.0.1    petstore.swagger.io" >> /etc/hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ before_install:
   - gem install bundler
   - npm install -g typescript
   - sudo pip install virtualenv
+  # to run petstore server locally
+  - docker pull swaggerapi/swagger-petstore
+  - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/swagger-petstore
+  - docker ps -a
+  # update host table
+  - sudo echo "127.0.0.1    petstore.swagger.io" >> /etc/hosts
+  - cat /etc/hosts
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ cache:
 services:
   - docker
 
+addons:
+  hosts:
+    - petstore.swagger.io
+
 before_install:
   # required when sudo: required for the Ruby petstore tests
   - gem install bundler
@@ -21,7 +25,7 @@ before_install:
   - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
   - docker ps -a
   # update host table
-  - sudo echo "127.0.0.1    petstore.swagger.io" >> /etc/hosts
+  #- sudo echo "127.0.0.1    petstore.swagger.io" >> /etc/hosts
   - cat /etc/hosts
 
 install:


### PR DESCRIPTION
Run petstore.swagger.io locally to
- improve performance
- avoid issues with 2 or more jobs sharing the same backend (http://petstore.swagger.io)
- avoid bad data in public petstore server causing test failures