### PR TITLE
[typescript-angular2] npm publish missing files

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
@@ -7,10 +7,10 @@
     "swagger-client"
   ],
   "license": "Apache-2.0",
-  "main": "./lib/index.js",
-  "typings": "./lib/index.d.ts",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "typings install && tsc",
+    "build": "typings install && tsc --outDir dist/",
     "postinstall": "npm run build"
   },
   "peerDependencies": {

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/package.mustache
@@ -7,9 +7,6 @@
     "swagger-client"
   ],
   "license": "Apache-2.0",
-  "files": [
-    "lib"
-  ],
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "scripts": {

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201609121640
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201609141041
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201609121640 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201609141041 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,19 +1,16 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201609121640",
+  "version": "0.0.1-SNAPSHOT.201609141041",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [
     "swagger-client"
   ],
   "license": "Apache-2.0",
-  "files": [
-    "lib"
-  ],
-  "main": "./lib/index.js",
-  "typings": "./lib/index.d.ts",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "typings install && tsc",
+    "build": "typings install && tsc --outDir dist/",
     "postinstall": "npm run build"
   },
   "peerDependencies": {

--- a/samples/client/petstore/typescript-angular2/npm/variables.ts
+++ b/samples/client/petstore/typescript-angular2/npm/variables.ts
@@ -1,0 +1,3 @@
+import { OpaqueToken } from '@angular/core';
+
+export const BASE_PATH = new OpaqueToken('basePath');


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Removed files property from typescript-angular2 package.json so that all files are uploaded during npm publish.