### PR TITLE
[aspnet5] Fix basePath application to operations

### DIFF
--- a/modules/swagger-codegen/src/main/resources/aspnet5/controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnet5/controller.mustache
@@ -16,9 +16,8 @@ namespace {{packageName}}.Controllers
 { {{#operations}}
     /// <summary>
     /// {{description}}
-    /// </summary>{{#description}}{{#basePath}}
-    [Route("{{{basePath}}}")]
-    {{/basePath}}[Description("{{description}}")]{{/description}}
+    /// </summary>{{#description}}
+    [Description("{{description}}")]{{/description}}
     public class {{classname}}Controller : Controller
     { {{#operation}}
 
@@ -29,7 +28,7 @@ namespace {{packageName}}.Controllers
         /// <param name="{{paramName}}">{{description}}</param>{{/allParams}}{{#responses}}
         /// <response code="{{code}}">{{message}}</response>{{/responses}}
         [{{httpMethod}}]
-        [Route("{{path}}")]
+        [Route("{{basePathWithoutHost}}{{path}}")]
         [SwaggerOperation("{{operationId}}")]{{#returnType}}
         [SwaggerResponse(200, type: typeof({{&returnType}}))]{{/returnType}}
         public virtual {{#returnType}}IActionResult{{/returnType}}{{^returnType}}void{{/returnType}} {{operationId}}({{#allParams}}{{>pathParam}}{{>queryParam}}{{>bodyParam}}{{>formParam}}{{>headerParam}}{{#hasMore}}, {{/hasMore}}{{/allParams}})

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace IO.Swagger.Controllers
         /// <param name="body">Pet object that needs to be added to the store</param>
         /// <response code="405">Invalid input</response>
         [HttpPost]
-        [Route("/pet")]
+        [Route("/v2/pet")]
         [SwaggerOperation("AddPet")]
         public virtual void AddPet([FromBody]Pet body)
         { 
@@ -64,7 +64,7 @@ namespace IO.Swagger.Controllers
         /// <param name="apiKey"></param>
         /// <response code="400">Invalid pet value</response>
         [HttpDelete]
-        [Route("/pet/{petId}")]
+        [Route("/v2/pet/{petId}")]
         [SwaggerOperation("DeletePet")]
         public virtual void DeletePet([FromRoute]long? petId, [FromHeader]string apiKey)
         { 
@@ -80,7 +80,7 @@ namespace IO.Swagger.Controllers
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid status value</response>
         [HttpGet]
-        [Route("/pet/findByStatus")]
+        [Route("/v2/pet/findByStatus")]
         [SwaggerOperation("FindPetsByStatus")]
         [SwaggerResponse(200, type: typeof(List<Pet>))]
         public virtual IActionResult FindPetsByStatus([FromQuery]List<string> status)
@@ -102,7 +102,7 @@ namespace IO.Swagger.Controllers
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid tag value</response>
         [HttpGet]
-        [Route("/pet/findByTags")]
+        [Route("/v2/pet/findByTags")]
         [SwaggerOperation("FindPetsByTags")]
         [SwaggerResponse(200, type: typeof(List<Pet>))]
         public virtual IActionResult FindPetsByTags([FromQuery]List<string> tags)
@@ -125,7 +125,7 @@ namespace IO.Swagger.Controllers
         /// <response code="400">Invalid ID supplied</response>
         /// <response code="404">Pet not found</response>
         [HttpGet]
-        [Route("/pet/{petId}")]
+        [Route("/v2/pet/{petId}")]
         [SwaggerOperation("GetPetById")]
         [SwaggerResponse(200, type: typeof(Pet))]
         public virtual IActionResult GetPetById([FromRoute]long? petId)
@@ -148,7 +148,7 @@ namespace IO.Swagger.Controllers
         /// <response code="404">Pet not found</response>
         /// <response code="405">Validation exception</response>
         [HttpPut]
-        [Route("/pet")]
+        [Route("/v2/pet")]
         [SwaggerOperation("UpdatePet")]
         public virtual void UpdatePet([FromBody]Pet body)
         { 
@@ -165,7 +165,7 @@ namespace IO.Swagger.Controllers
         /// <param name="status">Updated status of the pet</param>
         /// <response code="405">Invalid input</response>
         [HttpPost]
-        [Route("/pet/{petId}")]
+        [Route("/v2/pet/{petId}")]
         [SwaggerOperation("UpdatePetWithForm")]
         public virtual void UpdatePetWithForm([FromRoute]long? petId, [FromForm]string name, [FromForm]string status)
         { 
@@ -182,7 +182,7 @@ namespace IO.Swagger.Controllers
         /// <param name="file">file to upload</param>
         /// <response code="200">successful operation</response>
         [HttpPost]
-        [Route("/pet/{petId}/uploadImage")]
+        [Route("/v2/pet/{petId}/uploadImage")]
         [SwaggerOperation("UploadFile")]
         [SwaggerResponse(200, type: typeof(ApiResponse))]
         public virtual IActionResult UploadFile([FromRoute]long? petId, [FromForm]string additionalMetadata, [FromForm]System.IO.Stream file)

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Controllers/StoreApi.cs
@@ -49,7 +49,7 @@ namespace IO.Swagger.Controllers
         /// <response code="400">Invalid ID supplied</response>
         /// <response code="404">Order not found</response>
         [HttpDelete]
-        [Route("/store/order/{orderId}")]
+        [Route("/v2/store/order/{orderId}")]
         [SwaggerOperation("DeleteOrder")]
         public virtual void DeleteOrder([FromRoute]string orderId)
         { 
@@ -63,7 +63,7 @@ namespace IO.Swagger.Controllers
         /// <remarks>Returns a map of status codes to quantities</remarks>
         /// <response code="200">successful operation</response>
         [HttpGet]
-        [Route("/store/inventory")]
+        [Route("/v2/store/inventory")]
         [SwaggerOperation("GetInventory")]
         [SwaggerResponse(200, type: typeof(Dictionary<string, int?>))]
         public virtual IActionResult GetInventory()
@@ -86,7 +86,7 @@ namespace IO.Swagger.Controllers
         /// <response code="400">Invalid ID supplied</response>
         /// <response code="404">Order not found</response>
         [HttpGet]
-        [Route("/store/order/{orderId}")]
+        [Route("/v2/store/order/{orderId}")]
         [SwaggerOperation("GetOrderById")]
         [SwaggerResponse(200, type: typeof(Order))]
         public virtual IActionResult GetOrderById([FromRoute]long? orderId)
@@ -108,7 +108,7 @@ namespace IO.Swagger.Controllers
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid Order</response>
         [HttpPost]
-        [Route("/store/order")]
+        [Route("/v2/store/order")]
         [SwaggerOperation("PlaceOrder")]
         [SwaggerResponse(200, type: typeof(Order))]
         public virtual IActionResult PlaceOrder([FromBody]Order body)

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Controllers/UserApi.cs
@@ -48,7 +48,7 @@ namespace IO.Swagger.Controllers
         /// <param name="body">Created user object</param>
         /// <response code="0">successful operation</response>
         [HttpPost]
-        [Route("/user")]
+        [Route("/v2/user")]
         [SwaggerOperation("CreateUser")]
         public virtual void CreateUser([FromBody]User body)
         { 
@@ -63,7 +63,7 @@ namespace IO.Swagger.Controllers
         /// <param name="body">List of user object</param>
         /// <response code="0">successful operation</response>
         [HttpPost]
-        [Route("/user/createWithArray")]
+        [Route("/v2/user/createWithArray")]
         [SwaggerOperation("CreateUsersWithArrayInput")]
         public virtual void CreateUsersWithArrayInput([FromBody]List<User> body)
         { 
@@ -78,7 +78,7 @@ namespace IO.Swagger.Controllers
         /// <param name="body">List of user object</param>
         /// <response code="0">successful operation</response>
         [HttpPost]
-        [Route("/user/createWithList")]
+        [Route("/v2/user/createWithList")]
         [SwaggerOperation("CreateUsersWithListInput")]
         public virtual void CreateUsersWithListInput([FromBody]List<User> body)
         { 
@@ -94,7 +94,7 @@ namespace IO.Swagger.Controllers
         /// <response code="400">Invalid username supplied</response>
         /// <response code="404">User not found</response>
         [HttpDelete]
-        [Route("/user/{username}")]
+        [Route("/v2/user/{username}")]
         [SwaggerOperation("DeleteUser")]
         public virtual void DeleteUser([FromRoute]string username)
         { 
@@ -111,7 +111,7 @@ namespace IO.Swagger.Controllers
         /// <response code="400">Invalid username supplied</response>
         /// <response code="404">User not found</response>
         [HttpGet]
-        [Route("/user/{username}")]
+        [Route("/v2/user/{username}")]
         [SwaggerOperation("GetUserByName")]
         [SwaggerResponse(200, type: typeof(User))]
         public virtual IActionResult GetUserByName([FromRoute]string username)
@@ -134,7 +134,7 @@ namespace IO.Swagger.Controllers
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid username/password supplied</response>
         [HttpGet]
-        [Route("/user/login")]
+        [Route("/v2/user/login")]
         [SwaggerOperation("LoginUser")]
         [SwaggerResponse(200, type: typeof(string))]
         public virtual IActionResult LoginUser([FromQuery]string username, [FromQuery]string password)
@@ -154,7 +154,7 @@ namespace IO.Swagger.Controllers
         /// <remarks></remarks>
         /// <response code="0">successful operation</response>
         [HttpGet]
-        [Route("/user/logout")]
+        [Route("/v2/user/logout")]
         [SwaggerOperation("LogoutUser")]
         public virtual void LogoutUser()
         { 
@@ -171,7 +171,7 @@ namespace IO.Swagger.Controllers
         /// <response code="400">Invalid user supplied</response>
         /// <response code="404">User not found</response>
         [HttpPut]
-        [Route("/user/{username}")]
+        [Route("/v2/user/{username}")]
         [SwaggerOperation("UpdateUser")]
         public virtual void UpdateUser([FromRoute]string username, [FromBody]User body)
         { 

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/ApiResponse.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/ApiResponse.cs
@@ -33,7 +33,7 @@ using Newtonsoft.Json;
 namespace IO.Swagger.Models
 {
     /// <summary>
-    /// 
+    /// Describes the result of uploading an image resource
     /// </summary>
     [DataContract]
     public partial class ApiResponse :  IEquatable<ApiResponse>

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Category.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Category.cs
@@ -33,7 +33,7 @@ using Newtonsoft.Json;
 namespace IO.Swagger.Models
 {
     /// <summary>
-    /// 
+    /// A category for a pet
     /// </summary>
     [DataContract]
     public partial class Category :  IEquatable<Category>

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Order.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Order.cs
@@ -33,7 +33,7 @@ using Newtonsoft.Json;
 namespace IO.Swagger.Models
 {
     /// <summary>
-    /// 
+    /// An order for a pets from the pet store
     /// </summary>
     [DataContract]
     public partial class Order :  IEquatable<Order>

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Pet.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Pet.cs
@@ -33,7 +33,7 @@ using Newtonsoft.Json;
 namespace IO.Swagger.Models
 {
     /// <summary>
-    /// 
+    /// A pet for sale in the pet store
     /// </summary>
     [DataContract]
     public partial class Pet :  IEquatable<Pet>

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Tag.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/Tag.cs
@@ -33,7 +33,7 @@ using Newtonsoft.Json;
 namespace IO.Swagger.Models
 {
     /// <summary>
-    /// 
+    /// A tag for a pet
     /// </summary>
     [DataContract]
     public partial class Tag :  IEquatable<Tag>

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Models/User.cs
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Models/User.cs
@@ -33,7 +33,7 @@ using Newtonsoft.Json;
 namespace IO.Swagger.Models
 {
     /// <summary>
-    /// 
+    /// A User who is purchasing from the pet store
     /// </summary>
     [DataContract]
     public partial class User :  IEquatable<User>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This applies `basePath` to operations in aspnet5 generator. Previously, it assumed `basePath` could be applied globally (e.g. `additionalProperties`) rather than per-operation.

This PR moves `basePath` from the class definition's `RouteAttribute` to the existing operation route definition.


