### PR TITLE
[WIP] Improve PHP client emitted code quality

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
@@ -31,13 +31,13 @@ namespace {{invokerPackage}};
  */
 class ApiClient
 {
-    public static $PATCH = "PATCH";
-    public static $POST = "POST";
-    public static $GET = "GET";
-    public static $HEAD = "HEAD";
-    public static $OPTIONS = "OPTIONS";
-    public static $PUT = "PUT";
-    public static $DELETE = "DELETE";
+    public static $PATCH = 'PATCH';
+    public static $POST = 'POST';
+    public static $GET = 'GET';
+    public static $HEAD = 'HEAD';
+    public static $OPTIONS = 'OPTIONS';
+    public static $PUT = 'PUT';
+    public static $DELETE = 'DELETE';
 
     /**
      * Configuration
@@ -58,7 +58,7 @@ class ApiClient
      *
      * @param Configuration $config config for this ApiClient
      */
-    public function __construct(\{{invokerPackage}}\Configuration $config = null)
+    public function __construct(Configuration $config = null)
     {
         if ($config === null) {
             $config = Configuration::getDefaultConfiguration();
@@ -91,7 +91,7 @@ class ApiClient
     /**
      * Get API key (with prefix if set)
      *
-     * @param  string $apiKeyIdentifier name of apikey
+     * @param  string $apiKeyIdentifier name of API key
      *
      * @return string API key with the prefix
      */
@@ -100,14 +100,13 @@ class ApiClient
         $prefix = $this->config->getApiKeyPrefix($apiKeyIdentifier);
         $apiKey = $this->config->getApiKey($apiKeyIdentifier);
 
-        if (!isset($apiKey)) {
+        if ($apiKey === null) {
             return null;
         }
 
-        if (isset($prefix)) {
-            $keyWithPrefix = $prefix." ".$apiKey;
-        } else {
-            $keyWithPrefix = $apiKey;
+        $keyWithPrefix = $apiKey;
+        if ($prefix !== null) {
+            $keyWithPrefix = $prefix.' '.$apiKey;
         }
 
         return $keyWithPrefix;
@@ -116,19 +115,24 @@ class ApiClient
     /**
      * Make the HTTP call (Sync)
      *
-     * @param string $resourcePath path to method endpoint
-     * @param string $method       method to call
-     * @param array  $queryParams  parameters to be place in query URL
-     * @param array  $postData     parameters to be placed in POST body
-     * @param array  $headerParams parameters to be place in request header
-     * @param string $responseType expected response type of the endpoint
-     * @param string $endpointPath path to method endpoint before expanding parameters
+     * @param string       $resourcePath path to method endpoint
+     * @param string       $method       method to call
+     * @param array        $queryParams  parameters to be place in query URL
+     * @param array|string $postData     parameters to be placed in POST body
+     * @param array        $headerParams parameters to be place in request header
+     * @param string       $responseType expected response type of the endpoint
      *
-     * @throws \{{invokerPackage}}\ApiException on a non 2xx response
+     * @throws ApiException on a non 2xx response
      * @return mixed
      */
-    public function callApi($resourcePath, $method, $queryParams, $postData, $headerParams, $responseType = null, $endpointPath = null)
-    {
+    public function callApi(
+        $resourcePath,
+        $method,
+        array $queryParams,
+        $postData,
+        array $headerParams,
+        $responseType = null
+    ) {
         $headers = [];
 
         // construct the http header
@@ -142,10 +146,10 @@ class ApiClient
         }
 
         // form data
-        if ($postData and in_array('Content-Type: application/x-www-form-urlencoded', $headers, true)) {
+        if (is_array($postData) && in_array('Content-Type: application/x-www-form-urlencoded', $headers, true)) {
             $postData = http_build_query($postData);
-        } elseif ((is_object($postData) or is_array($postData)) and !in_array('Content-Type: multipart/form-data', $headers, true)) { // json model
-            $postData = json_encode(\{{invokerPackage}}\ObjectSerializer::sanitizeForSerialization($postData));
+        } elseif ((is_object($postData) || is_array($postData)) && !in_array('Content-Type: multipart/form-data', $headers, true)) { // json model
+            $postData = json_encode(ObjectSerializer::sanitizeForSerialization($postData));
         }
 
         $url = $this->config->getHost() . $resourcePath;
@@ -161,12 +165,12 @@ class ApiClient
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 
         // disable SSL verification, if needed
-        if ($this->config->getSSLVerification() === false) {
+        if ($this->config->isSSLVerification() === false) {
             curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
             curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
         }
 
-        if (!empty($queryParams)) {
+        if ($queryParams !== null) {
             $url = ($url . '?' . http_build_query($queryParams));
         }
 
@@ -176,16 +180,16 @@ class ApiClient
         } elseif ($method === self::$HEAD) {
             curl_setopt($curl, CURLOPT_NOBODY, true);
         } elseif ($method === self::$OPTIONS) {
-            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'OPTIONS');
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } elseif ($method === self::$PATCH) {
-            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PATCH");
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PATCH');
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } elseif ($method === self::$PUT) {
-            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "PUT");
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } elseif ($method === self::$DELETE) {
-            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
         } elseif ($method !== self::$GET) {
             throw new ApiException('Method ' . $method . ' is not recognized.');
@@ -196,8 +200,12 @@ class ApiClient
         curl_setopt($curl, CURLOPT_USERAGENT, $this->config->getUserAgent());
 
         // debugging for curl
-        if ($this->config->getDebug()) {
-            error_log("[DEBUG] HTTP Request body  ~BEGIN~".PHP_EOL.print_r($postData, true).PHP_EOL."~END~".PHP_EOL, 3, $this->config->getDebugFile());
+        if ($this->config->isDebug()) {
+            error_log(
+                '[DEBUG] HTTP Request body  ~BEGIN~'.PHP_EOL.print_r($postData, true).PHP_EOL.'~END~'.PHP_EOL,
+                3,
+                $this->config->getDebugFile()
+            );
 
             curl_setopt($curl, CURLOPT_VERBOSE, 1);
             curl_setopt($curl, CURLOPT_STDERR, fopen($this->config->getDebugFile(), 'a'));
@@ -210,55 +218,59 @@ class ApiClient
 
         // Make the request
         $response = curl_exec($curl);
-        $http_header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
-        $http_header = $this->httpParseHeaders(substr($response, 0, $http_header_size));
-        $http_body = substr($response, $http_header_size);
-        $response_info = curl_getinfo($curl);
+        $httpHeaderSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+        $httpHeader = $this->httpParseHeaders(substr($response, 0, $httpHeaderSize));
+        $httpBody = substr($response, $httpHeaderSize);
+        $responseInfo = curl_getinfo($curl);
 
         // debug HTTP response body
-        if ($this->config->getDebug()) {
-            error_log("[DEBUG] HTTP Response body ~BEGIN~".PHP_EOL.print_r($http_body, true).PHP_EOL."~END~".PHP_EOL, 3, $this->config->getDebugFile());
+        if ($this->config->isDebug()) {
+            error_log(
+                '[DEBUG] HTTP Response body ~BEGIN~'.PHP_EOL.print_r($httpBody, true).PHP_EOL.'~END~'.PHP_EOL,
+                3,
+                $this->config->getDebugFile()
+            );
         }
 
         // Handle the response
-        if ($response_info['http_code'] === 0) {
-            $curl_error_message = curl_error($curl);
+        if ($responseInfo['http_code'] === 0) {
+            $curlErrorMessage = curl_error($curl);
 
             // curl_exec can sometimes fail but still return a blank message from curl_error().
-            if (!empty($curl_error_message)) {
-                $error_message = "API call to $url failed: $curl_error_message";
+            if ($curlErrorMessage !== '') {
+                $errorMessage = 'API call to '.$url.' failed: '.$curlErrorMessage;
             } else {
-                $error_message = "API call to $url failed, but for an unknown reason. " .
-                    "This could happen if you are disconnected from the network.";
+                $errorMessage = 'API call to '.$url.' failed, but for an unknown reason. ' .
+                    'This could happen if you are disconnected from the network.';
             }
 
-            $exception = new ApiException($error_message, 0, null, null);
-            $exception->setResponseObject($response_info);
+            $exception = new ApiException($errorMessage, 0, null, null);
+            $exception->setResponseObject($responseInfo);
             throw $exception;
-        } elseif ($response_info['http_code'] >= 200 && $response_info['http_code'] <= 299) {
+        } elseif ($responseInfo['http_code'] >= 200 && $responseInfo['http_code'] <= 299) {
             // return raw body if response is a file
             if ($responseType === '\SplFileObject' || $responseType === 'string') {
-                return [$http_body, $response_info['http_code'], $http_header];
+                return [$httpBody, $responseInfo['http_code'], $httpHeader];
             }
 
-            $data = json_decode($http_body);
+            $data = json_decode($httpBody);
             if (json_last_error() > 0) { // if response is a string
-                $data = $http_body;
+                $data = $httpBody;
             }
         } else {
-            $data = json_decode($http_body);
+            $data = json_decode($httpBody);
             if (json_last_error() > 0) { // if response is a string
-                $data = $http_body;
+                $data = $httpBody;
             }
 
             throw new ApiException(
-                "[".$response_info['http_code']."] Error connecting to the API ($url)",
-                $response_info['http_code'],
-                $http_header,
+                '['.$responseInfo['http_code'].'] Error connecting to the API ('.$url.')',
+                $responseInfo['http_code'],
+                $httpHeader,
                 $data
             );
         }
-        return [$data, $response_info['http_code'], $http_header];
+        return [$data, $responseInfo['http_code'], $httpHeader];
     }
 
     /**
@@ -270,9 +282,9 @@ class ApiClient
      */
     public function selectHeaderAccept($accept)
     {
-        if (count($accept) === 0 or (count($accept) === 1 and $accept[0] === '')) {
+        if (count($accept) === 0 || (count($accept) === 1 && $accept[0] === '')) {
             return null;
-        } elseif (preg_grep("/application\/json/i", $accept)) {
+        } elseif (preg_grep('/application\\/json/i', $accept)) {
             return 'application/json';
         } else {
             return implode(',', $accept);
@@ -282,35 +294,35 @@ class ApiClient
     /**
      * Return the content type based on an array of content-type provided
      *
-     * @param string[] $content_type Array fo content-type
+     * @param string[] $contentType Array for Content-type
      *
      * @return string Content-Type (e.g. application/json)
      */
-    public function selectHeaderContentType($content_type)
+    public function selectHeaderContentType($contentType)
     {
-        if (count($content_type) === 0 or (count($content_type) === 1 and $content_type[0] === '')) {
+        if (count($contentType) === 0 || (count($contentType) === 1 && $contentType[0] === '')) {
             return 'application/json';
-        } elseif (preg_grep("/application\/json/i", $content_type)) {
+        } elseif (preg_grep('/application\\/json/i', $contentType)) {
             return 'application/json';
         } else {
-            return implode(',', $content_type);
+            return implode(',', $contentType);
         }
     }
 
    /**
     * Return an array of HTTP response headers
     *
-    * @param string $raw_headers A string of raw HTTP response headers
+    * @param string $rawHeaders A string of raw HTTP response headers
     *
-    * @return string[] Array of HTTP response heaers
+    * @return string[] Array of HTTP response headers
     */
-    protected function httpParseHeaders($raw_headers)
+    protected function httpParseHeaders($rawHeaders)
     {
         // ref/credit: http://php.net/manual/en/function.http-parse-headers.php#112986
         $headers = [];
         $key = '';
 
-        foreach (explode("\n", $raw_headers) as $h) {
+        foreach (explode("\n", $rawHeaders) as $h) {
             $h = explode(':', $h, 2);
 
             if (isset($h[1])) {
@@ -324,7 +336,7 @@ class ApiClient
 
                 $key = $h[0];
             } else {
-                if (substr($h[0], 0, 1) === "\t") {
+                if (strpos($h[0], "\t") === 0) {
                     $headers[$key] .= "\r\n\t".trim($h[0]);
                 } elseif (!$key) {
                     $headers[0] = trim($h[0]);

--- a/modules/swagger-codegen/src/main/resources/php/ApiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiException.mustache
@@ -62,7 +62,7 @@ class ApiException extends Exception
      * @param string $responseHeaders HTTP response header
      * @param mixed  $responseBody    HTTP body of the server response either as Json or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = null, $responseBody = null)
+    public function __construct($message = '', $code = 0, $responseHeaders = null, $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -90,7 +90,7 @@ class ApiException extends Exception
     }
 
     /**
-     * Sets the deseralized response object (during deserialization)
+     * Sets the deserialized response object (during deserialization)
      *
      * @param mixed $obj Deserialized response object
      *
@@ -102,7 +102,7 @@ class ApiException extends Exception
     }
 
     /**
-     * Gets the deseralized response object (during deserialization)
+     * Gets the deserialized response object (during deserialization)
      *
      * @return mixed the deserialized response object
      */

--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -213,7 +213,7 @@ class ObjectSerializer
         } elseif (substr($class, 0, 4) === 'map[') { // for associative array e.g. map[string,int]
             $inner = substr($class, 4, -1);
             $deserialized = [];
-            if (strrpos($inner, ",") !== false) {
+            if (strrpos($inner, ',') !== false) {
                 $subClass_array = explode(',', $inner, 2);
                 $subClass = $subClass_array[1];
                 foreach ($data as $key => $value) {
@@ -254,9 +254,9 @@ class ObjectSerializer
             } else {
                 $filename = tempnam(Configuration::getDefaultConfiguration()->getTempFolderPath(), '');
             }
-            $deserialized = new \SplFileObject($filename, "w");
+            $deserialized = new \SplFileObject($filename, 'w');
             $byte_written = $deserialized->fwrite($data);
-            if (Configuration::getDefaultConfiguration()->getDebug()) {
+            if (Configuration::getDefaultConfiguration()->isDebug()) {
                 error_log("[DEBUG] Written $byte_written byte to $filename. Please move the file to a proper folder or delete the temp file after processing.".PHP_EOL, 3, Configuration::getDefaultConfiguration()->getDebugFile());
             }
 

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -21,8 +21,6 @@ namespace {{apiPackage}};
 
 use \{{invokerPackage}}\ApiClient;
 use \{{invokerPackage}}\ApiException;
-use \{{invokerPackage}}\Configuration;
-use \{{invokerPackage}}\ObjectSerializer;
 
 /**
  * {{classname}} Class Doc Comment
@@ -38,29 +36,28 @@ use \{{invokerPackage}}\ObjectSerializer;
     /**
      * API Client
      *
-     * @var \{{invokerPackage}}\ApiClient instance of the ApiClient
+     * @var ApiClient instance of the ApiClient
      */
     protected $apiClient;
 
     /**
      * Constructor
      *
-     * @param \{{invokerPackage}}\ApiClient|null $apiClient The api client to use
+     * @param ApiClient|null $apiClient The API client to use
      */
-    public function __construct(\{{invokerPackage}}\ApiClient $apiClient = null)
+    public function __construct(ApiClient $apiClient = null)
     {
         if ($apiClient === null) {
             $apiClient = new ApiClient();
             $apiClient->getConfig()->setHost('{{basePath}}');
         }
-
-        $this->apiClient = $apiClient;
+        $this->setApiClient($apiClient);
     }
 
     /**
      * Get API client
      *
-     * @return \{{invokerPackage}}\ApiClient get the API client
+     * @return ApiClient get the API client
      */
     public function getApiClient()
     {
@@ -70,11 +67,11 @@ use \{{invokerPackage}}\ObjectSerializer;
     /**
      * Set the API client
      *
-     * @param \{{invokerPackage}}\ApiClient $apiClient set the API client
+     * @param ApiClient $apiClient set the API client
      *
      * @return {{classname}}
      */
-    public function setApiClient(\{{invokerPackage}}\ApiClient $apiClient)
+    public function setApiClient(ApiClient $apiClient)
     {
         $this->apiClient = $apiClient;
         return $this;
@@ -115,6 +112,7 @@ use \{{invokerPackage}}\ObjectSerializer;
      * @param {{dataType}} ${{paramName}} {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
      * @return array of {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}null{{/returnType}}, HTTP status code, HTTP response headers (array of strings)
      */
     public function {{operationId}}WithHttpInfo({{#allParams}}${{paramName}}{{^required}} = null{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
@@ -166,7 +164,7 @@ use \{{invokerPackage}}\ObjectSerializer;
         {{/hasValidation}}
         {{/allParams}}
         // parse inputs
-        $resourcePath = "{{path}}";
+        $resourcePath = '{{path}}';
         $httpBody = '';
         $queryParams = [];
         $headerParams = [];
@@ -208,14 +206,14 @@ use \{{invokerPackage}}\ObjectSerializer;
         {{/collectionFormat}}
         if (${{paramName}} !== null) {
             $resourcePath = str_replace(
-                "{" . "{{baseName}}" . "}",
+                '{'.'{{baseName}}'.'}',
                 $this->apiClient->getSerializer()->toPathValue(${{paramName}}),
                 $resourcePath
             );
         }
         {{/pathParams}}
         // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
+        $resourcePath = str_replace('{format}', 'json', $resourcePath);
 
         {{#formParams}}
         // form params
@@ -277,12 +275,11 @@ use \{{invokerPackage}}\ObjectSerializer;
                 $httpBody,
                 $headerParams,
                 {{#returnType}}
-                '{{returnType}}',
+                '{{returnType}}'
                 {{/returnType}}
                 {{^returnType}}
-                null,
+                null
                 {{/returnType}}
-                '{{path}}'
             );
 
             {{#returnType}}

--- a/modules/swagger-codegen/src/main/resources/php/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api_test.mustache
@@ -19,11 +19,6 @@
 
 namespace {{invokerPackage}};
 
-use \{{invokerPackage}}\Configuration;
-use \{{invokerPackage}}\ApiClient;
-use \{{invokerPackage}}\ApiException;
-use \{{invokerPackage}}\ObjectSerializer;
-
 /**
  * {{classname}}Test Class Doc Comment
  *
@@ -35,7 +30,6 @@ use \{{invokerPackage}}\ObjectSerializer;
  */
 {{#operations}}class {{classname}}Test extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * Setup before running any test cases
      */
@@ -73,7 +67,6 @@ use \{{invokerPackage}}\ObjectSerializer;
      * Test case for {{{operationId}}}
      *
      * {{{summary}}}.
-     *
      */
     public function test{{vendorExtensions.x-testOperationId}}()
     {

--- a/modules/swagger-codegen/src/main/resources/php/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/configuration.mustache
@@ -31,7 +31,10 @@ namespace {{invokerPackage}};
  */
 class Configuration
 {
-    private static $defaultConfiguration = null;
+    /**
+     * @var Configuration
+     */
+    private static $defaultConfiguration;
 
     /**
      * Associate array to store API key(s)
@@ -94,7 +97,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = "{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{#artifactVersion}}{{{.}}}{{/artifactVersion}}{{^artifactVersion}}1.0.0{{/artifactVersion}}/php{{/httpUserAgent}}";
+    protected $userAgent = '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{#artifactVersion}}{{{.}}}{{/artifactVersion}}{{^artifactVersion}}1.0.0{{/artifactVersion}}/php{{/httpUserAgent}}';
 
     /**
      * Debug switch (default set to false)
@@ -261,6 +264,7 @@ class Configuration
      * @param string $headerName  header name (e.g. Token)
      * @param string $headerValue header value (e.g. 1z8wp3)
      *
+     * @throws \InvalidArgumentException
      * @return Configuration
      */
     public function addDefaultHeader($headerName, $headerValue)
@@ -293,6 +297,7 @@ class Configuration
     public function deleteDefaultHeader($headerName)
     {
         unset($this->defaultHeaders[$headerName]);
+        return $this;
     }
 
     /**
@@ -323,6 +328,7 @@ class Configuration
      *
      * @param string $userAgent the user agent of the api client
      *
+     * @throws \InvalidArgumentException
      * @return Configuration
      */
     public function setUserAgent($userAgent)
@@ -350,6 +356,7 @@ class Configuration
      *
      * @param integer $seconds Number of seconds before timing out [set to 0 for no timeout]
      *
+     * @throws \InvalidArgumentException
      * @return Configuration
      */
     public function setCurlTimeout($seconds)
@@ -389,6 +396,17 @@ class Configuration
      * Gets the debug flag
      *
      * @return bool
+     */
+    public function isDebug()
+    {
+        return $this->debug;
+    }
+
+    /**
+     * Gets the debug flag
+     *
+     * @return bool
+     * @deprecated
      */
     public function getDebug()
     {
@@ -459,6 +477,17 @@ class Configuration
      *
      * @return boolean True if the certificate should be validated, false otherwise
      */
+    public function isSSLVerification()
+    {
+        return $this->sslVerification;
+    }
+
+    /**
+     * Gets if SSL verification should be enabled or disabled
+     *
+     * @return boolean True if the certificate should be validated, false otherwise
+     * @deprecated
+     */
     public function getSSLVerification()
     {
         return $this->sslVerification;
@@ -479,7 +508,7 @@ class Configuration
     }
 
     /**
-     * Sets the detault configuration instance
+     * Sets the default configuration instance
      *
      * @param Configuration $config An instance of the Configuration Object
      *

--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -23,6 +23,7 @@
 namespace {{modelPackage}};
 
 use \ArrayAccess;
+use \{{invokerPackage}}\ObjectSerializer;
 
 /**
  * {{classname}} Class Doc Comment

--- a/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
@@ -183,7 +183,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}imple
      * validate all the properties in the model
      * return true if all passed
      *
-     * @return bool True if all properteis are valid
+     * @return bool True if all properties are valid
      */
     public function valid()
     {
@@ -365,9 +365,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}imple
     public function __toString()
     {
         if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
-            return json_encode(\{{invokerPackage}}\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+            return json_encode(ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
         }
 
-        return json_encode(\{{invokerPackage}}\ObjectSerializer::sanitizeForSerialization($this));
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This is a fix for #3867 which tries to significantly improve PHP client's code quality using insights offered by PHPStorm's inspections (including built-in inspections, [EA Extended](https://plugins.jetbrains.com/plugin/7622?pr=idea),  [PHP Mess Detector](https://phpmd.org/), [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), etc).

WIP