### PR TITLE
Sanitize tuples properly

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -176,12 +176,12 @@ class ApiClient(object):
         :param obj: The data to serialize.
         :return: The serialized form of data.
         """
-        types = (str, float, bool, tuple) + tuple(integer_types) + (text_type,)
+        types = (str, float, bool) + tuple(integer_types) + (text_type,)
         if isinstance(obj, type(None)):
             return None
         elif isinstance(obj, types):
             return obj
-        elif isinstance(obj, list):
+        elif isinstance(obj, (list, tuple)):
             return [self.sanitize_for_serialization(sub_obj)
                     for sub_obj in obj]
         elif isinstance(obj, (datetime, date)):

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -176,7 +176,7 @@ class ApiClient(object):
         :param obj: The data to serialize.
         :return: The serialized form of data.
         """
-        types = (str, float, bool) + tuple(integer_types) + (text_type,)
+        types = (str, float, bool, bytes) + tuple(integer_types) + (text_type,)
         if isinstance(obj, type(None)):
             return None
         elif isinstance(obj, types):
@@ -188,8 +188,8 @@ class ApiClient(object):
             if len(obj) == 1 and isinstance(obj[0], list) and len(obj[0]) == 3:
                 return obj
             else:
-                return [self.sanitize_for_serialization(sub_obj)
-                    for sub_obj in obj]
+                return tuple(self.sanitize_for_serialization(sub_obj)
+                    for sub_obj in obj)
         elif isinstance(obj, (datetime, date)):
             return obj.isoformat()
         else:

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -181,8 +181,14 @@ class ApiClient(object):
             return None
         elif isinstance(obj, types):
             return obj
-        elif isinstance(obj, (list, tuple)):
+        elif isinstance(obj, list):
             return [self.sanitize_for_serialization(sub_obj)
+                    for sub_obj in obj]
+        elif isinstance(obj, tuple):
+            if len(obj) == 1 and isinstance(obj[0], list) and len(obj[0]) == 3:
+                return obj
+            else:
+                return [self.sanitize_for_serialization(sub_obj)
                     for sub_obj in obj]
         elif isinstance(obj, (datetime, date)):
             return obj.isoformat()

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -185,11 +185,8 @@ class ApiClient(object):
             return [self.sanitize_for_serialization(sub_obj)
                     for sub_obj in obj]
         elif isinstance(obj, tuple):
-            if len(obj) == 1 and isinstance(obj[0], list) and len(obj[0]) == 3:
-                return obj
-            else:
-                return tuple(self.sanitize_for_serialization(sub_obj)
-                    for sub_obj in obj)
+            return tuple(self.sanitize_for_serialization(sub_obj)
+                for sub_obj in obj)
         elif isinstance(obj, (datetime, date)):
             return obj.isoformat()
         else:

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -176,12 +176,12 @@ class ApiClient(object):
         :param obj: The data to serialize.
         :return: The serialized form of data.
         """
-        types = (str, float, bool, tuple) + tuple(integer_types) + (text_type,)
+        types = (str, float, bool) + tuple(integer_types) + (text_type,)
         if isinstance(obj, type(None)):
             return None
         elif isinstance(obj, types):
             return obj
-        elif isinstance(obj, list):
+        elif isinstance(obj, (list, tuple)):
             return [self.sanitize_for_serialization(sub_obj)
                     for sub_obj in obj]
         elif isinstance(obj, (datetime, date)):

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -176,7 +176,7 @@ class ApiClient(object):
         :param obj: The data to serialize.
         :return: The serialized form of data.
         """
-        types = (str, float, bool) + tuple(integer_types) + (text_type,)
+        types = (str, float, bool, bytes) + tuple(integer_types) + (text_type,)
         if isinstance(obj, type(None)):
             return None
         elif isinstance(obj, types):
@@ -188,8 +188,8 @@ class ApiClient(object):
             if len(obj) == 1 and isinstance(obj[0], list) and len(obj[0]) == 3:
                 return obj
             else:
-                return [self.sanitize_for_serialization(sub_obj)
-                    for sub_obj in obj]
+                return tuple(self.sanitize_for_serialization(sub_obj)
+                    for sub_obj in obj)
         elif isinstance(obj, (datetime, date)):
             return obj.isoformat()
         else:

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -181,8 +181,14 @@ class ApiClient(object):
             return None
         elif isinstance(obj, types):
             return obj
-        elif isinstance(obj, (list, tuple)):
+        elif isinstance(obj, list):
             return [self.sanitize_for_serialization(sub_obj)
+                    for sub_obj in obj]
+        elif isinstance(obj, tuple):
+            if len(obj) == 1 and isinstance(obj[0], list) and len(obj[0]) == 3:
+                return obj
+            else:
+                return [self.sanitize_for_serialization(sub_obj)
                     for sub_obj in obj]
         elif isinstance(obj, (datetime, date)):
             return obj.isoformat()

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -185,11 +185,8 @@ class ApiClient(object):
             return [self.sanitize_for_serialization(sub_obj)
                     for sub_obj in obj]
         elif isinstance(obj, tuple):
-            if len(obj) == 1 and isinstance(obj[0], list) and len(obj[0]) == 3:
-                return obj
-            else:
-                return tuple(self.sanitize_for_serialization(sub_obj)
-                    for sub_obj in obj)
+            return tuple(self.sanitize_for_serialization(sub_obj)
+                for sub_obj in obj)
         elif isinstance(obj, (datetime, date)):
             return obj.isoformat()
         else:


### PR DESCRIPTION
In Python, tuples are fixed size in nature whereas lists are dynamic. So they should be sanitized as same as lists. Failure case here is when you have a query or post parameter as Datetime.