### PR TITLE
2208 fix Objc Mapping Generation

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -359,7 +359,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
                         return getSwaggerType(p) + "<NSString*, " + innerTypeDeclaration + "*>*";
                     }
                 }
-                return getSwaggerType(p) + "<NSString*, " + innerTypeDeclaration + ">*";
+                return getSwaggerType(p) + "<" + innerTypeDeclaration + ">*";
             }
         } else {
             String swaggerType = getSwaggerType(p);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/objc/ObjcModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/objc/ObjcModelTest.java
@@ -224,7 +224,7 @@ public class ObjcModelTest {
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
         Assert.assertEquals(property1.complexType, "SWGChildren");
-        Assert.assertEquals(property1.datatype, "NSDictionary<NSString*, SWGChildren>*");
+        Assert.assertEquals(property1.datatype, "NSDictionary<SWGChildren>*");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "NSDictionary");
         Assert.assertEquals(property1.containerType, "map");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

fixes https://github.com/swagger-api/swagger-codegen/issues/2208

Fixes Objective-C generation of maps via additionalProperties, to create a string-to-object map. The JSON Mapping library used by the generated code, JSONModel, see https://github.com/jsonmodel/jsonmodel/issues/341



