### PR TITLE
Add missing spring-cloud client to Swagger Editor

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCloudCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCloudCodegen.java
@@ -1,0 +1,27 @@
+package io.swagger.codegen.languages;
+
+import io.swagger.codegen.*;
+
+public class SpringCloudCodegen extends SpringCodegen {
+
+    public SpringCloudCodegen() {
+        super();
+        setLibrary(SPRING_CLOUD_LIBRARY);
+    }
+
+    @Override
+    public CodegenType getTag() {
+        return CodegenType.CLIENT;
+    }
+
+    @Override
+    public String getName() {
+        return "spring-cloud";
+    }
+
+    @Override
+    public String getHelp() {
+        return supportedLibraries.get(SPRING_CLOUD_LIBRARY);
+    }
+
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCloudCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCloudCodegen.java
@@ -2,6 +2,13 @@ package io.swagger.codegen.languages;
 
 import io.swagger.codegen.*;
 
+/**
+ * This is a temporary workaround, so spring cloud can be listed by
+ *
+ * http://generator.swagger.io/api/gen/clients
+ *
+ * as a client and eventually Spring cloud can be displayed by the swagger editor' generate client menu.
+ */
 public class SpringCloudCodegen extends SpringCodegen {
 
     public SpringCloudCodegen() {

--- a/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -34,6 +34,7 @@ io.swagger.codegen.languages.SinatraServerCodegen
 io.swagger.codegen.languages.Rails5ServerCodegen
 io.swagger.codegen.languages.SlimFrameworkServerCodegen
 io.swagger.codegen.languages.SpringCodegen
+io.swagger.codegen.languages.SpringCloudCodegen
 io.swagger.codegen.languages.StaticDocCodegen
 io.swagger.codegen.languages.StaticHtmlGenerator
 io.swagger.codegen.languages.StaticHtml2Generator

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringCloudOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringCloudOptionsProvider.java
@@ -1,0 +1,14 @@
+package io.swagger.codegen.options;
+
+public class SpringCloudOptionsProvider extends SpringOptionsProvider {
+
+    @Override
+    public String getLanguage() {
+        return "spring-cloud";
+    }
+
+    @Override
+    public boolean isServer() {
+        return false;
+    }
+}

--- a/modules/swagger-generator/README.md
+++ b/modules/swagger-generator/README.md
@@ -1,0 +1,7 @@
+# Swagger Code Generator Backend
+
+This module can generate Client or Server code from Swagger definitions. It is available under https://generator.swagger.io .To run it locally execute
+
+```shell
+mvn jetty:run
+```

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -24,6 +24,11 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty-version}</version>
+            </plugin>
+            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
Swagger Editor is not listing spring cloud among the available clients. This is because Swagger editor reads the available clients from the backend. Code generators are are categorized as either Server or Client. The spring code generator is categorized as Server therefore it won't be listed as a client. I created a new code generator only so it can be registered as Client. This is clearly a workaround, but a proper solution would require a bigger refactor and I am not sure it worth the effort. It also worth mentioning that even though the list of available languages are coming from the backend, the human readable name is coded into Swagger Editor's

```
$scope.capitalizeGeneratorName
```

method. This requires changes in two modules when a new code generator is created. This pull request solves the issue for spring-cloud client, but it wont work for java/feign or spring/stubs because it requires additional parameters, not just language. I think a proper solution would be that every code generator returns a list of available server and client implementations along with all options, then the two apis

http://generator.swagger.io/api/gen/clients
http://generator.swagger.io/api/gen/servers

should return something like

[{
    "displayName": "Java spring cloud client",
    "options": {
        "l": "spring"
    }
}, {
    "displayName": "Java spring stubs",
    "options": {
        "l": "spring",
        "D": "DinterfaceOnly=true"
    }
}]

This is either a breaking change or a new endpoint, or versioning, or an extra parameter needs to be introduced.
