### PR TITLE
[Typescript] fix typescript-fetch base path by removing ending slash

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
@@ -10,7 +10,7 @@ import * as assign from "core-js/library/fn/object/assign";
 interface Dictionary<T> { [index: string]: T; }
 export interface FetchAPI { (url: string, init?: any): Promise<any>; }
 
-const BASE_PATH = "{{basePath}}";
+const BASE_PATH = "{{{basePath}}}".replace(/\/+$/, '');
 
 export interface FetchArgs {
     url: string;

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -31,7 +31,7 @@ import * as assign from "core-js/library/fn/object/assign";
 interface Dictionary<T> { [index: string]: T; }
 export interface FetchAPI { (url: string, init?: any): Promise<any>; }
 
-const BASE_PATH = "http://petstore.swagger.io/v2";
+const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, '');
 
 export interface FetchArgs {
     url: string;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/api.ts
@@ -30,7 +30,7 @@ import * as isomorphicFetch from "isomorphic-fetch";
 interface Dictionary<T> { [index: string]: T; }
 export interface FetchAPI { (url: string, init?: any): Promise<any>; }
 
-const BASE_PATH = "http://petstore.swagger.io/v2";
+const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, '');
 
 export interface FetchArgs {
     url: string;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/api.ts
@@ -31,7 +31,7 @@ import * as assign from "core-js/library/fn/object/assign";
 interface Dictionary<T> { [index: string]: T; }
 export interface FetchAPI { (url: string, init?: any): Promise<any>; }
 
-const BASE_PATH = "http://petstore.swagger.io/v2";
+const BASE_PATH = "http://petstore.swagger.io/v2".replace(/\/+$/, '');
 
 export interface FetchArgs {
     url: string;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

To fix https://github.com/swagger-api/swagger-codegen/issues/3832


