### PR TITLE
Don't escape path in generated okhttp-gson client code

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -58,7 +58,7 @@ public class {{classname}} {
         {{/required}}{{/allParams}}
 
         // create path and map variables
-        String {{localVariablePrefix}}localVarPath = "{{path}}".replaceAll("\\{format\\}","json"){{#pathParams}}
+        String {{localVariablePrefix}}localVarPath = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
         .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
         {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();{{#queryParams}}


### PR DESCRIPTION
The mustache templates for the other Java clients (e.g
Java/api.mustache) use 3 curly brackets around the path variable
so the path is not escaped. Make the okhttp-gson template
consistent with them.