### PR TITLE
Fix duplicate entries (property inheritance)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2738,7 +2738,7 @@ public class DefaultCodegen {
 
             Set<String> mandatory = required == null ? Collections.<String> emptySet()
                     : new TreeSet<String>(required);
-            addVars(m, m.vars, properties, mandatory);
+            addVars(m, m.vars, properties, mandatory, null);
             m.allMandatory = m.mandatory = mandatory;
         } else {
             m.emptyVars = true;
@@ -2749,12 +2749,12 @@ public class DefaultCodegen {
         if (allProperties != null) {
             Set<String> allMandatory = allRequired == null ? Collections.<String> emptySet()
                     : new TreeSet<String>(allRequired);
-            addVars(m, m.allVars, allProperties, allMandatory);
+            addVars(m, m.allVars, allProperties, allMandatory, properties.keySet());
             m.allMandatory = allMandatory;
         }
     }
 
-    private void addVars(CodegenModel m, List<CodegenProperty> vars, Map<String, Property> properties, Set<String> mandatory) {
+    private void addVars(CodegenModel m, List<CodegenProperty> vars, Map<String, Property> properties, Set<String> mandatory, Set<String> alreadyAdded) {
         // convert set to list so that we can access the next entry in the loop
         List<Map.Entry<String, Property>> propertyList = new ArrayList<Map.Entry<String, Property>>(properties.entrySet());
         final int totalCount = propertyList.size();
@@ -2801,18 +2801,22 @@ public class DefaultCodegen {
                 }
                 vars.add(cp);
 
-                // if required, add to the list "requiredVars"
-                if (Boolean.TRUE.equals(cp.required)) {
-                    m.requiredVars.add(cp);
-                } else { // else add to the list "optionalVars" for optional property
-                    m.optionalVars.add(cp);
-                }
+                // only add to the other lists if we haven't done so already
+                if (alreadyAdded == null || !alreadyAdded.contains(key)) {
 
-                // if readonly, add to readOnlyVars (list of properties)
-                if (Boolean.TRUE.equals(cp.isReadOnly)) {
-                    m.readOnlyVars.add(cp);
-                } else { // else add to readWriteVars (list of properties)
-                    m.readWriteVars.add(cp);
+                    // if required, add to the list "requiredVars"
+                    if (Boolean.TRUE.equals(cp.required)) {
+                        m.requiredVars.add(cp);
+                    } else { // else add to the list "optionalVars" for optional property
+                        m.optionalVars.add(cp);
+                    }
+
+                    // if readonly, add to readOnlyVars (list of properties)
+                    if (Boolean.TRUE.equals(cp.isReadOnly)) {
+                        m.readOnlyVars.add(cp);
+                    } else { // else add to readWriteVars (list of properties)
+                        m.readWriteVars.add(cp);
+                    }
                 }
             }
         }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2817,6 +2817,16 @@ public class DefaultCodegen {
                     } else { // else add to readWriteVars (list of properties)
                         m.readWriteVars.add(cp);
                     }
+
+                    if (alreadyAdded != null) {
+                        // the current var comes from the parent 
+                        CodegenProperty parent_cp = cp.clone();
+                        parent_cp.hasMore = Boolean.FALSE;
+                        if (!m.parentVars.isEmpty()) {
+                            m.parentVars.get( m.parentVars.size() - 1 ).hasMore = Boolean.TRUE;
+                        }
+                        m.parentVars.add( parent_cp );
+                    }
                 }
             }
         }

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -91,7 +91,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
         {{/hasMore}}{{/vars}}{{#parent}} &&
         super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
   }
 
   @Override


### PR DESCRIPTION
If 'supportsInheritance' is set to true, a model property is part of both the list 'properties' and 'allProperties'. The DefaultCodegen::addVars method is then called with both lists, so that the property is added twice to the m.requiredVars/m.optionalVars and m.readOnlyVars/m.readWriteVars lists

Example shown here: https://gist.github.com/j4velin/915d5ad70141685e8b588781adf7c4c7

Change-Id: I76e562fb629c28c869c7e4622e369cc79df7620a
