### PR TITLE
For Qt5 server generator, add BaseIntegerProperty to default values

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -267,12 +267,14 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
             return "0.0";
         } else if (p instanceof FloatProperty) {
             return "0.0f";
-        } else if (p instanceof BaseIntegerProperty) {
-            return "0";
         } else if (p instanceof IntegerProperty) {
             return "0";
         } else if (p instanceof LongProperty) {
             return "0L";
+        } else if (p instanceof BaseIntegerProperty) {
+            // catchall for any other format of the swagger specifiction
+            // integer type not explictly handled above
+            return "0";
         } else if (p instanceof DecimalProperty) {
             return "0.0";
         } else if (p instanceof MapProperty) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -11,6 +11,7 @@ import io.swagger.models.properties.DateTimeProperty;
 import io.swagger.models.properties.DecimalProperty;
 import io.swagger.models.properties.DoubleProperty;
 import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.BaseIntegerProperty;
 import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.MapProperty;
@@ -266,6 +267,8 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
             return "0.0";
         } else if (p instanceof FloatProperty) {
             return "0.0f";
+        } else if (p instanceof BaseIntegerProperty) {
+            return "0";
         } else if (p instanceof IntegerProperty) {
             return "0";
         } else if (p instanceof LongProperty) {


### PR DESCRIPTION
Fixes #3192 

**edit:** I have barely touched Java at all, so please double check that this change makes sense. I just made the default values stop being NULL, without any understanding of how the entire codegen project goes together.