### PR TITLE
Qt5: Added missing datatype handlers for QByteArray for swagger-type "byte"

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -124,6 +124,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
         //TODO binary should be mapped to byte array
         // mapped to String as a workaround
         typeMapping.put("binary", "QString");
+        typeMapping.put("ByteArray", "QByteArray");
 
         importMapping = new HashMap<String, String>();
 
@@ -138,6 +139,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
         systemIncludes.add("QMap");
         systemIncludes.add("QDate");
         systemIncludes.add("QDateTime");
+        systemIncludes.add("QByteArray");
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -94,6 +94,27 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
             qDebug() << "Can't set value because the target pointer is NULL";
         }
     }
+    else if (QStringLiteral("QByteArray").compare(type) == 0) {
+        QByteArray **val = static_cast<QByteArray**>(value);
+
+        if(val != NULL) {
+            if(!obj.isNull()) {
+                // create a new value and return
+                delete *val;
+
+                *val = new QByteArray(QByteArray::fromBase64(QByteArray::fromStdString(obj.toString().toStdString())));
+                return;
+            }
+            else {
+                // set target to NULL
+                delete *val;
+                *val = NULL;
+            }
+        }
+        else {
+            qDebug() << "Can't set value because the target pointer is NULL";
+        }
+    }
     else if(type.startsWith("SWG") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
@@ -220,6 +241,10 @@ toJsonValue(QString name, void* value, QJsonObject* output, QString type) {
     else if(QStringLiteral("QDateTime").compare(type) == 0) {
         QDateTime* datetime = static_cast<QDateTime*>(value);
         output->insert(name, QJsonValue(datetime->toString(Qt::ISODate)));
+    }
+    else if(QStringLiteral("QByteArray").compare(type) == 0) {
+        QByteArray* byteArray = static_cast<QByteArray*>(value);
+        output->insert(name, QJsonValue(QString(byteArray->toBase64())));
     }
 }
 


### PR DESCRIPTION
Now you can have sth like this in your swagger and it will work with Qt5 SDK

```
  ProductObject:
    type: object
    properties:
      image:
        type: string
        format: byte
```

the property will be base64 encoded/decoded to/from JSON
