### PR TITLE
[PHP] Correct Composer license identifier

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/composer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/composer.mustache
@@ -11,7 +11,7 @@
         "api"
     ],
     "homepage": "http://swagger.io",
-    "license": "Apache v2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Swagger and contributors",

--- a/samples/client/petstore/php/SwaggerClient-php/composer.json
+++ b/samples/client/petstore/php/SwaggerClient-php/composer.json
@@ -8,7 +8,7 @@
         "api"
     ],
     "homepage": "http://swagger.io",
-    "license": "Apache v2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Swagger and contributors",


### PR DESCRIPTION
Correct Composer license identifier to follow the standard [defined by SPDX Open Source License Registry](https://spdx.org/licenses/Apache-2.0.html) as described in [Composer doc](https://getcomposer.org/doc/04-schema.md#license)