### PR TITLE
Add Java6 compatibility for Jersey2

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -22,7 +22,13 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 import java.io.IOException;
 import java.io.InputStream;
+
+{{^supportJava6}}
 import java.nio.file.Files;
+{{/supportJava6}}
+{{#supportJava6}}
+import org.apache.commons.io.FileUtils;
+{{/supportJava6}}
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -521,7 +527,13 @@ public class ApiClient {
   public File downloadFileFromResponse(Response response) throws ApiException {
     try {
       File file = prepareDownloadFile(response);
+{{^supportJava6}}
       Files.copy(response.readEntity(InputStream.class), file.toPath());
+{{/supportJava6}}
+{{#supportJava6}}
+      // Java6 falls back to commons.io for file copying
+      FileUtils.copyToFile(response.readEntity(InputStream.class), file);
+{{/supportJava6}}
       return file;
     } catch (IOException e) {
       throw new ApiException(e);


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Java6 compatibility is being added via supportJava6 option. This PR makes a small change to Jersey2 to replace usage of Java 7 class java.nio.file.Files with reference to Apache commons.io.FileUtils. 

I'm not sure exactly how to manage the additional dependency for commons io. Originally I saw it as part of swagger-codegen but of course that is only for the generation process. I doubt we want to add it as a dependency on the swagger runtime code, are you happy for it be up to users of supportJava6 to add manually?
