### PR TITLE
[objc] Remove the custom security policy

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -80,7 +80,6 @@ static NSString * {{classPrefix}}__fileNameForResponse(NSURLResponse *response) 
             @"application/x-www-form-urlencoded": afhttpRequestSerializer,
             @"multipart/form-data": afhttpRequestSerializer
         };
-        self.securityPolicy = [self createSecurityPolicy];
         self.responseSerializer = [AFHTTPResponseSerializer serializer];
     }
     return self;
@@ -350,27 +349,6 @@ static NSString * {{classPrefix}}__fileNameForResponse(NSURLResponse *response) 
 
     *headers = [NSDictionary dictionaryWithDictionary:headersWithAuth];
     *querys = [NSDictionary dictionaryWithDictionary:querysWithAuth];
-}
-
-- (AFSecurityPolicy *) createSecurityPolicy {
-    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
-
-    id<{{classPrefix}}Configuration> config = self.configuration;
-
-    if (config.sslCaCert) {
-        NSData *certData = [NSData dataWithContentsOfFile:config.sslCaCert];
-        [securityPolicy setPinnedCertificates:[NSSet setWithObject:certData]];
-    }
-
-    if (config.verifySSL) {
-        [securityPolicy setAllowInvalidCertificates:NO];
-    }
-    else {
-        [securityPolicy setAllowInvalidCertificates:YES];
-        [securityPolicy setValidatesDomainName:NO];
-    }
-
-    return securityPolicy;
 }
 
 @end

--- a/modules/swagger-codegen/src/main/resources/objc/Configuration-protocol.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/Configuration-protocol.mustache
@@ -54,18 +54,6 @@ static NSString * const k{{classPrefix}}APIVersion = @"{{podVersion}}";
 @property (readonly, nonatomic) BOOL debug;
 
 /**
- * SSL/TLS verification
- * Set this to NO to skip verifying SSL certificate when calling API from https server
- */
-@property (readonly, nonatomic) BOOL verifySSL;
-
-/**
- * SSL/TLS verification
- * Set this to customize the certificate file to verify the peer
- */
-@property (readonly, nonatomic) NSString *sslCaCert;
-
-/**
  * Authentication Settings
  */
 @property (readonly, nonatomic) NSDictionary *authSettings;

--- a/modules/swagger-codegen/src/main/resources/objc/DefaultConfiguration-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/DefaultConfiguration-body.mustache
@@ -32,7 +32,6 @@
         _username = @"";
         _password = @"";
         _accessToken= @"";
-        _verifySSL = YES;
         _mutableApiKey = [NSMutableDictionary dictionary];
         _mutableApiKeyPrefix = [NSMutableDictionary dictionary];
         _mutableDefaultHeaders = [NSMutableDictionary dictionary];

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGApiClient.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGApiClient.m
@@ -80,7 +80,6 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
             @"application/x-www-form-urlencoded": afhttpRequestSerializer,
             @"multipart/form-data": afhttpRequestSerializer
         };
-        self.securityPolicy = [self createSecurityPolicy];
         self.responseSerializer = [AFHTTPResponseSerializer serializer];
     }
     return self;
@@ -350,27 +349,6 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
     *headers = [NSDictionary dictionaryWithDictionary:headersWithAuth];
     *querys = [NSDictionary dictionaryWithDictionary:querysWithAuth];
-}
-
-- (AFSecurityPolicy *) createSecurityPolicy {
-    AFSecurityPolicy *securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
-
-    id<SWGConfiguration> config = self.configuration;
-
-    if (config.sslCaCert) {
-        NSData *certData = [NSData dataWithContentsOfFile:config.sslCaCert];
-        [securityPolicy setPinnedCertificates:[NSSet setWithObject:certData]];
-    }
-
-    if (config.verifySSL) {
-        [securityPolicy setAllowInvalidCertificates:NO];
-    }
-    else {
-        [securityPolicy setAllowInvalidCertificates:YES];
-        [securityPolicy setValidatesDomainName:NO];
-    }
-
-    return securityPolicy;
 }
 
 @end

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGConfiguration.h
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGConfiguration.h
@@ -76,18 +76,6 @@ static NSString * const kSWGAPIVersion = @"1.0.0";
 @property (readonly, nonatomic) BOOL debug;
 
 /**
- * SSL/TLS verification
- * Set this to NO to skip verifying SSL certificate when calling API from https server
- */
-@property (readonly, nonatomic) BOOL verifySSL;
-
-/**
- * SSL/TLS verification
- * Set this to customize the certificate file to verify the peer
- */
-@property (readonly, nonatomic) NSString *sslCaCert;
-
-/**
  * Authentication Settings
  */
 @property (readonly, nonatomic) NSDictionary *authSettings;

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGDefaultConfiguration.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGDefaultConfiguration.m
@@ -32,7 +32,6 @@
         _username = @"";
         _password = @"";
         _accessToken= @"";
-        _verifySSL = YES;
         _mutableApiKey = [NSMutableDictionary dictionary];
         _mutableApiKeyPrefix = [NSMutableDictionary dictionary];
         _mutableDefaultHeaders = [NSMutableDictionary dictionary];


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

There are several issues with the security policy:

* The security policy is created with `AFSSLPinningModeNone` which means that even if pinned certificates are set (if config.sslCaCert is not nil), they will be ignored. Pinning will not work at all with this security policy.

* The configuration wrapper for the security policy is a bad idea.
  * `verifySSL` controls both invalid certificates and domain validation. A vanilla `AFSecurityPolicy` clearly exposes both `allowInvalidCertificates` and `validatesDomainName`.
  * `sslCaCert` only allows for a single pinned certificate. A vanilla `AFSecurityPolicy` clearly exposes a set of pinned certificates and makes it very convenient to load them with either `+[AFSecurityPolicy policyWithPinningMode:]` or `+[AFSecurityPolicy certificatesInBundle:]`

Since the security policy does not work at all and adds confusion, it is better to just remove it and let the user configure a security policy that fits their needs.