### PR TITLE
[Spring Boot] use port defined in spec file for server.port value

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/application.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/application.mustache
@@ -1,3 +1,3 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath={{^contextPath}}/{{/contextPath}}{{#contextPath}}{{contextPath}}{{/contextPath}}
-#server.port=8090
+server.port={{serverPort}}


### PR DESCRIPTION
Title says it all. Sets the `server.port` value in `application.properties` to the port defined in the spec file (or to 8080 by default, which matches the current behavior). The `serverPort` property is an existing value that is already being properly parsed by [SpringCodegen.java](https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java#L233).