### PR TITLE
Make InlineModelResolver resolve vendorExtensions correctly for Schema Object

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -45,27 +45,26 @@ public class InlineModelResolver {
                                 BodyParameter bp = (BodyParameter) parameter;
                                 if (bp.getSchema() != null) {
                                     Model model = bp.getSchema();
-                                    if(model instanceof ModelImpl) {
+                                    if (model instanceof ModelImpl) {
                                         ModelImpl obj = (ModelImpl) model;
                                         if (obj.getType() == null || "object".equals(obj.getType())) {
                                             if (obj.getProperties() != null && obj.getProperties().size() > 0) {
                                                 flattenProperties(obj.getProperties(), pathname);
-                                                String modelName = resolveModelName( obj.getTitle(), bp.getName());
+                                                String modelName = resolveModelName(obj.getTitle(), bp.getName());
                                                 bp.setSchema(new RefModel(modelName));
                                                 addGenerated(modelName, model);
                                                 swagger.addDefinition(modelName, model);
                                             }
                                         }
-                                    }
-                                    else if (model instanceof ArrayModel) {
+                                    } else if (model instanceof ArrayModel) {
                                         ArrayModel am = (ArrayModel) model;
                                         Property inner = am.getItems();
 
-                                        if(inner instanceof ObjectProperty) {
+                                        if (inner instanceof ObjectProperty) {
                                             ObjectProperty op = (ObjectProperty) inner;
                                             if (op.getProperties() != null && op.getProperties().size() > 0) {
                                                 flattenProperties(op.getProperties(), pathname);
-                                                String modelName = resolveModelName( op.getTitle(), bp.getName());
+                                                String modelName = resolveModelName(op.getTitle(), bp.getName());
                                                 Model innerModel = modelFromProperty(op, modelName);
                                                 String existing = matchGenerated(innerModel);
                                                 if (existing != null) {
@@ -91,16 +90,16 @@ public class InlineModelResolver {
                                 if (property instanceof ObjectProperty) {
                                     ObjectProperty op = (ObjectProperty) property;
                                     if (op.getProperties() != null && op.getProperties().size() > 0) {
-					String modelName = resolveModelName( op.getTitle(),"inline_response_" + key);
+                                        String modelName = resolveModelName(op.getTitle(), "inline_response_" + key);
                                         Model model = modelFromProperty(op, modelName);
                                         String existing = matchGenerated(model);
                                         if (existing != null) {
                                             RefProperty newSchema = new RefProperty(existing);
                                             this.copyVenderExtensions(property, newSchema);
-											response.setSchema(newSchema);
+                                            response.setSchema(newSchema);
                                         } else {
                                             RefProperty newSchema = new RefProperty(modelName);
-											response.setSchema(newSchema);
+                                            response.setSchema(newSchema);
                                             this.copyVenderExtensions(property, newSchema);
                                             addGenerated(modelName, model);
                                             swagger.addDefinition(modelName, model);
@@ -110,41 +109,43 @@ public class InlineModelResolver {
                                     ArrayProperty ap = (ArrayProperty) property;
                                     Property inner = ap.getItems();
 
-                                    if(inner instanceof ObjectProperty) {
+                                    if (inner instanceof ObjectProperty) {
                                         ObjectProperty op = (ObjectProperty) inner;
-					if (op.getProperties() != null && op.getProperties().size() > 0) {
-					flattenProperties(op.getProperties(), pathname);
-					String modelName = resolveModelName( op.getTitle(),"inline_response_" + key);
-					Model innerModel = modelFromProperty(op, modelName);
-					String existing = matchGenerated(innerModel);
-                                        if (existing != null) {
-                                            	ap.setItems(new RefProperty(existing));
-                                        } else {
+                                        if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                            flattenProperties(op.getProperties(), pathname);
+                                            String modelName = resolveModelName(op.getTitle(),
+                                                    "inline_response_" + key);
+                                            Model innerModel = modelFromProperty(op, modelName);
+                                            String existing = matchGenerated(innerModel);
+                                            if (existing != null) {
+                                                ap.setItems(new RefProperty(existing));
+                                            } else {
                                                 ap.setItems(new RefProperty(modelName));
                                                 addGenerated(modelName, innerModel);
                                                 swagger.addDefinition(modelName, innerModel);
-                                        	}
+                                            }
                                         }
                                     }
                                 } else if (property instanceof MapProperty) {
                                     MapProperty mp = (MapProperty) property;
 
                                     Property innerProperty = mp.getAdditionalProperties();
-                                    if(innerProperty instanceof ObjectProperty) {
+                                    if (innerProperty instanceof ObjectProperty) {
                                         ObjectProperty op = (ObjectProperty) innerProperty;
                                         if (op.getProperties() != null && op.getProperties().size() > 0) {
-					flattenProperties(op.getProperties(), pathname);
-					String modelName = resolveModelName( op.getTitle(),"inline_response_" + key);
-					Model innerModel = modelFromProperty(op, modelName);
-					String existing = matchGenerated(innerModel);
-	                                if (existing != null) {
-	                                    mp.setAdditionalProperties(new RefProperty(existing));
-	                                } else {
-	                                    mp.setAdditionalProperties(new RefProperty(modelName));
-	                                    addGenerated(modelName, innerModel);
-	                                    swagger.addDefinition(modelName, innerModel);
-	                                  }
-					}
+                                            flattenProperties(op.getProperties(), pathname);
+                                            String modelName = resolveModelName(op.getTitle(),
+                                                    "inline_response_" + key);
+                                            Model innerModel = modelFromProperty(op, modelName);
+                                            String existing = matchGenerated(innerModel);
+                                            if (existing != null) {
+                                                mp.setAdditionalProperties(new RefProperty(existing));
+                                            } else {
+                                                mp.setAdditionalProperties(new RefProperty(modelName));
+                                                addGenerated(modelName, innerModel);
+                                                swagger.addDefinition(modelName, innerModel);
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -171,7 +172,7 @@ public class InlineModelResolver {
                     if (inner instanceof ObjectProperty) {
                         ObjectProperty op = (ObjectProperty) inner;
                         if (op.getProperties() != null && op.getProperties().size() > 0) {
-                            String innerModelName = resolveModelName(op.getTitle(),modelName + "_inner");
+                            String innerModelName = resolveModelName(op.getTitle(), modelName + "_inner");
                             Model innerModel = modelFromProperty(op, innerModelName);
                             String existing = matchGenerated(innerModel);
                             if (existing == null) {
@@ -192,13 +193,12 @@ public class InlineModelResolver {
         }
     }
 
-    private String resolveModelName(String title, String key ) {
-	if (title == null) {
-	    return uniqueName(key);
-	}
-	else {
-	    return uniqueName(title);
-	}
+    private String resolveModelName(String title, String key) {
+        if (title == null) {
+            return uniqueName(key);
+        } else {
+            return uniqueName(title);
+        }
     }
 
     public String matchGenerated(Model model) {
@@ -219,7 +219,11 @@ public class InlineModelResolver {
     public String uniqueName(String key) {
         int count = 0;
         boolean done = false;
-        key = key.replaceAll("[^a-z_\\.A-Z0-9 ]", ""); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+        key = key.replaceAll("[^a-z_\\.A-Z0-9 ]", ""); // FIXME: a parameter
+                                                       // should not be
+                                                       // assigned. Also declare
+                                                       // the methods parameters
+                                                       // as 'final'.
         while (!done) {
             String name = key;
             if (count > 0) {
@@ -243,12 +247,11 @@ public class InlineModelResolver {
         Map<String, Model> modelsToAdd = new HashMap<String, Model>();
         for (String key : properties.keySet()) {
             Property property = properties.get(key);
-            if (property instanceof ObjectProperty &&
-                    ((ObjectProperty)property).getProperties() != null &&
-                    ((ObjectProperty)property).getProperties().size() > 0) {
+            if (property instanceof ObjectProperty && ((ObjectProperty) property).getProperties() != null
+                    && ((ObjectProperty) property).getProperties().size() > 0) {
 
                 ObjectProperty op = (ObjectProperty) property;
-                
+
                 String modelName = resolveModelName(op.getTitle(), path + "_" + key);
                 Model model = modelFromProperty(op, modelName);
 
@@ -270,7 +273,7 @@ public class InlineModelResolver {
                     ObjectProperty op = (ObjectProperty) inner;
                     if (op.getProperties() != null && op.getProperties().size() > 0) {
                         flattenProperties(op.getProperties(), path);
-                        String modelName = resolveModelName(op.getTitle(),path + "_" + key);
+                        String modelName = resolveModelName(op.getTitle(), path + "_" + key);
                         Model innerModel = modelFromProperty(op, modelName);
                         String existing = matchGenerated(innerModel);
                         if (existing != null) {
@@ -321,10 +324,10 @@ public class InlineModelResolver {
         String example = null;
 
         Object obj = object.getExample();
-        if(obj != null) {
+        if (obj != null) {
             example = obj.toString();
         }
-        
+
         Property inner = object.getItems();
         if (inner instanceof ObjectProperty) {
             ArrayModel model = new ArrayModel();
@@ -334,16 +337,16 @@ public class InlineModelResolver {
             this.copyVenderExtensions(object, model);
             return model;
         }
-        
+
         return null;
     }
 
-	public Model modelFromProperty(ObjectProperty object, String path) {
+    public Model modelFromProperty(ObjectProperty object, String path) {
         String description = object.getDescription();
         String example = null;
 
         Object obj = object.getExample();
-        if(obj != null) {
+        if (obj != null) {
             example = obj.toString();
         }
         String name = object.getName();
@@ -372,7 +375,7 @@ public class InlineModelResolver {
         String example = null;
 
         Object obj = object.getExample();
-        if(obj != null) {
+        if (obj != null) {
             example = obj.toString();
         }
 
@@ -381,7 +384,7 @@ public class InlineModelResolver {
         model.setExample(example);
         model.setItems(object.getAdditionalProperties());
         this.copyVenderExtensions(object, model);
-		
+
         return model;
     }
 
@@ -392,11 +395,11 @@ public class InlineModelResolver {
      * @param target
      */
     private void copyVenderExtensions(Property source, AbstractModel target) {
-		Map<String, Object> venderExtensions = source.getVendorExtensions();
-		for (String extName : venderExtensions.keySet()) {
-			target.setVendorExtension(extName, venderExtensions.get(extName));
-		}
-	}
+        Map<String, Object> venderExtensions = source.getVendorExtensions();
+        for (String extName : venderExtensions.keySet()) {
+            target.setVendorExtension(extName, venderExtensions.get(extName));
+        }
+    }
 
     /**
      * Copy vender extensions from Property to another Property
@@ -404,14 +407,14 @@ public class InlineModelResolver {
      * @param source
      * @param target
      */
-	private void copyVenderExtensions(Property source, AbstractProperty target) {
-		Map<String, Object> venderExtensions = source.getVendorExtensions();
-		for (String extName : venderExtensions.keySet()) {
-			target.setVendorExtension(extName, venderExtensions.get(extName));
-		}
-	}
+    private void copyVenderExtensions(Property source, AbstractProperty target) {
+        Map<String, Object> venderExtensions = source.getVendorExtensions();
+        for (String extName : venderExtensions.keySet()) {
+            target.setVendorExtension(extName, venderExtensions.get(extName));
+        }
+    }
 
-	public boolean isSkipMatches() {
+    public boolean isSkipMatches() {
         return skipMatches;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -94,13 +94,9 @@ public class InlineModelResolver {
                                         Model model = modelFromProperty(op, modelName);
                                         String existing = matchGenerated(model);
                                         if (existing != null) {
-                                            RefProperty newSchema = new RefProperty(existing);
-                                            this.copyVenderExtensions(property, newSchema);
-                                            response.setSchema(newSchema);
+                                            response.setSchema(this.makeRefProperty(existing, property));
                                         } else {
-                                            RefProperty newSchema = new RefProperty(modelName);
-                                            response.setSchema(newSchema);
-                                            this.copyVenderExtensions(property, newSchema);
+                                            response.setSchema(this.makeRefProperty(modelName, property));
                                             addGenerated(modelName, model);
                                             swagger.addDefinition(modelName, model);
                                         }
@@ -118,9 +114,9 @@ public class InlineModelResolver {
                                             Model innerModel = modelFromProperty(op, modelName);
                                             String existing = matchGenerated(innerModel);
                                             if (existing != null) {
-                                                ap.setItems(new RefProperty(existing));
+                                                ap.setItems(this.makeRefProperty(existing, op));
                                             } else {
-                                                ap.setItems(new RefProperty(modelName));
+                                                ap.setItems(this.makeRefProperty(modelName, op));
                                                 addGenerated(modelName, innerModel);
                                                 swagger.addDefinition(modelName, innerModel);
                                             }
@@ -334,7 +330,6 @@ public class InlineModelResolver {
             model.setDescription(description);
             model.setExample(example);
             model.setItems(object.getItems());
-            this.copyVenderExtensions(object, model);
             return model;
         }
 
@@ -364,8 +359,6 @@ public class InlineModelResolver {
             model.setProperties(properties);
         }
 
-        this.copyVenderExtensions(object, model);
-
         return model;
     }
 
@@ -383,34 +376,33 @@ public class InlineModelResolver {
         model.setDescription(description);
         model.setExample(example);
         model.setItems(object.getAdditionalProperties());
-        this.copyVenderExtensions(object, model);
 
         return model;
     }
 
     /**
-     * Copy vender extensions from Property to Model
+     * Make a RefProperty
      * 
-     * @param source
-     * @param target
+     * @param ref
+     * @param property
+     * @return
      */
-    private void copyVenderExtensions(Property source, AbstractModel target) {
-        Map<String, Object> venderExtensions = source.getVendorExtensions();
-        for (String extName : venderExtensions.keySet()) {
-            target.setVendorExtension(extName, venderExtensions.get(extName));
-        }
+    public Property makeRefProperty(String ref, Property property) {
+        RefProperty newProperty = new RefProperty(ref);
+        this.copyVendorExtensions(property, newProperty);
+        return newProperty;
     }
 
     /**
-     * Copy vender extensions from Property to another Property
+     * Copy vendor extensions from Property to another Property
      * 
      * @param source
      * @param target
      */
-    private void copyVenderExtensions(Property source, AbstractProperty target) {
-        Map<String, Object> venderExtensions = source.getVendorExtensions();
-        for (String extName : venderExtensions.keySet()) {
-            target.setVendorExtension(extName, venderExtensions.get(extName));
+    public void copyVendorExtensions(Property source, AbstractProperty target) {
+        Map<String, Object> vendorExtensions = source.getVendorExtensions();
+        for (String extName : vendorExtensions.keySet()) {
+            target.setVendorExtension(extName, vendorExtensions.get(extName));
         }
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/InlineModelResolverTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/InlineModelResolverTest.java
@@ -191,14 +191,14 @@ public class InlineModelResolverTest {
                     .response(200, new Response()
                             .description("it works!")
                             .schema(new ObjectProperty()
-                                    .property("name", new StringProperty()).vendorExtension("x-ext", "ext-value")))))
+                                    .property("name", new StringProperty()).vendorExtension("x-ext", "ext-prop")))))
         .path("/foo/baz", new Path()
                 .get(new Operation()
                         .response(200, new Response()
                                 .vendorExtension("x-foo", "bar")
                                 .description("it works!")
                                 .schema(new ObjectProperty()
-                                        .property("name", new StringProperty()).vendorExtension("x-ext", "ext-value")))));
+                                        .property("name", new StringProperty()).vendorExtension("x-ext", "ext-prop")))));
         new InlineModelResolver().flatten(swagger);
 
         Map<String, Response> responses = swagger.getPaths().get("/foo/bar").getGet().getResponses();
@@ -208,14 +208,12 @@ public class InlineModelResolverTest {
         Property schema = response.getSchema();
 		assertTrue(schema instanceof RefProperty);
         assertEquals(1, schema.getVendorExtensions().size());
-        assertEquals("ext-value", schema.getVendorExtensions().get("x-ext"));
+        assertEquals("ext-prop", schema.getVendorExtensions().get("x-ext"));
 
         ModelImpl model = (ModelImpl)swagger.getDefinitions().get("inline_response_200");
         assertTrue(model.getProperties().size() == 1);
         assertNotNull(model.getProperties().get("name"));
         assertTrue(model.getProperties().get("name") instanceof StringProperty);
-        assertEquals(1, model.getVendorExtensions().size());
-        assertEquals("ext-value", model.getVendorExtensions().get("x-ext"));
     }
 
     
@@ -441,8 +439,8 @@ public class InlineModelResolverTest {
 		ArrayProperty schema = new ArrayProperty()
 				.items(new ObjectProperty()
 						.property("name", new StringProperty())
-						.vendorExtension("x-ext", "ext-value"))
-				.vendorExtension("x-ext", "ext-value");
+						.vendorExtension("x-ext", "ext-items"))
+				.vendorExtension("x-ext", "ext-prop");
 		swagger.path("/foo/baz", new Path()
                 .get(new Operation()
                         .response(200, new Response()
@@ -463,7 +461,7 @@ public class InlineModelResolverTest {
 
         ArrayProperty ap = (ArrayProperty) responseProperty;
         assertEquals(1, ap.getVendorExtensions().size());
-        assertEquals("ext-value", ap.getVendorExtensions().get("x-ext"));
+        assertEquals("ext-prop", ap.getVendorExtensions().get("x-ext"));
         
         Property p = ap.getItems();
 
@@ -473,6 +471,8 @@ public class InlineModelResolverTest {
         assertEquals(rp.getType(), "ref");
         assertEquals(rp.get$ref(), "#/definitions/inline_response_200");
         assertEquals(rp.getSimpleRef(), "inline_response_200");
+        assertEquals(1, rp.getVendorExtensions().size());
+        assertEquals("ext-items", rp.getVendorExtensions().get("x-ext"));
 
         Model inline = swagger.getDefinitions().get("inline_response_200");
         assertNotNull(inline);
@@ -480,8 +480,6 @@ public class InlineModelResolverTest {
         ModelImpl impl = (ModelImpl) inline;
         assertNotNull(impl.getProperties().get("name"));
         assertTrue(impl.getProperties().get("name") instanceof StringProperty);
-        assertEquals(1, impl.getVendorExtensions().size());
-        assertEquals("ext-value", impl.getVendorExtensions().get("x-ext"));
     }
 
     @Test
@@ -534,6 +532,7 @@ public class InlineModelResolverTest {
 
         MapProperty schema = new MapProperty();
         schema.setAdditionalProperties(new StringProperty());
+        schema.setVendorExtension("x-ext", "ext-prop");
 
         swagger.path("/foo/baz", new Path()
                 .get(new Operation()
@@ -549,6 +548,8 @@ public class InlineModelResolverTest {
         Property property = response.getSchema();
         assertTrue(property instanceof MapProperty);
         assertTrue(swagger.getDefinitions().size() == 0);
+        assertEquals(1, property.getVendorExtensions().size());
+        assertEquals("ext-prop", property.getVendorExtensions().get("x-ext"));
     }
 
     @Test
@@ -558,7 +559,7 @@ public class InlineModelResolverTest {
         MapProperty schema = new MapProperty();
         schema.setAdditionalProperties(new ObjectProperty()
                 .property("name", new StringProperty()));
-        schema.setVendorExtension("x-ext", "ext-value");
+        schema.setVendorExtension("x-ext", "ext-prop");
 
         swagger.path("/foo/baz", new Path()
                 .get(new Operation()
@@ -572,7 +573,7 @@ public class InlineModelResolverTest {
         Property property = response.getSchema();
         assertTrue(property instanceof MapProperty);
         assertEquals(1, property.getVendorExtensions().size());
-        assertEquals("ext-value", property.getVendorExtensions().get("x-ext"));
+        assertEquals("ext-prop", property.getVendorExtensions().get("x-ext"));
         assertTrue(swagger.getDefinitions().size() == 1);
 
         Model inline = swagger.getDefinitions().get("inline_response_200");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fix this issue: #3706 
