### PR TITLE
[JaxRS]Show correct default value on CLI option description

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJerseyServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJerseyServerCodegen.java
@@ -9,6 +9,15 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
+
+    protected static final String LIBRARY_JERSEY1 = "jersey1";
+    protected static final String LIBRARY_JERSEY2 = "jersey2";
+
+    /**
+     * Default library template to use. (Default:{@value #DEFAULT_LIBRARY})
+     */
+    public static final String DEFAULT_LIBRARY = LIBRARY_JERSEY2;
+
     public JavaJerseyServerCodegen() {
         super();
 
@@ -29,10 +38,10 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
         CliOption library = new CliOption(CodegenConstants.LIBRARY, "library template (sub-template) to use");
 
-        supportedLibraries.put("jersey1", "Jersey core 1.x");
-        supportedLibraries.put("jersey2", "Jersey core 2.x (default)");
+        supportedLibraries.put(LIBRARY_JERSEY1, "Jersey core 1.x");
+        supportedLibraries.put(LIBRARY_JERSEY2, "Jersey core 2.x");
         library.setEnum(supportedLibraries);
-        library.setDefault("jersey1");
+        library.setDefault(DEFAULT_LIBRARY);
 
         cliOptions.add(library);
 
@@ -71,9 +80,9 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public void processOpts() {
         super.processOpts();
 
-        // set jersey2 as default
+        // use default library if unset
         if (StringUtils.isEmpty(library)) {
-            setLibrary("jersey2");
+            setLibrary(DEFAULT_LIBRARY);
         }
 
         if ( additionalProperties.containsKey(CodegenConstants.IMPL_FOLDER)) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApi.java
@@ -8,8 +8,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
 import io.swagger.model.Client;
-import java.util.Date;
 import java.math.BigDecimal;
+import java.util.Date;
 
 import java.util.List;
 import io.swagger.api.NotFoundException;
@@ -48,41 +48,49 @@ public class FakeApi  {
     
     @Consumes({ "application/xml; charset=utf-8", "application/json; charset=utf-8" })
     @Produces({ "application/xml; charset=utf-8", "application/json; charset=utf-8" })
-    @io.swagger.annotations.ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", response = void.class, authorizations = {
+        @io.swagger.annotations.Authorization(value = "http_basic_test")
+    }, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = void.class) })
     public Response testEndpointParameters(@ApiParam(value = "None", required=true)  @FormParam("number")  BigDecimal number
 ,@ApiParam(value = "None", required=true)  @FormParam("double")  Double _double
-,@ApiParam(value = "None", required=true)  @FormParam("string")  String string
+,@ApiParam(value = "None", required=true)  @FormParam("pattern_without_delimiter")  String patternWithoutDelimiter
 ,@ApiParam(value = "None", required=true)  @FormParam("byte")  byte[] _byte
 ,@ApiParam(value = "None")  @FormParam("integer")  Integer integer
 ,@ApiParam(value = "None")  @FormParam("int32")  Integer int32
 ,@ApiParam(value = "None")  @FormParam("int64")  Long int64
 ,@ApiParam(value = "None")  @FormParam("float")  Float _float
+,@ApiParam(value = "None")  @FormParam("string")  String string
 ,@ApiParam(value = "None")  @FormParam("binary")  byte[] binary
 ,@ApiParam(value = "None")  @FormParam("date")  Date date
 ,@ApiParam(value = "None")  @FormParam("dateTime")  Date dateTime
 ,@ApiParam(value = "None")  @FormParam("password")  String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEndpointParameters(number,_double,string,_byte,integer,int32,int64,_float,binary,date,dateTime,password,securityContext);
+        return delegate.testEndpointParameters(number,_double,patternWithoutDelimiter,_byte,integer,int32,int64,_float,string,binary,date,dateTime,password,securityContext);
     }
     @GET
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "To test enum query parameters", notes = "", response = void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiOperation(value = "To test enum parameters", notes = "", response = void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid request", response = void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Not found", response = void.class) })
-    public Response testEnumQueryParameters(@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_query_string")  String enumQueryString
+    public Response testEnumParameters(@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $")  @FormParam("enum_form_string_array")  List<String> enumFormStringArray
+,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
+,@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $")@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray
+,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString
+,@ApiParam(value = "Query parameter enum test (string array)", allowableValues=">, $") @QueryParam("enum_query_string_array") List<String> enumQueryStringArray
+,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg") @QueryParam("enum_query_string") String enumQueryString
 ,@ApiParam(value = "Query parameter enum test (double)") @QueryParam("enum_query_integer") BigDecimal enumQueryInteger
 ,@ApiParam(value = "Query parameter enum test (double)")  @FormParam("enum_query_double")  Double enumQueryDouble
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEnumQueryParameters(enumQueryString,enumQueryInteger,enumQueryDouble,securityContext);
+        return delegate.testEnumParameters(enumFormStringArray,enumFormString,enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApiService.java
@@ -6,8 +6,8 @@ import io.swagger.model.*;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
 import io.swagger.model.Client;
-import java.util.Date;
 import java.math.BigDecimal;
+import java.util.Date;
 
 import java.util.List;
 import io.swagger.api.NotFoundException;
@@ -20,6 +20,6 @@ import javax.ws.rs.core.SecurityContext;
 
 public abstract class FakeApiService {
     public abstract Response testClientModel(Client body,SecurityContext securityContext) throws NotFoundException;
-    public abstract Response testEndpointParameters(BigDecimal number,Double _double,String string,byte[] _byte,Integer integer,Integer int32,Long int64,Float _float,byte[] binary,Date date,Date dateTime,String password,SecurityContext securityContext) throws NotFoundException;
-    public abstract Response testEnumQueryParameters(String enumQueryString,BigDecimal enumQueryInteger,Double enumQueryDouble,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response testEndpointParameters(BigDecimal number,Double _double,String patternWithoutDelimiter,byte[] _byte,Integer integer,Integer int32,Long int64,Float _float,String string,byte[] binary,Date date,Date dateTime,String password,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response testEnumParameters(List<String> enumFormStringArray,String enumFormString,List<String> enumHeaderStringArray,String enumHeaderString,List<String> enumQueryStringArray,String enumQueryString,BigDecimal enumQueryInteger,Double enumQueryDouble,SecurityContext securityContext) throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/PetApi.java
@@ -8,8 +8,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.jaxrs.*;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import java.util.List;
 import io.swagger.api.NotFoundException;

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/PetApiService.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/PetApiService.java
@@ -6,8 +6,8 @@ import io.swagger.model.*;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import java.util.List;
 import io.swagger.api.NotFoundException;

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
@@ -16,8 +17,10 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass   {
+  @JsonProperty("map_property")
   private Map<String, String> mapProperty = new HashMap<String, String>();
 
+  @JsonProperty("map_of_map_property")
   private Map<String, Map<String, String>> mapOfMapProperty = new HashMap<String, Map<String, String>>();
 
   public AdditionalPropertiesClass mapProperty(Map<String, String> mapProperty) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Animal.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,8 +14,10 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Animal   {
+  @JsonProperty("className")
   private String className = null;
 
+  @JsonProperty("color")
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
@@ -16,6 +17,7 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly   {
+  @JsonProperty("ArrayArrayNumber")
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
@@ -16,6 +17,7 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly   {
+  @JsonProperty("ArrayNumber")
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ArrayTest.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.ReadOnlyFirst;
@@ -16,10 +17,13 @@ import java.util.List;
  */
 
 public class ArrayTest   {
+  @JsonProperty("array_of_string")
   private List<String> arrayOfString = new ArrayList<String>();
 
+  @JsonProperty("array_array_of_integer")
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
+  @JsonProperty("array_array_of_model")
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Cat.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.Animal;
@@ -14,6 +15,7 @@ import io.swagger.model.Animal;
  */
 
 public class Cat extends Animal  {
+  @JsonProperty("declawed")
   private Boolean declawed = null;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Category.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,8 +14,10 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category   {
+  @JsonProperty("id")
   private Long id = null;
 
+  @JsonProperty("name")
   private String name = null;
 
   public Category id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Client.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,6 +14,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client   {
+  @JsonProperty("client")
   private String client = null;
 
   public Client client(String client) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Dog.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.Animal;
@@ -14,6 +15,7 @@ import io.swagger.model.Animal;
  */
 
 public class Dog extends Animal  {
+  @JsonProperty("breed")
   private String breed = null;
 
   public Dog breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/EnumArrays.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -17,26 +18,38 @@ import java.util.List;
 
 public class EnumArrays   {
   /**
-   * Gets or Sets justEnum
+   * Gets or Sets justSymbol
    */
-  public enum JustEnumEnum {
-    BIRD("bird"),
+  public enum JustSymbolEnum {
+    GREATER_THAN_OR_EQUAL_TO(">="),
     
-    EAGLE("eagle");
+    DOLLAR("$");
 
     private String value;
 
-    JustEnumEnum(String value) {
+    JustSymbolEnum(String value) {
       this.value = value;
     }
 
     @Override
+    @JsonValue
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static JustSymbolEnum fromValue(String text) {
+      for (JustSymbolEnum b : JustSymbolEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
   }
 
-  private JustEnumEnum justEnum = null;
+  @JsonProperty("just_symbol")
+  private JustSymbolEnum justSymbol = null;
 
   /**
    * Gets or Sets arrayEnum
@@ -53,29 +66,41 @@ public class EnumArrays   {
     }
 
     @Override
+    @JsonValue
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static ArrayEnumEnum fromValue(String text) {
+      for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
   }
 
+  @JsonProperty("array_enum")
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
-  public EnumArrays justEnum(JustEnumEnum justEnum) {
-    this.justEnum = justEnum;
+  public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    this.justSymbol = justSymbol;
     return this;
   }
 
    /**
-   * Get justEnum
-   * @return justEnum
+   * Get justSymbol
+   * @return justSymbol
   **/
   @ApiModelProperty(value = "")
-  public JustEnumEnum getJustEnum() {
-    return justEnum;
+  public JustSymbolEnum getJustSymbol() {
+    return justSymbol;
   }
 
-  public void setJustEnum(JustEnumEnum justEnum) {
-    this.justEnum = justEnum;
+  public void setJustSymbol(JustSymbolEnum justSymbol) {
+    this.justSymbol = justSymbol;
   }
 
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
@@ -111,13 +136,13 @@ public class EnumArrays   {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(this.justEnum, enumArrays.justEnum) &&
+    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
         Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(justEnum, arrayEnum);
+    return Objects.hash(justSymbol, arrayEnum);
   }
 
   @Override
@@ -125,7 +150,7 @@ public class EnumArrays   {
     StringBuilder sb = new StringBuilder();
     sb.append("class EnumArrays {\n");
     
-    sb.append("    justEnum: ").append(toIndentedString(justEnum)).append("\n");
+    sb.append("    justSymbol: ").append(toIndentedString(justSymbol)).append("\n");
     sb.append("    arrayEnum: ").append(toIndentedString(arrayEnum)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/EnumClass.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * Gets or Sets EnumClass
  */
@@ -23,8 +25,19 @@ public enum EnumClass {
   }
 
   @Override
+  @JsonValue
   public String toString() {
     return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static EnumClass fromValue(String text) {
+    for (EnumClass b : EnumClass.values()) {
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
+    }
+    return null;
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/EnumTest.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -29,11 +30,23 @@ public class EnumTest   {
     }
 
     @Override
+    @JsonValue
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static EnumStringEnum fromValue(String text) {
+      for (EnumStringEnum b : EnumStringEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
   }
 
+  @JsonProperty("enum_string")
   private EnumStringEnum enumString = null;
 
   /**
@@ -51,11 +64,23 @@ public class EnumTest   {
     }
 
     @Override
+    @JsonValue
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static EnumIntegerEnum fromValue(String text) {
+      for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
   }
 
+  @JsonProperty("enum_integer")
   private EnumIntegerEnum enumInteger = null;
 
   /**
@@ -73,11 +98,23 @@ public class EnumTest   {
     }
 
     @Override
+    @JsonValue
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static EnumNumberEnum fromValue(String text) {
+      for (EnumNumberEnum b : EnumNumberEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
   }
 
+  @JsonProperty("enum_number")
   private EnumNumberEnum enumNumber = null;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/FormatTest.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
@@ -15,30 +16,43 @@ import java.util.Date;
  */
 
 public class FormatTest   {
+  @JsonProperty("integer")
   private Integer integer = null;
 
+  @JsonProperty("int32")
   private Integer int32 = null;
 
+  @JsonProperty("int64")
   private Long int64 = null;
 
+  @JsonProperty("number")
   private BigDecimal number = null;
 
+  @JsonProperty("float")
   private Float _float = null;
 
+  @JsonProperty("double")
   private Double _double = null;
 
+  @JsonProperty("string")
   private String string = null;
 
+  @JsonProperty("byte")
   private byte[] _byte = null;
 
+  @JsonProperty("binary")
   private byte[] binary = null;
 
+  @JsonProperty("date")
   private Date date = null;
 
+  @JsonProperty("dateTime")
   private Date dateTime = null;
 
+  @JsonProperty("uuid")
   private String uuid = null;
 
+  @JsonProperty("password")
   private String password = null;
 
   public FormatTest integer(Integer integer) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,8 +14,10 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly   {
+  @JsonProperty("bar")
   private String bar = null;
 
+  @JsonProperty("foo")
   private String foo = null;
 
    /**

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/MapTest.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -17,6 +18,7 @@ import java.util.Map;
  */
 
 public class MapTest   {
+  @JsonProperty("map_map_of_string")
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -34,11 +36,23 @@ public class MapTest   {
     }
 
     @Override
+    @JsonValue
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static InnerEnum fromValue(String text) {
+      for (InnerEnum b : InnerEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
   }
 
+  @JsonProperty("map_of_enum_string")
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.Animal;
@@ -18,10 +19,13 @@ import java.util.Map;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
+  @JsonProperty("uuid")
   private String uuid = null;
 
+  @JsonProperty("dateTime")
   private Date dateTime = null;
 
+  @JsonProperty("map")
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Model200Response.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -17,9 +18,11 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response   {
+  @JsonProperty("name")
   private Integer name = null;
 
-  private String PropertyClass = null;
+  @JsonProperty("class")
+  private String propertyClass = null;
 
   public Model200Response name(Integer name) {
     this.name = name;
@@ -39,22 +42,22 @@ public class Model200Response   {
     this.name = name;
   }
 
-  public Model200Response PropertyClass(String PropertyClass) {
-    this.PropertyClass = PropertyClass;
+  public Model200Response propertyClass(String propertyClass) {
+    this.propertyClass = propertyClass;
     return this;
   }
 
    /**
-   * Get PropertyClass
-   * @return PropertyClass
+   * Get propertyClass
+   * @return propertyClass
   **/
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
-    return PropertyClass;
+    return propertyClass;
   }
 
-  public void setPropertyClass(String PropertyClass) {
-    this.PropertyClass = PropertyClass;
+  public void setPropertyClass(String propertyClass) {
+    this.propertyClass = propertyClass;
   }
 
 
@@ -68,12 +71,12 @@ public class Model200Response   {
     }
     Model200Response _200Response = (Model200Response) o;
     return Objects.equals(this.name, _200Response.name) &&
-        Objects.equals(this.PropertyClass, _200Response.PropertyClass);
+        Objects.equals(this.propertyClass, _200Response.propertyClass);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, PropertyClass);
+    return Objects.hash(name, propertyClass);
   }
 
   @Override
@@ -82,7 +85,7 @@ public class Model200Response   {
     sb.append("class Model200Response {\n");
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    PropertyClass: ").append(toIndentedString(PropertyClass)).append("\n");
+    sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,10 +14,13 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse   {
+  @JsonProperty("code")
   private Integer code = null;
 
+  @JsonProperty("type")
   private String type = null;
 
+  @JsonProperty("message")
   private String message = null;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ModelReturn.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -17,6 +18,7 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn   {
+  @JsonProperty("return")
   private Integer _return = null;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Name.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -17,12 +18,16 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name   {
+  @JsonProperty("name")
   private Integer name = null;
 
+  @JsonProperty("snake_case")
   private Integer snakeCase = null;
 
+  @JsonProperty("property")
   private String property = null;
 
+  @JsonProperty("123Number")
   private Integer _123Number = null;
 
   public Name name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/NumberOnly.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
@@ -14,6 +15,7 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly   {
+  @JsonProperty("JustNumber")
   private BigDecimal justNumber = null;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Order.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -15,12 +16,16 @@ import java.util.Date;
  */
 
 public class Order   {
+  @JsonProperty("id")
   private Long id = null;
 
+  @JsonProperty("petId")
   private Long petId = null;
 
+  @JsonProperty("quantity")
   private Integer quantity = null;
 
+  @JsonProperty("shipDate")
   private Date shipDate = null;
 
   /**
@@ -40,13 +45,26 @@ public class Order   {
     }
 
     @Override
+    @JsonValue
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
   }
 
+  @JsonProperty("status")
   private StatusEnum status = null;
 
+  @JsonProperty("complete")
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Pet.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -18,14 +19,19 @@ import java.util.List;
  */
 
 public class Pet   {
+  @JsonProperty("id")
   private Long id = null;
 
+  @JsonProperty("category")
   private Category category = null;
 
+  @JsonProperty("name")
   private String name = null;
 
+  @JsonProperty("photoUrls")
   private List<String> photoUrls = new ArrayList<String>();
 
+  @JsonProperty("tags")
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -45,11 +51,23 @@ public class Pet   {
     }
 
     @Override
+    @JsonValue
     public String toString() {
       return String.valueOf(value);
     }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      return null;
+    }
   }
 
+  @JsonProperty("status")
   private StatusEnum status = null;
 
   public Pet id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/ReadOnlyFirst.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,8 +14,10 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst   {
+  @JsonProperty("bar")
   private String bar = null;
 
+  @JsonProperty("baz")
   private String baz = null;
 
    /**

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/SpecialModelName.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,6 +14,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName   {
+  @JsonProperty("$special[property.name]")
   private Long specialPropertyName = null;
 
   public SpecialModelName specialPropertyName(Long specialPropertyName) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/Tag.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,8 +14,10 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag   {
+  @JsonProperty("id")
   private Long id = null;
 
+  @JsonProperty("name")
   private String name = null;
 
   public Tag id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/User.java
@@ -2,6 +2,7 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -13,20 +14,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User   {
+  @JsonProperty("id")
   private Long id = null;
 
+  @JsonProperty("username")
   private String username = null;
 
+  @JsonProperty("firstName")
   private String firstName = null;
 
+  @JsonProperty("lastName")
   private String lastName = null;
 
+  @JsonProperty("email")
   private String email = null;
 
+  @JsonProperty("password")
   private String password = null;
 
+  @JsonProperty("phone")
   private String phone = null;
 
+  @JsonProperty("userStatus")
   private Integer userStatus = null;
 
   public User id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/io/swagger/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/io/swagger/api/impl/FakeApiServiceImpl.java
@@ -4,8 +4,8 @@ import io.swagger.api.*;
 import io.swagger.model.*;
 
 import io.swagger.model.Client;
-import java.util.Date;
 import java.math.BigDecimal;
+import java.util.Date;
 
 import java.util.List;
 import io.swagger.api.NotFoundException;
@@ -25,12 +25,12 @@ public class FakeApiServiceImpl extends FakeApiService {
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
-    public Response testEndpointParameters(BigDecimal number, Double _double, String string, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, byte[] binary, Date date, Date dateTime, String password, SecurityContext securityContext) throws NotFoundException {
+    public Response testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, byte[] binary, Date date, Date dateTime, String password, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
-    public Response testEnumQueryParameters(String enumQueryString, BigDecimal enumQueryInteger, Double enumQueryDouble, SecurityContext securityContext) throws NotFoundException {
+    public Response testEnumParameters(List<String> enumFormStringArray, String enumFormString, List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, BigDecimal enumQueryInteger, Double enumQueryDouble, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
@@ -4,8 +4,8 @@ import io.swagger.api.*;
 import io.swagger.model.*;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import java.util.List;
 import io.swagger.api.NotFoundException;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixed jaxrs cli option handling to print correct default library template.

Fixes #3861