### PR TITLE
Cgardens nested object regex

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/base_object.mustache
@@ -46,7 +46,7 @@
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
@@ -151,7 +151,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/animal.rb
@@ -150,7 +150,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/animal_farm.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/animal_farm.rb
@@ -129,7 +129,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
@@ -156,7 +156,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
@@ -140,7 +140,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
@@ -140,7 +140,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
@@ -162,7 +162,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/cat.rb
@@ -159,7 +159,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/category.rb
@@ -147,7 +147,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/client.rb
@@ -138,7 +138,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/dog.rb
@@ -159,7 +159,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
@@ -182,7 +182,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -213,7 +213,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -435,7 +435,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
@@ -147,7 +147,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/list.rb
@@ -138,7 +138,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
@@ -172,7 +172,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -158,7 +158,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/model_200_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model_200_response.rb
@@ -147,7 +147,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
@@ -138,7 +138,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/name.rb
@@ -166,7 +166,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
@@ -138,7 +138,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/order.rb
@@ -219,7 +219,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -223,7 +223,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
@@ -147,7 +147,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
@@ -138,7 +138,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/tag.rb
@@ -147,7 +147,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|

--- a/samples/client/petstore/ruby/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/user.rb
@@ -202,7 +202,7 @@ module Petstore
       when /\AArray<(?<inner_type>.+)>\z/
         inner_type = Regexp.last_match[:inner_type]
         value.map { |v| _deserialize(inner_type, v) }
-      when /\AHash<(?<k_type>.+), (?<v_type>.+)>\z/
+      when /\AHash<(?<k_type>.+?), (?<v_type>.+)>\z/
         k_type = Regexp.last_match[:k_type]
         v_type = Regexp.last_match[:v_type]
         {}.tap do |hash|


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run`./bin/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.
- [x] Tests passed locally.

### Description of the PR

This regex causes a NameError in ruby clients when parsing nested anonymous objects.

```
NameError (wrong constant name String, Hash<String)
```

See issue for more details: https://github.com/swagger-api/swagger-codegen/issues/3880



