### PR TITLE
Python fixes

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -163,7 +163,7 @@ class {{classname}}(object):
         local_var_files = {}
 {{#formParams}}
         if '{{paramName}}' in params:
-            {{#notFile}}form_params.append(('{{baseName}}', params['{{paramName}}'])){{/notFile}}{{#isFile}}local_var_files['{{baseName}}'] = params['{{paramName}}']{{/isFile}}
+            {{#notFile}}form_params.extend(self.api_client.parameter_to_tuples('{{collectionFormat}}', '{{baseName}}', params['{{paramName}}'])){{/notFile}}{{#isFile}}local_var_files['{{baseName}}'] = params['{{paramName}}']{{/isFile}}
 {{/formParams}}
 
         body_params = None

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -374,6 +374,31 @@ class ApiClient(object):
                 " `POST`, `PATCH`, `PUT` or `DELETE`."
             )
 
+    def parameter_to_tuples(self, collection_format, name, value):
+        """
+        Get parameter as list of tuples according to collection format.
+
+        :param str collection_format: Collection format
+        :param str name: Parameter name
+        :param value: Parameter value
+        :return: Parameter as list of tuples
+        """
+        if isinstance(value, (list, tuple)):
+            if collection_format == "multi":
+                return [(name, v) for v in value]
+            else:
+                if collection_format == "ssv":
+                    delimiter = " "
+                elif collection_format == "tsv":
+                    delimiter = "\t"
+                elif collection_format == "pipes":
+                    delimiter = "|"
+                else:  # csv is the default
+                    delimiter = ","
+                return [(name, delimiter.join(value))]
+        else:
+            return [(name, value)]
+
     def prepare_post_parameters(self, post_params=None, files=None):
         """
         Builds form parameters.

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -370,7 +370,7 @@ class ApiClient(object):
                                            body=body)
         else:
             raise ValueError(
-                "http method must be `GET`, `HEAD`,"
+                "http method must be `GET`, `HEAD`, `OPTIONS`,"
                 " `POST`, `PATCH`, `PUT` or `DELETE`."
             )
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -374,6 +374,31 @@ class ApiClient(object):
                 " `POST`, `PATCH`, `PUT` or `DELETE`."
             )
 
+    def parameter_to_tuples(self, collection_format, name, value):
+        """
+        Get parameter as list of tuples according to collection format.
+
+        :param str collection_format: Collection format
+        :param str name: Parameter name
+        :param value: Parameter value
+        :return: Parameter as list of tuples
+        """
+        if isinstance(value, (list, tuple)):
+            if collection_format == "multi":
+                return [(name, v) for v in value]
+            else:
+                if collection_format == "ssv":
+                    delimiter = " "
+                elif collection_format == "tsv":
+                    delimiter = "\t"
+                elif collection_format == "pipes":
+                    delimiter = "|"
+                else:  # csv is the default
+                    delimiter = ","
+                return [(name, delimiter.join(value))]
+        else:
+            return [(name, value)]
+
     def prepare_post_parameters(self, post_params=None, files=None):
         """
         Builds form parameters.

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -370,7 +370,7 @@ class ApiClient(object):
                                            body=body)
         else:
             raise ValueError(
-                "http method must be `GET`, `HEAD`,"
+                "http method must be `GET`, `HEAD`, `OPTIONS`,"
                 " `POST`, `PATCH`, `PUT` or `DELETE`."
             )
 

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -289,31 +289,31 @@ class FakeApi(object):
         form_params = []
         local_var_files = {}
         if 'integer' in params:
-            form_params.append(('integer', params['integer']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'integer', params['integer']))
         if 'int32' in params:
-            form_params.append(('int32', params['int32']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'int32', params['int32']))
         if 'int64' in params:
-            form_params.append(('int64', params['int64']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'int64', params['int64']))
         if 'number' in params:
-            form_params.append(('number', params['number']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'number', params['number']))
         if 'float' in params:
-            form_params.append(('float', params['float']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'float', params['float']))
         if 'double' in params:
-            form_params.append(('double', params['double']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'double', params['double']))
         if 'string' in params:
-            form_params.append(('string', params['string']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'string', params['string']))
         if 'pattern_without_delimiter' in params:
-            form_params.append(('pattern_without_delimiter', params['pattern_without_delimiter']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'pattern_without_delimiter', params['pattern_without_delimiter']))
         if 'byte' in params:
-            form_params.append(('byte', params['byte']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'byte', params['byte']))
         if 'binary' in params:
-            form_params.append(('binary', params['binary']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'binary', params['binary']))
         if 'date' in params:
-            form_params.append(('date', params['date']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'date', params['date']))
         if 'date_time' in params:
-            form_params.append(('dateTime', params['date_time']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'dateTime', params['date_time']))
         if 'password' in params:
-            form_params.append(('password', params['password']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'password', params['password']))
 
         body_params = None
 
@@ -438,11 +438,11 @@ class FakeApi(object):
         form_params = []
         local_var_files = {}
         if 'enum_form_string_array' in params:
-            form_params.append(('enum_form_string_array', params['enum_form_string_array']))
+            form_params.extend(self.api_client.parameter_to_tuples('csv', 'enum_form_string_array', params['enum_form_string_array']))
         if 'enum_form_string' in params:
-            form_params.append(('enum_form_string', params['enum_form_string']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'enum_form_string', params['enum_form_string']))
         if 'enum_query_double' in params:
-            form_params.append(('enum_query_double', params['enum_query_double']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'enum_query_double', params['enum_query_double']))
 
         body_params = None
 

--- a/samples/client/petstore/python/petstore_api/apis/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/pet_api.py
@@ -760,9 +760,9 @@ class PetApi(object):
         form_params = []
         local_var_files = {}
         if 'name' in params:
-            form_params.append(('name', params['name']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'name', params['name']))
         if 'status' in params:
-            form_params.append(('status', params['status']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'status', params['status']))
 
         body_params = None
 
@@ -872,7 +872,7 @@ class PetApi(object):
         form_params = []
         local_var_files = {}
         if 'additional_metadata' in params:
-            form_params.append(('additionalMetadata', params['additional_metadata']))
+            form_params.extend(self.api_client.parameter_to_tuples('', 'additionalMetadata', params['additional_metadata']))
         if 'file' in params:
             local_var_files['file'] = params['file']
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Implements collection formatting to Python. Previously, collections were not formatted at all, but serialized as e.g. literal `['foo', 'bar']`.

This implements it for form data only for now; I don't think it can be implemented sanely without API changes for query string data. The `query_params` arg for `api_client.call_api` would have to be changed from dict to a list (like `post_params` already is). Is that considered a breaking API change that needs to go to the 2.3.0 branch?