### PR TITLE
required tag is used in model, allows null values

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -90,7 +90,7 @@ class {{classname}}(object):
 {{^isEnum}}
 {{#hasValidation}}
 {{#required}}
-        if not {{name}}:
+        if {{name}} is None:
             raise ValueError("Invalid value for `{{name}}`, must not be `None`")
 {{/required}}
 {{#maxLength}}

--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -66,7 +66,7 @@ class {{classname}}(object):
         if not set({{{name}}}).issubset(set(allowed_values)):
             raise ValueError(
                 "Invalid values for `{{{name}}}` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set({{{name}}})-set(allowed_values))), 
+                .format(", ".join(map(str, set({{{name}}})-set(allowed_values))),
                         ", ".join(map(str, allowed_values)))
             )
 {{/isListContainer}}
@@ -74,7 +74,7 @@ class {{classname}}(object):
         if not set({{{name}}}.keys()).issubset(set(allowed_values)):
             raise ValueError(
                 "Invalid keys in `{{{name}}}` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set({{{name}}}.keys())-set(allowed_values))), 
+                .format(", ".join(map(str, set({{{name}}}.keys())-set(allowed_values))),
                         ", ".join(map(str, allowed_values)))
             )
 {{/isMapContainer}}
@@ -89,9 +89,10 @@ class {{classname}}(object):
 {{/isEnum}}
 {{^isEnum}}
 {{#hasValidation}}
-
+{{#required}}
         if not {{name}}:
             raise ValueError("Invalid value for `{{name}}`, must not be `None`")
+{{/required}}
 {{#maxLength}}
         if len({{name}}) > {{maxLength}}:
             raise ValueError("Invalid value for `{{name}}`, length must be less than or equal to `{{maxLength}}`")

--- a/samples/client/petstore/python/petstore_api/models/enum_arrays.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_arrays.py
@@ -108,7 +108,7 @@ class EnumArrays(object):
         if not set(array_enum).issubset(set(allowed_values)):
             raise ValueError(
                 "Invalid values for `array_enum` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set(array_enum)-set(allowed_values))), 
+                .format(", ".join(map(str, set(array_enum)-set(allowed_values))),
                         ", ".join(map(str, allowed_values)))
             )
 

--- a/samples/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python/petstore_api/models/format_test.py
@@ -108,9 +108,6 @@ class FormatTest(object):
         :param integer: The integer of this FormatTest.
         :type: int
         """
-
-        if not integer:
-            raise ValueError("Invalid value for `integer`, must not be `None`")
         if integer > 100.0:
             raise ValueError("Invalid value for `integer`, must be a value less than or equal to `100.0`")
         if integer < 10.0:
@@ -138,9 +135,6 @@ class FormatTest(object):
         :param int32: The int32 of this FormatTest.
         :type: int
         """
-
-        if not int32:
-            raise ValueError("Invalid value for `int32`, must not be `None`")
         if int32 > 200.0:
             raise ValueError("Invalid value for `int32`, must be a value less than or equal to `200.0`")
         if int32 < 20.0:
@@ -191,7 +185,6 @@ class FormatTest(object):
         :param number: The number of this FormatTest.
         :type: float
         """
-
         if not number:
             raise ValueError("Invalid value for `number`, must not be `None`")
         if number > 543.2:
@@ -221,9 +214,6 @@ class FormatTest(object):
         :param float: The float of this FormatTest.
         :type: float
         """
-
-        if not float:
-            raise ValueError("Invalid value for `float`, must not be `None`")
         if float > 987.6:
             raise ValueError("Invalid value for `float`, must be a value less than or equal to `987.6`")
         if float < 54.3:
@@ -251,9 +241,6 @@ class FormatTest(object):
         :param double: The double of this FormatTest.
         :type: float
         """
-
-        if not double:
-            raise ValueError("Invalid value for `double`, must not be `None`")
         if double > 123.4:
             raise ValueError("Invalid value for `double`, must be a value less than or equal to `123.4`")
         if double < 67.8:
@@ -281,9 +268,6 @@ class FormatTest(object):
         :param string: The string of this FormatTest.
         :type: str
         """
-
-        if not string:
-            raise ValueError("Invalid value for `string`, must not be `None`")
         if not re.search('[a-z]', string, flags=re.IGNORECASE):
             raise ValueError("Invalid value for `string`, must be a follow pattern or equal to `/[a-z]/i`")
 
@@ -424,7 +408,6 @@ class FormatTest(object):
         :param password: The password of this FormatTest.
         :type: str
         """
-
         if not password:
             raise ValueError("Invalid value for `password`, must not be `None`")
         if len(password) > 64:

--- a/samples/client/petstore/python/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python/petstore_api/models/map_test.py
@@ -102,7 +102,7 @@ class MapTest(object):
         if not set(map_of_enum_string.keys()).issubset(set(allowed_values)):
             raise ValueError(
                 "Invalid keys in `map_of_enum_string` [{0}], must be a subset of [{1}]"
-                .format(", ".join(map(str, set(map_of_enum_string.keys())-set(allowed_values))), 
+                .format(", ".join(map(str, set(map_of_enum_string.keys())-set(allowed_values))),
                         ", ".join(map(str, allowed_values)))
             )
 

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -158,7 +158,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is provided
                 # in serialized form
-                elif isinstance(body, basestring):
+                elif isinstance(body, str):
                     request_body = body
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -91,7 +91,8 @@ opts = {
   binary: "B", # String | None
   date: Date.parse("2013-10-20"), # Date | None
   date_time: DateTime.parse("2013-10-20T19:20:30+01:00"), # DateTime | None
-  password: "password_example" # String | None
+  password: "password_example", # String | None
+  callback: "callback_example" # String | None
 }
 
 begin
@@ -119,6 +120,7 @@ Name | Type | Description  | Notes
  **date** | **Date**| None | [optional] 
  **date_time** | **DateTime**| None | [optional] 
  **password** | **String**| None | [optional] 
+ **callback** | **String**| None | [optional] 
 
 ### Return type
 

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -104,6 +104,7 @@ module Petstore
     # @option opts [Date] :date None
     # @option opts [DateTime] :date_time None
     # @option opts [String] :password None
+    # @option opts [String] :callback None
     # @return [nil]
     def test_endpoint_parameters(number, double, pattern_without_delimiter, byte, opts = {})
       test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, opts)
@@ -126,6 +127,7 @@ module Petstore
     # @option opts [Date] :date None
     # @option opts [DateTime] :date_time None
     # @option opts [String] :password None
+    # @option opts [String] :callback None
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, opts = {})
       if @api_client.config.debugging
@@ -223,6 +225,7 @@ module Petstore
       form_params["date"] = opts[:'date'] if !opts[:'date'].nil?
       form_params["dateTime"] = opts[:'date_time'] if !opts[:'date_time'].nil?
       form_params["password"] = opts[:'password'] if !opts[:'password'].nil?
+      form_params["callback"] = opts[:'callback'] if !opts[:'callback'].nil?
 
       # http body (model)
       post_body = nil


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Swagger ignores 'required' tag in model.mustache in python.
The setter function for these properties does not allow null values, unlike ruby and other languages

Issue: https://github.com/swagger-api/swagger-codegen/issues/3922


