### PR TITLE
[Typescript] Fix order of generated classes for typescript-node

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -267,6 +267,14 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     private Model getParent(Model model) {
                         if (model instanceof ComposedModel) {
                             Model parent = ((ComposedModel) model).getParent();
+                            if (parent == null) {
+                                // check for interfaces
+                                List<RefModel> interfaces = ((ComposedModel) model).getInterfaces();
+                                if (interfaces.size() > 0) {
+                                    RefModel interf = interfaces.get(0);
+                                    return definitions.get(interf.getSimpleRef());
+                                }
+                            }
                             if(parent != null) {
                                 return definitions.get(parent.getReference());
                             }


### PR DESCRIPTION
When generating typescript, the typescript classes must be in the right order, classes must be defined before used, especially subclasses must be defined after there superclasses. If not done correctly the typescript file will compile without errors but a runtime error will occure.
This pull requests corrects the order of classes when using inheritance in the style of swagger 2.0 (see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#composition-and-inheritance-polymorphism) and makes sure that superclasses are defined before subclasses in the generate typescript

[simple-api.yaml.txt](https://github.com/swagger-api/swagger-codegen/files/469359/simple-api.yaml.txt)

Example: 
definitions:
  SuperClass:
    type: object
    discriminator: ctype
    properties:
      field1:
        type: string
      ctype:
        type: string

  SubClass:
    allOf:
    - $ref: "#/definitions/SuperClass"
    - type: object
      properties:
        field2:
          type: string
(full yaml file attached)
