### PR TITLE
[Java][jersey1] add Java6 support to Java (jersey1) API client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -15,6 +15,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
 
     public static final String USE_RX_JAVA = "useRxJava";
     public static final String PARCELABLE_MODEL = "parcelableModel";
+    public static final String SUPPORT_JAVA6 = "supportJava6";
 
     public static final String RETROFIT_1 = "retrofit";
     public static final String RETROFIT_2 = "retrofit2";
@@ -22,6 +23,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
     protected String gradleWrapperPackage = "gradle.wrapper";
     protected boolean useRxJava = false;
     protected boolean parcelableModel = false;
+    protected boolean supportJava6= false;
 
     public JavaClientCodegen() {
         super();
@@ -34,8 +36,9 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
 
         cliOptions.add(CliOption.newBoolean(USE_RX_JAVA, "Whether to use the RxJava adapter with the retrofit2 library."));
         cliOptions.add(CliOption.newBoolean(PARCELABLE_MODEL, "Whether to generate models for Android that implement Parcelable with the okhttp-gson library."));
+        cliOptions.add(CliOption.newBoolean(SUPPORT_JAVA6, "Whether to support Java6 with the Jersey1 library. (Default: false)"));
 
-        supportedLibraries.put("jersey1", "HTTP client: Jersey client 1.19.1. JSON processing: Jackson 2.7.0");
+        supportedLibraries.put("jersey1", "HTTP client: Jersey client 1.19.1. JSON processing: Jackson 2.7.0. Enable Java6 support using '-DsupportJava6=true'.");
         supportedLibraries.put("feign", "HTTP client: Netflix Feign 8.16.0. JSON processing: Jackson 2.7.0");
         supportedLibraries.put("jersey2", "HTTP client: Jersey client 2.22.2. JSON processing: Jackson 2.7.0");
         supportedLibraries.put("okhttp-gson", "HTTP client: OkHttp 2.7.5. JSON processing: Gson 2.6.2. Enable Parcelable modles on Android using '-DparcelableModel=true'");
@@ -44,9 +47,9 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
 
         CliOption libraryOption = new CliOption(CodegenConstants.LIBRARY, "library template (sub-template) to use");
         libraryOption.setEnum(supportedLibraries);
+        // set okhttp-gson as the default
         libraryOption.setDefault("okhttp-gson");
         cliOptions.add(libraryOption);
-
         setLibrary("okhttp-gson");
 
     }
@@ -79,6 +82,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
         // put the boolean value back to PARCELABLE_MODEL in additionalProperties
         additionalProperties.put(PARCELABLE_MODEL, parcelableModel);
 
+        if (additionalProperties.containsKey(SUPPORT_JAVA6)) {
+            this.setSupportJava6(Boolean.valueOf(additionalProperties.get(SUPPORT_JAVA6).toString()));
+        }
+
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
         final String authFolder = (sourceFolder + '/' + invokerPackage + ".auth").replace(".", "/");
 
@@ -97,11 +104,11 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
         supportingFiles.add(new SupportingFile("auth/ApiKeyAuth.mustache", authFolder, "ApiKeyAuth.java"));
         supportingFiles.add(new SupportingFile("auth/OAuth.mustache", authFolder, "OAuth.java"));
         supportingFiles.add(new SupportingFile("auth/OAuthFlow.mustache", authFolder, "OAuthFlow.java"));
-        supportingFiles.add( new SupportingFile( "gradlew.mustache", "", "gradlew") );
-        supportingFiles.add( new SupportingFile( "gradlew.bat.mustache", "", "gradlew.bat") );
-        supportingFiles.add( new SupportingFile( "gradle-wrapper.properties.mustache",
+        supportingFiles.add(new SupportingFile( "gradlew.mustache", "", "gradlew") );
+        supportingFiles.add(new SupportingFile( "gradlew.bat.mustache", "", "gradlew.bat") );
+        supportingFiles.add(new SupportingFile( "gradle-wrapper.properties.mustache",
                 gradleWrapperPackage.replace( ".", File.separator ), "gradle-wrapper.properties") );
-        supportingFiles.add( new SupportingFile( "gradle-wrapper.jar",
+        supportingFiles.add(new SupportingFile( "gradle-wrapper.jar",
                 gradleWrapperPackage.replace( ".", File.separator ), "gradle-wrapper.jar") );
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
@@ -232,4 +239,9 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
     public void setParcelableModel(boolean parcelableModel) {
         this.parcelableModel = parcelableModel;
     }
+
+    public void setSupportJava6(boolean value) {
+        this.supportJava6 = value;
+    }
+
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -85,6 +85,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen {
         if (additionalProperties.containsKey(SUPPORT_JAVA6)) {
             this.setSupportJava6(Boolean.valueOf(additionalProperties.get(SUPPORT_JAVA6).toString()));
         }
+        additionalProperties.put(SUPPORT_JAVA6, supportJava6);
 
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
         final String authFolder = (sourceFolder + '/' + invokerPackage + ".auth").replace(".", "/");

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -79,6 +79,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 
   {{/vars}}
 
+{{^supportJava6}}
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -99,6 +100,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
   }
 
+{{/supportJava6}}
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaClientOptionsTest.java
@@ -56,6 +56,8 @@ public class JavaClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setFullJavaUtil(Boolean.valueOf(JavaOptionsProvider.FULL_JAVA_UTIL_VALUE));
             times = 1;
+            //clientCodegen.setSupportJava6(Boolean.valueOf(JavaOptionsProvider.SUPPORT_JAVA6));
+            //times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaClientOptionsProvider.java
@@ -17,6 +17,7 @@ public class JavaClientOptionsProvider extends JavaOptionsProvider {
         options.put(CodegenConstants.LIBRARY, DEFAULT_LIBRARY_VALUE);
         options.put(JavaClientCodegen.USE_RX_JAVA, "false");
         options.put(JavaClientCodegen.PARCELABLE_MODEL, "false");
+        options.put(JavaClientCodegen.SUPPORT_JAVA6, "false");
 
         return options;
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
@@ -19,6 +19,7 @@ public class JavaOptionsProvider implements OptionsProvider {
     public static final String SERIALIZABLE_MODEL_VALUE = "false";
     public static final String FULL_JAVA_UTIL_VALUE = "true";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
+    //public static final String SUPPORT_JAVA6 = "true";
 
     private ImmutableMap<String, String> options;
 
@@ -42,6 +43,7 @@ public class JavaOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING, "true")
                 .put(JavaClientCodegen.DATE_LIBRARY, "joda")
                 .put("hideGenerationTimestamp", "true")
+                //.put("supportJava6", "true")
                 .build();
     }
 
@@ -49,7 +51,7 @@ public class JavaOptionsProvider implements OptionsProvider {
      * Use the default options, but override the ones found in additionalOptions.
      */
     public JavaOptionsProvider(Map<String, String> additionalOptions) {
-        options = new ImmutableMap.Builder<String, String>()
+         options = new ImmutableMap.Builder<String, String>()
                 .putAll(options)
                 .putAll(additionalOptions)
                 .build();


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add `supportJava6` flag to remove equals and hashCode methods in the model as these methods are not compatible with Java6.

