### PR TITLE
Fix hasHeaderParams mustache tag

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ConfluenceWikiGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ConfluenceWikiGenerator.java
@@ -92,4 +92,16 @@ public class ConfluenceWikiGenerator extends DefaultCodegen implements CodegenCo
         }
         return objs;
     }
+
+    @Override
+    public String escapeQuotationMark(String input) {
+        // just return the original string
+        return input;
+    }
+
+    @Override
+    public String escapeUnsafeCharacters(String input) {
+        // just return the original string
+        return input;
+    }
 }

--- a/modules/swagger-codegen/src/main/resources/confluenceWikiDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/confluenceWikiDocs/index.mustache
@@ -32,12 +32,12 @@ h2. Endpoints
         {{/bodyParams}}
     {{/hasBodyParam}}
 
-    {{#hasHeaderParam}}
+    {{#hasHeaderParams}}
         h5. Header Parameters
         ||Name||Description||Required||Default||Pattern||
         {{#headerParam}}{{>param}}
         {{/headerParam}}
-    {{/hasHeaderParam}}
+    {{/hasHeaderParams}}
 
     {{#hasQueryParams}}
         h5. Query Parameters

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
@@ -80,12 +80,12 @@
     </div>  <!-- field-items -->
     {{/hasBodyParam}}
 
-    {{#hasHeaderParam}}
+    {{#hasHeaderParams}}
     <h3 class="field-label">Request headers</h3>
     <div class="field-items">
       {{#headerParam}}{{>headerParam}}{{/headerParam}}
     </div>  <!-- field-items -->
-    {{/hasHeaderParam}}
+    {{/hasHeaderParams}}
 
     {{#hasQueryParams}}
     <h3 class="field-label">Query parameters</h3>

--- a/samples/documentation/cwiki/confluence-markup.txt
+++ b/samples/documentation/cwiki/confluence-markup.txt
@@ -60,7 +60,9 @@ h2. Endpoints
         |petId |Pet id to delete |(/) | |  |
 
 
-
+        h5. Header Parameters
+        ||Name||Description||Required||Default||Pattern||
+        
 
 
 

--- a/samples/html/index.html
+++ b/samples/html/index.html
@@ -288,6 +288,10 @@ font-style: italic;
 
 
 
+    <h3 class="field-label">Request headers</h3>
+    <div class="field-items">
+      
+    </div>  <!-- field-items -->
 
 
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Should be `hasHeaderParams` instead of `hasHeaderParam`
