### PR TITLE
Feature/#3738 add source folder property

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
@@ -46,6 +46,24 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
 
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, CodegenConstants.SOURCE_FOLDER_DESC));
+    }
+
+    @Override
+    public void processOpts() {
+        super.processOpts();
+
+        if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
+            this.setSourceFolder((String) additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
+        }
+    }
+
+    public void setSourceFolder(String sourceFolder) {
+        this.sourceFolder = sourceFolder;
+    }
+
+    public String getSourceFolder() {
+        return sourceFolder;
     }
 
     @Override

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/akkascala/AkkaScalaClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/akkascala/AkkaScalaClientOptionsTest.java
@@ -32,6 +32,8 @@ public class AkkaScalaClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(AkkaScalaClientOptionsProvider.SORT_PARAMS_VALUE));
             times = 1;
+            clientCodegen.setSourceFolder(AkkaScalaClientOptionsProvider.SOURCE_FOLDER_VALUE);
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/asyncscala/AsyncScalaClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/asyncscala/AsyncScalaClientOptionsTest.java
@@ -32,6 +32,8 @@ public class AsyncScalaClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(AsyncScalaClientOptionsProvider.SORT_PARAMS_VALUE));
             times = 1;
+            clientCodegen.setSourceFolder(AsyncScalaClientOptionsProvider.SOURCE_FOLDER_VALUE);
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AkkaScalaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AkkaScalaClientOptionsProvider.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
 public class AkkaScalaClientOptionsProvider implements OptionsProvider {
+    public static final String SOURCE_FOLDER_VALUE = "sourceFolder";
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
@@ -24,6 +25,7 @@ public class AkkaScalaClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
+                .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AsyncScalaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AsyncScalaClientOptionsProvider.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
 public class AsyncScalaClientOptionsProvider implements OptionsProvider {
+    public static final String SOURCE_FOLDER_VALUE = "sourceFolder";
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
@@ -24,6 +25,7 @@ public class AsyncScalaClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
+                .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/ScalaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/ScalaClientOptionsProvider.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
 public class ScalaClientOptionsProvider implements OptionsProvider {
+    public static final String SOURCE_FOLDER_VALUE = "sourceFolder";
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
@@ -26,6 +27,7 @@ public class ScalaClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.MODEL_PROPERTY_NAMING, MODEL_PROPERTY_NAMING)
+                .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/ScalatraServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/ScalatraServerOptionsProvider.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
 public class ScalatraServerOptionsProvider implements OptionsProvider {
+    public static final String SOURCE_FOLDER_VALUE = "sourceFolder";
     public static final String MODEL_PACKAGE_VALUE = "package";
     public static final String API_PACKAGE_VALUE = "apiPackage";
     public static final String SORT_PARAMS_VALUE = "false";
@@ -24,6 +25,7 @@ public class ScalatraServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
+                .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/scala/ScalaClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/scala/ScalaClientOptionsTest.java
@@ -34,6 +34,8 @@ public class ScalaClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setModelPropertyNaming(ScalaClientOptionsProvider.MODEL_PROPERTY_NAMING);
             times = 1;
+            clientCodegen.setSourceFolder(ScalaClientOptionsProvider.SOURCE_FOLDER_VALUE);
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/scalatra/ScalatraServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/scalatra/ScalatraServerOptionsTest.java
@@ -32,6 +32,8 @@ public class ScalatraServerOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(ScalatraServerOptionsProvider.SORT_PARAMS_VALUE));
             times = 1;
+            clientCodegen.setSourceFolder(ScalatraServerOptionsProvider.SOURCE_FOLDER_VALUE);
+            times = 1;
         }};
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates) → no changes at all.
- [x] Filed the PR against the correct branch: master for non-breaking changes ~~and `2.3.0` branch for breaking (non-backward compatible) changes~~.

### Description of the PR

This tries to fix #3738 by adding the `sourceFolder` parameter to all the scala-based languages: `scala`, `async-scala`, `scalatra`, `akka-scala`. It works analogously to how it works in the Java-generators, replacing the default `src/main/scala` by whatever is used in the parameter.

The new parameter is not used by the Petstore tests, therefore those did not change.