### PR TITLE
[Java] Fix @JsonCreator annotation issue with Java API clients using gson

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/modelEnum.mustache
@@ -28,6 +28,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
   public String toString() {
     return String.valueOf(value);
   }
+{{#jackson}}
 
   @JsonCreator
   public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
@@ -38,5 +39,5 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     }
     return null;
   }
-
+{{/jackson}}
 }

--- a/modules/swagger-codegen/src/main/resources/Java/modelInnerEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/modelInnerEnum.mustache
@@ -30,6 +30,7 @@
     public String toString() {
       return String.valueOf(value);
     }
+{{#jackson}}
 
     @JsonCreator
     public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
@@ -40,4 +41,5 @@
       }
       return null;
     }
+{{/jackson}}
   }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
@@ -41,10 +41,10 @@ public class ApiClient {
     this();
     for(String authName : authNames) { 
       RequestInterceptor auth;
-      if (authName == "petstore_auth") { 
-        auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
-      } else if (authName == "api_key") { 
+      if (authName == "api_key") { 
         auth = new ApiKeyAuth("header", "api_key");
+      } else if (authName == "petstore_auth") { 
+        auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
       }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
@@ -4,8 +4,8 @@ import io.swagger.client.ApiClient;
 
 import io.swagger.client.model.Client;
 import org.joda.time.LocalDate;
-import java.math.BigDecimal;
 import org.joda.time.DateTime;
+import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
@@ -3,8 +3,8 @@ package io.swagger.client.api;
 import io.swagger.client.ApiClient;
 
 import io.swagger.client.model.Pet;
-import io.swagger.client.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.client.model.ModelApiResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +40,7 @@ public interface PetApi extends ApiClient.Api {
   @Headers({
     "Content-type: application/json",
     "Accept: application/json",
-    "apiKey: {apiKey}"
+    "api_key: {apiKey}"
   })
   void deletePet(@Param("petId") Long petId, @Param("apiKey") String apiKey);
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Animal.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ArrayTest.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.ReadOnlyFirst;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Cat.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Animal;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Category.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Client.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Client.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Dog.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Dog.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Animal;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumClass.java
@@ -28,6 +28,8 @@ package io.swagger.client.model;
 import java.util.Objects;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Gets or Sets EnumClass
  */
@@ -48,6 +50,16 @@ public enum EnumClass {
   @Override
   public String toString() {
     return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static EnumClass fromValue(String text) {
+    for (EnumClass b : EnumClass.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+            return b;
+        }
+    }
+    return null;
   }
 }
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -54,6 +55,16 @@ public class EnumTest   {
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static EnumStringEnum fromValue(String text) {
+      for (EnumStringEnum b : EnumStringEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
+    }
   }
 
   @JsonProperty("enum_string")
@@ -77,6 +88,16 @@ public class EnumTest   {
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static EnumIntegerEnum fromValue(String text) {
+      for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
+    }
   }
 
   @JsonProperty("enum_integer")
@@ -99,6 +120,16 @@ public class EnumTest   {
     @Override
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static EnumNumberEnum fromValue(String text) {
+      for (EnumNumberEnum b : EnumNumberEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
     }
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/FormatTest.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/HasOnlyReadOnly.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MapTest.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
@@ -59,6 +60,16 @@ public class MapTest   {
     @Override
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static InnerEnum fromValue(String text) {
+      for (InnerEnum b : InnerEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
     }
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Animal;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Model200Response.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ModelApiResponse.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ModelReturn.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Name.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Name.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/NumberOnly.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.joda.time.DateTime;
@@ -68,6 +69,16 @@ public class Order   {
     @Override
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
     }
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Category;
@@ -74,6 +75,16 @@ public class Pet   {
     @Override
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
     }
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/ReadOnlyFirst.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/SpecialModelName.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Tag.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/User.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumClass.java
@@ -61,6 +61,5 @@ public enum EnumClass {
     }
     return null;
   }
-
 }
 

--- a/samples/client/petstore/java/jersey2-java8/docs/MapTest.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/MapTest.md
@@ -12,6 +12,8 @@ Name | Type | Description | Notes
 ## Enum: Map&lt;String, InnerEnum&gt;
 Name | Value
 ---- | -----
+UPPER | &quot;UPPER&quot;
+LOWER | &quot;lower&quot;
 
 
 

--- a/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
@@ -158,7 +158,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter |
+ **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [enum: available, pending, sold]
 
 ### Return type
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/ApiClient.java
@@ -84,8 +84,8 @@ public class ApiClient {
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
-    authentications.put("petstore_auth", new OAuth());
     authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
+    authentications.put("petstore_auth", new OAuth());
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/FakeApi.java
@@ -8,8 +8,8 @@ import io.swagger.client.Pair;
 import javax.ws.rs.core.GenericType;
 
 import io.swagger.client.model.Client;
-import java.time.OffsetDateTime;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.math.BigDecimal;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/PetApi.java
@@ -8,8 +8,8 @@ import io.swagger.client.Pair;
 import javax.ws.rs.core.GenericType;
 
 import io.swagger.client.model.Pet;
-import io.swagger.client.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.client.model.ModelApiResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Animal.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ArrayTest.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.ReadOnlyFirst;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Cat.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Animal;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Category.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Client.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Dog.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Animal;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumClass.java
@@ -28,6 +28,8 @@ package io.swagger.client.model;
 import java.util.Objects;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Gets or Sets EnumClass
  */
@@ -48,6 +50,16 @@ public enum EnumClass {
   @Override
   public String toString() {
     return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static EnumClass fromValue(String text) {
+    for (EnumClass b : EnumClass.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+            return b;
+        }
+    }
+    return null;
   }
 }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumTest.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -54,6 +55,16 @@ public class EnumTest   {
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static EnumStringEnum fromValue(String text) {
+      for (EnumStringEnum b : EnumStringEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
+    }
   }
 
   @JsonProperty("enum_string")
@@ -77,6 +88,16 @@ public class EnumTest   {
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static EnumIntegerEnum fromValue(String text) {
+      for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
+    }
   }
 
   @JsonProperty("enum_integer")
@@ -99,6 +120,16 @@ public class EnumTest   {
     @Override
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static EnumNumberEnum fromValue(String text) {
+      for (EnumNumberEnum b : EnumNumberEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/FormatTest.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/HasOnlyReadOnly.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MapTest.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
@@ -59,6 +60,16 @@ public class MapTest   {
     @Override
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static InnerEnum fromValue(String text) {
+      for (InnerEnum b : InnerEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Animal;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Model200Response.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ModelApiResponse.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ModelReturn.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Name.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/NumberOnly.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Order.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
@@ -68,6 +69,16 @@ public class Order   {
     @Override
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Pet.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.client.model.Category;
@@ -74,6 +75,16 @@ public class Pet   {
     @Override
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+          if (String.valueOf(b.value).equals(text)) {
+              return b;
+          }
+      }
+      return null;
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/ReadOnlyFirst.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/SpecialModelName.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Tag.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/User.java
@@ -27,6 +27,7 @@ package io.swagger.client.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumClass.java
@@ -61,6 +61,5 @@ public enum EnumClass {
     }
     return null;
   }
-
 }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumClass.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
 
+
 /**
  * Gets or Sets EnumClass
  */

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/ApiClient.java
@@ -54,10 +54,10 @@ public class ApiClient {
         this();
         for(String authName : authNames) { 
             Interceptor auth;
-            if (authName == "petstore_auth") { 
-                auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
-            } else if (authName == "api_key") { 
+            if (authName == "api_key") { 
                 auth = new ApiKeyAuth("header", "api_key");
+            } else if (authName == "petstore_auth") { 
+                auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
             } else {
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
             }

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/FakeApi.java
@@ -8,8 +8,8 @@ import retrofit.mime.*;
 
 import io.swagger.client.model.Client;
 import org.joda.time.LocalDate;
-import java.math.BigDecimal;
 import org.joda.time.DateTime;
+import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/PetApi.java
@@ -7,8 +7,8 @@ import retrofit.http.*;
 import retrofit.mime.*;
 
 import io.swagger.client.model.Pet;
-import io.swagger.client.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.client.model.ModelApiResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumClass.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
 
+
 /**
  * Gets or Sets EnumClass
  */

--- a/samples/client/petstore/java/retrofit2/docs/MapTest.md
+++ b/samples/client/petstore/java/retrofit2/docs/MapTest.md
@@ -12,6 +12,8 @@ Name | Type | Description | Notes
 ## Enum: Map&lt;String, InnerEnum&gt;
 Name | Value
 ---- | -----
+UPPER | &quot;UPPER&quot;
+LOWER | &quot;lower&quot;
 
 
 

--- a/samples/client/petstore/java/retrofit2/docs/PetApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/PetApi.md
@@ -160,7 +160,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter |
+ **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [enum: available, pending, sold]
 
 ### Return type
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/ApiClient.java
@@ -53,10 +53,10 @@ public class ApiClient {
         this();
         for(String authName : authNames) { 
             Interceptor auth;
-            if (authName == "petstore_auth") { 
-                auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
-            } else if (authName == "api_key") { 
+            if (authName == "api_key") { 
                 auth = new ApiKeyAuth("header", "api_key");
+            } else if (authName == "petstore_auth") { 
+                auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
             } else {
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
             }

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/FakeApi.java
@@ -10,8 +10,8 @@ import okhttp3.RequestBody;
 
 import io.swagger.client.model.Client;
 import org.joda.time.LocalDate;
-import java.math.BigDecimal;
 import org.joda.time.DateTime;
+import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/PetApi.java
@@ -9,8 +9,8 @@ import retrofit2.http.*;
 import okhttp3.RequestBody;
 
 import io.swagger.client.model.Pet;
-import io.swagger.client.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.client.model.ModelApiResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumClass.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
 
+
 /**
  * Gets or Sets EnumClass
  */

--- a/samples/client/petstore/java/retrofit2rx/docs/MapTest.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/MapTest.md
@@ -12,6 +12,8 @@ Name | Type | Description | Notes
 ## Enum: Map&lt;String, InnerEnum&gt;
 Name | Value
 ---- | -----
+UPPER | &quot;UPPER&quot;
+LOWER | &quot;lower&quot;
 
 
 

--- a/samples/client/petstore/java/retrofit2rx/docs/PetApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/PetApi.md
@@ -160,7 +160,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter |
+ **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [enum: available, pending, sold]
 
 ### Return type
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
@@ -53,10 +53,10 @@ public class ApiClient {
         this();
         for(String authName : authNames) { 
             Interceptor auth;
-            if (authName == "petstore_auth") { 
-                auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
-            } else if (authName == "api_key") { 
+            if (authName == "api_key") { 
                 auth = new ApiKeyAuth("header", "api_key");
+            } else if (authName == "petstore_auth") { 
+                auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
             } else {
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
             }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/FakeApi.java
@@ -10,8 +10,8 @@ import okhttp3.RequestBody;
 
 import io.swagger.client.model.Client;
 import org.joda.time.LocalDate;
-import java.math.BigDecimal;
 import org.joda.time.DateTime;
+import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/PetApi.java
@@ -9,8 +9,8 @@ import retrofit2.http.*;
 import okhttp3.RequestBody;
 
 import io.swagger.client.model.Pet;
-import io.swagger.client.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.client.model.ModelApiResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumClass.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import com.google.gson.annotations.SerializedName;
 
 
+
 /**
  * Gets or Sets EnumClass
  */


### PR DESCRIPTION
The issue was due to not using {{#jackson}} tab to handle the JsonCreator (we've done it for import but not `fromValue`) and it's causing issue for Java API clients using gson (okhttp-gson, retrofit, retrofit2)

Ran `./bin/java-petstore-all.sh` to update all Java API client so as to back test API clients using jackson and  to confirm API clients using gson no longer having the issue. 

The issue was caused by https://github.com/swagger-api/swagger-codegen/pull/3531 in an attempt to fix deserializaiton issue with jackson.