### PR TITLE
[aspnet] Fix .sln/.xproj guids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ samples/client/petstore/typescript-angular/**/typings
 samples/client/petstore/typescript-fetch/**/dist/
 samples/client/petstore/typescript-fetch/**/typings
 
+# aspnet5
+samples/server/petstore/aspnet5/.vs/
+

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNet5ServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNet5ServerCodegen.java
@@ -9,9 +9,13 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
+import static java.util.UUID.randomUUID;
+
 public class AspNet5ServerCodegen extends AbstractCSharpCodegen {
 
     protected String sourceFolder = "src" + File.separator + packageName;
+
+    private final String packageGuid = "{" + randomUUID().toString().toUpperCase() + "}";
 
     @SuppressWarnings("hiding")
     protected Logger LOGGER = LoggerFactory.getLogger(AspNet5ServerCodegen.class);
@@ -80,6 +84,8 @@ public class AspNet5ServerCodegen extends AbstractCSharpCodegen {
     @Override
     public void processOpts() {
         super.processOpts();
+
+        additionalProperties.put("packageGuid", packageGuid);
 
         apiPackage = packageName + ".Controllers";
         modelPackage = packageName + ".Models";

--- a/modules/swagger-codegen/src/main/resources/aspnet5/Project.xproj.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnet5/Project.xproj.mustache
@@ -1,4 +1,4 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -6,8 +6,8 @@
     </PropertyGroup>
     <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
     <PropertyGroup Label="Globals">
-        <ProjectGuid>{{projectGuid}}</ProjectGuid>
-        <RootNamespace>Sample</RootNamespace>
+        <ProjectGuid>{{packageGuid}}</ProjectGuid>
+        <RootNamespace>{{packageName}}</RootNamespace>
         <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
         <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
         <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>

--- a/modules/swagger-codegen/src/main/resources/aspnet5/Solution.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnet5/Solution.mustache
@@ -1,10 +1,7 @@
-﻿﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{815BE834-0656-4C12-84A4-43F2BA4B8BDE}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AFF6BF88-8A7D-4736-AF81-31BCE86B19BD}"
         ProjectSection(SolutionItems) = preProject
                 global.json = global.json
@@ -18,15 +15,12 @@ Global
                 Release|Any CPU = Release|Any CPU
         EndGlobalSection
         GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                {3B5990B3-40F1-4148-89B5-84AC71432557}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {3B5990B3-40F1-4148-89B5-84AC71432557}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {3B5990B3-40F1-4148-89B5-84AC71432557}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {3B5990B3-40F1-4148-89B5-84AC71432557}.Release|Any CPU.Build.0 = Release|Any CPU
+                {{packageGuid}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {{packageGuid}}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {{packageGuid}}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {{packageGuid}}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
         GlobalSection(SolutionProperties) = preSolution
                 HideSolutionNode = FALSE
-        EndGlobalSection
-        GlobalSection(NestedProjects) = preSolution
-                {{packageGuid}} = {815BE834-0656-4C12-84A4-43F2BA4B8BDE}
         EndGlobalSection
 EndGlobal

--- a/samples/server/petstore/aspnet5/IO.Swagger.sln
+++ b/samples/server/petstore/aspnet5/IO.Swagger.sln
@@ -1,16 +1,13 @@
-﻿﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{815BE834-0656-4C12-84A4-43F2BA4B8BDE}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AFF6BF88-8A7D-4736-AF81-31BCE86B19BD}"
         ProjectSection(SolutionItems) = preProject
                 global.json = global.json
         EndProjectSection
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.xproj", ""
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.xproj", "{CF700387-34B9-4172-B648-7535827D5EEB}"
 EndProject
 Global
         GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,15 +15,12 @@ Global
                 Release|Any CPU = Release|Any CPU
         EndGlobalSection
         GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                {3B5990B3-40F1-4148-89B5-84AC71432557}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {3B5990B3-40F1-4148-89B5-84AC71432557}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {3B5990B3-40F1-4148-89B5-84AC71432557}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {3B5990B3-40F1-4148-89B5-84AC71432557}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CF700387-34B9-4172-B648-7535827D5EEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CF700387-34B9-4172-B648-7535827D5EEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CF700387-34B9-4172-B648-7535827D5EEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CF700387-34B9-4172-B648-7535827D5EEB}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
         GlobalSection(SolutionProperties) = preSolution
                 HideSolutionNode = FALSE
-        EndGlobalSection
-        GlobalSection(NestedProjects) = preSolution
-                 = {815BE834-0656-4C12-84A4-43F2BA4B8BDE}
         EndGlobalSection
 EndGlobal

--- a/samples/server/petstore/aspnet5/README.md
+++ b/samples/server/petstore/aspnet5/README.md
@@ -1,7 +1,25 @@
-# {{packageName}} - ASP.NET Core 1.0 Server
+# IO.Swagger - ASP.NET Core 1.0 Server
 
-{{#appDescription}}
-{{{appDescription}}}
-{{/appDescription}}
+This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
 
+## Run
 
+Linux/OS X:
+
+```
+sh build.sh
+```
+
+Windows:
+
+```
+build.bat
+```
+
+## Run in Docker
+
+```
+cd src/IO.Swagger
+docker build -t IO.Swagger .
+docker run -p 5000:5000 IO.Swagger
+```

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/Dockerfile
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/Dockerfile
@@ -1,7 +1,5 @@
 FROM microsoft/dotnet:latest
 
-RUN groupadd -r app && useradd -r -g app app
-
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 
 RUN mkdir -p /app/IO.Swagger
@@ -9,8 +7,6 @@ COPY . /app/IO.Swagger
 WORKDIR /app/IO.Swagger
 
 EXPOSE 5000/tcp
-
-USER app
 
 RUN ["dotnet", "restore"]
 ENTRYPOINT ["dotnet", "run", "-p", "project.json", "web"]

--- a/samples/server/petstore/aspnet5/src/IO.Swagger/IO.Swagger.xproj
+++ b/samples/server/petstore/aspnet5/src/IO.Swagger/IO.Swagger.xproj
@@ -1,4 +1,4 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -6,8 +6,8 @@
     </PropertyGroup>
     <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
     <PropertyGroup Label="Globals">
-        <ProjectGuid></ProjectGuid>
-        <RootNamespace>Sample</RootNamespace>
+        <ProjectGuid>{CF700387-34B9-4172-B648-7535827D5EEB}</ProjectGuid>
+        <RootNamespace>IO.Swagger</RootNamespace>
         <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
         <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
         <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The AspNet5 generator was originally written to support project.json.
The Project.xproj was implemented without a valid project guid or root
namespace. During the transition period from project.json to
Project.xproj, VS2015 would fallback to project.json. Newer versions of
VS2015 don't seem to do this any longer.

This commit defines the project's guid correctly, and sets the project's
root namespace.

See: #3680