### PR TITLE
Fix ExampleGenerator

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -98,7 +98,7 @@ public class ExampleGenerator {
             }
             return mp;
         } else if (property instanceof ObjectProperty) {
-            return "{}";
+            return Collections.EMPTY_MAP;
         } else if (property instanceof RefProperty) {
             String simpleName = ((RefProperty) property).getSimpleRef();
             Model model = examples.get(simpleName);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -2,22 +2,7 @@ package io.swagger.codegen.examples;
 
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.BooleanProperty;
-import io.swagger.models.properties.DateProperty;
-import io.swagger.models.properties.DateTimeProperty;
-import io.swagger.models.properties.DecimalProperty;
-import io.swagger.models.properties.DoubleProperty;
-import io.swagger.models.properties.FileProperty;
-import io.swagger.models.properties.FloatProperty;
-import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.LongProperty;
-import io.swagger.models.properties.MapProperty;
-import io.swagger.models.properties.ObjectProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.UUIDProperty;
+import io.swagger.models.properties.*;
 import io.swagger.util.Json;
 
 import java.math.BigDecimal;
@@ -90,8 +75,6 @@ public class ExampleGenerator {
             return "2000-01-23T04:56:07.000+00:00";
         } else if (property instanceof DateTimeProperty) {
             return "2000-01-23T04:56:07.000+00:00";
-        } else if (property instanceof DecimalProperty) {
-            return new BigDecimal(1.3579);
         } else if (property instanceof DoubleProperty) {
             return 3.149;
         } else if (property instanceof FileProperty) {
@@ -102,6 +85,8 @@ public class ExampleGenerator {
             return 123;
         } else if (property instanceof LongProperty) {
             return 123456789L;
+        } else if (property instanceof DecimalProperty) {
+            return new BigDecimal(1.3579);
         } else if (property instanceof MapProperty) {
             Map<String, Object> mp = new HashMap<>();
             if (property.getName() != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -1,7 +1,9 @@
 package io.swagger.codegen.examples;
 
+import io.swagger.models.ComposedModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
+import io.swagger.models.RefModel;
 import io.swagger.models.properties.*;
 import io.swagger.util.Json;
 
@@ -125,6 +127,22 @@ public class ExampleGenerator {
                 for (String propertyName : impl.getProperties().keySet()) {
                     Property property = impl.getProperties().get(propertyName);
                     values.put(propertyName, resolvePropertyToExample(mediaType, property, processedModels));
+                }
+            }
+            return values;
+        } else if (model instanceof ComposedModel) {
+            Map<String, Object> values = new HashMap<>();
+            ComposedModel composedModel = (ComposedModel) model;
+            if (composedModel.getInterfaces() != null) {
+                for (RefModel refModel : composedModel.getInterfaces()) {
+                    String simpleRef = refModel.getSimpleRef();
+                    Model ifModel = examples.get(simpleRef);
+                    if (ifModel != null){
+                        Object example = resolveModelToExample(simpleRef, mediaType, ifModel, processedModels);
+                        if (example instanceof Map){
+                            values.putAll((Map) example);
+                        }
+                    }
                 }
             }
             return values;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -21,13 +21,7 @@ import io.swagger.models.properties.UUIDProperty;
 import io.swagger.util.Json;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class ExampleGenerator {
     protected Map<String, Model> examples;
@@ -37,15 +31,15 @@ public class ExampleGenerator {
     }
 
     public List<Map<String, String>> generate(Map<String, Object> examples, List<String> mediaTypes, Property property) {
-        List<Map<String, String>> output = new ArrayList<Map<String, String>>();
-        Set<String> processedModels = new HashSet<String>();
+        List<Map<String, String>> output = new ArrayList<>();
+        Set<String> processedModels = new HashSet<>();
         if (examples == null) {
             if (mediaTypes == null) {
                 // assume application/json for this
                 mediaTypes = Arrays.asList("application/json"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
             }
             for (String mediaType : mediaTypes) {
-                Map<String, String> kv = new HashMap<String, String>();
+                Map<String, String> kv = new HashMap<>();
                 kv.put("contentType", mediaType);
                 if (property != null && mediaType.startsWith("application/json")) {
                     String example = Json.pretty(resolvePropertyToExample(mediaType, property, processedModels));
@@ -64,21 +58,21 @@ public class ExampleGenerator {
             }
         } else {
             for (Map.Entry<String, Object> entry : examples.entrySet()) {
-                final Map<String, String> kv = new HashMap<String, String>();
+                final Map<String, String> kv = new HashMap<>();
                 kv.put("contentType", entry.getKey());
                 kv.put("example", Json.pretty(entry.getValue()));
                 output.add(kv);
             }
         }
         if (output.size() == 0) {
-            Map<String, String> kv = new HashMap<String, String>();
+            Map<String, String> kv = new HashMap<>();
             kv.put("output", "none");
             output.add(kv);
         }
         return output;
     }
 
-    protected Object resolvePropertyToExample(String mediaType, Property property, Set<String> processedModels) {
+    private Object resolvePropertyToExample(String mediaType, Property property, Set<String> processedModels) {
         if (property.getExample() != null) {
             return property.getExample();
         } else if (property instanceof StringProperty) {
@@ -99,17 +93,17 @@ public class ExampleGenerator {
         } else if (property instanceof DecimalProperty) {
             return new BigDecimal(1.3579);
         } else if (property instanceof DoubleProperty) {
-            return new Double(3.149);
+            return 3.149;
         } else if (property instanceof FileProperty) {
             return "";  // TODO
         } else if (property instanceof FloatProperty) {
-            return new Float(1.23);
+            return 1.23f;
         } else if (property instanceof IntegerProperty) {
-            return new Integer(123);
+            return 123;
         } else if (property instanceof LongProperty) {
-            return new Long(123456789);
+            return 123456789L;
         } else if (property instanceof MapProperty) {
-            Map<String, Object> mp = new HashMap<String, Object>();
+            Map<String, Object> mp = new HashMap<>();
             if (property.getName() != null) {
                 mp.put(property.getName(),
                         resolvePropertyToExample(mediaType, ((MapProperty) property).getAdditionalProperties(), processedModels));
@@ -133,14 +127,14 @@ public class ExampleGenerator {
         return "";
     }
 
-    public Object resolveModelToExample(String name, String mediaType, Model model, Set<String> processedModels) {
+    private Object resolveModelToExample(String name, String mediaType, Model model, Set<String> processedModels) {
         if (processedModels.contains(name)) {
             return "";
         }
         if (model instanceof ModelImpl) {
             processedModels.add(name);
             ModelImpl impl = (ModelImpl) model;
-            Map<String, Object> values = new HashMap<String, Object>();
+            Map<String, Object> values = new HashMap<>();
 
             if (impl.getProperties() != null) {
                 for (String propertyName : impl.getProperties().keySet()) {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/ExampleGeneratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/ExampleGeneratorTest.java
@@ -1,30 +1,25 @@
 package io.swagger.codegen;
 
-import io.swagger.codegen.examples.ExampleGenerator;
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.Xml;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
-
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import io.swagger.codegen.examples.ExampleGenerator;
+import io.swagger.models.*;
+import io.swagger.models.properties.*;
+import io.swagger.util.Json;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @SuppressWarnings("static-method")
 public class ExampleGeneratorTest {
 
+    private static final String JSON = "application/json";
+    private static final String XML = "application/xml";
+
     @Test(description = "check handling of recursive models")
     public void recursiveModelsTest() {
-        final String JSON = "application/json";
-        final String XML = "application/xml";
         final String nodeType = "Node";
         final RefProperty ref = new RefProperty(nodeType);
         final Model node = new ModelImpl().name(nodeType).property("name", new StringProperty())
@@ -69,5 +64,71 @@ public class ExampleGeneratorTest {
 
         Assert.assertEqualsNoOrder(types.toArray(new String[types.size()]),
                 expectedTypes.toArray(new String[expectedTypes.size()]));
+    }
+
+    @Test(description = "check primitive types generation")
+    public void testPrimitiveTypes() throws Exception {
+        final String nodeType = "Node";
+        RefProperty ref = new RefProperty(nodeType);
+        Model node = new ModelImpl().name(nodeType)
+                .property("parent", ref)
+                .property("str", new StringProperty())
+                .property("bool", new BooleanProperty())
+                .property("dbl", new DoubleProperty())
+                .property("float", new FloatProperty())
+                .property("int", new IntegerProperty())
+                .property("long", new LongProperty())
+                .property("obj", new ObjectProperty());
+
+        ExampleGenerator generator = new ExampleGenerator(ImmutableMap.of(nodeType, node));
+        List<Map<String, String>> generate = generator.generate(null, Collections.singletonList(JSON), ref);
+        String example = generate.get(0).get("example");
+
+        Map<String, Object> result = Json.mapper().readValue(example, new TypeReference<Map<String, Object>>() {});
+        Assert.assertEquals(result.get("str"), "aeiou");
+        Assert.assertEquals(result.get("bool"), Boolean.TRUE);
+        Assert.assertEquals(result.get("dbl"), 3.149);
+        Assert.assertEquals(result.get("float"), 1.23);
+        Assert.assertEquals(result.get("int"), 123);
+        Assert.assertEquals(result.get("long"), 123456789);
+        Assert.assertTrue(result.get("obj") instanceof Map);
+        Assert.assertEquals(((Map)result.get("obj")).size(), 0);
+    }
+
+    @Test(description = "check composed model generation")
+    public void testComposedModel() throws Exception {
+        final String nodeType = "Node";
+        RefProperty ref = new RefProperty(nodeType);
+        RefProperty parent = new RefProperty("parent");
+        Model modelOne = new ModelImpl().name("ModelOne")
+                .property("parent", parent)
+                .property("str", new StringProperty())
+                .property("bool", new BooleanProperty())
+                .property("dbl", new DoubleProperty());
+
+        Model modelTwo = new ModelImpl().name("ModelTwo")
+                .property("parent", parent)
+                .property("float", new FloatProperty())
+                .property("int", new IntegerProperty())
+                .property("long", new LongProperty())
+                .property("obj", new ObjectProperty());
+
+        Model model = new ComposedModel()
+                .interfaces(Arrays.asList(new RefModel("ModelOne"), new RefModel("ModelTwo")))
+                .parent(new RefModel(nodeType));
+
+        ExampleGenerator generator = new ExampleGenerator(ImmutableMap.of("ModelOne", modelOne, "ModelTwo", modelTwo, nodeType, model));
+        List<Map<String, String>> generate = generator.generate(null, Collections.singletonList(JSON), ref);
+        String example = generate.get(0).get("example");
+
+        Map<String, Object> result = Json.mapper().readValue(example, new TypeReference<Map<String, Object>>() {});
+        Assert.assertEquals(result.get("str"), "aeiou");
+        Assert.assertEquals(result.get("bool"), Boolean.TRUE);
+        Assert.assertEquals(result.get("dbl"), 3.149);
+        Assert.assertEquals(result.get("float"), 1.23);
+        Assert.assertEquals(result.get("int"), 123);
+        Assert.assertEquals(result.get("long"), 123456789);
+        Assert.assertTrue(result.get("obj") instanceof Map);
+        Assert.assertEquals(((Map)result.get("obj")).size(), 0);
     }
 }


### PR DESCRIPTION
Fixes several issues in ExampleGenerator:

-  Incorrect float & double generation (values  taken from DecimalProperty)

Definition:
```
 "Test" : {
      "type" : "object",
      "properties" : {
        "pFloat" : {
          "type" : "number",
          "format" : "float"
        },
        "pDouble" : {
          "type" : "number",
          "format" : "double"
        }
      }
    }
```
Result:
````
examples['application/json'] = {
  "pFloat" : 1.3579000000000001069366817318950779736042022705078125,
  "pDouble" : 1.3579000000000001069366817318950779736042022705078125
};
```

-  Incorrect object example generation as string, not an object:

Definition:
```
 "Test" : {
      "type" : "object",
      "properties" : {
        "obj" : {
          "type" : "object"
        }
      }
    }
```

Result:
```
examples['application/json'] = {
  "obj" : "{}"
};
```

-  ComposedModel generates empty example result

Definition:
```
    "Test" : {
      "allOf" : [
        {
          "$ref" : "#/definitions/TypeOne"
        },
        {
          "$ref" : "#/definitions/TypeTwo"
        }
      ]
    },
    "TypeOne" : {
      "type" : "object",
      ...
    },
    "TypeTwo" : {
      "type" : "object",
      ...
    }
```

Result:
```
  examples['application/json'] = "";
```