### PR TITLE
fixing bug of rendering an extra spaces into @FeignClient annotation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/apiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-cloud/apiClient.mustache
@@ -3,6 +3,8 @@ package {{package}};
 import org.springframework.cloud.netflix.feign.FeignClient;
 import {{configPackage}}.ClientConfiguration;
 
-@FeignClient(name="${ {{{title}}}.name:{{{title}}}}", url="${ {{{title}}}.url:{{{basePath}}}}", configuration = ClientConfiguration.class)
+{{=<% %>=}}
+@FeignClient(name="${<%title%>.name:<%title%>}", url="${<%title%>.url:<%basePath%>}", configuration = ClientConfiguration.class)
+<%={{ }}=%>
 public interface {{classname}}Client extends {{classname}} {
 }

--- a/samples/client/petstore/spring-cloud/README.md
+++ b/samples/client/petstore/spring-cloud/README.md
@@ -1,5 +1,14 @@
 # swagger-petstore-spring-cloud
 
+Spring cloud (Feign) client can be generated using the below command :
+```shell
+swagger-codegen-cli generate \
+   -l spring \
+   -i http://petstore.swagger.io/v2/swagger.json \
+   -DhideGenerationTimestamp=true   
+```
+example is [here](https://github.com/swagger-api/swagger-codegen/blob/master/bin/spring-cloud-feign-petstore.sh)
+
 ## Requirements
 
 Building the API client library requires [Maven](https://maven.apache.org/) to be installed.

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApiClient.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApiClient.java
@@ -3,6 +3,6 @@ package io.swagger.api;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name="${ swaggerPetstore.name:swaggerPetstore}", url="${ swaggerPetstore.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${swaggerPetstore.name:swaggerPetstore}", url="${swaggerPetstore.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface PetApiClient extends PetApi {
 }

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/StoreApiClient.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/StoreApiClient.java
@@ -3,6 +3,6 @@ package io.swagger.api;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name="${ swaggerPetstore.name:swaggerPetstore}", url="${ swaggerPetstore.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${swaggerPetstore.name:swaggerPetstore}", url="${swaggerPetstore.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface StoreApiClient extends StoreApi {
 }

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/UserApiClient.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/UserApiClient.java
@@ -3,6 +3,6 @@ package io.swagger.api;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import io.swagger.configuration.ClientConfiguration;
 
-@FeignClient(name="${ swaggerPetstore.name:swaggerPetstore}", url="${ swaggerPetstore.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${swaggerPetstore.name:swaggerPetstore}", url="${swaggerPetstore.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface UserApiClient extends UserApi {
 }

--- a/samples/client/petstore/spring-stubs/README.md
+++ b/samples/client/petstore/spring-stubs/README.md
@@ -1,5 +1,14 @@
-
 # Swagger generated API stub
+
+Spring stub can be generated using the below command :
+```shell
+swagger-codegen-cli generate \
+   -l spring \
+   -i http://petstore.swagger.io/v2/swagger.json \
+   -DinterfaceOnly=true,singleContentTypes=true,hideGenerationTimestamp=true
+```
+example is [here](https://github.com/swagger-api/swagger-codegen/blob/master/bin/spring-stubs.sh)
+
 
 Spring Framework stub
 


### PR DESCRIPTION
FeignClient annotations are redered incorrectly with an extra space. This causes a problem that spring properties are not loaded. E.g: the below annotation was generated

```@FeignClient(name="${ swaggerPetstoreSimple.name:swaggerPetstoreSimple}", url="${ swaggerPetstoreSimple.url:https://localhost:8080/api}", configuration = ClientConfiguration.class)```

and overwriting 

swaggerPetstoreSimple.name:swaggerPetstoreSimple

was not possible because of the extra spaces.