### PR TITLE
Issue 3462 caseified query param

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -88,14 +88,14 @@ func (a {{{classname}}}) {{{nickname}}}({{#allParams}}{{paramName}} {{{dataType}
 	var collectionFormat = "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"
 	if collectionFormat == "multi" {
 		for _, value := range {{paramName}} {
-			queryParams.Add("{{paramName}}", value)
+			queryParams.Add("{{baseName}}", value)
 		}
 	} else {
-		queryParams.Add("{{paramName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, collectionFormat))
+		queryParams.Add("{{baseName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, collectionFormat))
 	}
 	{{/isListContainer}}
 	{{^isListContainer}}
-		queryParams.Add("{{paramName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, ""))
+		queryParams.Add("{{baseName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, ""))
 	{{/isListContainer}}
 	{{/queryParams}}{{/hasQueryParams}}
 

--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -45,11 +45,7 @@ func (a {{{classname}}}) {{{nickname}}}({{#allParams}}{{paramName}} {{{dataType}
 	// create path and map variables
 	path := a.Configuration.BasePath + "{{path}}"{{#pathParams}}
 	path = strings.Replace(path, "{"+"{{baseName}}"+"}", fmt.Sprintf("%v", {{paramName}}), -1){{/pathParams}}
-{{#allParams}}{{#required}}
-	// verify the required parameter '{{paramName}}' is set
-	if &{{paramName}} == nil {
-		return {{#returnType}}{{#isListContainer}}*{{/isListContainer}}new({{{returnType}}}), {{/returnType}}nil, errors.New("Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}")
-	}{{/required}}{{/allParams}}
+
 
 	headerParams := make(map[string]string)
 	queryParams := url.Values{}


### PR DESCRIPTION
Addresses #3462 

Query params are now sent in their original base name (e.g. `project_id`) instead of the camelized param name (`projectId`).

Note this PR builds on currently-unmerged PR #3460.