### PR TITLE
hashCode and equals support for jdk6 for jersey2

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -111,6 +111,10 @@ ext {
     {{^java8}}
     jodatime_version = "2.9.4"
     {{/java8}}
+    {{#supportJava6}}
+    commons_io_version=2.5
+    commons_lang3_version=3.5
+    {{/supportJava6}}
     junit_version = "4.12"
 }
 
@@ -129,6 +133,10 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jackson_version"
     compile "joda-time:joda-time:$jodatime_version"
     {{/java8}}
+    {{#supportJava6}}
+    compile "commons-io:commons-io:$commons_io_version"
+    compile "org.apache.commons:commons-lang3:$commons_lang3_version"
+    {{/supportJava6}}
     compile "com.brsanthu:migbase64:2.2"
     testCompile "junit:junit:$junit_version"
 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
@@ -24,6 +24,10 @@ lazy val root = (project in file(".")).
       "joda-time" % "joda-time" % "2.9.4",
       {{/java8}}
       "com.brsanthu" % "migbase64" % "2.2",
+      {{#supportJava6}}
+      "org.apache.commons" % "commons-lang3" % "3.5",
+      "commons-io" % "commons-io" % "2.5",
+      {{/supportJava6}}
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.10" % "test"
     )

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -183,6 +183,19 @@
       <artifactId>migbase64</artifactId>
       <version>2.2</version>
     </dependency>
+    {{#supportJava6}}
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons_lang3_version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons_io_version}</version>
+    </dependency>
+    {{/supportJava6}}
 
     <!-- test dependencies -->
     <dependency>
@@ -199,6 +212,10 @@
     {{^java8}}
     <jodatime-version>2.9.4</jodatime-version>
     {{/java8}}
+    {{#supportJava6}}
+    <commons_io_version>2.5</commons_io_version>
+    <commons_lang3_version>3.5</commons_lang3_version>
+    {{/supportJava6}}
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <junit-version>4.12</junit-version>
   </properties>

--- a/modules/swagger-codegen/src/main/resources/Java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/model.mustache
@@ -5,6 +5,9 @@ package {{package}};
 {{^supportJava6}}
 import java.util.Objects;
 {{/supportJava6}}
+{{#supportJava6}}
+import org.apache.commons.lang3.ObjectUtils;
+{{/supportJava6}}
 {{#imports}}
 import {{import}};
 {{/imports}}

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -101,6 +101,29 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   }
 
 {{/supportJava6}}
+{{#supportJava6}}
+  @Override
+  public boolean equals(java.lang.Object o) {
+  if (this == o) {
+    return true;
+  }
+  if (o == null || getClass() != o.getClass()) {
+    return false;
+  }{{#hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+    return {{#vars}}ObjectUtils.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+    {{/hasMore}}{{/vars}}{{#parent}} &&
+    super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    return true;{{/hasVars}}
+  }
+
+  @Override
+  public int hashCode() {
+    return ObjectUtils.hashCodeMulti({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+  }
+
+{{/supportJava6}}
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-codegen/src/main/resources/Java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pom.mustache
@@ -181,6 +181,20 @@
       <version>2.2</version>
     </dependency>
 
+    {{#supportJava6}}
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons_lang3_version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons_io_version}</version>
+    </dependency>
+    {{/supportJava6}}
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -197,6 +211,10 @@
     {{^java8}}
     <jodatime-version>2.9.4</jodatime-version>
     {{/java8}}
+    {{#supportJava6}}
+    <commons_io_version>2.5</commons_io_version>
+    <commons_lang3_version>3.5</commons_lang3_version>
+    {{/supportJava6}}
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <junit-version>4.12</junit-version>
   </properties>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

We are working with jdk6 and jersey2 at the moment and cannot use jdk7 generated classes. I have reused 'supportJava6' flag as a switch to make some changes to the templates, so, apache commons libs can be used instead. I have changed pom, gradle and sbt as well. 
