### PR TITLE
[csharp] Fix apiPackage,modelPackage,excludeTests

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/README.mustache
@@ -46,9 +46,7 @@ Then include the DLL (under the `bin` folder) in the C# project, and use the nam
 ```csharp
 using {{packageName}}.{{apiPackage}};
 using {{packageName}}.Client;
-{{#modelPackage}}
-using {{{.}}};
-{{/modelPackage}}
+using {{packageName}}.{{modelPackage}};
 ```
 
 ## Getting Started
@@ -58,9 +56,7 @@ using System;
 using System.Diagnostics;
 using {{packageName}}.{{apiPackage}};
 using {{packageName}}.Client;
-{{#modelPackage}}
-using {{{.}}};
-{{/modelPackage}}
+using {{packageName}}.{{modelPackage}};
 
 namespace Example
 {

--- a/modules/swagger-codegen/src/main/resources/csharp/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/README.mustache
@@ -44,7 +44,7 @@ Run the following command to generate the DLL
 
 Then include the DLL (under the `bin` folder) in the C# project, and use the namespaces:
 ```csharp
-using {{packageName}}.Api;
+using {{packageName}}.{{apiPackage}};
 using {{packageName}}.Client;
 {{#modelPackage}}
 using {{{.}}};
@@ -56,7 +56,7 @@ using {{{.}}};
 ```csharp
 using System;
 using System.Diagnostics;
-using {{packageName}}.Api;
+using {{packageName}}.{{apiPackage}};
 using {{packageName}}.Client;
 {{#modelPackage}}
 using {{{.}}};

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -5,10 +5,10 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using RestSharp;
 using {{packageName}}.Client;
-{{#hasImport}}using {{packageName}}.Model;
+{{#hasImport}}using {{packageName}}.{{modelPackage}};
 {{/hasImport}}
 
-namespace {{packageName}}.Api
+namespace {{packageName}}.{{apiPackage}}
 {
     {{#operations}}
     /// <summary>

--- a/modules/swagger-codegen/src/main/resources/csharp/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api_doc.mustache
@@ -1,4 +1,4 @@
-# {{packageName}}.Api.{{classname}}{{#description}}
+# {{packageName}}.{{apiPackage}}.{{classname}}{{#description}}
 {{description}}{{/description}}
 
 All URIs are relative to *{{{basePath}}}*
@@ -22,9 +22,9 @@ Method | HTTP request | Description
 ```csharp
 using System;
 using System.Diagnostics;
-using {{packageName}}.Api;
+using {{packageName}}.{{apiPackage}};
 using {{packageName}}.Client;
-using {{packageName}}.Model;
+using {{packageName}}.{{modelPackage}};
 
 namespace Example
 {

--- a/modules/swagger-codegen/src/main/resources/csharp/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api_test.mustache
@@ -9,8 +9,8 @@ using RestSharp;
 using NUnit.Framework;
 
 using {{packageName}}.Client;
-using {{packageName}}.Api;
-{{#hasImport}}using {{packageName}}.Model;
+using {{packageName}}.{{apiPackage}};
+{{#hasImport}}using {{packageName}}.{{modelPackage}};
 {{/hasImport}}
 
 namespace {{packageName}}.Test

--- a/modules/swagger-codegen/src/main/resources/csharp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model.mustache
@@ -18,7 +18,7 @@ using System.ComponentModel.DataAnnotations;
 
 {{#models}}
 {{#model}}
-namespace {{packageName}}.Model
+namespace {{packageName}}.{{modelPackage}}
 {
 {{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>modelGeneric}}{{/isEnum}}
 {{/model}}

--- a/modules/swagger-codegen/src/main/resources/csharp/model_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model_doc.mustache
@@ -1,6 +1,6 @@
 {{#models}}
 {{#model}}
-# {{{packageName}}}.Model.{{{classname}}}
+# {{{packageName}}}.{{modelPackage}}.{{{classname}}}
 ## Properties
 
 Name | Type | Description | Notes

--- a/modules/swagger-codegen/src/main/resources/csharp/model_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model_test.mustache
@@ -6,8 +6,8 @@ using System;
 using System.Linq;
 using System.IO;
 using System.Collections.Generic;
-using {{packageName}}.Api;
-using {{packageName}}.Model;
+using {{packageName}}.{{apiPackage}};
+using {{packageName}}.{{modelPackage}};
 using {{packageName}}.Client;
 using System.Reflection;
 

--- a/samples/client/petstore/csharp/SwaggerClient/IO.Swagger.sln
+++ b/samples/client/petstore/csharp/SwaggerClient/IO.Swagger.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{473916C4-D026-4063-8A3D-34BC255A0E7A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{D6453B3C-D08D-41D7-A59B-DE1F3581D258}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger.Test", "src\IO.Swagger.Test\IO.Swagger.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Debug|Any CPU = Debug|Any CPU
 Release|Any CPU = Release|Any CPU
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
-{473916C4-D026-4063-8A3D-34BC255A0E7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{473916C4-D026-4063-8A3D-34BC255A0E7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{473916C4-D026-4063-8A3D-34BC255A0E7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{473916C4-D026-4063-8A3D-34BC255A0E7A}.Release|Any CPU.Build.0 = Release|Any CPU
+{D6453B3C-D08D-41D7-A59B-DE1F3581D258}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{D6453B3C-D08D-41D7-A59B-DE1F3581D258}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{D6453B3C-D08D-41D7-A59B-DE1F3581D258}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{D6453B3C-D08D-41D7-A59B-DE1F3581D258}.Release|Any CPU.Build.0 = Release|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/client/petstore/csharp/SwaggerClient/build.bat
+++ b/samples/client/petstore/csharp/SwaggerClient/build.bat
@@ -16,7 +16,6 @@
 
 SET CSCPATH=%SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319
 
-
 if not exist ".\nuget.exe" powershell -Command "(new-object System.Net.WebClient).DownloadFile('https://nuget.org/nuget.exe', '.\nuget.exe')"
 .\nuget.exe install src\IO.Swagger\packages.config -o packages
 

--- a/samples/client/petstore/csharp/SwaggerClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/FakeApi.md
@@ -71,7 +71,7 @@ No authorization required
 
 <a name="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null)
+> void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -110,11 +110,12 @@ namespace Example
             var date = 2013-10-20;  // DateTime? | None (optional) 
             var dateTime = 2013-10-20T19:20:30+01:00;  // DateTime? | None (optional) 
             var password = password_example;  // string | None (optional) 
+            var callback = callback_example;  // string | None (optional) 
 
             try
             {
                 // Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-                apiInstance.TestEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, _string, binary, date, dateTime, password);
+                apiInstance.TestEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, _string, binary, date, dateTime, password, callback);
             }
             catch (Exception e)
             {
@@ -142,6 +143,7 @@ Name | Type | Description  | Notes
  **date** | **DateTime?**| None | [optional] 
  **dateTime** | **DateTime?**| None | [optional] 
  **password** | **string**| None | [optional] 
+ **callback** | **string**| None | [optional] 
 
 ### Return type
 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/FakeApi.cs
@@ -77,8 +77,9 @@ namespace IO.Swagger.Api
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional)</param>
         /// <param name="password">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <returns></returns>
-        void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null);
+        void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -100,8 +101,9 @@ namespace IO.Swagger.Api
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional)</param>
         /// <param name="password">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null);
+        ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
         /// <summary>
         /// To test enum parameters
         /// </summary>
@@ -180,8 +182,9 @@ namespace IO.Swagger.Api
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional)</param>
         /// <param name="password">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task TestEndpointParametersAsync (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null);
+        System.Threading.Tasks.Task TestEndpointParametersAsync (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -203,8 +206,9 @@ namespace IO.Swagger.Api
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional)</param>
         /// <param name="password">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null);
+        System.Threading.Tasks.Task<ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
         /// <summary>
         /// To test enum parameters
         /// </summary>
@@ -526,10 +530,11 @@ namespace IO.Swagger.Api
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional)</param>
         /// <param name="password">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <returns></returns>
-        public void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null)
+        public void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
         {
-             TestEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, _string, binary, date, dateTime, password);
+             TestEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, _string, binary, date, dateTime, password, callback);
         }
 
         /// <summary>
@@ -549,8 +554,9 @@ namespace IO.Swagger.Api
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional)</param>
         /// <param name="password">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null)
+        public ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
         {
             // verify the required parameter 'number' is set
             if (number == null)
@@ -605,6 +611,7 @@ namespace IO.Swagger.Api
             if (date != null) localVarFormParams.Add("date", Configuration.ApiClient.ParameterToString(date)); // form parameter
             if (dateTime != null) localVarFormParams.Add("dateTime", Configuration.ApiClient.ParameterToString(dateTime)); // form parameter
             if (password != null) localVarFormParams.Add("password", Configuration.ApiClient.ParameterToString(password)); // form parameter
+            if (callback != null) localVarFormParams.Add("callback", Configuration.ApiClient.ParameterToString(callback)); // form parameter
 
             // authentication (http_basic_test) required
             // http basic authentication required
@@ -650,10 +657,11 @@ namespace IO.Swagger.Api
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional)</param>
         /// <param name="password">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task TestEndpointParametersAsync (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null)
+        public async System.Threading.Tasks.Task TestEndpointParametersAsync (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
         {
-             await TestEndpointParametersAsyncWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, _string, binary, date, dateTime, password);
+             await TestEndpointParametersAsyncWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, _string, binary, date, dateTime, password, callback);
 
         }
 
@@ -674,8 +682,9 @@ namespace IO.Swagger.Api
         /// <param name="date">None (optional)</param>
         /// <param name="dateTime">None (optional)</param>
         /// <param name="password">None (optional)</param>
+        /// <param name="callback">None (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null)
+        public async System.Threading.Tasks.Task<ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, byte[] binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
         {
             // verify the required parameter 'number' is set
             if (number == null)
@@ -730,6 +739,7 @@ namespace IO.Swagger.Api
             if (date != null) localVarFormParams.Add("date", Configuration.ApiClient.ParameterToString(date)); // form parameter
             if (dateTime != null) localVarFormParams.Add("dateTime", Configuration.ApiClient.ParameterToString(dateTime)); // form parameter
             if (password != null) localVarFormParams.Add("password", Configuration.ApiClient.ParameterToString(password)); // form parameter
+            if (callback != null) localVarFormParams.Add("callback", Configuration.ApiClient.ParameterToString(callback)); // form parameter
 
             // authentication (http_basic_test) required
             // http basic authentication required

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
@@ -24,7 +24,7 @@ limitations under the License.
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{473916C4-D026-4063-8A3D-34BC255A0E7A}</ProjectGuid>
+    <ProjectGuid>{D6453B3C-D08D-41D7-A59B-DE1F3581D258}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IO.Swagger</RootNamespace>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description

The apiPackage, modelPackage, and excludeTests values were not being
populated correctly from external configs (passing -c filename to
generator).

This commit allows those properties to work correctly with the Csharp
client generator. Previously the Api and Model namespaces were hard
coded after additionalProperties for these were evaluated.

The files which generate test files for models and api classes
didn't honor the excludeTests option.

see #3993, #3961