### PR TITLE
[PHP] fix PHPUnit invocation, add basic phpunit.xml.dist

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractPhpCodegen.java
@@ -198,10 +198,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         additionalProperties.put("escapedInvokerPackage", invokerPackage.replace("\\", "\\\\"));
 
         // make api and model src path available in mustache template
-        additionalProperties.put("apiSrcPath", toPackagePath(apiPackage, srcBasePath));
-        additionalProperties.put("modelSrcPath", toPackagePath(modelPackage, srcBasePath));
-        additionalProperties.put("apiTestPath", getPackagePath() + "/" + testBasePath + "/" + apiDirName);
-        additionalProperties.put("modelTestPath", getPackagePath() + "/" + testBasePath + "/" + modelDirName);
+        additionalProperties.put("apiSrcPath", "./" + toSrcPath(apiPackage, srcBasePath));
+        additionalProperties.put("modelSrcPath", "./" + toSrcPath(modelPackage, srcBasePath));
+        additionalProperties.put("apiTestPath", "./" + testBasePath + "/" + apiDirName);
+        additionalProperties.put("modelTestPath", "./" + testBasePath + "/" + modelDirName);
 
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);
@@ -219,6 +219,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     }
 
     public String toPackagePath(String packageName, String basePath) {
+        return (getPackagePath() + File.separatorChar + toSrcPath(packageName, basePath));
+    }
+
+    public String toSrcPath(String packageName, String basePath) {
         packageName = packageName.replace(invokerPackage, ""); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         if (basePath != null && basePath.length() > 0) {
             basePath = basePath.replaceAll("[\\\\/]?$", "") + File.separatorChar; // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
@@ -238,13 +242,13 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             regLastPathSeparator = "\\\\$";
         }
 
-        return (getPackagePath() + File.separatorChar + basePath
-                    // Replace period, backslash, forward slash with file separator in package name
-                    + packageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement(File.separator))
-                    // Trim prefix file separators from package path
-                    .replaceAll(regFirstPathSeparator, ""))
-                    // Trim trailing file separators from the overall path
-                    .replaceAll(regLastPathSeparator+ "$", "");
+        return (basePath
+                // Replace period, backslash, forward slash with file separator in package name
+                + packageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement(File.separator))
+                // Trim prefix file separators from package path
+                .replaceAll(regFirstPathSeparator, ""))
+                // Trim trailing file separators from the overall path
+                .replaceAll(regLastPathSeparator+ "$", "");
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractPhpCodegen.java
@@ -56,7 +56,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         apiTestTemplateFiles.put("api_test.mustache", ".php");
         modelDocTemplateFiles.put("model_doc.mustache", ".md");
         apiDocTemplateFiles.put("api_doc.mustache", ".md");
-       
+
         apiPackage = invokerPackage + "\\" + apiDirName;
         modelPackage = invokerPackage + "\\" + modelDirName;
 
@@ -196,6 +196,12 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         }
 
         additionalProperties.put("escapedInvokerPackage", invokerPackage.replace("\\", "\\\\"));
+
+        // make api and model src path available in mustache template
+        additionalProperties.put("apiSrcPath", toPackagePath(apiPackage, srcBasePath));
+        additionalProperties.put("modelSrcPath", toPackagePath(modelPackage, srcBasePath));
+        additionalProperties.put("apiTestPath", getPackagePath() + "/" + testBasePath + "/" + apiDirName);
+        additionalProperties.put("modelTestPath", getPackagePath() + "/" + testBasePath + "/" + modelDirName);
 
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);
@@ -392,7 +398,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toModelName(String name) {
-        // remove [ 
+        // remove [
         name = name.replaceAll("\\]", "");
 
         // Note: backslash ("\\") is allowed for e.g. "\\DateTime"
@@ -417,7 +423,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         if (!name.matches("^\\\\.*")) {
             name = modelNamePrefix + name + modelNameSuffix;
         }
-        
+
         // camelize the model name
         // phone_number => PhoneNumber
         return camelize(name);
@@ -642,5 +648,5 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     public String escapeUnsafeCharacters(String input) {
         return input.replace("*/", "");
     }
-    
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -150,6 +150,10 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     public String toPackagePath(String packageName, String basePath) {
+        return (getPackagePath() + File.separatorChar + toSrcPath(packageName, basePath));
+    }
+
+    public String toSrcPath(String packageName, String basePath) {
         packageName = packageName.replace(invokerPackage, ""); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         if (basePath != null && basePath.length() > 0) {
             basePath = basePath.replaceAll("[\\\\/]?$", "") + File.separatorChar; // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
@@ -169,13 +173,13 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
             regLastPathSeparator = "\\\\$";
         }
 
-        return (getPackagePath() + File.separatorChar + basePath
-                    // Replace period, backslash, forward slash with file separator in package name
-                    + packageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement(File.separator))
-                    // Trim prefix file separators from package path
-                    .replaceAll(regFirstPathSeparator, ""))
-                    // Trim trailing file separators from the overall path
-                    .replaceAll(regLastPathSeparator+ "$", "");
+        return (basePath
+                // Replace period, backslash, forward slash with file separator in package name
+                + packageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement(File.separator))
+                // Trim prefix file separators from package path
+                .replaceAll(regFirstPathSeparator, ""))
+                // Trim trailing file separators from the overall path
+                .replaceAll(regLastPathSeparator+ "$", "");
     }
 
     @Override
@@ -277,10 +281,10 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         additionalProperties.put("escapedInvokerPackage", invokerPackage.replace("\\", "\\\\"));
 
         // make api and model src path available in mustache template
