### PR TITLE
Java: Fix UUID mapping to a UUID instead of a string

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -107,7 +107,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         instantiationTypes.put("map", "HashMap");
         typeMapping.put("date", "Date");
         typeMapping.put("file", "File");
-        typeMapping.put("UUID", "String");
 
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
@@ -790,10 +789,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         CodegenOperation op = super.fromOperation(path, httpMethod, operation, definitions, swagger);
 
         op.path = sanitizePath(op.path);
-        
+
         return op;
     }
-    
+
     private static CodegenModel reconcileInlineEnums(CodegenModel codegenModel, CodegenModel parentCodegenModel) {
         // This generator uses inline classes to define enums, which breaks when
         // dealing with models that have subTypes. To clean this up, we will analyze

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/FormatTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -74,7 +75,7 @@ public class FormatTest   {
   private DateTime dateTime = null;
 
   @JsonProperty("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @JsonProperty("password")
   private String password = null;
@@ -287,7 +288,7 @@ public class FormatTest   {
     this.dateTime = dateTime;
   }
 
-  public FormatTest uuid(String uuid) {
+  public FormatTest uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -297,11 +298,11 @@ public class FormatTest   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -34,6 +34,7 @@ import io.swagger.client.model.Animal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.joda.time.DateTime;
 
 
@@ -43,7 +44,7 @@ import org.joda.time.DateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   @JsonProperty("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @JsonProperty("dateTime")
   private DateTime dateTime = null;
@@ -51,7 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   @JsonProperty("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -61,11 +62,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/jersey1/docs/FormatTest.md
+++ b/samples/client/petstore/java/jersey1/docs/FormatTest.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **binary** | **byte[]** |  |  [optional]
 **date** | [**LocalDate**](LocalDate.md) |  | 
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
 
 

--- a/samples/client/petstore/java/jersey1/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/jersey1/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
 **map** | [**Map&lt;String, Animal&gt;**](Animal.md) |  |  [optional]
 

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/FormatTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -74,7 +75,7 @@ public class FormatTest   {
   private DateTime dateTime = null;
 
   @JsonProperty("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @JsonProperty("password")
   private String password = null;
@@ -287,7 +288,7 @@ public class FormatTest   {
     this.dateTime = dateTime;
   }
 
-  public FormatTest uuid(String uuid) {
+  public FormatTest uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -297,11 +298,11 @@ public class FormatTest   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -34,6 +34,7 @@ import io.swagger.client.model.Animal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.joda.time.DateTime;
 
 
@@ -43,7 +44,7 @@ import org.joda.time.DateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   @JsonProperty("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @JsonProperty("dateTime")
   private DateTime dateTime = null;
@@ -51,7 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   @JsonProperty("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -61,11 +62,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/jersey2-java8/docs/FormatTest.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FormatTest.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **binary** | **byte[]** |  |  [optional]
 **date** | [**LocalDate**](LocalDate.md) |  | 
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
 
 

--- a/samples/client/petstore/java/jersey2-java8/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **map** | [**Map&lt;String, Animal&gt;**](Animal.md) |  |  [optional]
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/FormatTest.java
@@ -33,6 +33,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 
 /**
@@ -74,7 +75,7 @@ public class FormatTest   {
   private OffsetDateTime dateTime = null;
 
   @JsonProperty("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @JsonProperty("password")
   private String password = null;
@@ -287,7 +288,7 @@ public class FormatTest   {
     this.dateTime = dateTime;
   }
 
-  public FormatTest uuid(String uuid) {
+  public FormatTest uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -297,11 +298,11 @@ public class FormatTest   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -35,6 +35,7 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 
 /**
@@ -43,7 +44,7 @@ import java.util.Map;
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   @JsonProperty("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @JsonProperty("dateTime")
   private OffsetDateTime dateTime = null;
@@ -51,7 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   @JsonProperty("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -61,11 +62,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/jersey2/docs/FormatTest.md
+++ b/samples/client/petstore/java/jersey2/docs/FormatTest.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **binary** | **byte[]** |  |  [optional]
 **date** | [**LocalDate**](LocalDate.md) |  | 
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
 
 

--- a/samples/client/petstore/java/jersey2/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/jersey2/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
 **map** | [**Map&lt;String, Animal&gt;**](Animal.md) |  |  [optional]
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/FormatTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -74,7 +75,7 @@ public class FormatTest   {
   private DateTime dateTime = null;
 
   @JsonProperty("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @JsonProperty("password")
   private String password = null;
@@ -287,7 +288,7 @@ public class FormatTest   {
     this.dateTime = dateTime;
   }
 
-  public FormatTest uuid(String uuid) {
+  public FormatTest uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -297,11 +298,11 @@ public class FormatTest   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -34,6 +34,7 @@ import io.swagger.client.model.Animal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.joda.time.DateTime;
 
 
@@ -43,7 +44,7 @@ import org.joda.time.DateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   @JsonProperty("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @JsonProperty("dateTime")
   private DateTime dateTime = null;
@@ -51,7 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   @JsonProperty("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -61,11 +62,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/okhttp-gson/docs/FormatTest.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FormatTest.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **binary** | **byte[]** |  |  [optional]
 **date** | [**LocalDate**](LocalDate.md) |  | 
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
 
 

--- a/samples/client/petstore/java/okhttp-gson/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
 **map** | [**Map&lt;String, Animal&gt;**](Animal.md) |  |  [optional]
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/FormatTest.java
@@ -30,6 +30,7 @@ import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -73,7 +74,7 @@ public class FormatTest   {
   private DateTime dateTime = null;
 
   @SerializedName("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @SerializedName("password")
   private String password = null;
@@ -286,7 +287,7 @@ public class FormatTest   {
     this.dateTime = dateTime;
   }
 
-  public FormatTest uuid(String uuid) {
+  public FormatTest uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -296,11 +297,11 @@ public class FormatTest   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -33,6 +33,7 @@ import io.swagger.client.model.Animal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.joda.time.DateTime;
 
 
@@ -42,7 +43,7 @@ import org.joda.time.DateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   @SerializedName("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @SerializedName("dateTime")
   private DateTime dateTime = null;
@@ -50,7 +51,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   @SerializedName("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -60,11 +61,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/FormatTest.java
@@ -30,6 +30,7 @@ import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -73,7 +74,7 @@ public class FormatTest   {
   private DateTime dateTime = null;
 
   @SerializedName("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @SerializedName("password")
   private String password = null;
@@ -286,7 +287,7 @@ public class FormatTest   {
     this.dateTime = dateTime;
   }
 
-  public FormatTest uuid(String uuid) {
+  public FormatTest uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -296,11 +297,11 @@ public class FormatTest   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -33,6 +33,7 @@ import io.swagger.client.model.Animal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.joda.time.DateTime;
 
 
@@ -42,7 +43,7 @@ import org.joda.time.DateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   @SerializedName("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @SerializedName("dateTime")
   private DateTime dateTime = null;
@@ -50,7 +51,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   @SerializedName("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -60,11 +61,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/retrofit2/docs/FormatTest.md
+++ b/samples/client/petstore/java/retrofit2/docs/FormatTest.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **binary** | **byte[]** |  |  [optional]
 **date** | [**LocalDate**](LocalDate.md) |  | 
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
 
 

--- a/samples/client/petstore/java/retrofit2/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/retrofit2/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
 **map** | [**Map&lt;String, Animal&gt;**](Animal.md) |  |  [optional]
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/FormatTest.java
@@ -30,6 +30,7 @@ import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -73,7 +74,7 @@ public class FormatTest   {
   private DateTime dateTime = null;
 
   @SerializedName("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @SerializedName("password")
   private String password = null;
@@ -286,7 +287,7 @@ public class FormatTest   {
     this.dateTime = dateTime;
   }
 
-  public FormatTest uuid(String uuid) {
+  public FormatTest uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -296,11 +297,11 @@ public class FormatTest   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -33,6 +33,7 @@ import io.swagger.client.model.Animal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.joda.time.DateTime;
 
 
@@ -42,7 +43,7 @@ import org.joda.time.DateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   @SerializedName("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @SerializedName("dateTime")
   private DateTime dateTime = null;
@@ -50,7 +51,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   @SerializedName("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -60,11 +61,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/retrofit2rx/docs/FormatTest.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/FormatTest.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 **binary** | **byte[]** |  |  [optional]
 **date** | [**LocalDate**](LocalDate.md) |  | 
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
 
 

--- a/samples/client/petstore/java/retrofit2rx/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **String** |  |  [optional]
+**uuid** | [**UUID**](UUID.md) |  |  [optional]
 **dateTime** | [**DateTime**](DateTime.md) |  |  [optional]
 **map** | [**Map&lt;String, Animal&gt;**](Animal.md) |  |  [optional]
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/FormatTest.java
@@ -30,6 +30,7 @@ import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -73,7 +74,7 @@ public class FormatTest   {
   private DateTime dateTime = null;
 
   @SerializedName("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @SerializedName("password")
   private String password = null;
@@ -286,7 +287,7 @@ public class FormatTest   {
     this.dateTime = dateTime;
   }
 
-  public FormatTest uuid(String uuid) {
+  public FormatTest uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -296,11 +297,11 @@ public class FormatTest   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -33,6 +33,7 @@ import io.swagger.client.model.Animal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.joda.time.DateTime;
 
 
@@ -42,7 +43,7 @@ import org.joda.time.DateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   @SerializedName("uuid")
-  private String uuid = null;
+  private UUID uuid = null;
 
   @SerializedName("dateTime")
   private DateTime dateTime = null;
@@ -50,7 +51,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   @SerializedName("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     this.uuid = uuid;
     return this;
   }
@@ -60,11 +61,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * @return uuid
   **/
   @ApiModelProperty(example = "null", value = "")
-  public String getUuid() {
+  public UUID getUuid() {
     return uuid;
   }
 
-  public void setUuid(String uuid) {
+  public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

It looks like there was a commit back in January that reverted a previous fix that added UUID types for java.  The commit is 7aac639.

This fixes the issue by allowing UUID to be used in generated code.