### PR TITLE
[Javascript] Fix #3416 - String enums in codegen

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/enumClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/enumClass.mustache
@@ -12,7 +12,7 @@
      * @const
      */
 {{/emitJSDoc}}
-    "{{name}}": {{{value}}}{{^-last}},
+    "{{name}}": "{{{value}}}"{{^-last}},
     {{/-last}}
   {{/enumVars}}
   {{/allowableValues}}

--- a/modules/swagger-codegen/src/main/resources/Javascript/partial_model_enum_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/partial_model_enum_class.mustache
@@ -14,7 +14,7 @@
      * @const
      */
 {{/emitJSDoc}}
-    "{{name}}": {{{value}}}{{^-last}},
+    "{{name}}": "{{{value}}}"{{^-last}},
     {{/-last}}
   {{/enumVars}}
   {{/allowableValues}}

--- a/modules/swagger-codegen/src/main/resources/Javascript/partial_model_inner_enum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/partial_model_inner_enum.mustache
@@ -14,7 +14,7 @@
      * @const
      */
 {{/emitJSDoc}}
-    "{{name}}": {{{value}}}{{^-last}},
+    "{{name}}": "{{{value}}}"{{^-last}},
     {{/-last}}
   {{/enumVars}}
   {{/allowableValues}}


### PR DESCRIPTION
When using String enums, codegen will generate undefined constant names for enum types. This is our current workaround for this issue.

This is a workaround for #3416 