### PR TITLE
[csharp] PropertyChanged support .NET 4.x+

### DIFF
--- a/bin/csharp-petstore.sh
+++ b/bin/csharp-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClient"
+ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClient"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -127,4 +127,7 @@ public class CodegenConstants {
     public static final String GENERATE_MODEL_TESTS = "generateModelTests";
     public static final String GENERATE_MODEL_TESTS_DESC = "Specifies that model tests are to be generated.";
 
+    public static final String GENERATE_PROPERTY_CHANGED = "generatePropertyChanged";
+    public static final String GENERATE_PROPERTY_CHANGED_DESC = "Specifies that models support raising property changed events.";
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -1,32 +1,20 @@
 package io.swagger.codegen.languages;
 
-import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
-import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.CodegenModel;
-import io.swagger.codegen.DefaultCodegen;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.codegen.CodegenProperty;
-import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenOperation;
-import io.swagger.codegen.CodegenParameter;
-import io.swagger.models.properties.*;
 import io.swagger.codegen.CliOption;
 import io.swagger.models.Model;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.ArrayList;
 import java.util.Iterator;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.WordUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +36,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     protected String targetFrameworkNuget = "net45";
     protected boolean supportsAsync = Boolean.TRUE;
     protected boolean supportsUWP = Boolean.FALSE;
+    protected boolean generatePropertyChanged = Boolean.FALSE;
 
 
     protected final Map<String, String> frameworks;
@@ -173,6 +162,14 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
             additionalProperties.put("supportsAsync", this.supportsAsync);
         }
 
