### PR TITLE
Adding support for JMustache compiler customization

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.samskivert.mustache.Mustache.Compiler;
+
 public interface CodegenConfig {
     CodegenType getTag();
 
@@ -116,6 +118,8 @@ public interface CodegenConfig {
     void preprocessSwagger(Swagger swagger);
 
     void processSwagger(Swagger swagger);
+
+    Compiler processCompiler(Compiler compiler);
 
     String sanitizeTag(String tag);
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2,6 +2,8 @@ package io.swagger.codegen;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import com.samskivert.mustache.Mustache.Compiler;
+
 import io.swagger.codegen.examples.ExampleGenerator;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
@@ -325,6 +327,12 @@ public class DefaultCodegen {
     // override with any special handling of the entire swagger spec
     @SuppressWarnings("unused")
     public void processSwagger(Swagger swagger) {
+    }
+    
+    // override with any special handling of the JMustache compiler
+    @SuppressWarnings("unused")
+    public Compiler processCompiler(Compiler compiler) {
+    	return compiler;
     }
 
     // override with any special text escaping logic

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -560,7 +560,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         if(ignoreProcessor.allowsFile(new File(outputFilename))) {
                             if (templateFile.endsWith("mustache")) {
                                 String template = readTemplate(templateFile);
-                                Template tmpl = Mustache.compiler()
+                                Mustache.Compiler compiler = Mustache.compiler();
+                                compiler = config.processCompiler(compiler);                                
+                                Template tmpl = compiler
                                         .withLoader(new Mustache.TemplateLoader() {
                                             @Override
                                             public Reader getTemplate(String name) {
@@ -641,7 +643,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if(ignoreProcessor.allowsFile(new File(outputFilename.replaceAll("//", "/")))) {
             String templateFile = getFullTemplateFile(config, templateName);
             String template = readTemplate(templateFile);
-            Template tmpl = Mustache.compiler()
+            Mustache.Compiler compiler = Mustache.compiler();
+            compiler = config.processCompiler(compiler);                                
+            Template tmpl = compiler
                     .withLoader(new Mustache.TemplateLoader() {
                         @Override
                         public Reader getTemplate(String name) {


### PR DESCRIPTION
Extension of the CodegenConfig interface in order to use JMustache compiler native features, such as the deactivation of HTML escaping.

My custom generator implements it like this : 
```
@Override
public Compiler processCompiler(Compiler compiler) {
   return compiler.escapeHTML(false);
}
```