### PR TITLE
NodeJS generator - Harken to the the warnings ...

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -320,4 +320,14 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
         return removeNonNameElementToCamelCase(name, "[-:;#]");
     }
 
+    @Override
+    public String escapeUnsafeCharacters(String input) {
+        return input.replace("*/", "*_/").replace("/*", "/_*");
+    }
+
+    @Override
+    public String escapeQuotationMark(String input) {
+        // remove " to avoid code injection
+        return input.replace("\"", "");
+    }
 }


### PR DESCRIPTION
2 types of warnings are emitted in bulk whenever using the nodeJS generator:

```
[main] WARN io.swagger.codegen.DefaultCodegen - escapeUnsafeCharacters should be overriden in the code generator with proper logic to escape unsafe characters
```
and
```
[main] WARN io.swagger.codegen.DefaultCodegen - escapeQuotationMark should be overriden in the code generator with proper logic to escape single/double quote
```

I did some guesswork: since JS is a c-type language like C# and Java - I looked there for reference, and followed their example.