### PR TITLE
Updates to html2 templates to use security headers in curl examples

### DIFF
--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/index.mustache
@@ -266,7 +266,7 @@ function loadGoogleFontCss() {
                                             <div class="tab-content">
                                                 <div class="tab-pane active" id="examples-{{baseName}}-{{nickname}}-0-curl">
                                                     <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">{{httpMethod}}</span>{{#isApiKey}} -H "apiKey: [[apiKey]]" -H "apiSecret: [[apiSecret]]"{{/isApiKey}} "{{basePath}}{{path}}{{#hasQueryParams}}?{{#queryParams}}{{^-first}}&{{/-first}}{{paramName}}={{vendorExtensions.x-eg}}{{/queryParams}}{{/hasQueryParams}}"
+curl -X <span style="text-transform: uppercase;">{{httpMethod}}</span>{{#authMethods}}{{#isApiKey}}{{#isKeyInHeader}} -H "{{keyParamName}}: [[apiKey]]" {{/isKeyInHeader}}{{/isApiKey}}{{#isBasic}} -H "Authorization: Basic [[basicHash]]" {{/isBasic}}{{/authMethods}} "{{basePath}}{{path}}{{#hasQueryParams}}?{{#queryParams}}{{^-first}}&{{/-first}}{{paramName}}={{vendorExtensions.x-eg}}{{/queryParams}}{{/hasQueryParams}}"
 
 
 </code></pre>

--- a/samples/html2/index.html
+++ b/samples/html2/index.html
@@ -2834,7 +2834,7 @@ try {
                                             <div class="tab-content">
                                                 <div class="tab-pane active" id="examples-Pet-getPetById-0-curl">
                                                     <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/pet/{petId}"
+curl -X <span style="text-transform: uppercase;">get</span> -H "api_key: [[apiKey]]"  "http://petstore.swagger.io/v2/pet/{petId}"
 
 
 </code></pre>
@@ -5195,7 +5195,7 @@ try {
                                             <div class="tab-content">
                                                 <div class="tab-pane active" id="examples-Store-getInventory-0-curl">
                                                     <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/store/inventory"
+curl -X <span style="text-transform: uppercase;">get</span> -H "api_key: [[apiKey]]"  "http://petstore.swagger.io/v2/store/inventory"
 
 
 </code></pre>
@@ -9921,7 +9921,7 @@ try {
             </div>
             <div id="generator">
                 <div class="content">
-                    Generated 2016-09-29T11:08:44.942+08:00
+                    Generated 2016-10-13T09:03:51.792-07:00
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #3974

