### PR TITLE
[PHP] Change APIException to expect headers as array

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ApiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiException.mustache
@@ -43,7 +43,7 @@ class ApiException extends Exception
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]
+     * @var string[]|null
      */
     protected $responseHeaders;
 
@@ -57,12 +57,12 @@ class ApiException extends Exception
     /**
      * Constructor
      *
-     * @param string $message         Error message
-     * @param int    $code            HTTP status code
-     * @param string $responseHeaders HTTP response header
-     * @param mixed  $responseBody    HTTP body of the server response either as Json or string
+     * @param string        $message         Error message
+     * @param int           $code            HTTP status code
+     * @param string[]|null $responseHeaders HTTP response header
+     * @param mixed         $responseBody    HTTP body of the server response either as Json or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = null, $responseBody = null)
+    public function __construct($message = "", $code = 0, array $responseHeaders = null, $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -72,7 +72,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string HTTP response header
+     * @return string[]|null HTTP response header
      */
     public function getResponseHeaders()
     {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ApiException.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ApiException.php
@@ -64,7 +64,7 @@ class ApiException extends Exception
     /**
      * The HTTP header of the server response.
      *
-     * @var string[]
+     * @var string[]|null
      */
     protected $responseHeaders;
 
@@ -78,12 +78,12 @@ class ApiException extends Exception
     /**
      * Constructor
      *
-     * @param string $message         Error message
-     * @param int    $code            HTTP status code
-     * @param string $responseHeaders HTTP response header
-     * @param mixed  $responseBody    HTTP body of the server response either as Json or string
+     * @param string        $message         Error message
+     * @param int           $code            HTTP status code
+     * @param string[]|null $responseHeaders HTTP response header
+     * @param mixed         $responseBody    HTTP body of the server response either as Json or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = null, $responseBody = null)
+    public function __construct($message = "", $code = 0, array $responseHeaders = null, $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -93,7 +93,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string HTTP response header
+     * @return string[]|null HTTP response header
      */
     public function getResponseHeaders()
     {


### PR DESCRIPTION
In the ApiClient the headers param is always given array or null so the PHPDoc is definitely wrong.

I have made the pull request to v2.3.0 since the change of ApiException constructor param from  `$responseHeaders = null` to `array $responseHeaders = null` technically speaking breaks backward compatibility by forcing array or null.