### PR TITLE
[Android] fix URL encoding for Android API client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/android/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/apiInvoker.mustache
@@ -16,6 +16,8 @@ import org.apache.http.params.*;
 import org.apache.http.util.EntityUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.net.URLEncoder;
@@ -25,8 +27,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
@@ -207,7 +207,11 @@ public class ApiInvoker {
   }
 
   public String escapeString(String str) {
-    return URLEncoder.encode(str, "UTF-8");
+    try {
+      return URLEncoder.encode(str, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return str;
+    }
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {

--- a/modules/swagger-codegen/src/main/resources/android/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/apiInvoker.mustache
@@ -207,7 +207,7 @@ public class ApiInvoker {
   }
 
   public String escapeString(String str) {
-    return str;
+    return URLEncoder.encode(str, "UTF-8");
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {

--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/apiInvoker.mustache
@@ -232,7 +232,7 @@ public class ApiInvoker {
   }
 
   public String escapeString(String str) {
-    return str;
+    return URLEncoder.encode(str, "UTF-8");
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {

--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/apiInvoker.mustache
@@ -20,6 +20,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -232,7 +233,11 @@ public class ApiInvoker {
   }
 
   public String escapeString(String str) {
-    return URLEncoder.encode(str, "UTF-8");
+    try {
+      return URLEncoder.encode(str, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return str;
+    }
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {

--- a/samples/client/petstore/android/httpclient/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android/httpclient/src/main/java/io/swagger/client/ApiInvoker.java
@@ -39,6 +39,8 @@ import org.apache.http.params.*;
 import org.apache.http.util.EntityUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.net.URLEncoder;
@@ -48,8 +50,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
@@ -230,7 +230,11 @@ public class ApiInvoker {
   }
 
   public String escapeString(String str) {
-    return URLEncoder.encode(str, "UTF-8");
+    try {
+      return URLEncoder.encode(str, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return str;
+    }
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {

--- a/samples/client/petstore/android/httpclient/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android/httpclient/src/main/java/io/swagger/client/ApiInvoker.java
@@ -230,7 +230,7 @@ public class ApiInvoker {
   }
 
   public String escapeString(String str) {
-    return str;
+    return URLEncoder.encode(str, "UTF-8");
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java
@@ -43,6 +43,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -246,7 +247,11 @@ public class ApiInvoker {
   }
 
   public String escapeString(String str) {
-    return URLEncoder.encode(str, "UTF-8");
+    try {
+      return URLEncoder.encode(str, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return str;
+    }
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java
@@ -246,7 +246,7 @@ public class ApiInvoker {
   }
 
   public String escapeString(String str) {
-    return str;
+    return URLEncoder.encode(str, "UTF-8");
   }
 
   public static Object deserialize(String json, String containerType, Class cls) throws ApiException {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

To fix https://github.com/swagger-api/swagger-codegen/issues/3406, https://github.com/swagger-api/swagger-codegen/issues/3202

