### PR TITLE
Restore ability to configure Go

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
@@ -115,7 +115,7 @@ public class GoClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public void processOpts() {
-        //super.processOpts();
+        super.processOpts();
 
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));


### PR DESCRIPTION
This fixes that passing a template directory (`-t ./anything`) on the command line is ignored for generating Go projects.
Original bug introduced here: https://github.com/swagger-api/swagger-codegen/commit/579e356e5bab30aa8aea1b8554491ad92cf38d38#diff-e72dbab4ab666029c71bd9b1028c03faR110