### PR TITLE
Python collection formatting fixes/support

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -153,7 +153,8 @@ class {{classname}}(object):
         query_params = {}
 {{#queryParams}}
         if '{{paramName}}' in params:
-            query_params['{{baseName}}'] = params['{{paramName}}']
+            query_params['{{baseName}}'] = params['{{paramName}}']{{#isListContainer}}
+            collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
 {{/queryParams}}
 
         header_params = {}

--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -140,6 +140,9 @@ class {{classname}}(object):
     {{/pattern}}
 {{/hasValidation}}
 {{/allParams}}
+
+        collection_formats = {}
+
         resource_path = '{{path}}'.replace('{format}', 'json')
         path_params = {}
 {{#pathParams}}
@@ -163,7 +166,8 @@ class {{classname}}(object):
         local_var_files = {}
 {{#formParams}}
         if '{{paramName}}' in params:
-            {{#notFile}}form_params.extend(self.api_client.parameter_to_tuples('{{collectionFormat}}', '{{baseName}}', params['{{paramName}}'])){{/notFile}}{{#isFile}}local_var_files['{{baseName}}'] = params['{{paramName}}']{{/isFile}}
+            {{#notFile}}form_params.append(('{{baseName}}', params['{{paramName}}'])){{/notFile}}{{#isFile}}local_var_files['{{baseName}}'] = params['{{paramName}}']{{/isFile}}{{#isListContainer}}
+            collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
 {{/formParams}}
 
         body_params = None
@@ -195,6 +199,7 @@ class {{classname}}(object):
                                             response_type={{#returnType}}'{{returnType}}'{{/returnType}}{{^returnType}}None{{/returnType}},
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 {{/operation}}
 {{/operations}}

--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -161,7 +161,8 @@ class {{classname}}(object):
         header_params = {}
 {{#headerParams}}
         if '{{paramName}}' in params:
-            header_params['{{baseName}}'] = params['{{paramName}}']
+            header_params['{{baseName}}'] = params['{{paramName}}']{{#isListContainer}}
+            collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
 {{/headerParams}}
 
         form_params = []

--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -147,7 +147,8 @@ class {{classname}}(object):
         path_params = {}
 {{#pathParams}}
         if '{{paramName}}' in params:
-            path_params['{{baseName}}'] = params['{{paramName}}']
+            path_params['{{baseName}}'] = params['{{paramName}}']{{#isListContainer}}
+            collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
 {{/pathParams}}
 
         query_params = {}

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -109,10 +109,11 @@ class ApiClient(object):
         # path parameters
         if path_params:
             path_params = self.sanitize_for_serialization(path_params)
-            for k, v in iteritems(path_params):
-                replacement = quote(str(self.to_path_value(v)))
-                resource_path = resource_path.\
-                    replace('{' + k + '}', replacement)
+            path_params = self.parameters_to_tuples(path_params,
+                                                    collection_formats)
+            for k, v in path_params:
+                resource_path = resource_path.replace(
+                    '{%s}' % k, quote(str(v)))
 
         # query parameters
         if query_params:
@@ -157,20 +158,6 @@ class ApiClient(object):
             return (deserialized_data)
         else:
             return (deserialized_data, response_data.status, response_data.getheaders())
-        
-    def to_path_value(self, obj):
-        """
-        Takes value and turn it into a string suitable for inclusion in
-        the path, by url-encoding.
-
-        :param obj: object or string value.
-
-        :return string: quoted value.
-        """
-        if type(obj) == list:
-            return ','.join(obj)
-        else:
-            return str(obj)
 
     def sanitize_for_serialization(self, obj):
         """

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -105,6 +105,8 @@ class ApiClient(object):
             header_params['Cookie'] = self.cookie
         if header_params:
             header_params = self.sanitize_for_serialization(header_params)
+            header_params = dict(self.parameters_to_tuples(header_params,
+                                                           collection_formats))
 
         # path parameters
         if path_params:

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -117,8 +117,8 @@ class ApiClient(object):
         # query parameters
         if query_params:
             query_params = self.sanitize_for_serialization(query_params)
-            query_params = {k: self.to_path_value(v)
-                            for k, v in iteritems(query_params)}
+            query_params = self.parameters_to_tuples(query_params,
+                                                     collection_formats)
 
         # post parameters
         if post_params or files:
@@ -480,7 +480,7 @@ class ApiClient(object):
         Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
-        :param querys: Query parameters dict to be updated.
+        :param querys: Query parameters tuple list to be updated.
         :param auth_settings: Authentication setting identifiers list.
         """
         config = Configuration()
@@ -496,7 +496,7 @@ class ApiClient(object):
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
-                    querys[auth_setting['key']] = auth_setting['value']
+                    querys.append((auth_setting['key'], auth_setting['value']))
                 else:
                     raise ValueError(
                         'Authentication token must be in `query` or `header`'

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -109,10 +109,11 @@ class ApiClient(object):
         # path parameters
         if path_params:
             path_params = self.sanitize_for_serialization(path_params)
-            for k, v in iteritems(path_params):
-                replacement = quote(str(self.to_path_value(v)))
-                resource_path = resource_path.\
-                    replace('{' + k + '}', replacement)
+            path_params = self.parameters_to_tuples(path_params,
+                                                    collection_formats)
+            for k, v in path_params:
+                resource_path = resource_path.replace(
+                    '{%s}' % k, quote(str(v)))
 
         # query parameters
         if query_params:
@@ -157,20 +158,6 @@ class ApiClient(object):
             return (deserialized_data)
         else:
             return (deserialized_data, response_data.status, response_data.getheaders())
-        
-    def to_path_value(self, obj):
-        """
-        Takes value and turn it into a string suitable for inclusion in
-        the path, by url-encoding.
-
-        :param obj: object or string value.
-
-        :return string: quoted value.
-        """
-        if type(obj) == list:
-            return ','.join(obj)
-        else:
-            return str(obj)
 
     def sanitize_for_serialization(self, obj):
         """

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -105,6 +105,8 @@ class ApiClient(object):
             header_params['Cookie'] = self.cookie
         if header_params:
             header_params = self.sanitize_for_serialization(header_params)
+            header_params = dict(self.parameters_to_tuples(header_params,
+                                                           collection_formats))
 
         # path parameters
         if path_params:

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -117,8 +117,8 @@ class ApiClient(object):
         # query parameters
         if query_params:
             query_params = self.sanitize_for_serialization(query_params)
-            query_params = {k: self.to_path_value(v)
-                            for k, v in iteritems(query_params)}
+            query_params = self.parameters_to_tuples(query_params,
+                                                     collection_formats)
 
         # post parameters
         if post_params or files:
@@ -480,7 +480,7 @@ class ApiClient(object):
         Updates header and query params based on authentication setting.
 
         :param headers: Header parameters dict to be updated.
-        :param querys: Query parameters dict to be updated.
+        :param querys: Query parameters tuple list to be updated.
         :param auth_settings: Authentication setting identifiers list.
         """
         config = Configuration()
@@ -496,7 +496,7 @@ class ApiClient(object):
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
-                    querys[auth_setting['key']] = auth_setting['value']
+                    querys.append((auth_setting['key'], auth_setting['value']))
                 else:
                     raise ValueError(
                         'Authentication token must be in `query` or `header`'

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -116,6 +116,9 @@ class FakeApi(object):
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `test_client_model`")
 
+
+        collection_formats = {}
+
         resource_path = '/fake'.replace('{format}', 'json')
         path_params = {}
 
@@ -153,7 +156,8 @@ class FakeApi(object):
                                             response_type='Client',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):
         """
@@ -279,6 +283,9 @@ class FakeApi(object):
             raise ValueError("Invalid value for parameter `password` when calling `test_endpoint_parameters`, length must be less than or equal to `64`")
         if 'password' in params and len(params['password']) < 10:
             raise ValueError("Invalid value for parameter `password` when calling `test_endpoint_parameters`, length must be greater than or equal to `10`")
+
+        collection_formats = {}
+
         resource_path = '/fake'.replace('{format}', 'json')
         path_params = {}
 
@@ -289,31 +296,31 @@ class FakeApi(object):
         form_params = []
         local_var_files = {}
         if 'integer' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'integer', params['integer']))
+            form_params.append(('integer', params['integer']))
         if 'int32' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'int32', params['int32']))
+            form_params.append(('int32', params['int32']))
         if 'int64' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'int64', params['int64']))
+            form_params.append(('int64', params['int64']))
         if 'number' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'number', params['number']))
+            form_params.append(('number', params['number']))
         if 'float' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'float', params['float']))
+            form_params.append(('float', params['float']))
         if 'double' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'double', params['double']))
+            form_params.append(('double', params['double']))
         if 'string' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'string', params['string']))
+            form_params.append(('string', params['string']))
         if 'pattern_without_delimiter' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'pattern_without_delimiter', params['pattern_without_delimiter']))
+            form_params.append(('pattern_without_delimiter', params['pattern_without_delimiter']))
         if 'byte' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'byte', params['byte']))
+            form_params.append(('byte', params['byte']))
         if 'binary' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'binary', params['binary']))
+            form_params.append(('binary', params['binary']))
         if 'date' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'date', params['date']))
+            form_params.append(('date', params['date']))
         if 'date_time' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'dateTime', params['date_time']))
+            form_params.append(('dateTime', params['date_time']))
         if 'password' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'password', params['password']))
+            form_params.append(('password', params['password']))
 
         body_params = None
 
@@ -340,7 +347,8 @@ class FakeApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def test_enum_parameters(self, **kwargs):
         """
@@ -418,6 +426,9 @@ class FakeApi(object):
             params[key] = val
         del params['kwargs']
 
+
+        collection_formats = {}
+
         resource_path = '/fake'.replace('{format}', 'json')
         path_params = {}
 
@@ -438,11 +449,12 @@ class FakeApi(object):
         form_params = []
         local_var_files = {}
         if 'enum_form_string_array' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('csv', 'enum_form_string_array', params['enum_form_string_array']))
+            form_params.append(('enum_form_string_array', params['enum_form_string_array']))
+            collection_formats['enum_form_string_array'] = 'csv'
         if 'enum_form_string' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'enum_form_string', params['enum_form_string']))
+            form_params.append(('enum_form_string', params['enum_form_string']))
         if 'enum_query_double' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'enum_query_double', params['enum_query_double']))
+            form_params.append(('enum_query_double', params['enum_query_double']))
 
         body_params = None
 
@@ -469,4 +481,5 @@ class FakeApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -444,6 +444,7 @@ class FakeApi(object):
         header_params = {}
         if 'enum_header_string_array' in params:
             header_params['enum_header_string_array'] = params['enum_header_string_array']
+            collection_formats['enum_header_string_array'] = 'csv'
         if 'enum_header_string' in params:
             header_params['enum_header_string'] = params['enum_header_string']
 

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -435,6 +435,7 @@ class FakeApi(object):
         query_params = {}
         if 'enum_query_string_array' in params:
             query_params['enum_query_string_array'] = params['enum_query_string_array']
+            collection_formats['enum_query_string_array'] = 'csv'
         if 'enum_query_string' in params:
             query_params['enum_query_string'] = params['enum_query_string']
         if 'enum_query_integer' in params:

--- a/samples/client/petstore/python/petstore_api/apis/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/pet_api.py
@@ -116,6 +116,9 @@ class PetApi(object):
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `add_pet`")
 
+
+        collection_formats = {}
+
         resource_path = '/pet'.replace('{format}', 'json')
         path_params = {}
 
@@ -153,7 +156,8 @@ class PetApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def delete_pet(self, pet_id, **kwargs):
         """
@@ -222,6 +226,9 @@ class PetApi(object):
         if ('pet_id' not in params) or (params['pet_id'] is None):
             raise ValueError("Missing the required parameter `pet_id` when calling `delete_pet`")
 
+
+        collection_formats = {}
+
         resource_path = '/pet/{petId}'.replace('{format}', 'json')
         path_params = {}
         if 'pet_id' in params:
@@ -261,7 +268,8 @@ class PetApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def find_pets_by_status(self, status, **kwargs):
         """
@@ -328,6 +336,9 @@ class PetApi(object):
         if ('status' not in params) or (params['status'] is None):
             raise ValueError("Missing the required parameter `status` when calling `find_pets_by_status`")
 
+
+        collection_formats = {}
+
         resource_path = '/pet/findByStatus'.replace('{format}', 'json')
         path_params = {}
 
@@ -365,7 +376,8 @@ class PetApi(object):
                                             response_type='list[Pet]',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def find_pets_by_tags(self, tags, **kwargs):
         """
@@ -432,6 +444,9 @@ class PetApi(object):
         if ('tags' not in params) or (params['tags'] is None):
             raise ValueError("Missing the required parameter `tags` when calling `find_pets_by_tags`")
 
+
+        collection_formats = {}
+
         resource_path = '/pet/findByTags'.replace('{format}', 'json')
         path_params = {}
 
@@ -469,7 +484,8 @@ class PetApi(object):
                                             response_type='list[Pet]',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def get_pet_by_id(self, pet_id, **kwargs):
         """
@@ -536,6 +552,9 @@ class PetApi(object):
         if ('pet_id' not in params) or (params['pet_id'] is None):
             raise ValueError("Missing the required parameter `pet_id` when calling `get_pet_by_id`")
 
+
+        collection_formats = {}
+
         resource_path = '/pet/{petId}'.replace('{format}', 'json')
         path_params = {}
         if 'pet_id' in params:
@@ -573,7 +592,8 @@ class PetApi(object):
                                             response_type='Pet',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def update_pet(self, body, **kwargs):
         """
@@ -640,6 +660,9 @@ class PetApi(object):
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `update_pet`")
 
+
+        collection_formats = {}
+
         resource_path = '/pet'.replace('{format}', 'json')
         path_params = {}
 
@@ -677,7 +700,8 @@ class PetApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def update_pet_with_form(self, pet_id, **kwargs):
         """
@@ -748,6 +772,9 @@ class PetApi(object):
         if ('pet_id' not in params) or (params['pet_id'] is None):
             raise ValueError("Missing the required parameter `pet_id` when calling `update_pet_with_form`")
 
+
+        collection_formats = {}
+
         resource_path = '/pet/{petId}'.replace('{format}', 'json')
         path_params = {}
         if 'pet_id' in params:
@@ -760,9 +787,9 @@ class PetApi(object):
         form_params = []
         local_var_files = {}
         if 'name' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'name', params['name']))
+            form_params.append(('name', params['name']))
         if 'status' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'status', params['status']))
+            form_params.append(('status', params['status']))
 
         body_params = None
 
@@ -789,7 +816,8 @@ class PetApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def upload_file(self, pet_id, **kwargs):
         """
@@ -860,6 +888,9 @@ class PetApi(object):
         if ('pet_id' not in params) or (params['pet_id'] is None):
             raise ValueError("Missing the required parameter `pet_id` when calling `upload_file`")
 
+
+        collection_formats = {}
+
         resource_path = '/pet/{petId}/uploadImage'.replace('{format}', 'json')
         path_params = {}
         if 'pet_id' in params:
@@ -872,7 +903,7 @@ class PetApi(object):
         form_params = []
         local_var_files = {}
         if 'additional_metadata' in params:
-            form_params.extend(self.api_client.parameter_to_tuples('', 'additionalMetadata', params['additional_metadata']))
+            form_params.append(('additionalMetadata', params['additional_metadata']))
         if 'file' in params:
             local_var_files['file'] = params['file']
 
@@ -901,4 +932,5 @@ class PetApi(object):
                                             response_type='ApiResponse',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/pet_api.py
@@ -345,6 +345,7 @@ class PetApi(object):
         query_params = {}
         if 'status' in params:
             query_params['status'] = params['status']
+            collection_formats['status'] = 'csv'
 
         header_params = {}
 
@@ -453,6 +454,7 @@ class PetApi(object):
         query_params = {}
         if 'tags' in params:
             query_params['tags'] = params['tags']
+            collection_formats['tags'] = 'csv'
 
         header_params = {}
 

--- a/samples/client/petstore/python/petstore_api/apis/store_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/store_api.py
@@ -118,6 +118,9 @@ class StoreApi(object):
 
         if 'order_id' in params and params['order_id'] < 1.0:
             raise ValueError("Invalid value for parameter `order_id` when calling `delete_order`, must be a value greater than or equal to `1.0`")
+
+        collection_formats = {}
+
         resource_path = '/store/order/{orderId}'.replace('{format}', 'json')
         path_params = {}
         if 'order_id' in params:
@@ -155,7 +158,8 @@ class StoreApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def get_inventory(self, **kwargs):
         """
@@ -217,6 +221,9 @@ class StoreApi(object):
             params[key] = val
         del params['kwargs']
 
+
+        collection_formats = {}
+
         resource_path = '/store/inventory'.replace('{format}', 'json')
         path_params = {}
 
@@ -252,7 +259,8 @@ class StoreApi(object):
                                             response_type='dict(str, int)',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def get_order_by_id(self, order_id, **kwargs):
         """
@@ -323,6 +331,9 @@ class StoreApi(object):
             raise ValueError("Invalid value for parameter `order_id` when calling `get_order_by_id`, must be a value less than or equal to  `5.0`")
         if 'order_id' in params and params['order_id'] < 1.0:
             raise ValueError("Invalid value for parameter `order_id` when calling `get_order_by_id`, must be a value greater than or equal to `1.0`")
+
+        collection_formats = {}
+
         resource_path = '/store/order/{orderId}'.replace('{format}', 'json')
         path_params = {}
         if 'order_id' in params:
@@ -360,7 +371,8 @@ class StoreApi(object):
                                             response_type='Order',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def place_order(self, body, **kwargs):
         """
@@ -427,6 +439,9 @@ class StoreApi(object):
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `place_order`")
 
+
+        collection_formats = {}
+
         resource_path = '/store/order'.replace('{format}', 'json')
         path_params = {}
 
@@ -464,4 +479,5 @@ class StoreApi(object):
                                             response_type='Order',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/user_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/user_api.py
@@ -116,6 +116,9 @@ class UserApi(object):
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `create_user`")
 
+
+        collection_formats = {}
+
         resource_path = '/user'.replace('{format}', 'json')
         path_params = {}
 
@@ -153,7 +156,8 @@ class UserApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def create_users_with_array_input(self, body, **kwargs):
         """
@@ -220,6 +224,9 @@ class UserApi(object):
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `create_users_with_array_input`")
 
+
+        collection_formats = {}
+
         resource_path = '/user/createWithArray'.replace('{format}', 'json')
         path_params = {}
 
@@ -257,7 +264,8 @@ class UserApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def create_users_with_list_input(self, body, **kwargs):
         """
@@ -324,6 +332,9 @@ class UserApi(object):
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `create_users_with_list_input`")
 
+
+        collection_formats = {}
+
         resource_path = '/user/createWithList'.replace('{format}', 'json')
         path_params = {}
 
@@ -361,7 +372,8 @@ class UserApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def delete_user(self, username, **kwargs):
         """
@@ -428,6 +440,9 @@ class UserApi(object):
         if ('username' not in params) or (params['username'] is None):
             raise ValueError("Missing the required parameter `username` when calling `delete_user`")
 
+
+        collection_formats = {}
+
         resource_path = '/user/{username}'.replace('{format}', 'json')
         path_params = {}
         if 'username' in params:
@@ -465,7 +480,8 @@ class UserApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def get_user_by_name(self, username, **kwargs):
         """
@@ -532,6 +548,9 @@ class UserApi(object):
         if ('username' not in params) or (params['username'] is None):
             raise ValueError("Missing the required parameter `username` when calling `get_user_by_name`")
 
+
+        collection_formats = {}
+
         resource_path = '/user/{username}'.replace('{format}', 'json')
         path_params = {}
         if 'username' in params:
@@ -569,7 +588,8 @@ class UserApi(object):
                                             response_type='User',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def login_user(self, username, password, **kwargs):
         """
@@ -641,6 +661,9 @@ class UserApi(object):
         if ('password' not in params) or (params['password'] is None):
             raise ValueError("Missing the required parameter `password` when calling `login_user`")
 
+
+        collection_formats = {}
+
         resource_path = '/user/login'.replace('{format}', 'json')
         path_params = {}
 
@@ -680,7 +703,8 @@ class UserApi(object):
                                             response_type='str',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def logout_user(self, **kwargs):
         """
@@ -742,6 +766,9 @@ class UserApi(object):
             params[key] = val
         del params['kwargs']
 
+
+        collection_formats = {}
+
         resource_path = '/user/logout'.replace('{format}', 'json')
         path_params = {}
 
@@ -777,7 +804,8 @@ class UserApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)
 
     def update_user(self, username, body, **kwargs):
         """
@@ -849,6 +877,9 @@ class UserApi(object):
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `update_user`")
 
+
+        collection_formats = {}
+
         resource_path = '/user/{username}'.replace('{format}', 'json')
         path_params = {}
         if 'username' in params:
@@ -888,4 +919,5 @@ class UserApi(object):
                                             response_type=None,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
-                                            _return_http_data_only=params.get('_return_http_data_only'))
+                                            _return_http_data_only=params.get('_return_http_data_only'),
+                                            collection_formats=collection_formats)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This reworks support for form data collection formatting, and adds collection formatting support for paths, headers, and query string. The rework is because the previous implementation would fail for non-string collection items, and to provide basis for the other types.

This _does_ contain breaking changes for the methods in `api_client`; however if I understand correctly, the breaking changes meant in the PR checklist would be ones that affect client code that uses the generated api classes. This one doesn't contain any of them, so I suppose it's good for `master`.