### PR TITLE
Uses this.{{name}} to scope instance

### DIFF
--- a/modules/swagger-codegen/src/main/resources/android/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/model.mustache
@@ -47,7 +47,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
       return false;
     }
     {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}({{name}} == null ? {{classVarName}}.{{name}} == null : {{name}}.equals({{classVarName}}.{{name}})){{#hasMore}} &&
+    return {{#vars}}(this.{{name}} == null ? {{classVarName}}.{{name}} == null : this.{{name}}.equals({{classVarName}}.{{name}})){{#hasMore}} &&
         {{/hasMore}}{{^hasMore}};{{/hasMore}}{{/vars}}{{/hasVars}}{{^hasVars}}
     return true;{{/hasVars}}
   }


### PR DESCRIPTION
Otherwise, if {{classVarName}} is the same as a class member name, the function will not work.