### PR TITLE
[Python][Flask] fix python flask controller issue without tag

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -145,10 +145,6 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
         }
 
         if(!new java.io.File(controllerPackage + File.separator + defaultController + ".py").exists()) {
-            //supportingFiles.add(new SupportingFile("controller.mustache",
-            //                controllerPackage,
-            //                defaultController + ".py")
-            //);
             supportingFiles.add(new SupportingFile("__init__.mustache",
                             controllerPackage,
                             "__init__.py")
@@ -269,7 +265,7 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
                         }
                         else {
                             // no tag found, use "default_controller" as the default
-                            String tag = "default_controller";
+                            String tag = "default";
                             operation.setTags(Arrays.asList(tag));
                             controllerName = tag + "_controller";
                         }

--- a/samples/server/petstore/flaskConnexion/swagger/swagger.yaml
+++ b/samples/server/petstore/flaskConnexion/swagger/swagger.yaml
@@ -644,6 +644,8 @@ definitions:
       complete:
         type: "boolean"
         default: false
+    title: "Pet Order"
+    description: "An order for a pets from the pet store"
     xml:
       name: "Order"
   Category:
@@ -654,6 +656,8 @@ definitions:
         format: "int64"
       name:
         type: "string"
+    title: "Pet catehgry"
+    description: "A category for a pet"
     xml:
       name: "Category"
   User:
@@ -678,6 +682,8 @@ definitions:
         type: "integer"
         format: "int32"
         description: "User Status"
+    title: "a User"
+    description: "A User who is purchasing from the pet store"
     xml:
       name: "User"
   Tag:
@@ -688,6 +694,8 @@ definitions:
         format: "int64"
       name:
         type: "string"
+    title: "Pet Tag"
+    description: "A tag for a pet"
     xml:
       name: "Tag"
   Pet:
@@ -725,6 +733,8 @@ definitions:
         - "available"
         - "pending"
         - "sold"
+    title: "a Pet"
+    description: "A pet for sale in the pet store"
     xml:
       name: "Pet"
   ApiResponse:
@@ -737,6 +747,8 @@ definitions:
         type: "string"
       message:
         type: "string"
+    title: "An uploaded response"
+    description: "Describes the result of uploading an image resource"
 externalDocs:
   description: "Find out more about Swagger"
   url: "http://swagger.io"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

If no tag is provided, python flask generator produces incorrect controller (default_controller_controller.py), which is fixed by this PR by generating `default_controller.py` instead.

Ref: https://github.com/swagger-api/swagger-codegen/issues/3786