-        additionalProperties.put("apiSrcPath", toPackagePath(apiPackage, srcBasePath));
-        additionalProperties.put("modelSrcPath", toPackagePath(modelPackage, srcBasePath));
-        additionalProperties.put("apiTestPath", getPackagePath() + "/" + testBasePath + "/" + apiDirName);
-        additionalProperties.put("modelTestPath", getPackagePath() + "/" + testBasePath + "/" + modelDirName);
+        additionalProperties.put("apiSrcPath", "./" + toSrcPath(apiPackage, srcBasePath));
+        additionalProperties.put("modelSrcPath", "./" + toSrcPath(modelPackage, srcBasePath));
+        additionalProperties.put("apiTestPath", "./" + testBasePath + "/" + apiDirName);
+        additionalProperties.put("modelTestPath", "./" + testBasePath + "/" + modelDirName);
 
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -276,6 +276,12 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
 
         additionalProperties.put("escapedInvokerPackage", invokerPackage.replace("\\", "\\\\"));
 
+        // make api and model src path available in mustache template
+        additionalProperties.put("apiSrcPath", toPackagePath(apiPackage, srcBasePath));
+        additionalProperties.put("modelSrcPath", toPackagePath(modelPackage, srcBasePath));
+        additionalProperties.put("apiTestPath", getPackagePath() + "/" + testBasePath + "/" + apiDirName);
+        additionalProperties.put("modelTestPath", getPackagePath() + "/" + testBasePath + "/" + modelDirName);
+
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);
         additionalProperties.put("modelDocPath", modelDocPath);
@@ -290,6 +296,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("composer.mustache", getPackagePath(), "composer.json"));
         supportingFiles.add(new SupportingFile("autoload.mustache", getPackagePath(), "autoload.php"));
         supportingFiles.add(new SupportingFile("README.mustache", getPackagePath(), "README.md"));
+        supportingFiles.add(new SupportingFile("phpunit.xml.mustache", getPackagePath(), "phpunit.xml.dist"));
         supportingFiles.add(new SupportingFile(".travis.yml", getPackagePath(), ".travis.yml"));
         supportingFiles.add(new SupportingFile(".php_cs", getPackagePath(), ".php_cs"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", getPackagePath(), "git_push.sh"));

--- a/modules/swagger-codegen/src/main/resources/php/.travis.yml
+++ b/modules/swagger-codegen/src/main/resources/php/.travis.yml
@@ -7,4 +7,4 @@ php:
     - 7.0
     - hhvm
 before_install: "composer install"
-script: "phpunit lib/Tests"
+script: "vendor/bin/phpunit"

--- a/modules/swagger-codegen/src/main/resources/php/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/README.mustache
@@ -56,7 +56,7 @@ To run the unit tests:
 
 ```
 composer install
-./vendor/bin/phpunit lib/Tests
+./vendor/bin/phpunit
 ```
 
 ## Getting Started

--- a/modules/swagger-codegen/src/main/resources/php/phpunit.xml.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/phpunit.xml.mustache
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite>
+            <directory>{{apiTestPath}}</directory>
+            <directory>{{modelTestPath}}</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">{{apiSrcPath}}</directory>
+            <directory suffix=".php">{{modelSrcPath}}</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/samples/client/petstore/php/SwaggerClient-php/.travis.yml
+++ b/samples/client/petstore/php/SwaggerClient-php/.travis.yml
@@ -7,4 +7,4 @@ php:
     - 7.0
     - hhvm
 before_install: "composer install"
-script: "phpunit lib/Tests"
+script: "vendor/bin/phpunit"

--- a/samples/client/petstore/php/SwaggerClient-php/README.md
+++ b/samples/client/petstore/php/SwaggerClient-php/README.md
@@ -45,7 +45,7 @@ To run the unit tests:
 
 ```
 composer install
-./vendor/bin/phpunit lib/Tests
+./vendor/bin/phpunit
 ```
 
 ## Getting Started

--- a/samples/client/petstore/php/SwaggerClient-php/phpunit.xml.dist
+++ b/samples/client/petstore/php/SwaggerClient-php/phpunit.xml.dist
@@ -7,15 +7,15 @@
          stopOnFailure="false">
     <testsuites>
         <testsuite>
-            <directory>SwaggerClient-php/test/Api</directory>
-            <directory>SwaggerClient-php/test/Model</directory>
+            <directory>./test/Api</directory>
+            <directory>./test/Model</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">SwaggerClient-php/lib/Api</directory>
-            <directory suffix=".php">SwaggerClient-php/lib/Model</directory>
+            <directory suffix=".php">./lib/Api</directory>
+            <directory suffix=".php">./lib/Model</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/samples/client/petstore/php/SwaggerClient-php/phpunit.xml.dist
+++ b/samples/client/petstore/php/SwaggerClient-php/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite>
+            <directory>SwaggerClient-php/test/Api</directory>
+            <directory>SwaggerClient-php/test/Model</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">SwaggerClient-php/lib/Api</directory>
+            <directory suffix=".php">SwaggerClient-php/lib/Model</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/samples/client/petstore/php/SwaggerClient-php/pom.xml
+++ b/samples/client/petstore/php/SwaggerClient-php/pom.xml
@@ -47,9 +47,6 @@
                         </goals>
                         <configuration>
                             <executable>vendor/bin/phpunit</executable>
-                            <arguments>
-                                <argument>test</argument>
-                            </arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR fixes the PHPUnit setup in PHP client. The new setup provides a basic [phpunit.xml](https://phpunit.de/manual/4.8/en/appendixes.configuration.html) file which allows for more simple invocation.

Also, `.travis` used a hardcoded path to test folder which is not necessarily valid with directory name config changes.

To verify it works, just run:

    # swagger-codegen as usual

    # install Composer depencencies
    composer install

    # run PHPUnit with predefined config in phpunit.xml.dist
    vendor/bin/phpunit