### PR TITLE
[aspnet] Honor casing of properties from definition

### DIFF
--- a/modules/swagger-codegen/src/main/resources/aspnet5/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnet5/model.mustache
@@ -16,6 +16,7 @@ namespace {{packageName}}.Models
     /// <summary>
     /// {{description}}
     /// </summary>
+    [DataContract]
     public partial class {{classname}} : {{#parent}}{{{parent}}}, {{/parent}} IEquatable<{{classname}}>
     {
         /// <summary>
@@ -52,6 +53,7 @@ namespace {{packageName}}.Models
         /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
         /// </summary>{{#description}}
         /// <value>{{{description}}}</value>{{/description}}
+        [DataMember(Name="{{baseName}}")]
         public {{{datatype}}} {{name}} { get; set; }
 
         {{/vars}}
@@ -64,7 +66,8 @@ namespace {{packageName}}.Models
         {
             var sb = new StringBuilder();
             sb.Append("class {{classname}} {\n");
-            {{#vars}}sb.Append("  {{name}}: ").Append({{name}}).Append("\n");
+            {{#vars}}
+            sb.Append("  {{name}}: ").Append({{name}}).Append("\n");
             {{/vars}}
             sb.Append("}\n");
             return sb.ToString();

--- a/modules/swagger-codegen/src/main/resources/csharp/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelEnum.mustache
@@ -1,5 +1,5 @@
     /// <summary>
-    /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
+    /// {{^description}}Defines {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
     /// </summary>{{#description}}
     /// <value>{{{description}}}</value>{{/description}}
     [JsonConverter(typeof(StringEnumConverter))]

--- a/samples/server/petstore/aspnet5/README.md
+++ b/samples/server/petstore/aspnet5/README.md
@@ -1,7 +1,25 @@
-# {{packageName}} - ASP.NET Core 1.0 Server
+# IO.Swagger - ASP.NET Core 1.0 Server
 
-{{#appDescription}}
-{{{appDescription}}}
-{{/appDescription}}
+This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
 
+## Run
 
+Linux/OS X:
+
+```
+sh build.sh
+```
+
+Windows:
+
+```
+build.bat
+```
+
+## Run in Docker
+
+```
+cd src/IO.Swagger
+docker build -t IO.Swagger .
+docker run -p 5000:5000 IO.Swagger
+```

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Dockerfile
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Dockerfile
@@ -1,7 +1,5 @@
 FROM microsoft/dotnet:latest
 
-RUN groupadd -r app && useradd -r -g app app
-
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 
 RUN mkdir -p /app/IO.Swagger
@@ -9,8 +7,6 @@ COPY . /app/IO.Swagger
 WORKDIR /app/IO.Swagger
 
 EXPOSE 5000/tcp
-
-USER app
 
 RUN ["dotnet", "restore"]
 ENTRYPOINT ["dotnet", "run", "-p", "project.json", "web"]

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/ApiResponse.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/ApiResponse.cs
@@ -35,6 +35,7 @@ namespace IO.Swagger.Models
     /// <summary>
     /// 
     /// </summary>
+    [DataContract]
     public partial class ApiResponse :  IEquatable<ApiResponse>
     {
         /// <summary>
@@ -54,16 +55,19 @@ namespace IO.Swagger.Models
         /// <summary>
         /// Gets or Sets Code
         /// </summary>
+        [DataMember(Name="code")]
         public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type
         /// </summary>
+        [DataMember(Name="type")]
         public string Type { get; set; }
 
         /// <summary>
         /// Gets or Sets Message
         /// </summary>
+        [DataMember(Name="message")]
         public string Message { get; set; }
 
 
@@ -76,8 +80,8 @@ namespace IO.Swagger.Models
             var sb = new StringBuilder();
             sb.Append("class ApiResponse {\n");
             sb.Append("  Code: ").Append(Code).Append("\n");
-sb.Append("  Type: ").Append(Type).Append("\n");
-sb.Append("  Message: ").Append(Message).Append("\n");
+            sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  Message: ").Append(Message).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Category.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Category.cs
@@ -35,6 +35,7 @@ namespace IO.Swagger.Models
     /// <summary>
     /// 
     /// </summary>
+    [DataContract]
     public partial class Category :  IEquatable<Category>
     {
         /// <summary>
@@ -52,11 +53,13 @@ namespace IO.Swagger.Models
         /// <summary>
         /// Gets or Sets Id
         /// </summary>
+        [DataMember(Name="id")]
         public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
+        [DataMember(Name="name")]
         public string Name { get; set; }
 
 
@@ -69,7 +72,7 @@ namespace IO.Swagger.Models
             var sb = new StringBuilder();
             sb.Append("class Category {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
-sb.Append("  Name: ").Append(Name).Append("\n");
+            sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Order.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Order.cs
@@ -35,6 +35,7 @@ namespace IO.Swagger.Models
     /// <summary>
     /// 
     /// </summary>
+    [DataContract]
     public partial class Order :  IEquatable<Order>
     {
         /// <summary>
@@ -68,32 +69,38 @@ namespace IO.Swagger.Models
         /// <summary>
         /// Gets or Sets Id
         /// </summary>
+        [DataMember(Name="id")]
         public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
+        [DataMember(Name="petId")]
         public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
+        [DataMember(Name="quantity")]
         public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
+        [DataMember(Name="shipDate")]
         public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Order Status
         /// </summary>
         /// <value>Order Status</value>
+        [DataMember(Name="status")]
         public string Status { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
+        [DataMember(Name="complete")]
         public bool? Complete { get; set; }
 
 
@@ -106,11 +113,11 @@ namespace IO.Swagger.Models
             var sb = new StringBuilder();
             sb.Append("class Order {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
-sb.Append("  PetId: ").Append(PetId).Append("\n");
-sb.Append("  Quantity: ").Append(Quantity).Append("\n");
-sb.Append("  ShipDate: ").Append(ShipDate).Append("\n");
-sb.Append("  Status: ").Append(Status).Append("\n");
-sb.Append("  Complete: ").Append(Complete).Append("\n");
+            sb.Append("  PetId: ").Append(PetId).Append("\n");
+            sb.Append("  Quantity: ").Append(Quantity).Append("\n");
+            sb.Append("  ShipDate: ").Append(ShipDate).Append("\n");
+            sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  Complete: ").Append(Complete).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Pet.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Pet.cs
@@ -35,6 +35,7 @@ namespace IO.Swagger.Models
     /// <summary>
     /// 
     /// </summary>
+    [DataContract]
     public partial class Pet :  IEquatable<Pet>
     {
         /// <summary>
@@ -76,32 +77,38 @@ namespace IO.Swagger.Models
         /// <summary>
         /// Gets or Sets Id
         /// </summary>
+        [DataMember(Name="id")]
         public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category
         /// </summary>
+        [DataMember(Name="category")]
         public Category Category { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
+        [DataMember(Name="name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or Sets PhotoUrls
         /// </summary>
+        [DataMember(Name="photoUrls")]
         public List<string> PhotoUrls { get; set; }
 
         /// <summary>
         /// Gets or Sets Tags
         /// </summary>
+        [DataMember(Name="tags")]
         public List<Tag> Tags { get; set; }
 
         /// <summary>
         /// pet status in the store
         /// </summary>
         /// <value>pet status in the store</value>
+        [DataMember(Name="status")]
         public string Status { get; set; }
 
 
@@ -114,11 +121,11 @@ namespace IO.Swagger.Models
             var sb = new StringBuilder();
             sb.Append("class Pet {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
-sb.Append("  Category: ").Append(Category).Append("\n");
-sb.Append("  Name: ").Append(Name).Append("\n");
-sb.Append("  PhotoUrls: ").Append(PhotoUrls).Append("\n");
-sb.Append("  Tags: ").Append(Tags).Append("\n");
-sb.Append("  Status: ").Append(Status).Append("\n");
+            sb.Append("  Category: ").Append(Category).Append("\n");
+            sb.Append("  Name: ").Append(Name).Append("\n");
+            sb.Append("  PhotoUrls: ").Append(PhotoUrls).Append("\n");
+            sb.Append("  Tags: ").Append(Tags).Append("\n");
+            sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Tag.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Tag.cs
@@ -35,6 +35,7 @@ namespace IO.Swagger.Models
     /// <summary>
     /// 
     /// </summary>
+    [DataContract]
     public partial class Tag :  IEquatable<Tag>
     {
         /// <summary>
@@ -52,11 +53,13 @@ namespace IO.Swagger.Models
         /// <summary>
         /// Gets or Sets Id
         /// </summary>
+        [DataMember(Name="id")]
         public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
+        [DataMember(Name="name")]
         public string Name { get; set; }
 
 
@@ -69,7 +72,7 @@ namespace IO.Swagger.Models
             var sb = new StringBuilder();
             sb.Append("class Tag {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
-sb.Append("  Name: ").Append(Name).Append("\n");
+            sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/User.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/User.cs
@@ -35,6 +35,7 @@ namespace IO.Swagger.Models
     /// <summary>
     /// 
     /// </summary>
+    [DataContract]
     public partial class User :  IEquatable<User>
     {
         /// <summary>
@@ -64,42 +65,50 @@ namespace IO.Swagger.Models
         /// <summary>
         /// Gets or Sets Id
         /// </summary>
+        [DataMember(Name="id")]
         public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
         /// </summary>
+        [DataMember(Name="username")]
         public string Username { get; set; }
 
         /// <summary>
         /// Gets or Sets FirstName
         /// </summary>
+        [DataMember(Name="firstName")]
         public string FirstName { get; set; }
 
         /// <summary>
         /// Gets or Sets LastName
         /// </summary>
+        [DataMember(Name="lastName")]
         public string LastName { get; set; }
 
         /// <summary>
         /// Gets or Sets Email
         /// </summary>
+        [DataMember(Name="email")]
         public string Email { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
         /// </summary>
+        [DataMember(Name="password")]
         public string Password { get; set; }
 
         /// <summary>
         /// Gets or Sets Phone
         /// </summary>
+        [DataMember(Name="phone")]
         public string Phone { get; set; }
 
         /// <summary>
         /// User Status
         /// </summary>
         /// <value>User Status</value>
+        [DataMember(Name="userStatus")]
         public int? UserStatus { get; set; }
 
 
@@ -112,13 +121,13 @@ namespace IO.Swagger.Models
             var sb = new StringBuilder();
             sb.Append("class User {\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
-sb.Append("  Username: ").Append(Username).Append("\n");
-sb.Append("  FirstName: ").Append(FirstName).Append("\n");
-sb.Append("  LastName: ").Append(LastName).Append("\n");
-sb.Append("  Email: ").Append(Email).Append("\n");
-sb.Append("  Password: ").Append(Password).Append("\n");
-sb.Append("  Phone: ").Append(Phone).Append("\n");
-sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
+            sb.Append("  Username: ").Append(Username).Append("\n");
+            sb.Append("  FirstName: ").Append(FirstName).Append("\n");
+            sb.Append("  LastName: ").Append(LastName).Append("\n");
+            sb.Append("  Email: ").Append(Email).Append("\n");
+            sb.Append("  Password: ").Append(Password).Append("\n");
+            sb.Append("  Phone: ").Append(Phone).Append("\n");
+            sb.Append("  UserStatus: ").Append(UserStatus).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }


### PR DESCRIPTION
See #3262

This would replace #3263, which provides a correct implementation for JSON endpoints only. Although generated code for the `aspnet5` generator outputs to JSON, we still need to support all output types (i.e. from the `produces` definition of the api endpoint).

I've also fixed the formatting in the `ToString` method for models and changed the generic description on enums which was previously worded like an auto-implemented property description.