### PR TITLE
add optional parameters to init when unwrapRequired is true

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift/model.mustache
@@ -33,10 +33,10 @@ public class {{classname}}: JSONEncodable {
     public init() {}
 {{/unwrapRequired}}
 {{#unwrapRequired}}
-    public init({{#requiredVars}}{{^-first}}, {{/-first}}{{name}}: {{#isEnum}}{{datatypeWithEnum}}{{/isEnum}}{{^isEnum}}{{datatype}}{{/isEnum}}{{/requiredVars}}) {
-        {{#requiredVars}}
+    public init({{#allVars}}{{^-first}}, {{/-first}}{{name}}: {{#isEnum}}{{datatypeWithEnum}}{{/isEnum}}{{^isEnum}}{{datatype}}{{/isEnum}}{{^required}}?=nil{{/required}}{{/allVars}}) {
+        {{#allVars}}
         self.{{name}} = {{name}}
-        {{/requiredVars}}
+        {{/allVars}}
     }
 {{/unwrapRequired}}
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Previously when running with unwrapRequired=true, the init function would only list required parameters.  I added the optional ones with default values to nil.

