### PR TITLE
[Spring Boot] use port defined in spec file for server.port value

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/application.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/application.mustache
@@ -1,3 +1,3 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath={{^contextPath}}/{{/contextPath}}{{#contextPath}}{{contextPath}}{{/contextPath}}
-#server.port=8090
+server.port={{serverPort}}

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
@@ -73,7 +73,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter", required = true) @RequestParam(value = "status", required = true) List<String> status
+    ResponseEntity<List<Pet>> findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "AVAILABLE, PENDING, SOLD") @RequestParam(value = "status", required = true) List<String> status
 
 
 );

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/configuration/ClientConfiguration.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/configuration/ClientConfiguration.java
@@ -22,15 +22,6 @@ import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 @EnableConfigurationProperties
 public class ClientConfiguration {
 
-  @Value("${ swaggerPetstore.security.apiKey.key:}")
-  private String apiKeyKey;
-
-  @Bean
-  @ConditionalOnProperty(name = "swaggerPetstore.security.apiKey.key")
-  public ApiKeyRequestInterceptor apiKeyRequestInterceptor() {
-    return new ApiKeyRequestInterceptor("header", "api_key", this.apiKeyKey);
-  }
-
   @Bean
   @ConditionalOnProperty("swaggerPetstore.security.petstoreAuth.client-id")
   public OAuth2FeignRequestInterceptor petstoreAuthRequestInterceptor() {
@@ -44,6 +35,15 @@ public class ClientConfiguration {
     ImplicitResourceDetails details = new ImplicitResourceDetails();
     details.setUserAuthorizationUri("http://petstore.swagger.io/api/oauth/dialog");
     return details;
+  }
+
+  @Value("${ swaggerPetstore.security.apiKey.key:}")
+  private String apiKeyKey;
+
+  @Bean
+  @ConditionalOnProperty(name = "swaggerPetstore.security.apiKey.key")
+  public ApiKeyRequestInterceptor apiKeyRequestInterceptor() {
+    return new ApiKeyRequestInterceptor("header", "api_key", this.apiKeyKey);
   }
 
 }

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/Category.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/Category.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/ModelApiResponse.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/Order.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/Order.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/Pet.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/Tag.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/Tag.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/User.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/model/User.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
@@ -76,7 +76,7 @@ public interface PetApi {
         produces = "application/json",
         consumes = "application/json",
         method = RequestMethod.GET)
-    ResponseEntity<List<Pet>> findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter", required = true) @RequestParam(value = "status", required = true) List<String> status
+    ResponseEntity<List<Pet>> findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "AVAILABLE, PENDING, SOLD") @RequestParam(value = "status", required = true) List<String> status
 
 
 

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/Category.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/Category.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/ModelApiResponse.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/Order.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/Order.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/Pet.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/Pet.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/Tag.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/Tag.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/User.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/model/User.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.LocalDate;
 import java.math.BigDecimal;
 
 import io.swagger.annotations.*;
@@ -41,7 +41,9 @@ public interface FakeApi {
     }
 
 
-    @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = Void.class, tags={ "fake", })
+    @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = Void.class, authorizations = {
+        @Authorization(value = "http_basic_test")
+    }, tags={ "fake", })
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         @ApiResponse(code = 404, message = "User not found", response = Void.class) })

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApi.java
@@ -2,8 +2,8 @@ package io.swagger.api;
 
 import io.swagger.model.Client;
 import org.joda.time.LocalDate;
-import org.joda.time.DateTime;
 import java.math.BigDecimal;
+import org.joda.time.DateTime;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +36,9 @@ public interface FakeApi {
 );
 
 
-    @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = Void.class, tags={ "fake", })
+    @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = Void.class, authorizations = {
+        @Authorization(value = "http_basic_test")
+    }, tags={ "fake", })
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         @ApiResponse(code = 404, message = "User not found", response = Void.class) })

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
@@ -2,8 +2,8 @@ package io.swagger.api;
 
 import io.swagger.model.Client;
 import org.joda.time.LocalDate;
-import org.joda.time.DateTime;
 import java.math.BigDecimal;
+import org.joda.time.DateTime;
 
 import io.swagger.annotations.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import io.swagger.annotations.*;
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApi.java
@@ -2,8 +2,8 @@ package io.swagger.api;
 
 import io.swagger.model.Client;
 import org.joda.time.LocalDate;
-import org.joda.time.DateTime;
 import java.math.BigDecimal;
+import org.joda.time.DateTime;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +36,9 @@ public interface FakeApi {
 );
 
 
-    @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = Void.class, tags={ "fake", })
+    @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = Void.class, authorizations = {
+        @Authorization(value = "http_basic_test")
+    }, tags={ "fake", })
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         @ApiResponse(code = 404, message = "User not found", response = Void.class) })

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
@@ -2,8 +2,8 @@ package io.swagger.api;
 
 import io.swagger.model.Client;
 import org.joda.time.LocalDate;
-import org.joda.time.DateTime;
 import java.math.BigDecimal;
+import org.joda.time.DateTime;
 
 import io.swagger.annotations.*;
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import io.swagger.annotations.*;
 

--- a/samples/server/petstore/springboot/src/main/resources/application.properties
+++ b/samples/server/petstore/springboot/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/v2
-#server.port=8090
+server.port=8080


### PR DESCRIPTION
Title says it all. Sets the `server.port` value in `application.properties` to the port defined by the `host` field in the swagger spec file. If no port is provided `server.port` is set to 8080 by default, which matches current template behavior. 

The `serverPort` property is an existing value that is already being parsed by [SpringCodegen.java](https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java#L233).