+        if(additionalProperties.containsKey(CodegenConstants.GENERATE_PROPERTY_CHANGED)) {
+            if(NET35.equals(targetFramework)) {
+                LOGGER.warn(CodegenConstants.GENERATE_PROPERTY_CHANGED + " is only supported by generated code for .NET 4+.");
+            } else {
+                setGeneratePropertyChanged(Boolean.valueOf(additionalProperties.get(CodegenConstants.GENERATE_PROPERTY_CHANGED).toString()));
+            }
+        }
+
         additionalProperties.put("targetFrameworkNuget", this.targetFrameworkNuget);
 
         if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_PROJECT_FILE)) {
@@ -237,6 +234,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
         if(Boolean.FALSE.equals(excludeTests)) {
             supportingFiles.add(new SupportingFile("packages_test.config.mustache", testPackageFolder + File.separator, "packages.config"));
+        }
+
+        if(Boolean.TRUE.equals(generatePropertyChanged)) {
+            supportingFiles.add(new SupportingFile("FodyWeavers.xml", "", "FodyWeavers.xml"));
         }
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
@@ -444,6 +445,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
     public void setSupportsUWP(Boolean supportsUWP){
         this.supportsUWP = supportsUWP;
+    }
+
+    public void setGeneratePropertyChanged(final Boolean generatePropertyChanged){
+        this.generatePropertyChanged = generatePropertyChanged;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -116,6 +116,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         addSwitch(CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES,
                 CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES_DESC,
                 this.optionalEmitDefaultValue);
+
+        addSwitch(CodegenConstants.GENERATE_PROPERTY_CHANGED,
+                CodegenConstants.PACKAGE_DESCRIPTION_DESC,
+                this.generatePropertyChanged);
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/csharp/FodyWeavers.xml
+++ b/modules/swagger-codegen/src/main/resources/csharp/FodyWeavers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Weavers>
+    <PropertyChanged/>
+</Weavers>

--- a/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
@@ -82,13 +82,19 @@ limitations under the License.
         <HintPath Condition="Exists('..\..\packages')">..\..\packages\RestSharp.105.1.0\lib\{{targetFrameworkNuget}}\RestSharp.dll</HintPath>
       <HintPath Condition="Exists('{{binRelativePath}}')">{{binRelativePath}}\RestSharp.105.1.0\lib\{{targetFrameworkNuget}}\RestSharp.dll</HintPath>
     </Reference>
+    {{#generatePropertyChanged}}<Reference Include="PropertyChanged">
+      <HintPath>..\..\packages\PropertyChanged.Fody.1.51.3\Lib\portable-net4+sl4+wp8+win8+wpa81+MonoAndroid16+MonoTouch40\PropertyChanged.dll</HintPath>
+    </Reference>{{/generatePropertyChanged}}
   </ItemGroup>
   <ItemGroup>
     <Compile Include="**\*.cs"/>
   </ItemGroup>
   <ItemGroup>
       <None Include="packages.config" />
+      {{#generatePropertyChanged}}<None Include="FodyWeavers.xml" />{{/generatePropertyChanged}}
   </ItemGroup>
-  <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />{{#generatePropertyChanged}}
+  <Import Project="..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\..\packages\Fody.1.29.2\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
+  {{/generatePropertyChanged}}
 </Project>
 

--- a/modules/swagger-codegen/src/main/resources/csharp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model.mustache
@@ -9,6 +9,8 @@ using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+{{#generatePropertyChanged}}using PropertyChanged;
+using System.ComponentModel;{{/generatePropertyChanged}}
 
 {{#models}}
 {{#model}}

--- a/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
@@ -1,7 +1,8 @@
     /// <summary>
     /// {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
     /// </summary>
-    [DataContract]
+    [DataContract]{{#generatePropertyChanged}}
+    [ImplementPropertyChanged]{{/generatePropertyChanged}}
     public partial class {{classname}} : {{#parent}}{{{parent}}}, {{/parent}} IEquatable<{{classname}}>
     {
         {{#vars}}
@@ -169,4 +170,16 @@ this.{{name}} = {{name}};
                 return hash;
             }
         }
+    {{#generatePropertyChanged}}
+        public event PropertyChangedEventHandler PropertyChanged;
+        public virtual void OnPropertyChanged(string propertyName)
+        {
+            // NOTE: property changed is handled via "code weaving" using Fody.
+            // Properties with setters are modified at compile time to notify of changes.
+            var propertyChanged = PropertyChanged;
+            if (propertyChanged != null)
+            {
+                propertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }{{/generatePropertyChanged}}
     }

--- a/modules/swagger-codegen/src/main/resources/csharp/packages.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/packages.config.mustache
@@ -2,4 +2,6 @@
 <packages>
   <package id="RestSharp" version="105.1.0" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
+  {{#generatePropertyChanged}}<package id="Fody" version="1.29.2" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />
+  <package id="PropertyChanged.Fody" version="1.51.3" targetFramework="{{targetFrameworkNuget}}" developmentDependency="true" />{{/generatePropertyChanged}}
 </packages>

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpClientOptionsTest.java
@@ -48,6 +48,8 @@ public class CSharpClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setOptionalEmitDefaultValue(true);
             times = 1;
+            clientCodegen.setGeneratePropertyChanged(true);
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/CSharpClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/CSharpClientOptionsProvider.java
@@ -33,6 +33,7 @@ public class CSharpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.OPTIONAL_PROJECT_GUID, PACKAGE_GUID_VALUE)
                 .put(CodegenConstants.DOTNET_FRAMEWORK, "4.x")
                 .put(CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES, "true")
+                .put(CodegenConstants.GENERATE_PROPERTY_CHANGED, "true")
                 .build();
     }
 


### PR DESCRIPTION
This adds support for additional property `generatePropertyChanged=true` which will add an `OnPropertyChanged` method and a `PropertyChanged` event to all models and use Fody code weaving to inject the raised events into property setters.

For more information on code weaving, check out [Fody](https://github.com/Fody/Fody) on github.

see feature request #3356.

@wing328 question... I moved the `$@` in `bin/csharp-petstore.sh` to support running the script with properties passed to CLI. For example:

```
./bin/csharp-petstore.sh --additional-properties=generatePropertyChanged=true
```

Was there a reason it previously went `$@ generate...` instead? Usage of those sample generator scripts doesn't seem to be documented anywhere.