### PR TITLE
Update JavaJaxRS/resteasy/api.mustache to have swagger annotations

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/api.mustache
@@ -21,6 +21,7 @@ import javax.ws.rs.*;
 @Path("/{{baseName}}")
 {{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}
 {{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
+@io.swagger.annotations.Api(description = "the {{baseName}} API")
 {{>generatedAnnotation}}
 {{#operations}}
 public class {{classname}}  {
@@ -31,6 +32,16 @@ public class {{classname}}  {
     {{#subresourceOperation}}@Path("{{path}}"){{/subresourceOperation}}
     {{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}
     {{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
+    @io.swagger.annotations.ApiOperation(value = "{{{summary}}}", notes = "{{{notes}}}", response = {{{returnType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}{{#hasAuthMethods}}, authorizations = {
+            {{#authMethods}}@io.swagger.annotations.Authorization(value = "{{name}}"{{#isOAuth}}, scopes = {
+            {{#scopes}}@io.swagger.annotations.AuthorizationScope(scope = "{{scope}}", description = "{{description}}"){{#hasMore}},
+        {{/hasMore}}{{/scopes}}
+        }{{/isOAuth}}){{#hasMore}},
+        {{/hasMore}}{{/authMethods}}
+    }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
+    @io.swagger.annotations.ApiResponses(value = { {{#responses}}
+        @io.swagger.annotations.ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{returnType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}){{#hasMore}},
+        {{/hasMore}}{{/responses}} })
     public Response {{nickname}}({{#isMultipart}}MultipartFormDataInput input,{{/isMultipart}}{{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{^isMultipart}}{{>formParams}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.{{nickname}}({{#isMultipart}}input,{{/isMultipart}}{{#allParams}}{{^isMultipart}}{{paramName}},{{/isMultipart}}{{#isMultipart}}{{^isFormParam}}{{paramName}},{{/isFormParam}}{{/isMultipart}}{{/allParams}}securityContext);

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/gradle.mustache
@@ -14,6 +14,7 @@ dependencies {
     providedCompile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.11.Final'
     providedCompile 'javax.annotation:javax.annotation-api:1.2'
     providedCompile 'org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec:1.0.0.Final'
+    compile         'io.swagger:swagger-annotations:1.5.10'
     compile         'org.jboss.resteasy:resteasy-jackson2-provider:3.0.11.Final'
 {{#joda}}
     compile         'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.4.1'

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pom.mustache
@@ -50,6 +50,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-core-version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-version}</version>

--- a/samples/server/petstore/jaxrs-resteasy/default/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/default/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     providedCompile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.11.Final'
     providedCompile 'javax.annotation:javax.annotation-api:1.2'
     providedCompile 'org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec:1.0.0.Final'
+    compile         'io.swagger:swagger-annotations:1.5.10'
     compile         'org.jboss.resteasy:resteasy-jackson2-provider:3.0.11.Final'
     testCompile     'junit:junit:4.12',
                     'org.hamcrest:hamcrest-core:1.3'

--- a/samples/server/petstore/jaxrs-resteasy/default/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/default/pom.xml
@@ -50,6 +50,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-core-version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-version}</version>
@@ -108,10 +113,10 @@
             <version>2.7</version>
         </dependency>
         <dependency>
-              <groupId>io.swagger</groupId>
-                <artifactId>swagger-jaxrs</artifactId>
-                <version>${swagger-core-version}</version>
-              </dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <version>${swagger-core-version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/io/swagger/api/PetApi.java
@@ -5,8 +5,8 @@ import io.swagger.api.PetApiService;
 import io.swagger.api.factories.PetApiServiceFactory;
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import java.util.List;
 import io.swagger.api.NotFoundException;
@@ -22,6 +22,7 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 @Path("/pet")
 
 
+@io.swagger.annotations.Api(description = "the pet API")
 
 public class PetApi  {
    private final PetApiService delegate = PetApiServiceFactory.getPetApi();
@@ -30,6 +31,14 @@ public class PetApi  {
     
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Add a new pet to the store", notes = "", response = Void.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response addPet( Pet body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.addPet(body,securityContext);
@@ -38,6 +47,14 @@ public class PetApi  {
     @Path("/{petId}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Deletes a pet", notes = "", response = Void.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
     public Response deletePet( @PathParam("petId") Long petId,@HeaderParam("api_key") String apiKey,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deletePet(petId,apiKey,securityContext);
@@ -46,6 +63,16 @@ public class PetApi  {
     @Path("/findByStatus")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Finds Pets by status", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid status value", response = Pet.class, responseContainer = "List") })
     public Response findPetsByStatus( @QueryParam("status") List<String> status,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByStatus(status,securityContext);
@@ -54,6 +81,16 @@ public class PetApi  {
     @Path("/findByTags")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Finds Pets by tags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class, responseContainer = "List") })
     public Response findPetsByTags( @QueryParam("tags") List<String> tags,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByTags(tags,securityContext);
@@ -62,6 +99,15 @@ public class PetApi  {
     @Path("/{petId}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Find pet by ID", notes = "Returns a single pet", response = Pet.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "api_key")
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
     public Response getPetById( @PathParam("petId") Long petId,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getPetById(petId,securityContext);
@@ -70,6 +116,18 @@ public class PetApi  {
     
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Update an existing pet", notes = "", response = Void.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
     public Response updatePet( Pet body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePet(body,securityContext);
@@ -78,6 +136,14 @@ public class PetApi  {
     @Path("/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Updates a pet in the store with form data", notes = "", response = Void.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response updatePetWithForm( @PathParam("petId") Long petId,@FormParam("name")  String name,@FormParam("status")  String status,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePetWithForm(petId,name,status,securityContext);
@@ -86,6 +152,14 @@ public class PetApi  {
     @Path("/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "uploads an image", notes = "", response = ModelApiResponse.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public Response uploadFile(MultipartFormDataInput input, @PathParam("petId") Long petId,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.uploadFile(input,petId,securityContext);

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/io/swagger/api/PetApiService.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/io/swagger/api/PetApiService.java
@@ -6,8 +6,8 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 
 
 import io.swagger.model.Pet;
-import java.io.File;
 import io.swagger.model.ModelApiResponse;
+import java.io.File;
 
 import java.util.List;
 import io.swagger.api.NotFoundException;

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/io/swagger/api/StoreApi.java
@@ -20,6 +20,7 @@ import javax.ws.rs.*;
 @Path("/store")
 
 
+@io.swagger.annotations.Api(description = "the store API")
 
 public class StoreApi  {
    private final StoreApiService delegate = StoreApiServiceFactory.getStoreApi();
@@ -28,6 +29,11 @@ public class StoreApi  {
     @Path("/order/{orderId}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Delete purchase order by ID", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", response = Void.class, tags={ "store", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     public Response deleteOrder( @PathParam("orderId") String orderId,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteOrder(orderId,securityContext);
@@ -36,6 +42,11 @@ public class StoreApi  {
     @Path("/inventory")
     
     @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Returns pet inventories by status", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
+            @io.swagger.annotations.Authorization(value = "api_key")
+    }, tags={ "store", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     public Response getInventory(@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getInventory(securityContext);
@@ -44,6 +55,13 @@ public class StoreApi  {
     @Path("/order/{orderId}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Order.class) })
     public Response getOrderById( @PathParam("orderId") Long orderId,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getOrderById(orderId,securityContext);
@@ -52,6 +70,11 @@ public class StoreApi  {
     @Path("/order")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
     public Response placeOrder( Order body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.placeOrder(body,securityContext);

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/io/swagger/api/UserApi.java
@@ -20,6 +20,7 @@ import javax.ws.rs.*;
 @Path("/user")
 
 
+@io.swagger.annotations.Api(description = "the user API")
 
 public class UserApi  {
    private final UserApiService delegate = UserApiServiceFactory.getUserApi();
@@ -28,6 +29,9 @@ public class UserApi  {
     
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUser( User body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUser(body,securityContext);
@@ -36,6 +40,9 @@ public class UserApi  {
     @Path("/createWithArray")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithArrayInput( List<User> body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithArrayInput(body,securityContext);
@@ -44,6 +51,9 @@ public class UserApi  {
     @Path("/createWithList")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithListInput( List<User> body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithListInput(body,securityContext);
@@ -52,6 +62,11 @@ public class UserApi  {
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Delete user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response deleteUser( @PathParam("username") String username,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteUser(username,securityContext);
@@ -60,6 +75,13 @@ public class UserApi  {
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = User.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = User.class) })
     public Response getUserByName( @PathParam("username") String username,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getUserByName(username,securityContext);
@@ -68,6 +90,11 @@ public class UserApi  {
     @Path("/login")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = String.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
     public Response loginUser( @QueryParam("username") String username, @QueryParam("password") String password,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.loginUser(username,password,securityContext);
@@ -76,6 +103,9 @@ public class UserApi  {
     @Path("/logout")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Logs out current logged in user session", notes = "", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response logoutUser(@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.logoutUser(securityContext);
@@ -84,6 +114,11 @@ public class UserApi  {
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Updated user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response updateUser( @PathParam("username") String username, User body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updateUser(username,body,securityContext);

--- a/samples/server/petstore/jaxrs-resteasy/joda/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/joda/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     providedCompile 'org.jboss.resteasy:resteasy-multipart-provider:3.0.11.Final'
     providedCompile 'javax.annotation:javax.annotation-api:1.2'
     providedCompile 'org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec:1.0.0.Final'
+    compile         'io.swagger:swagger-annotations:1.5.10'
     compile         'org.jboss.resteasy:resteasy-jackson2-provider:3.0.11.Final'
     compile         'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.4.1'
     compile         'joda-time:joda-time:2.7'

--- a/samples/server/petstore/jaxrs-resteasy/joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/joda/pom.xml
@@ -50,6 +50,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-core-version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-version}</version>
@@ -107,7 +112,11 @@
             <artifactId>joda-time</artifactId>
             <version>2.7</version>
         </dependency>
-
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <version>${swagger-core-version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/api/PetApi.java
@@ -22,6 +22,7 @@ import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 @Path("/pet")
 
 
+@io.swagger.annotations.Api(description = "the pet API")
 
 public class PetApi  {
    private final PetApiService delegate = PetApiServiceFactory.getPetApi();
@@ -30,6 +31,14 @@ public class PetApi  {
     
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Add a new pet to the store", notes = "", response = Void.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response addPet( Pet body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.addPet(body,securityContext);
@@ -38,6 +47,14 @@ public class PetApi  {
     @Path("/{petId}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Deletes a pet", notes = "", response = Void.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
     public Response deletePet( @PathParam("petId") Long petId,@HeaderParam("api_key") String apiKey,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deletePet(petId,apiKey,securityContext);
@@ -46,6 +63,16 @@ public class PetApi  {
     @Path("/findByStatus")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Finds Pets by status", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid status value", response = Pet.class, responseContainer = "List") })
     public Response findPetsByStatus( @QueryParam("status") List<String> status,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByStatus(status,securityContext);
@@ -54,6 +81,16 @@ public class PetApi  {
     @Path("/findByTags")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Finds Pets by tags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class, responseContainer = "List") })
     public Response findPetsByTags( @QueryParam("tags") List<String> tags,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByTags(tags,securityContext);
@@ -62,6 +99,15 @@ public class PetApi  {
     @Path("/{petId}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Find pet by ID", notes = "Returns a single pet", response = Pet.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "api_key")
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
     public Response getPetById( @PathParam("petId") Long petId,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getPetById(petId,securityContext);
@@ -70,6 +116,18 @@ public class PetApi  {
     
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Update an existing pet", notes = "", response = Void.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
     public Response updatePet( Pet body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePet(body,securityContext);
@@ -78,6 +136,14 @@ public class PetApi  {
     @Path("/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Updates a pet in the store with form data", notes = "", response = Void.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response updatePetWithForm( @PathParam("petId") Long petId,@FormParam("name")  String name,@FormParam("status")  String status,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePetWithForm(petId,name,status,securityContext);
@@ -86,6 +152,14 @@ public class PetApi  {
     @Path("/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "uploads an image", notes = "", response = ModelApiResponse.class, authorizations = {
+            @io.swagger.annotations.Authorization(value = "petstore_auth", scopes = {
+            @io.swagger.annotations.AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+        @io.swagger.annotations.AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public Response uploadFile(MultipartFormDataInput input, @PathParam("petId") Long petId,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.uploadFile(input,petId,securityContext);

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/api/StoreApi.java
@@ -20,6 +20,7 @@ import javax.ws.rs.*;
 @Path("/store")
 
 
+@io.swagger.annotations.Api(description = "the store API")
 
 public class StoreApi  {
    private final StoreApiService delegate = StoreApiServiceFactory.getStoreApi();
@@ -28,6 +29,11 @@ public class StoreApi  {
     @Path("/order/{orderId}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Delete purchase order by ID", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", response = Void.class, tags={ "store", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     public Response deleteOrder( @PathParam("orderId") String orderId,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteOrder(orderId,securityContext);
@@ -36,6 +42,11 @@ public class StoreApi  {
     @Path("/inventory")
     
     @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Returns pet inventories by status", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
+            @io.swagger.annotations.Authorization(value = "api_key")
+    }, tags={ "store", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     public Response getInventory(@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getInventory(securityContext);
@@ -44,6 +55,13 @@ public class StoreApi  {
     @Path("/order/{orderId}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Order.class) })
     public Response getOrderById( @PathParam("orderId") Long orderId,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getOrderById(orderId,securityContext);
@@ -52,6 +70,11 @@ public class StoreApi  {
     @Path("/order")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
     public Response placeOrder( Order body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.placeOrder(body,securityContext);

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/api/UserApi.java
@@ -20,6 +20,7 @@ import javax.ws.rs.*;
 @Path("/user")
 
 
+@io.swagger.annotations.Api(description = "the user API")
 
 public class UserApi  {
    private final UserApiService delegate = UserApiServiceFactory.getUserApi();
@@ -28,6 +29,9 @@ public class UserApi  {
     
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUser( User body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUser(body,securityContext);
@@ -36,6 +40,9 @@ public class UserApi  {
     @Path("/createWithArray")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithArrayInput( List<User> body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithArrayInput(body,securityContext);
@@ -44,6 +51,9 @@ public class UserApi  {
     @Path("/createWithList")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithListInput( List<User> body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithListInput(body,securityContext);
@@ -52,6 +62,11 @@ public class UserApi  {
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Delete user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response deleteUser( @PathParam("username") String username,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteUser(username,securityContext);
@@ -60,6 +75,13 @@ public class UserApi  {
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = User.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = User.class) })
     public Response getUserByName( @PathParam("username") String username,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getUserByName(username,securityContext);
@@ -68,6 +90,11 @@ public class UserApi  {
     @Path("/login")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = String.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
     public Response loginUser( @QueryParam("username") String username, @QueryParam("password") String password,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.loginUser(username,password,securityContext);
@@ -76,6 +103,9 @@ public class UserApi  {
     @Path("/logout")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Logs out current logged in user session", notes = "", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response logoutUser(@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.logoutUser(securityContext);
@@ -84,6 +114,11 @@ public class UserApi  {
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Updated user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response updateUser( @PathParam("username") String username, User body,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updateUser(username,body,securityContext);

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/Category.java
@@ -3,9 +3,8 @@ package io.swagger.model;
 import java.util.Objects;
 import java.util.ArrayList;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
 
 
 public class Category   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -3,9 +3,8 @@ package io.swagger.model;
 import java.util.Objects;
 import java.util.ArrayList;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
 
 
 public class ModelApiResponse   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/Order.java
@@ -3,11 +3,10 @@ package io.swagger.model;
 import java.util.Objects;
 import java.util.ArrayList;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
 import org.joda.time.DateTime;
-
-
-
 
 
 public class Order   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/Pet.java
@@ -3,13 +3,12 @@ package io.swagger.model;
 import java.util.Objects;
 import java.util.ArrayList;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
 import io.swagger.model.Category;
 import io.swagger.model.Tag;
 import java.util.List;
-
-
-
 
 
 public class Pet   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/Tag.java
@@ -3,9 +3,8 @@ package io.swagger.model;
 import java.util.Objects;
 import java.util.ArrayList;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
 
 
 public class Tag   {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/io/swagger/model/User.java
@@ -3,9 +3,8 @@ package io.swagger.model;
 import java.util.Objects;
 import java.util.ArrayList;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
 
 
 public class User   {


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Update resteasy api classes to have swagger annotations


The annotations should now appear on generated resteasy API classes.