### PR TITLE
[Java] Add maven-javadoc-plugin in pom.xml of generated Java client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pom.mustache
@@ -107,6 +107,11 @@
           {{/java8}}
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/samples/client/petstore/java/jersey1/pom.xml
+++ b/samples/client/petstore/java/jersey1/pom.xml
@@ -101,6 +101,11 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+      </plugin>
     </plugins>
   </build>
   <dependencies>


### PR DESCRIPTION
This plugin would allow the generation of Javadoc from the generated Java client using `mvn javadoc:javadoc`, making it easier to document the Java client API.