### PR TITLE
inject base_path opaque token for typescript angular2

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -68,6 +68,7 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
         supportingFiles.add(new SupportingFile("models.mustache", modelPackage().replace('.', File.separatorChar), "models.ts"));
         supportingFiles.add(new SupportingFile("apis.mustache", apiPackage().replace('.', File.separatorChar), "api.ts"));
         supportingFiles.add(new SupportingFile("index.mustache", getIndexDirectory(), "index.ts"));
+        supportingFiles.add(new SupportingFile("variables.mustache", getIndexDirectory(), "variables.ts"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
 

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/README.mustache
@@ -31,3 +31,14 @@ npm install PATH_TO_GENERATED_PACKAGE --save
 In your angular2 project:
 
 TODO: paste example.
+
+### Set service base path
+If different than the generated base path, during app bootstrap, you can provide the base path to your service. 
+
+```
+import { BASE_PATH } from './path-to-swagger-gen-service/index';
+
+bootstrap(AppComponent, [
+    { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
+]);
+```  

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -1,8 +1,9 @@
 {{>licenseInfo}}
 import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Injectable, Optional} from '@angular/core';
+import {Inject, Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import * as models from '../model/models';
+import {BASE_PATH} from '../variables';
 import 'rxjs/Rx';
 
 /* tslint:disable:no-unused-variable member-ordering */
@@ -20,7 +21,7 @@ export class {{classname}} {
     protected basePath = '{{basePath}}';
     public defaultHeaders : Headers = new Headers();
 
-    constructor(protected http: Http, @Optional() basePath: string) {
+    constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string) {
         if (basePath) {
             this.basePath = basePath;
         }
@@ -32,7 +33,7 @@ export class {{classname}} {
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any ) : Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
         const path = this.basePath + '{{path}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
 

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/index.mustache
@@ -1,2 +1,3 @@
 export * from './api/api';
 export * from './model/models';
+export * from './variables';

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/variables.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/variables.mustache
@@ -1,0 +1,3 @@
+import { OpaqueToken } from '@angular/core';
+
+export const BASE_PATH = new OpaqueToken('basePath');


### PR DESCRIPTION
Enable setup of base path for apis in angular2 bootstrap by providing the value to resolve #3513 

Need verifying I haven't missed anything as first code contribution to swagger-codegen and building the project from source