### PR TITLE
[wip][csharp] client property validations

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
@@ -66,6 +66,7 @@ limitations under the License.
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Runtime.Serialization" />

--- a/modules/swagger-codegen/src/main/resources/csharp/TestProject.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/TestProject.mustache
@@ -66,6 +66,7 @@ limitations under the License.
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Runtime.Serialization" />

--- a/modules/swagger-codegen/src/main/resources/csharp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model.mustache
@@ -3,12 +3,14 @@ using System;
 using System.Linq;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System.ComponentModel.DataAnnotations;
 
 {{#models}}
 {{#model}}

--- a/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
@@ -2,7 +2,7 @@
     /// {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
     /// </summary>
     [DataContract]
-    public partial class {{classname}} : {{#parent}}{{{parent}}}, {{/parent}} IEquatable<{{classname}}>
+    public partial class {{classname}} : {{#parent}}{{{parent}}}, {{/parent}} IEquatable<{{classname}}>, IValidatableObject
     {
         {{#vars}}
         {{#isEnum}}
@@ -168,5 +168,40 @@ this.{{name}} = {{name}};
                 {{/vars}}
                 return hash;
             }
+        }
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        { {{#vars}}{{#hasValidation}}{{#maxLength}}
+            // {{{name}}} ({{{datatype}}}) maxLength
+            if(this.{{{name}}} != null && this.{{{name}}}.Length > {{maxLength}})
+            {
+                yield return new ValidationResult("Invalid value for {{{name}}}, length must be less than {{maxLength}}.", new [] { "{{{name}}}" });
+            }
+{{/maxLength}}{{#minLength}}
+            // {{{name}}} ({{{datatype}}}) minLength
+            if(this.{{{name}}} != null && this.{{{name}}}.Length < {{minLength}})
+            {
+                yield return new ValidationResult("Invalid value for {{{name}}}, length must be greater than {{minLength}}.", new [] { "{{{name}}}" });
+            }
+{{/minLength}}{{#maximum}}
+            // {{{name}}} ({{{datatype}}}) maximum
+            if(this.{{{name}}} > ({{{datatype}}}){{maximum}})
+            {
+                yield return new ValidationResult("Invalid value for {{{name}}}, must be a value less than or equal to {{maximum}}.", new [] { "{{{name}}}" });
+            }
+{{/maximum}}{{#minimum}}
+            // {{{name}}} ({{{datatype}}}) minimum
+            if(this.{{{name}}} < ({{{datatype}}}){{minimum}})
+            {
+                yield return new ValidationResult("Invalid value for {{{name}}}, must be a value greater than or equal to {{minimum}}.", new [] { "{{{name}}}" });
+            }
+{{/minimum}}{{#pattern}}
+            // {{{name}}} ({{{datatype}}}) pattern
+            Regex regex{{{name}}} = new Regex(@"{{vendorExtensions.x-regex}}"{{#vendorExtensions.x-modifiers}}{{#-first}}, {{/-first}}RegexOptions.{{.}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}});
+            if (false == regex{{{name}}}.Match(this.{{{name}}}).Success)
+            {
+                yield return new ValidationResult("Invalid value for {{{name}}}, must match a pattern of {{pattern}}.", new [] { "{{{name}}}" });
+            }
+{{/pattern}}{{/hasValidation}}{{/vars}}
+            yield break;
         }
     }


### PR DESCRIPTION
Work in progress.

C# client property validation using data annotations. Based off of python client's implementation.

See #3222 and #2663 

TODO: I need to do more thorough testing on this. Currently, only C# client property validation. I plan to update `aspnet` and `nancyfx` too.

