### PR TITLE
Angular2 rc5

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -3,10 +3,13 @@ package io.swagger.codegen.languages;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 import io.swagger.codegen.CliOption;
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenParameter;
+import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.ArrayProperty;
@@ -161,6 +164,46 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
     public void postProcessParameter(CodegenParameter parameter) {
         super.postProcessParameter(parameter);
         parameter.dataType = addModelPrefix(parameter.dataType);
+    }
+
+    @Override
+    public Map<String, Object> postProcessOperations(Map<String, Object> operations) {
+        Map<String, Object> objs = (Map<String, Object>) operations.get("operations");
+        List<CodegenOperation> ops = (List<CodegenOperation>) objs.get("operation");
+        for (CodegenOperation op : ops) {
+            // Convert httpMethod to Angular's RequestMethod enum
+            // https://angular.io/docs/ts/latest/api/http/index/RequestMethod-enum.html
+            switch (op.httpMethod) {
+                case "GET":
+                    op.httpMethod = "RequestMethod.Get";
+                    break;
+                case "POST":
+                    op.httpMethod = "RequestMethod.Post";
+                    break;
+                case "PUT":
+                    op.httpMethod = "RequestMethod.Put";
+                    break;
+                case "DELETE":
+                    op.httpMethod = "RequestMethod.Delete";
+                    break;
+                case "OPTIONS":
+                    op.httpMethod = "RequestMethod.Options";
+                    break;
+                case "HEAD":
+                    op.httpMethod = "RequestMethod.Head";
+                    break;
+                case "PATCH":
+                    op.httpMethod = "RequestMethod.Patch";
+                    break;
+                default:
+                    throw new RuntimeException("Unknown HTTP Method " + op.httpMethod + " not allowed");
+            }
+
+            // Convert path to TypeScript template string
+            op.path = op.path.replaceAll("\\{(.*?)\\}", "\\$\\{$1\\}");
+        }
+
+        return operations;
     }
 
     public String getNpmName() {

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -1,7 +1,8 @@
 {{>licenseInfo}}
-import { Http, Headers, Response, URLSearchParams }          from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http'; 
 import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
+import { Response, ResponseContentType }                     from '@angular/http';
 
 import { Observable }                                        from 'rxjs/Observable';
 
@@ -34,14 +35,8 @@ export class {{classname}} {
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
-<<<<<<< 54fe7a731caec554d582b4b0a79defdc52751e05
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
-        const path = this.basePath + '{{path}}'{{#pathParams}}
-            .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
-=======
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
         const path = this.basePath + `{{path}}`;
->>>>>>> Changes due to changes in Angular's http module.
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.values()); // https://github.com/angular/angular/issues/6845

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -5,6 +5,7 @@ import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http
 import { Response, ResponseContentType }                     from '@angular/http';
 
 import { Observable }                                        from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
 
 import * as models                                           from '../model/models';
 import { BASE_PATH }                                         from '../variables';

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -1,10 +1,12 @@
 {{>licenseInfo}}
-import {Http, Headers, RequestOptionsArgs, Response, URLSearchParams} from '@angular/http';
-import {Inject, Injectable, Optional} from '@angular/core';
-import {Observable} from 'rxjs/Observable';
-import * as models from '../model/models';
-import {BASE_PATH} from '../variables';
-import 'rxjs/Rx';
+import { Http, Headers, Response, URLSearchParams }          from '@angular/http';
+import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http'; 
+import { Inject, Injectable, Optional }                      from '@angular/core';
+
+import { Observable }                                        from 'rxjs/Observable';
+
+import * as models                                           from '../model/models';
+import { BASE_PATH }                                         from '../variables';
 
 /* tslint:disable:no-unused-variable member-ordering */
 
@@ -19,7 +21,7 @@ import 'rxjs/Rx';
 @Injectable()
 export class {{classname}} {
     protected basePath = '{{basePath}}';
-    public defaultHeaders : Headers = new Headers();
+    public defaultHeaders: Headers = new Headers();
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string) {
         if (basePath) {
@@ -33,12 +35,17 @@ export class {{classname}} {
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
+<<<<<<< 54fe7a731caec554d582b4b0a79defdc52751e05
     public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
         const path = this.basePath + '{{path}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
+=======
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+        const path = this.basePath + `{{path}}`;
+>>>>>>> Changes due to changes in Angular's http module.
 
         let queryParameters = new URLSearchParams();
-        let headerParams = this.defaultHeaders;
+        let headers = new Headers(this.defaultHeaders.values());
 {{#hasFormParams}}
         let formParams = new URLSearchParams();
 
@@ -57,29 +64,49 @@ export class {{classname}} {
         }
 
 {{/queryParams}}
-{{#headerParams}}
-            headerParams.set('{{baseName}}', String({{paramName}}));
+{{#headers}}
+        headers.set('{{baseName}}', String({{paramName}}));
 
-{{/headerParams}}
+{{/headers}}
+
+        // to determine the Content-Type header
+        let consumes: string[] = [
+            {{#consumes}}
+            '{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}
+            {{/consumes}}
+        ];
+
+        // to determine the Accept header
+        let produces: string[] = [
+            {{#produces}}
+            '{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}
+            {{/produces}}
+        ];
+
 {{#hasFormParams}}
-        headerParams.set('Content-Type', 'application/x-www-form-urlencoded');
+        headers.set('Content-Type', 'application/x-www-form-urlencoded');
 
 {{/hasFormParams}}
+{{#bodyParam}}
+        headers.set('Content-Type', 'application/json');
+
+{{/bodyParam}}
 {{#formParams}}
         formParams['{{baseName}}'] = {{paramName}};
 
 {{/formParams}}
-        let requestOptions: RequestOptionsArgs = {
-            method: '{{httpMethod}}',
-            headers: headerParams,
-            search: queryParameters
-        };
-        {{#bodyParam}}
-        requestOptions.body = JSON.stringify({{paramName}});
-        {{/bodyParam}}
-        {{#hasFormParams}}
-        requestOptions.body = formParams.toString();
-        {{/hasFormParams}}
+        let requestOptions: RequestOptionsArgs = new RequestOptions({
+            method: {{httpMethod}},
+            headers: headers,
+{{#bodyParam}}
+            body: JSON.stringify({{paramName}}),
+{{/bodyParam}}
+{{#hasFormParams}}
+            body: formParams.toString(),
+{{/hasFormParams}}
+            search: queryParameters,
+            responseType: ResponseContentType.Json
+        });
 
         return this.http.request(path, requestOptions)
             .map((response: Response) => {

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -93,7 +93,7 @@ export class {{classname}} {
             method: {{httpMethod}},
             headers: headers,
 {{#bodyParam}}
-            body: JSON.stringify({{paramName}}),
+            body: {{paramName}} == null ? '' : JSON.stringify({{paramName}}), // https://github.com/angular/angular/issues/10612
 {{/bodyParam}}
 {{#hasFormParams}}
             body: formParams.toString(),

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -11,7 +11,6 @@ import { BASE_PATH }                                         from '../variables'
 /* tslint:disable:no-unused-variable member-ordering */
 
 {{#operations}}
-'use strict';
 
 {{#description}}
 /**
@@ -45,7 +44,7 @@ export class {{classname}} {
 >>>>>>> Changes due to changes in Angular's http module.
 
         let queryParameters = new URLSearchParams();
-        let headers = new Headers(this.defaultHeaders.values());
+        let headers = new Headers(this.defaultHeaders.values()); // https://github.com/angular/angular/issues/6845
 {{#hasFormParams}}
         let formParams = new URLSearchParams();
 

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/model.mustache
@@ -1,7 +1,6 @@
 {{>licenseInfo}}
 {{#models}}
 {{#model}}
-'use strict';
 import * as models from './models';
 
 {{#description}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
@@ -13,27 +13,33 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "scripts": {
-    "build": "typings install && tsc"
+    "build": "typings install && tsc",
+    "postinstall": "npm run build"
   },
   "peerDependencies": {
-    "@angular/core": "^2.0.0-rc.1",
-    "@angular/http": "^2.0.0-rc.1"
+    "@angular/core": "^2.0.0-rc.5",
+    "@angular/http": "^2.0.0-rc.5",
+    "@angular/common": "^2.0.0-rc.5",
+    "@angular/compiler": "^2.0.0-rc.5",
+    "core-js": "^2.4.0",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "5.0.0-beta.6",
+    "zone.js": "^0.6.17"
   },
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.1",
-    "@angular/compiler": "^2.0.0-rc.1",
-    "@angular/core": "^2.0.0-rc.1",
-    "@angular/http": "^2.0.0-rc.1",
-    "@angular/platform-browser": "^2.0.0-rc.1",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
-    "core-js": "^2.3.0",
-    "rxjs": "^5.0.0-beta.6",
-    "zone.js": "^0.6.12",
+    "@angular/core": "^2.0.0-rc.5",
+    "@angular/http": "^2.0.0-rc.5",
+    "@angular/common": "^2.0.0-rc.5",
+    "@angular/compiler": "^2.0.0-rc.5",
+    "@angular/platform-browser": "^2.0.0-rc.5",
+    "core-js": "^2.4.0",
+    "reflect-metadata": "^0.1.3",
+    "rxjs": "5.0.0-beta.6",
+    "zone.js": "^0.6.17",  
     "typescript": "^1.8.10",
-    "typings": "^0.8.1",
-    "es6-shim": "^0.35.0",
-    "es7-reflect-metadata": "^1.6.0"
-  }{{#npmRepository}},
+    "typings": "^1.3.2"
+  }{{#npmRepository}},{{/npmRepository}}
+{{#npmRepository}}
   "publishConfig":{
     "registry":"{{npmRepository}}"
   }

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/typings.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/typings.mustache
@@ -1,5 +1,5 @@
 {
-  "ambientDependencies": {
-    "core-js": "registry:dt/core-js#0.0.0+20160317120654"
+  "globalDependencies": {
+    "core-js": "registry:dt/core-js#0.0.0+20160725163759"
   }
 }


### PR DESCRIPTION
Due to changes in the latest version of Angular ([2.0.0-rc.5](https://github.com/angular/angular/releases/tag/2.0.0-rc.5)), I had to make a few changes to the existing codegen to make it work again for me.
I also believe these changes would make a good starting point for #3081.

### RequestOptions
See https://angular.io/docs/ts/latest/api/http/index/RequestOptions-class.html. A few changes here, the HTTP method can now be specified using an enum instead of a string, which I did to make the client more robust. I also set the response content type to JSON, which is the only type of content we can handle at the moment.

### Emtpy body issue
https://github.com/angular/angular/issues/10612
See line [95](https://github.com/swagger-api/swagger-codegen/compare/master...sebastianhaas:angular2-rc5?expand=1#diff-174bce348e2584ed556f2d1ce0714665R95).
Supplying an empty body (actually an undefined body) with the `content-type` header set, will lead to some null reference error. This issue occurs in the current release only and has already been fixed for the next one.

### Headers shallow copy issue
https://github.com/angular/angular/issues/6845
See line [41](https://github.com/swagger-api/swagger-codegen/compare/master...sebastianhaas:angular2-rc5?expand=1#diff-174bce348e2584ed556f2d1ce0714665R41). 
At the moment, every endpoint uses `this.defaultHeaders` as starting point for its request, which causes all subsequent requests being extended by the headers applied to previous requests.
To get around this, I used `Header`'s copy constructor, which lacks a proper implementation atm since it only creates a shallow copy copying the underlying data structure by reference only. This should also be fixed for the next release, however, for now `new Headers(this.defaultHeaders.values());` is the way to go.

### Removed `use-strict`
I removed the `'use-strict'` directives since TypeScript will automatically add them from 1.8 on.
https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#modules-are-now-emitted-with-a-use-strict-prologue

### TypeScript template string to build URLs
I changed the template to use TypeScript template strings instead of `string.replace()`.
So
```typescript
const path = this.basePath + '/store/{storeId}/order/{orderId}'
   .replace('{' + 'storeId' + '}', String(storeId))
   .replace('{' + 'orderId' + '}', String(orderId));
```
becomes
```typescript
const path = this.basePath + `/store/${storeId}/order/${orderId}`;
```
which I find more readable.

### Consumes and produces
I added collections for consumes and produces for later use.

### Imports
I refactored imports according to Google's heroes tour for angular. https://angular.io/docs/ts/latest/tutorial/

## Open issues
* #3081 
* Proper rxjs import according to latest docs https://angular.io/docs/ts/latest/guide/server-communication.html#!#rxjs
* Use of the new modules system `NgModules`. Angular will stop supporting non modules at some point. https://angular.io/docs/ts/latest/guide/ngmodule.html
* Barrel imports: I had lots of problems with barrel imports lately. It appears that Angular's DI doesn't always like them.
* Naming conventions: Services should be in a file called `something.service.ts` etc.

I will try to submit a separate PR for those.