### PR TITLE
[Android][Volley] add serializeModel support to Android

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
@@ -29,6 +29,7 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
     protected String projectFolder = "src/main";
     protected String sourceFolder = projectFolder + "/java";
     protected Boolean useAndroidMavenGradlePlugin = true;
+    protected Boolean serializableModel = false;
 
     // requestPackage and authPackage are used by the "volley" template/library
     protected String requestPackage = "io.swagger.client.request";
@@ -89,6 +90,8 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
         cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, CodegenConstants.SOURCE_FOLDER_DESC));
         cliOptions.add(CliOption.newBoolean(USE_ANDROID_MAVEN_GRADLE_PLUGIN, "A flag to toggle android-maven gradle plugin.")
                 .defaultValue(Boolean.TRUE.toString()));
+
+        cliOptions.add(CliOption.newBoolean(CodegenConstants.SERIALIZABLE_MODEL, CodegenConstants.SERIALIZABLE_MODEL_DESC));
 
         supportedLibraries.put("volley", "HTTP client: Volley 1.0.19 (default)");
         supportedLibraries.put("httpclient", "HTTP client: Apache HttpClient 4.3.6. JSON processing: Gson 2.3.1. IMPORTANT: Android client using HttpClient is not actively maintained and will be depecreated in the next major release.");
@@ -378,6 +381,14 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
             this.setLibrary((String) additionalProperties.get(CodegenConstants.LIBRARY));
         }
 
+        if (additionalProperties.containsKey(CodegenConstants.SERIALIZABLE_MODEL)) {
+            this.setSerializableModel(Boolean.valueOf(additionalProperties.get(CodegenConstants.SERIALIZABLE_MODEL).toString()));
+        }
+
+        // need to put back serializableModel (boolean) into additionalProperties as value in additionalProperties is string
+        additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, serializableModel);
+        LOGGER.info("CodegenConstants.SERIALIZABLE_MODEL = " + additionalProperties.get(CodegenConstants.SERIALIZABLE_MODEL));
+
         //make api and model doc path available in mustache template
         additionalProperties.put( "apiDocPath", apiDocPath );
         additionalProperties.put( "modelDocPath", modelDocPath );
@@ -502,6 +513,10 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
 
     public void setSourceFolder(String sourceFolder) {
         this.sourceFolder = sourceFolder;
+    }
+
+    public void setSerializableModel(Boolean serializableModel) {
+        this.serializableModel = serializableModel;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/model.mustache
@@ -3,17 +3,21 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
+{{#serializableModel}}
+import java.io.Serializable;
+{{/serializableModel}}
 {{#models}}
 
-{{#model}}{{#description}}
+{{#model}}
+{{#description}}
 /**
  * {{description}}
- **/{{/description}}
+ **/
+{{/description}}
 @ApiModel(description = "{{{description}}}")
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
+public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#serializableModel}}implements Serializable {{/serializableModel}}{
   {{#vars}}{{#isEnum}}
   public enum {{datatypeWithEnum}} {
     {{#allowableValues}}{{#values}} {{.}}, {{/values}}{{/allowableValues}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/android/AndroidClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/android/AndroidClientOptionsTest.java
@@ -46,6 +46,8 @@ public class AndroidClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setLibrary(AndroidClientOptionsProvider.LIBRARY_VALUE);
             times = 1;
+            clientCodegen.setSerializableModel(Boolean.valueOf(AndroidClientOptionsProvider.SERIALIZABLE_MODEL_VALUE));
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AndroidClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AndroidClientOptionsProvider.java
@@ -19,6 +19,7 @@ public class AndroidClientOptionsProvider implements OptionsProvider {
     public static final String SOURCE_FOLDER_VALUE = "src/main/java/test";
     public static final String ANDROID_MAVEN_GRADLE_PLUGIN_VALUE = "true";
     public static final String LIBRARY_VALUE = "httpclient";
+    public static final String SERIALIZABLE_MODEL_VALUE = "false";
 
     @Override
     public String getLanguage() {
@@ -39,6 +40,7 @@ public class AndroidClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
                 .put(AndroidClientCodegen.USE_ANDROID_MAVEN_GRADLE_PLUGIN, ANDROID_MAVEN_GRADLE_PLUGIN_VALUE)
                 .put(CodegenConstants.LIBRARY, LIBRARY_VALUE)
+                .put(CodegenConstants.SERIALIZABLE_MODEL, SERIALIZABLE_MODEL_VALUE)
                 .build();
     }
 

--- a/samples/client/petstore/android/volley/docs/PetApi.md
+++ b/samples/client/petstore/android/volley/docs/PetApi.md
@@ -222,7 +222,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[petstore_auth](../README.md#petstore_auth), [api_key](../README.md#api_key)
+[api_key](../README.md#api_key), [petstore_auth](../README.md#petstore_auth)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/PetApi.java
@@ -623,7 +623,7 @@ public class PetApi {
       // normal form params
         }
 
-      String[] authNames = new String[] { "petstore_auth", "api_key" };
+      String[] authNames = new String[] { "api_key", "petstore_auth" };
 
       try {
         String localVarResponse = apiInvoker.invokeAPI (basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames);
@@ -693,7 +693,7 @@ public class PetApi {
       // normal form params
           }
 
-      String[] authNames = new String[] { "petstore_auth", "api_key" };
+      String[] authNames = new String[] { "api_key", "petstore_auth" };
 
     try {
       apiInvoker.invokeAPI(basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames,

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/Category.java
@@ -24,13 +24,11 @@
 
 package io.swagger.client.model;
 
-
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
 
-
 @ApiModel(description = "")
-public class Category  {
+public class Category {
   
   @SerializedName("id")
   private Long id = null;

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/Order.java
@@ -25,13 +25,11 @@
 package io.swagger.client.model;
 
 import java.util.Date;
-
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
 
-
 @ApiModel(description = "")
-public class Order  {
+public class Order {
   
   @SerializedName("id")
   private Long id = null;

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/Pet.java
@@ -27,13 +27,11 @@ package io.swagger.client.model;
 import io.swagger.client.model.Category;
 import io.swagger.client.model.Tag;
 import java.util.*;
-
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
 
-
 @ApiModel(description = "")
-public class Pet  {
+public class Pet {
   
   @SerializedName("id")
   private Long id = null;

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/Tag.java
@@ -24,13 +24,11 @@
 
 package io.swagger.client.model;
 
-
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
 
-
 @ApiModel(description = "")
-public class Tag  {
+public class Tag {
   
   @SerializedName("id")
   private Long id = null;

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/model/User.java
@@ -24,13 +24,11 @@
 
 package io.swagger.client.model;
 
-
 import io.swagger.annotations.*;
 import com.google.gson.annotations.SerializedName;
 
-
 @ApiModel(description = "")
-public class User  {
+public class User {
   
   @SerializedName("id")
   private Long id = null;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add `serializeModel` support to Android, e.g.
```
java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
  -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml \
  -l android -DserializableModel=true \
  -o /var/tmp/android/serializableModel2/ 
```

