### PR TITLE
Go: Replace `.Username` with `.UserName` in generated API methods.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -63,7 +63,7 @@ func (a {{{classname}}}) {{{nickname}}}({{#allParams}}{{paramName}} {{{dataType}
 {{/isApiKey}}
 {{#isBasic}}
 	// http basic authentication required
-	if a.Configuration.Username != "" || a.Configuration.Password != ""{
+	if a.Configuration.UserName != "" || a.Configuration.Password != ""{
 		localVarHeaderParams["Authorization"] =  "Basic " + a.Configuration.GetBasicAuthEncodedString()
 	}
 {{/isBasic}}


### PR DESCRIPTION
Right now, any generated code where the http basic authentication is
required is broken, as it tries to access nonexistent field in the
generated `Configuration` struct.

The alternative is to fix `configuration.mustache` to replace the
`UserName` field with `Username` field.