### PR TITLE
[android] Make all models implement 'Serializable'

### DIFF
--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/model.mustache
@@ -13,7 +13,7 @@ import com.google.gson.annotations.SerializedName;
  * {{description}}
  **/{{/description}}
 @ApiModel(description = "{{{description}}}")
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
+public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} implements Serializable {
   {{#vars}}{{#isEnum}}
   public enum {{datatypeWithEnum}} {
     {{#allowableValues}}{{#values}} {{.}}, {{/values}}{{/allowableValues}}

--- a/modules/swagger-codegen/src/main/resources/android/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/model.mustache
@@ -12,7 +12,7 @@ import com.google.gson.annotations.SerializedName;
  * {{description}}
  **/{{/description}}
 @ApiModel(description = "{{{description}}}")
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
+public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} implements Serializable {
   {{#vars}}{{#isEnum}}
   public enum {{datatypeWithEnum}} {
     {{#allowableValues}}{{#values}} {{.}}, {{/values}}{{/allowableValues}}


### PR DESCRIPTION
This allows the models to be passed to `Activity` objects when creating them,