### PR TITLE
Allowing generators to be aware of original inputSpec path

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConfig.java
@@ -79,6 +79,10 @@ public interface CodegenConfig {
 
     List<SupportingFile> supportingFiles();
 
+    String getInputSpec();
+
+    void setInputSpec(String inputSpec);
+
     String getOutputDir();
 
     void setOutputDir(String dir);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -509,14 +509,14 @@ public class DefaultCodegen {
     }
 
     public String getInputSpec() {
-		return inputSpec;
-	}
+        return inputSpec;
+    }
 
-	public void setInputSpec(String inputSpec) {
-		this.inputSpec = inputSpec;
-	}
+    public void setInputSpec(String inputSpec) {
+        this.inputSpec = inputSpec;
+    }
 
-	public void setTemplateDir(String templateDir) {
+    public void setTemplateDir(String templateDir) {
         this.templateDir = templateDir;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -73,7 +73,8 @@ import java.util.regex.Pattern;
 
 public class DefaultCodegen {
     protected static final Logger LOGGER = LoggerFactory.getLogger(DefaultCodegen.class);
-
+    
+    protected String inputSpec;
     protected String outputFolder = "";
     protected Set<String> defaultIncludes = new HashSet<String>();
     protected Map<String, String> typeMapping = new HashMap<String, String>();
@@ -507,7 +508,15 @@ public class DefaultCodegen {
         return outputFolder();
     }
 
-    public void setTemplateDir(String templateDir) {
+    public String getInputSpec() {
+		return inputSpec;
+	}
+
+	public void setInputSpec(String inputSpec) {
+		this.inputSpec = inputSpec;
+	}
+
+	public void setTemplateDir(String templateDir) {
         this.templateDir = templateDir;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -140,7 +140,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
         config.additionalProperties().put("generatedDate", DateTime.now().toString());
         config.additionalProperties().put("generatorClass", config.getClass().toString());
-
+        config.additionalProperties().put("inputSpec", config.getInputSpec());
+        
         if (swagger.getInfo() != null) {
             Info info = swagger.getInfo();
             if (info.getTitle() != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -352,6 +352,7 @@ public class CodegenConfigurator {
 
         CodegenConfig config = CodegenConfigLoader.forName(lang);
 
+        config.setInputSpec(inputSpec);
         config.setOutputDir(outputDir);
         config.setSkipOverwrite(skipOverwrite);
 


### PR DESCRIPTION
I have two use cases where I would like my custom generator to be aware of the Swagger inputSpec path being used for generation:
- I am generating documentation for my API and I want to indicate the path of the original spec so it can also be downloaded by developers - as the spec also consists in useful documentation
- I want to parse myself the inputSpec in addition to the parsing performed by the SwaggerParser, as the SwaggerParser loses some information - such as the order of the operations in the spec, and I want to display the operations in that same exact order in the generated documentation

Currently the inputSpec path is only kept until the SwaggerParser is used to build the Swagger object, and then it is lost. Generators are not able to access that information.