### PR TITLE
Adjust Dateformat (ISO 8601) for Query Parameters with Input Date 

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -79,7 +79,11 @@ export class {{classname}} {
 {{/allParams}}
 {{#queryParams}}
         if ({{paramName}} !== undefined) {
-            queryParameters.set('{{baseName}}', <any>{{paramName}});
+            if({{paramName}} instanceof Date) {
+                queryParameters.set('{{baseName}}', <any>{{paramName}}.d.toISOString());
+            } else {
+                queryParameters.set('{{baseName}}', <any>{{paramName}});
+            }
         }
 {{/queryParams}}
 


### PR DESCRIPTION
[typescript-angular2] Handle date type correctly #3105
currently only works for query parameters
