### PR TITLE
[Java] minor indentation fix for java enum models

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/modelEnum.mustache
@@ -33,9 +33,9 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
   @JsonCreator
   public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
     for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-            return b;
-        }
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
     }
     return null;
   }

--- a/modules/swagger-codegen/src/main/resources/Java/modelInnerEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/modelInnerEnum.mustache
@@ -35,9 +35,9 @@
     @JsonCreator
     public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
       for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumClass.java
@@ -55,9 +55,9 @@ public enum EnumClass {
   @JsonCreator
   public static EnumClass fromValue(String text) {
     for (EnumClass b : EnumClass.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-            return b;
-        }
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
     }
     return null;
   }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
@@ -59,9 +59,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumStringEnum fromValue(String text) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -92,9 +92,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumIntegerEnum fromValue(String text) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -125,9 +125,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumNumberEnum fromValue(String text) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MapTest.java
@@ -65,9 +65,9 @@ public class MapTest   {
     @JsonCreator
     public static InnerEnum fromValue(String text) {
       for (InnerEnum b : InnerEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
@@ -74,9 +74,9 @@ public class Order   {
     @JsonCreator
     public static StatusEnum fromValue(String text) {
       for (StatusEnum b : StatusEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
@@ -80,9 +80,9 @@ public class Pet   {
     @JsonCreator
     public static StatusEnum fromValue(String text) {
       for (StatusEnum b : StatusEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -61,9 +61,9 @@ public class EnumArrays   {
     @JsonCreator
     public static JustSymbolEnum fromValue(String text) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -94,9 +94,9 @@ public class EnumArrays   {
     @JsonCreator
     public static ArrayEnumEnum fromValue(String text) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumClass.java
@@ -55,9 +55,9 @@ public enum EnumClass {
   @JsonCreator
   public static EnumClass fromValue(String text) {
     for (EnumClass b : EnumClass.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-            return b;
-        }
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
     }
     return null;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumTest.java
@@ -59,9 +59,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumStringEnum fromValue(String text) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -92,9 +92,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumIntegerEnum fromValue(String text) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -125,9 +125,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumNumberEnum fromValue(String text) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/MapTest.java
@@ -65,9 +65,9 @@ public class MapTest   {
     @JsonCreator
     public static InnerEnum fromValue(String text) {
       for (InnerEnum b : InnerEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Order.java
@@ -74,9 +74,9 @@ public class Order   {
     @JsonCreator
     public static StatusEnum fromValue(String text) {
       for (StatusEnum b : StatusEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Pet.java
@@ -80,9 +80,9 @@ public class Pet   {
     @JsonCreator
     public static StatusEnum fromValue(String text) {
       for (StatusEnum b : StatusEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -104,6 +104,11 @@
           <target>1.8</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumClass.java
@@ -55,9 +55,9 @@ public enum EnumClass {
   @JsonCreator
   public static EnumClass fromValue(String text) {
     for (EnumClass b : EnumClass.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-            return b;
-        }
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
     }
     return null;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumTest.java
@@ -59,9 +59,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumStringEnum fromValue(String text) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -92,9 +92,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumIntegerEnum fromValue(String text) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -125,9 +125,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumNumberEnum fromValue(String text) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MapTest.java
@@ -65,9 +65,9 @@ public class MapTest   {
     @JsonCreator
     public static InnerEnum fromValue(String text) {
       for (InnerEnum b : InnerEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Order.java
@@ -74,9 +74,9 @@ public class Order   {
     @JsonCreator
     public static StatusEnum fromValue(String text) {
       for (StatusEnum b : StatusEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Pet.java
@@ -80,9 +80,9 @@ public class Pet   {
     @JsonCreator
     public static StatusEnum fromValue(String text) {
       for (StatusEnum b : StatusEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -104,6 +104,11 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -61,9 +61,9 @@ public class EnumArrays   {
     @JsonCreator
     public static JustSymbolEnum fromValue(String text) {
       for (JustSymbolEnum b : JustSymbolEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -94,9 +94,9 @@ public class EnumArrays   {
     @JsonCreator
     public static ArrayEnumEnum fromValue(String text) {
       for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumClass.java
@@ -55,9 +55,9 @@ public enum EnumClass {
   @JsonCreator
   public static EnumClass fromValue(String text) {
     for (EnumClass b : EnumClass.values()) {
-        if (String.valueOf(b.value).equals(text)) {
-            return b;
-        }
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
     }
     return null;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumTest.java
@@ -59,9 +59,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumStringEnum fromValue(String text) {
       for (EnumStringEnum b : EnumStringEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -92,9 +92,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumIntegerEnum fromValue(String text) {
       for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }
@@ -125,9 +125,9 @@ public class EnumTest   {
     @JsonCreator
     public static EnumNumberEnum fromValue(String text) {
       for (EnumNumberEnum b : EnumNumberEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/MapTest.java
@@ -65,9 +65,9 @@ public class MapTest   {
     @JsonCreator
     public static InnerEnum fromValue(String text) {
       for (InnerEnum b : InnerEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
@@ -74,9 +74,9 @@ public class Order   {
     @JsonCreator
     public static StatusEnum fromValue(String text) {
       for (StatusEnum b : StatusEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
@@ -80,9 +80,9 @@ public class Pet   {
     @JsonCreator
     public static StatusEnum fromValue(String text) {
       for (StatusEnum b : StatusEnum.values()) {
-          if (String.valueOf(b.value).equals(text)) {
-              return b;
-          }
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
       }
       return null;
     }

--- a/samples/client/petstore/java/retrofit/pom.xml
+++ b/samples/client/petstore/java/retrofit/pom.xml
@@ -104,6 +104,11 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+      </plugin>
     </plugins>
   </build>
   <dependencies>


### PR DESCRIPTION
Changed 4-space indentation to 2-space to make it consistent with the rest of the code in the model