### PR TITLE
Add a new cli command to output version information (2nd attempt) #3892

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out/
 *.iws
 classpath.txt
 version.properties
+!modules/swagger-codegen-cli/src/main/resources/version.properties
 .project
 .classpath
 lib/*

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ packages/
 
 /target
 /generated-files
-/nbactions.xml
+nbactions.xml
 
 # scalatra
 samples/server-generator/scalatra/output

--- a/modules/swagger-codegen-cli/pom.xml
+++ b/modules/swagger-codegen-cli/pom.xml
@@ -18,6 +18,7 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
+                <filtering>true</filtering>
                 <excludes>
                     <exclude>logback.xml</exclude>
                 </excludes>

--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/SwaggerCodegen.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/SwaggerCodegen.java
@@ -6,6 +6,7 @@ import io.swagger.codegen.cmd.ConfigHelp;
 import io.swagger.codegen.cmd.Generate;
 import io.swagger.codegen.cmd.Langs;
 import io.swagger.codegen.cmd.Meta;
+import io.swagger.codegen.cmd.Version;
 
 /**
  * User: lanwen
@@ -21,16 +22,20 @@ public class SwaggerCodegen {
 
 
     public static void main(String[] args) {
+        String version = Version.readVersionFromResources();
         @SuppressWarnings("unchecked")
         Cli.CliBuilder<Runnable> builder = Cli.<Runnable>builder("swagger-codegen-cli")
-                .withDescription("Swagger code generator CLI. More info on swagger.io")
+                .withDescription(String.format(
+                        "Swagger code generator CLI (version %s). More info on swagger.io",
+                        version))
                 .withDefaultCommand(Langs.class)
                 .withCommands(
                         Generate.class,
                         Meta.class,
                         Langs.class,
                         Help.class,
-                        ConfigHelp.class
+                        ConfigHelp.class,
+                        Version.class
                 );
 
         builder.build().parse(args).run();

--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Meta.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Meta.java
@@ -68,12 +68,8 @@ public class Meta implements Runnable {
                         "src/main/resources/META-INF/services", "io.swagger.codegen.CodegenConfig")
         );
 
-        String swaggerVersion = this.getClass().getPackage().getImplementationVersion();
-        // if the code is running outside of the jar (i.e. from the IDE), it will not have the version available.
-        // let's default it with something.
-        if (swaggerVersion==null) {
-            swaggerVersion = "2.1.3";
-        }
+        String swaggerVersion = Version.readVersionFromResources();
+
         Map<String, Object> data = new ImmutableMap.Builder<String, Object>()
                 .put("generatorPackage", targetPackage)
                 .put("generatorClass", mainClass)

--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Version.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Version.java
@@ -1,0 +1,45 @@
+package io.swagger.codegen.cmd;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import io.airlift.airline.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Command(name = "version", description = "Show version information")
+public class Version implements Runnable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Meta.class);
+
+    private static final String VERSION_PLACEHOLDER = "${project.version}";
+
+    private static final String UNREADABLE_VERSION = "unset";
+    private static final String UNSET_VERSION = "unset";
+    private static final String UNKNOWN_VERSION = "unknown";
+
+    public static String readVersionFromResources() {
+        Properties versionProperties = new Properties();
+        try (InputStream is = Version.class.getResourceAsStream("/version.properties")) {
+            versionProperties.load(is);
+        } catch (IOException ex) {
+            LOGGER.error("Error loading version properties", ex);
+            return UNREADABLE_VERSION;
+        }
+
+        String version = versionProperties.getProperty("version", UNKNOWN_VERSION).trim();
+        if (VERSION_PLACEHOLDER.equals(version)) {
+            return UNSET_VERSION;
+        } else {
+            return version;
+        }
+    }
+
+    @Override
+    public void run() {
+        String version = readVersionFromResources();
+        System.out.println(version);
+    }
+
+}

--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Version.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Version.java
@@ -15,7 +15,7 @@ public class Version implements Runnable {
 
     private static final String VERSION_PLACEHOLDER = "${project.version}";
 
-    private static final String UNREADABLE_VERSION = "unset";
+    private static final String UNREADABLE_VERSION = "unreadable";
     private static final String UNSET_VERSION = "unset";
     private static final String UNKNOWN_VERSION = "unknown";
 

--- a/modules/swagger-codegen-cli/src/main/resources/version.properties
+++ b/modules/swagger-codegen-cli/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version = ${project.version}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(Second PR, after fixing issues with my account email references)

This is as per discussed in #3007. I am using maven resources filtering support to generate a resource file with the ${project.version} stamped on it.

Please note when running (from example from an IDE) from a non-maven env. this will lead to the 
version be the literal `unset` string.

