### PR TITLE
Confluence Wiki Documentation

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ConfluenceWikiGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ConfluenceWikiGenerator.java
@@ -1,0 +1,95 @@
+package io.swagger.codegen.languages;
+
+import io.swagger.codegen.*;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.Property;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class ConfluenceWikiGenerator extends DefaultCodegen implements CodegenConfig {
+    private static final String ALL_OPERATIONS = "";
+    protected String invokerPackage = "io.swagger.client";
+    protected String groupId = "io.swagger";
+    protected String artifactId = "swagger-client";
+    protected String artifactVersion = "1.0.0";
+
+    public ConfluenceWikiGenerator() {
+        super();
+        outputFolder = "docs";
+        embeddedTemplateDir = templateDir = "confluenceWikiDocs";
+
+        defaultIncludes = new HashSet<String>();
+
+        cliOptions.add(new CliOption("appName", "short name of the application"));
+        cliOptions.add(new CliOption("appDescription", "description of the application"));
+        cliOptions.add(new CliOption("infoUrl", "a URL where users can get more information about the application"));
+        cliOptions.add(new CliOption("infoEmail", "an email address to contact for inquiries about the application"));
+        cliOptions.add(new CliOption("licenseInfo", "a short description of the license"));
+        cliOptions.add(new CliOption("licenseUrl", "a URL pointing to the full license"));
+        cliOptions.add(new CliOption(CodegenConstants.INVOKER_PACKAGE, CodegenConstants.INVOKER_PACKAGE_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.GROUP_ID, CodegenConstants.GROUP_ID_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_ID, CodegenConstants.ARTIFACT_ID_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_VERSION, CodegenConstants.ARTIFACT_VERSION_DESC));
+        
+        additionalProperties.put("appName", "Swagger Sample");
+        additionalProperties.put("appDescription", "A sample swagger server");
+        additionalProperties.put("infoUrl", "https://helloreverb.com");
+        additionalProperties.put("infoEmail", "hello@helloreverb.com");
+        additionalProperties.put("licenseInfo", "All rights reserved");
+        additionalProperties.put("licenseUrl", "http://apache.org/licenses/LICENSE-2.0.html");
+        additionalProperties.put(CodegenConstants.INVOKER_PACKAGE, invokerPackage);
+        additionalProperties.put(CodegenConstants.GROUP_ID, groupId);
+        additionalProperties.put(CodegenConstants.ARTIFACT_ID, artifactId);
+        additionalProperties.put(CodegenConstants.ARTIFACT_VERSION, artifactVersion);
+
+        supportingFiles.add(new SupportingFile("index.mustache", "", "confluence-markup.txt"));
+        reservedWords = new HashSet<String>();
+
+        languageSpecificPrimitives = new HashSet<String>();
+        importMapping = new HashMap<String, String>();
+    }
+
+    @Override
+    public CodegenType getTag() {
+        return CodegenType.DOCUMENTATION;
+    }
+
+    @Override
+    public String getName() {
+        return "cwiki";
+    }
+
+    @Override
+    public String getHelp() {
+        return "Generates confluence wiki markup.";
+    }
+
+    @Override
+    public String getTypeDeclaration(Property p) {
+        if (p instanceof ArrayProperty) {
+            ArrayProperty ap = (ArrayProperty) p;
+            Property inner = ap.getItems();
+            return getSwaggerType(p) + "[" + getTypeDeclaration(inner) + "]";
+        } else if (p instanceof MapProperty) {
+            MapProperty mp = (MapProperty) p;
+            Property inner = mp.getAdditionalProperties();
+
+            return getSwaggerType(p) + "[String, " + getTypeDeclaration(inner) + "]";
+        }
+        return super.getTypeDeclaration(p);
+    }
+
+    @Override
+    public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
+        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+        List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
+        for (CodegenOperation op : operationList) {
+            op.httpMethod = op.httpMethod.toLowerCase();
+        }
+        return objs;
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -1,6 +1,7 @@
 io.swagger.codegen.languages.AndroidClientCodegen
 io.swagger.codegen.languages.AspNet5ServerCodegen
 io.swagger.codegen.languages.AsyncScalaClientCodegen
+io.swagger.codegen.languages.ConfluenceWikiGenerator
 io.swagger.codegen.languages.CSharpClientCodegen
 io.swagger.codegen.languages.CppRestClientCodegen
 io.swagger.codegen.languages.DartClientCodegen

--- a/modules/swagger-codegen/src/main/resources/confluenceWikiDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/confluenceWikiDocs/index.mustache
@@ -1,0 +1,94 @@
+h1. {{{appName}}} {{{appDescription}}}
+
+{{#version}}*Version:* {{{version}}}{{/version}}
+
+----
+
+{toc:printable=true|style=square|minLevel=2|maxLevel=3|type=list|outline=false|include=.*}
+
+h2. Endpoints
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
+    h3. {{nickname}}
+    {status:colour=Yellow|title={{httpMethod}}|subtle=false}
+    {code}
+    {{httpMethod}} {{path}}
+    {code}
+    *Summary:* {{summary}}
+    *Description:* {{notes}}
+
+
+    h4. Parameters
+    {{#hasPathParams}}
+        h5. Path Parameters
+        ||Name||Description||Required||Default||Pattern||
+        {{#pathParams}}{{>param}}
+        {{/pathParams}}
+    {{/hasPathParams}}
+
+    {{#hasBodyParam}}
+        h5. Body Parameter
+        ||Name||Description||Required||Default||Pattern||
+        {{#bodyParams}}{{>param}}
+        {{/bodyParams}}
+    {{/hasBodyParam}}
+
+    {{#hasHeaderParam}}
+        h5. Header Parameters
+        ||Name||Description||Required||Default||Pattern||
+        {{#headerParam}}{{>param}}
+        {{/headerParam}}
+    {{/hasHeaderParam}}
+
+    {{#hasQueryParams}}
+        h5. Query Parameters
+        ||Name||Description||Required||Default||Pattern||
+        {{#queryParams}}{{>param}}
+        {{/queryParams}}
+    {{/hasQueryParams}}
+
+
+
+
+    h4. Responses
+    {{#responses}}
+        *Status Code:* {{code}}
+        *Message:*     {{message}}
+        {code:title=Response Type}
+{{{dataType}}}
+        {code}
+        See [#models]
+
+        {{#hasExamples}}
+            {{#examples}}
+                {code:title=Example {{{contentType}}} |collapse=true }
+                {{{example}}}
+{code}
+            {{/examples}}
+        {{/hasExamples}}
+
+
+        {code:title=Response Schema |collapse=true}
+{{{jsonSchema}}}
+        {code}
+        {{#examples}}
+            {code:title=Example {{{contentType}}} |collapse=true }
+{{{example}}}
+            {code}
+        {{/examples}}
+    {{/responses}}
+    ----
+{{/operation}}
+{{/operations}}
+{{/apis}}
+{{/apiInfo}}
+
+h2. Models
+
+{{#models}}
+    {{#model}}
+        h3. {{classname}}
+        ||Field Name||Required||Type||Description||
+        {{#vars}} |{{name}} |{{#isNotRequired}}(x){{/isNotRequired}} |{{datatype}} |{{description}} |
+        {{/vars}}
+    {{/model}}
+{{/models}}

--- a/modules/swagger-codegen/src/main/resources/confluenceWikiDocs/param.mustache
+++ b/modules/swagger-codegen/src/main/resources/confluenceWikiDocs/param.mustache
@@ -1,0 +1,1 @@
+|{{paramName}} |{{description}} |{{^required}}(x){{/required}}{{#required}}(/){{/required}} |{{defaultValue}} | {{pattern}} |


### PR DESCRIPTION
Addition of a generator to create confluence wiki markup which can then be pasted into confluence to generate docs as per image

![cwiki](https://cloud.githubusercontent.com/assets/965054/17245169/8ced145e-5585-11e6-82eb-c9ef99496e93.png)
