### PR TITLE
[Qt5/C++] Arrays of primitive types fix

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
@@ -37,7 +37,7 @@ void HttpRequestInput::add_file(QString variable_name, QString local_filename, Q
 
 
 HttpRequestWorker::HttpRequestWorker(QObject *parent)
-    : QObject(parent), manager(NULL)
+    : QObject(parent), manager(nullptr)
 {
     qsrand(QDateTime::currentDateTime().toTime_t());
 
@@ -181,8 +181,8 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
 
             // ensure necessary variables are available
             if (
-                file_info->local_filename == NULL || file_info->local_filename.isEmpty()
-                || file_info->variable_name == NULL || file_info->variable_name.isEmpty()
+                file_info->local_filename == nullptr || file_info->local_filename.isEmpty()
+                || file_info->variable_name == nullptr || file_info->variable_name.isEmpty()
                 || !fi.exists() || !fi.isFile() || !fi.isReadable()
             ) {
                 // silent abort for the current file
@@ -196,7 +196,7 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
             }
 
             // ensure filename for the request
-            if (file_info->request_filename == NULL || file_info->request_filename.isEmpty()) {
+            if (file_info->request_filename == nullptr || file_info->request_filename.isEmpty()) {
                 file_info->request_filename = fi.fileName();
                 if (file_info->request_filename.isEmpty()) {
                     file_info->request_filename = "file";
@@ -215,7 +215,7 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
             ));
             request_content.append(new_line);
 
-            if (file_info->mime_type != NULL && !file_info->mime_type.isEmpty()) {
+            if (file_info->mime_type != nullptr && !file_info->mime_type.isEmpty()) {
                 request_content.append("Content-Type: ");
                 request_content.append(file_info->mime_type);
                 request_content.append(new_line);

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -87,7 +87,7 @@ void
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "{{httpMethod}}");
 
-    {{#formParams}}if ({{paramName}} != NULL) {
+    {{#formParams}}if ({{paramName}} != nullptr) {
         {{^isFile}}input.add_var("{{baseName}}", *{{paramName}});{{/isFile}}{{#isFile}}input.add_file("{{baseName}}", (*{{paramName}}).local_filename, (*{{paramName}}).request_filename, (*{{paramName}}).mime_type);{{/isFile}}
     }
     {{/formParams}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -10,7 +10,7 @@ namespace Swagger {
 
 void
 setValue(void* value, QJsonValue obj, QString type, QString complexType) {
-    if(value == NULL) {
+    if(value == nullptr) {
         // can't set value with a null pointer
         return;
     }
@@ -37,7 +37,7 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     else if (QStringLiteral("QString").compare(type) == 0) {
         QString **val = static_cast<QString**>(value);
 
-        if(val != NULL) {
+        if(val != nullptr) {
             if(!obj.isNull()) {
                 // create a new value and return
                 delete *val;
@@ -45,19 +45,19 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 return;
             }
             else {
-                // set target to NULL
+                // set target to nullptr
                 delete *val;
-                *val = NULL;
+                *val = nullptr;
             }
         }
         else {
-            qDebug() << "Can't set value because the target pointer is NULL";
+            qDebug() << "Can't set value because the target pointer is nullptr";
         }
     }
     else if (QStringLiteral("QDateTime").compare(type) == 0) {
         QDateTime **val = static_cast<QDateTime**>(value);
 
-        if(val != NULL) {
+        if(val != nullptr) {
             if(!obj.isNull()) {
                 // create a new value and return
                 delete *val;
@@ -65,19 +65,19 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 return;
             }
             else {
-                // set target to NULL
+                // set target to nullptr
                 delete *val;
-                *val = NULL;
+                *val = nullptr;
             }
         }
         else {
-            qDebug() << "Can't set value because the target pointer is NULL";
+            qDebug() << "Can't set value because the target pointer is nullptr";
         }
     }
     else if (QStringLiteral("QDate").compare(type) == 0) {
         QDate **val = static_cast<QDate**>(value);
 
-        if(val != NULL) {
+        if(val != nullptr) {
             if(!obj.isNull()) {
                 // create a new value and return
                 delete *val;
@@ -85,19 +85,19 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 return;
             }
             else {
-                // set target to NULL
+                // set target to nullptr
                 delete *val;
-                *val = NULL;
+                *val = nullptr;
             }
         }
         else {
-            qDebug() << "Can't set value because the target pointer is NULL";
+            qDebug() << "Can't set value because the target pointer is nullptr";
         }
     }
     else if (QStringLiteral("QByteArray").compare(type) == 0) {
         QByteArray **val = static_cast<QByteArray**>(value);
 
-        if(val != NULL) {
+        if(val != nullptr) {
             if(!obj.isNull()) {
                 // create a new value and return
                 delete *val;
@@ -106,20 +106,20 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 return;
             }
             else {
-                // set target to NULL
+                // set target to nullptr
                 delete *val;
-                *val = NULL;
+                *val = nullptr;
             }
         }
         else {
-            qDebug() << "Can't set value because the target pointer is NULL";
+            qDebug() << "Can't set value because the target pointer is nullptr";
         }
     }
     else if(type.startsWith("SWG") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
         SWGObject * so = (SWGObject*)Swagger::create(type);
-        if(so != NULL) {
+        if(so != nullptr) {
             so->fromJsonObject(jsonObj);
             SWGObject **val = static_cast<SWGObject**>(value);
             delete *val;
@@ -167,19 +167,19 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                     output->append((void*)&val);
                 }
                 else if(QStringLiteral("QString").compare(complexType) == 0) {
-                    QString val;
+                    QString * val = new QString();
                     setValue(&val, jval, QStringLiteral("QString"), QStringLiteral(""));
-                    output->append((void*)&val);
+                    output->append((void*)val);
                 }
                 else if(QStringLiteral("QDate").compare(complexType) == 0) {
-                    QDate val;
+                    QDate * val = new QDate();
                     setValue(&val, jval, QStringLiteral("QDate"), QStringLiteral(""));
-                    output->append((void*)&val);
+                    output->append((void*)val);
                 }
                 else if(QStringLiteral("QDateTime").compare(complexType) == 0) {
-                    QDateTime val;
+                    QDateTime * val = new QDateTime();
                     setValue(&val, jval, QStringLiteral("QDateTime"), QStringLiteral(""));
-                    output->append((void*)&val);
+                    output->append((void*)val);
                 }
             }
         }
@@ -191,14 +191,14 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
 
 void
 toJsonValue(QString name, void* value, QJsonObject* output, QString type) {
-    if(value == NULL) {
+    if(value == nullptr) {
         return;
     }
     if(type.startsWith("SWG")) {
         SWGObject *swgObject = reinterpret_cast<SWGObject *>(value);
-        if(swgObject != NULL) {
+        if(swgObject != nullptr) {
             QJsonObject* o = (*swgObject).asJsonObject();
-            if(name != NULL) {
+            if(name != nullptr) {
                 output->insert(name, *o);
                 delete o;
             }
@@ -253,7 +253,7 @@ toJsonArray(QList<void*>* value, QJsonArray* output, QString innerName, QString 
     foreach(void* obj, *value) {
         QJsonObject element;
 
-        toJsonValue(NULL, obj, &element, innerType);
+        toJsonValue(nullptr, obj, &element, innerType);
         output->append(element);
     }
 }

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -27,13 +27,15 @@ namespace Swagger {
 
 void
 {{classname}}::init() {
-    {{#vars}}{{name}} = {{{defaultValue}}};
+    {{#vars}}
+    {{name}} = {{{defaultValue}}};
     {{/vars}}
 }
 
 void
 {{classname}}::cleanup() {
-    {{#vars}}{{#complexType}}if({{name}} != NULL) {
+    {{#vars}}{{#complexType}}
+    if({{name}} != nullptr) {
         {{#isContainer}}QList<{{complexType}}*>* arr = {{name}};
         foreach({{complexType}}* o, *arr) {
             delete o;

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -54,7 +54,12 @@ void
 
 void
 {{classname}}::fromJsonObject(QJsonObject &pJson) {
-    {{#vars}}setValue(&{{name}}, pJson["{{name}}"], "{{baseType}}", "{{complexType}}");
+    {{#vars}}
+    {{^isContainer}}::Swagger::setValue(&{{name}}, pJson["{{name}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}}
+    {{#isContainer}}
+    {{#complexType}}::Swagger::setValue(&{{name}}, pJson["{{name}}"], "{{baseType}}", "{{complexType}}");{{/complexType}}
+    {{^complexType}}::Swagger::setValue(&{{name}}, pJson["{{name}}"], "{{baseType}}", "{{items.baseType}}");{{/complexType}}
+    {{/isContainer}}
     {{/vars}}
 }
 
@@ -71,21 +76,18 @@ QString
 QJsonObject*
 {{classname}}::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
-    {{#vars}}{{#complexType}}
-    {{^isContainer}}{{#complexType}}
-    toJsonValue(QString("{{name}}"), {{name}}, obj, QString("{{complexType}}"));
-    {{/complexType}}{{^complexType}}
-    else if({{name}} != NULL && *{{name}} != NULL) {
-      obj->insert("{{name}}", QJsonValue(*{{name}}));
-    }{{/complexType}}
-    {{/isContainer}}{{#isContainer}}
-    QList<{{complexType}}*>* {{name}}List = {{name}};
+    {{#vars}}{{#complexType}}{{^isContainer}}{{#complexType}}
+    toJsonValue(QString("{{name}}"), {{name}}, obj, QString("{{complexType}}"));{{/complexType}}{{^complexType}}
+    if({{name}} != nullptr && *{{name}} != nullptr) { 
+        obj->insert("{{name}}", QJsonValue(*{{name}}));
+    }{{/complexType}}{{/isContainer}}{{#isContainer}}
     QJsonArray {{name}}JsonArray;
     toJsonArray((QList<void*>*){{name}}, &{{name}}JsonArray, "{{name}}", "{{complexType}}");
-
-    obj->insert("{{name}}", {{name}}JsonArray);
-    {{/isContainer}}
-    {{/complexType}}{{^complexType}}obj->insert("{{name}}", QJsonValue({{name}}));{{/complexType}}
+    obj->insert("{{name}}", {{name}}JsonArray);{{/isContainer}}{{/complexType}}{{^complexType}}{{^isContainer}}
+    obj->insert("{{name}}", QJsonValue({{name}}));{{/isContainer}}{{#isContainer}}
+    QJsonArray {{name}}JsonArray;
+    toJsonArray((QList<void*>*){{name}}, &{{name}}JsonArray, "{{name}}", "{{items.baseType}}");
+    obj->insert("{{name}}", {{name}}JsonArray);{{/isContainer}}{{/complexType}}
     {{/vars}}
 
     return obj;

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-header.mustache
@@ -32,12 +32,15 @@ public:
     void fromJsonObject(QJsonObject &json);
     {{classname}}* fromJson(QString &jsonString);
 
-    {{#vars}}{{{datatype}}} {{getter}}();
+    {{#vars}}
+    {{{datatype}}} {{getter}}();
     void {{setter}}({{{datatype}}} {{name}});
+
     {{/vars}}
 
 private:
-    {{#vars}}{{{datatype}}} {{name}};
+    {{#vars}}
+    {{{datatype}}} {{name}};
     {{/vars}}
 };
 

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/modelFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/modelFactory.mustache
@@ -11,19 +11,19 @@ namespace Swagger {
       return new {{classname}}();
     }
     {{/model}}{{/models}}
-    return NULL;
+    return nullptr;
   }
 
   inline void* create(QString json, QString type) {
     void* val = create(type);
-    if(val != NULL) {
+    if(val != nullptr) {
       SWGObject* obj = static_cast<SWGObject*>(val);
       return obj->fromJson(json);
     }
     if(type.startsWith("QString")) {
       return new QString();
     }
-    return NULL;
+    return nullptr;
   }
 } /* namespace Swagger */
 

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/object.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/object.mustache
@@ -7,12 +7,12 @@
 class {{prefix}}Object {
   public:
     virtual QJsonObject* asJsonObject() {
-      return NULL;
+      return nullptr;
     }
     virtual ~SWGObject() {}
     virtual SWGObject* fromJson(QString &jsonString) {
         Q_UNUSED(jsonString);
-        return NULL;
+        return nullptr;
     }
     virtual void fromJsonObject(QJsonObject &json) {
         Q_UNUSED(json);

--- a/samples/client/petstore/qt5cpp/client/SWGApiResponse.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGApiResponse.cpp
@@ -51,17 +51,19 @@ SWGApiResponse::~SWGApiResponse() {
 void
 SWGApiResponse::init() {
     code = 0;
-type = new QString("");
-message = new QString("");
+    type = new QString("");
+    message = new QString("");
 }
 
 void
 SWGApiResponse::cleanup() {
     
-if(type != NULL) {
+
+    if(type != nullptr) {
         delete type;
     }
-if(message != NULL) {
+
+    if(message != nullptr) {
         delete message;
     }
 }
@@ -77,9 +79,9 @@ SWGApiResponse::fromJson(QString &json) {
 
 void
 SWGApiResponse::fromJsonObject(QJsonObject &pJson) {
-    setValue(&code, pJson["code"], "qint32", "");
-setValue(&type, pJson["type"], "QString", "QString");
-setValue(&message, pJson["message"], "QString", "QString");
+    ::Swagger::setValue(&code, pJson["code"], "qint32", "");
+    ::Swagger::setValue(&type, pJson["type"], "QString", "QString");
+    ::Swagger::setValue(&message, pJson["message"], "QString", "QString");
 }
 
 QString
@@ -95,17 +97,12 @@ SWGApiResponse::asJson ()
 QJsonObject*
 SWGApiResponse::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
+    
     obj->insert("code", QJsonValue(code));
 
-    
     toJsonValue(QString("type"), type, obj, QString("QString"));
-    
-        
 
-    
     toJsonValue(QString("message"), message, obj, QString("QString"));
-    
-        
 
     return obj;
 }

--- a/samples/client/petstore/qt5cpp/client/SWGApiResponse.h
+++ b/samples/client/petstore/qt5cpp/client/SWGApiResponse.h
@@ -56,15 +56,18 @@ public:
 
     qint32 getCode();
     void setCode(qint32 code);
-QString* getType();
+
+    QString* getType();
     void setType(QString* type);
-QString* getMessage();
+
+    QString* getMessage();
     void setMessage(QString* message);
+
 
 private:
     qint32 code;
-QString* type;
-QString* message;
+    QString* type;
+    QString* message;
 };
 
 } /* namespace Swagger */

--- a/samples/client/petstore/qt5cpp/client/SWGCategory.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGCategory.cpp
@@ -51,13 +51,14 @@ SWGCategory::~SWGCategory() {
 void
 SWGCategory::init() {
     id = 0L;
-name = new QString("");
+    name = new QString("");
 }
 
 void
 SWGCategory::cleanup() {
     
-if(name != NULL) {
+
+    if(name != nullptr) {
         delete name;
     }
 }
@@ -73,8 +74,8 @@ SWGCategory::fromJson(QString &json) {
 
 void
 SWGCategory::fromJsonObject(QJsonObject &pJson) {
-    setValue(&id, pJson["id"], "qint64", "");
-setValue(&name, pJson["name"], "QString", "QString");
+    ::Swagger::setValue(&id, pJson["id"], "qint64", "");
+    ::Swagger::setValue(&name, pJson["name"], "QString", "QString");
 }
 
 QString
@@ -90,12 +91,10 @@ SWGCategory::asJson ()
 QJsonObject*
 SWGCategory::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
+    
     obj->insert("id", QJsonValue(id));
 
-    
     toJsonValue(QString("name"), name, obj, QString("QString"));
-    
-        
 
     return obj;
 }

--- a/samples/client/petstore/qt5cpp/client/SWGCategory.h
+++ b/samples/client/petstore/qt5cpp/client/SWGCategory.h
@@ -56,12 +56,14 @@ public:
 
     qint64 getId();
     void setId(qint64 id);
-QString* getName();
+
+    QString* getName();
     void setName(QString* name);
+
 
 private:
     qint64 id;
-QString* name;
+    QString* name;
 };
 
 } /* namespace Swagger */

--- a/samples/client/petstore/qt5cpp/client/SWGHelpers.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGHelpers.cpp
@@ -33,7 +33,7 @@ namespace Swagger {
 
 void
 setValue(void* value, QJsonValue obj, QString type, QString complexType) {
-    if(value == NULL) {
+    if(value == nullptr) {
         // can't set value with a null pointer
         return;
     }
@@ -60,7 +60,7 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     else if (QStringLiteral("QString").compare(type) == 0) {
         QString **val = static_cast<QString**>(value);
 
-        if(val != NULL) {
+        if(val != nullptr) {
             if(!obj.isNull()) {
                 // create a new value and return
                 delete *val;
@@ -68,19 +68,19 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 return;
             }
             else {
-                // set target to NULL
+                // set target to nullptr
                 delete *val;
-                *val = NULL;
+                *val = nullptr;
             }
         }
         else {
-            qDebug() << "Can't set value because the target pointer is NULL";
+            qDebug() << "Can't set value because the target pointer is nullptr";
         }
     }
     else if (QStringLiteral("QDateTime").compare(type) == 0) {
         QDateTime **val = static_cast<QDateTime**>(value);
 
-        if(val != NULL) {
+        if(val != nullptr) {
             if(!obj.isNull()) {
                 // create a new value and return
                 delete *val;
@@ -88,19 +88,19 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 return;
             }
             else {
-                // set target to NULL
+                // set target to nullptr
                 delete *val;
-                *val = NULL;
+                *val = nullptr;
             }
         }
         else {
-            qDebug() << "Can't set value because the target pointer is NULL";
+            qDebug() << "Can't set value because the target pointer is nullptr";
         }
     }
     else if (QStringLiteral("QDate").compare(type) == 0) {
         QDate **val = static_cast<QDate**>(value);
 
-        if(val != NULL) {
+        if(val != nullptr) {
             if(!obj.isNull()) {
                 // create a new value and return
                 delete *val;
@@ -108,19 +108,19 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 return;
             }
             else {
-                // set target to NULL
+                // set target to nullptr
                 delete *val;
-                *val = NULL;
+                *val = nullptr;
             }
         }
         else {
-            qDebug() << "Can't set value because the target pointer is NULL";
+            qDebug() << "Can't set value because the target pointer is nullptr";
         }
     }
     else if (QStringLiteral("QByteArray").compare(type) == 0) {
         QByteArray **val = static_cast<QByteArray**>(value);
 
-        if(val != NULL) {
+        if(val != nullptr) {
             if(!obj.isNull()) {
                 // create a new value and return
                 delete *val;
@@ -129,20 +129,20 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                 return;
             }
             else {
-                // set target to NULL
+                // set target to nullptr
                 delete *val;
-                *val = NULL;
+                *val = nullptr;
             }
         }
         else {
-            qDebug() << "Can't set value because the target pointer is NULL";
+            qDebug() << "Can't set value because the target pointer is nullptr";
         }
     }
     else if(type.startsWith("SWG") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
         SWGObject * so = (SWGObject*)Swagger::create(type);
-        if(so != NULL) {
+        if(so != nullptr) {
             so->fromJsonObject(jsonObj);
             SWGObject **val = static_cast<SWGObject**>(value);
             delete *val;
@@ -190,19 +190,19 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
                     output->append((void*)&val);
                 }
                 else if(QStringLiteral("QString").compare(complexType) == 0) {
-                    QString val;
+                    QString * val = new QString();
                     setValue(&val, jval, QStringLiteral("QString"), QStringLiteral(""));
-                    output->append((void*)&val);
+                    output->append((void*)val);
                 }
                 else if(QStringLiteral("QDate").compare(complexType) == 0) {
-                    QDate val;
+                    QDate * val = new QDate();
                     setValue(&val, jval, QStringLiteral("QDate"), QStringLiteral(""));
-                    output->append((void*)&val);
+                    output->append((void*)val);
                 }
                 else if(QStringLiteral("QDateTime").compare(complexType) == 0) {
-                    QDateTime val;
+                    QDateTime * val = new QDateTime();
                     setValue(&val, jval, QStringLiteral("QDateTime"), QStringLiteral(""));
-                    output->append((void*)&val);
+                    output->append((void*)val);
                 }
             }
         }
@@ -214,14 +214,14 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
 
 void
 toJsonValue(QString name, void* value, QJsonObject* output, QString type) {
-    if(value == NULL) {
+    if(value == nullptr) {
         return;
     }
     if(type.startsWith("SWG")) {
         SWGObject *swgObject = reinterpret_cast<SWGObject *>(value);
-        if(swgObject != NULL) {
+        if(swgObject != nullptr) {
             QJsonObject* o = (*swgObject).asJsonObject();
-            if(name != NULL) {
+            if(name != nullptr) {
                 output->insert(name, *o);
                 delete o;
             }
@@ -276,7 +276,7 @@ toJsonArray(QList<void*>* value, QJsonArray* output, QString innerName, QString 
     foreach(void* obj, *value) {
         QJsonObject element;
 
-        toJsonValue(NULL, obj, &element, innerType);
+        toJsonValue(nullptr, obj, &element, innerType);
         output->append(element);
     }
 }

--- a/samples/client/petstore/qt5cpp/client/SWGHttpRequest.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGHttpRequest.cpp
@@ -60,7 +60,7 @@ void HttpRequestInput::add_file(QString variable_name, QString local_filename, Q
 
 
 HttpRequestWorker::HttpRequestWorker(QObject *parent)
-    : QObject(parent), manager(NULL)
+    : QObject(parent), manager(nullptr)
 {
     qsrand(QDateTime::currentDateTime().toTime_t());
 
@@ -204,8 +204,8 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
 
             // ensure necessary variables are available
             if (
-                file_info->local_filename == NULL || file_info->local_filename.isEmpty()
-                || file_info->variable_name == NULL || file_info->variable_name.isEmpty()
+                file_info->local_filename == nullptr || file_info->local_filename.isEmpty()
+                || file_info->variable_name == nullptr || file_info->variable_name.isEmpty()
                 || !fi.exists() || !fi.isFile() || !fi.isReadable()
             ) {
                 // silent abort for the current file
@@ -219,7 +219,7 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
             }
 
             // ensure filename for the request
-            if (file_info->request_filename == NULL || file_info->request_filename.isEmpty()) {
+            if (file_info->request_filename == nullptr || file_info->request_filename.isEmpty()) {
                 file_info->request_filename = fi.fileName();
                 if (file_info->request_filename.isEmpty()) {
                     file_info->request_filename = "file";
@@ -238,7 +238,7 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
             ));
             request_content.append(new_line);
 
-            if (file_info->mime_type != NULL && !file_info->mime_type.isEmpty()) {
+            if (file_info->mime_type != nullptr && !file_info->mime_type.isEmpty()) {
                 request_content.append("Content-Type: ");
                 request_content.append(file_info->mime_type);
                 request_content.append(new_line);

--- a/samples/client/petstore/qt5cpp/client/SWGModelFactory.h
+++ b/samples/client/petstore/qt5cpp/client/SWGModelFactory.h
@@ -54,19 +54,19 @@ namespace Swagger {
       return new SWGUser();
     }
     
-    return NULL;
+    return nullptr;
   }
 
   inline void* create(QString json, QString type) {
     void* val = create(type);
-    if(val != NULL) {
+    if(val != nullptr) {
       SWGObject* obj = static_cast<SWGObject*>(val);
       return obj->fromJson(json);
     }
     if(type.startsWith("QString")) {
       return new QString();
     }
-    return NULL;
+    return nullptr;
   }
 } /* namespace Swagger */
 

--- a/samples/client/petstore/qt5cpp/client/SWGObject.h
+++ b/samples/client/petstore/qt5cpp/client/SWGObject.h
@@ -30,12 +30,12 @@
 class SWGObject {
   public:
     virtual QJsonObject* asJsonObject() {
-      return NULL;
+      return nullptr;
     }
     virtual ~SWGObject() {}
     virtual SWGObject* fromJson(QString &jsonString) {
         Q_UNUSED(jsonString);
-        return NULL;
+        return nullptr;
     }
     virtual void fromJsonObject(QJsonObject &json) {
         Q_UNUSED(json);

--- a/samples/client/petstore/qt5cpp/client/SWGOrder.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGOrder.cpp
@@ -51,11 +51,11 @@ SWGOrder::~SWGOrder() {
 void
 SWGOrder::init() {
     id = 0L;
-pet_id = 0L;
-quantity = 0;
-ship_date = NULL;
-status = new QString("");
-complete = false;
+    pet_id = 0L;
+    quantity = 0;
+    ship_date = NULL;
+    status = new QString("");
+    complete = false;
 }
 
 void
@@ -63,10 +63,12 @@ SWGOrder::cleanup() {
     
 
 
-if(ship_date != NULL) {
+
+    if(ship_date != nullptr) {
         delete ship_date;
     }
-if(status != NULL) {
+
+    if(status != nullptr) {
         delete status;
     }
 
@@ -83,12 +85,12 @@ SWGOrder::fromJson(QString &json) {
 
 void
 SWGOrder::fromJsonObject(QJsonObject &pJson) {
-    setValue(&id, pJson["id"], "qint64", "");
-setValue(&pet_id, pJson["pet_id"], "qint64", "");
-setValue(&quantity, pJson["quantity"], "qint32", "");
-setValue(&ship_date, pJson["ship_date"], "QDateTime", "QDateTime");
-setValue(&status, pJson["status"], "QString", "QString");
-setValue(&complete, pJson["complete"], "bool", "");
+    ::Swagger::setValue(&id, pJson["id"], "qint64", "");
+    ::Swagger::setValue(&pet_id, pJson["pet_id"], "qint64", "");
+    ::Swagger::setValue(&quantity, pJson["quantity"], "qint32", "");
+    ::Swagger::setValue(&ship_date, pJson["ship_date"], "QDateTime", "QDateTime");
+    ::Swagger::setValue(&status, pJson["status"], "QString", "QString");
+    ::Swagger::setValue(&complete, pJson["complete"], "bool", "");
 }
 
 QString
@@ -104,20 +106,18 @@ SWGOrder::asJson ()
 QJsonObject*
 SWGOrder::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
+    
     obj->insert("id", QJsonValue(id));
-obj->insert("pet_id", QJsonValue(pet_id));
-obj->insert("quantity", QJsonValue(quantity));
 
-    
+    obj->insert("pet_id", QJsonValue(pet_id));
+
+    obj->insert("quantity", QJsonValue(quantity));
+
     toJsonValue(QString("ship_date"), ship_date, obj, QString("QDateTime"));
-    
-        
 
-    
     toJsonValue(QString("status"), status, obj, QString("QString"));
-    
-        
-obj->insert("complete", QJsonValue(complete));
+
+    obj->insert("complete", QJsonValue(complete));
 
     return obj;
 }

--- a/samples/client/petstore/qt5cpp/client/SWGOrder.h
+++ b/samples/client/petstore/qt5cpp/client/SWGOrder.h
@@ -57,24 +57,30 @@ public:
 
     qint64 getId();
     void setId(qint64 id);
-qint64 getPetId();
+
+    qint64 getPetId();
     void setPetId(qint64 pet_id);
-qint32 getQuantity();
+
+    qint32 getQuantity();
     void setQuantity(qint32 quantity);
-QDateTime* getShipDate();
+
+    QDateTime* getShipDate();
     void setShipDate(QDateTime* ship_date);
-QString* getStatus();
+
+    QString* getStatus();
     void setStatus(QString* status);
-bool getComplete();
+
+    bool getComplete();
     void setComplete(bool complete);
+
 
 private:
     qint64 id;
-qint64 pet_id;
-qint32 quantity;
-QDateTime* ship_date;
-QString* status;
-bool complete;
+    qint64 pet_id;
+    qint32 quantity;
+    QDateTime* ship_date;
+    QString* status;
+    bool complete;
 };
 
 } /* namespace Swagger */

--- a/samples/client/petstore/qt5cpp/client/SWGPet.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGPet.cpp
@@ -51,37 +51,42 @@ SWGPet::~SWGPet() {
 void
 SWGPet::init() {
     id = 0L;
-category = new SWGCategory();
-name = new QString("");
-photo_urls = new QList<QString*>();
-tags = new QList<SWGTag*>();
-status = new QString("");
+    category = new SWGCategory();
+    name = new QString("");
+    photo_urls = new QList<QString*>();
+    tags = new QList<SWGTag*>();
+    status = new QString("");
 }
 
 void
 SWGPet::cleanup() {
     
-if(category != NULL) {
+
+    if(category != nullptr) {
         delete category;
     }
-if(name != NULL) {
+
+    if(name != nullptr) {
         delete name;
     }
-if(photo_urls != NULL) {
+
+    if(photo_urls != nullptr) {
         QList<QString*>* arr = photo_urls;
         foreach(QString* o, *arr) {
             delete o;
         }
         delete photo_urls;
     }
-if(tags != NULL) {
+
+    if(tags != nullptr) {
         QList<SWGTag*>* arr = tags;
         foreach(SWGTag* o, *arr) {
             delete o;
         }
         delete tags;
     }
-if(status != NULL) {
+
+    if(status != nullptr) {
         delete status;
     }
 }
@@ -97,12 +102,16 @@ SWGPet::fromJson(QString &json) {
 
 void
 SWGPet::fromJsonObject(QJsonObject &pJson) {
-    setValue(&id, pJson["id"], "qint64", "");
-setValue(&category, pJson["category"], "SWGCategory", "SWGCategory");
-setValue(&name, pJson["name"], "QString", "QString");
-setValue(&photo_urls, pJson["photo_urls"], "QList", "QString");
-setValue(&tags, pJson["tags"], "QList", "SWGTag");
-setValue(&status, pJson["status"], "QString", "QString");
+    ::Swagger::setValue(&id, pJson["id"], "qint64", "");
+    ::Swagger::setValue(&category, pJson["category"], "SWGCategory", "SWGCategory");
+    ::Swagger::setValue(&name, pJson["name"], "QString", "QString");
+    
+    ::Swagger::setValue(&photo_urls, pJson["photo_urls"], "QList", "QString");
+    
+    
+    ::Swagger::setValue(&tags, pJson["tags"], "QList", "SWGTag");
+    
+    ::Swagger::setValue(&status, pJson["status"], "QString", "QString");
 }
 
 QString
@@ -118,38 +127,22 @@ SWGPet::asJson ()
 QJsonObject*
 SWGPet::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
+    
     obj->insert("id", QJsonValue(id));
 
-    
     toJsonValue(QString("category"), category, obj, QString("SWGCategory"));
-    
-        
 
-    
     toJsonValue(QString("name"), name, obj, QString("QString"));
-    
-        
 
-    
-    QList<QString*>* photo_urlsList = photo_urls;
     QJsonArray photo_urlsJsonArray;
     toJsonArray((QList<void*>*)photo_urls, &photo_urlsJsonArray, "photo_urls", "QString");
-
     obj->insert("photo_urls", photo_urlsJsonArray);
-    
 
-    
-    QList<SWGTag*>* tagsList = tags;
     QJsonArray tagsJsonArray;
     toJsonArray((QList<void*>*)tags, &tagsJsonArray, "tags", "SWGTag");
-
     obj->insert("tags", tagsJsonArray);
-    
 
-    
     toJsonValue(QString("status"), status, obj, QString("QString"));
-    
-        
 
     return obj;
 }

--- a/samples/client/petstore/qt5cpp/client/SWGPet.h
+++ b/samples/client/petstore/qt5cpp/client/SWGPet.h
@@ -59,24 +59,30 @@ public:
 
     qint64 getId();
     void setId(qint64 id);
-SWGCategory* getCategory();
+
+    SWGCategory* getCategory();
     void setCategory(SWGCategory* category);
-QString* getName();
+
+    QString* getName();
     void setName(QString* name);
-QList<QString*>* getPhotoUrls();
+
+    QList<QString*>* getPhotoUrls();
     void setPhotoUrls(QList<QString*>* photo_urls);
-QList<SWGTag*>* getTags();
+
+    QList<SWGTag*>* getTags();
     void setTags(QList<SWGTag*>* tags);
-QString* getStatus();
+
+    QString* getStatus();
     void setStatus(QString* status);
+
 
 private:
     qint64 id;
-SWGCategory* category;
-QString* name;
-QList<QString*>* photo_urls;
-QList<SWGTag*>* tags;
-QString* status;
+    SWGCategory* category;
+    QString* name;
+    QList<QString*>* photo_urls;
+    QList<SWGTag*>* tags;
+    QString* status;
 };
 
 } /* namespace Swagger */

--- a/samples/client/petstore/qt5cpp/client/SWGPetApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGPetApi.cpp
@@ -411,10 +411,10 @@ SWGPetApi::updatePetWithForm(qint64 pet_id, QString* name, QString* status) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "POST");
 
-    if (name != NULL) {
+    if (name != nullptr) {
         input.add_var("name", *name);
     }
-if (status != NULL) {
+if (status != nullptr) {
         input.add_var("status", *status);
     }
 
@@ -458,10 +458,10 @@ SWGPetApi::uploadFile(qint64 pet_id, QString* additional_metadata, SWGHttpReques
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "POST");
 
-    if (additional_metadata != NULL) {
+    if (additional_metadata != nullptr) {
         input.add_var("additionalMetadata", *additional_metadata);
     }
-if (file != NULL) {
+if (file != nullptr) {
         input.add_file("file", (*file).local_filename, (*file).request_filename, (*file).mime_type);
     }
 

--- a/samples/client/petstore/qt5cpp/client/SWGTag.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGTag.cpp
@@ -51,13 +51,14 @@ SWGTag::~SWGTag() {
 void
 SWGTag::init() {
     id = 0L;
-name = new QString("");
+    name = new QString("");
 }
 
 void
 SWGTag::cleanup() {
     
-if(name != NULL) {
+
+    if(name != nullptr) {
         delete name;
     }
 }
@@ -73,8 +74,8 @@ SWGTag::fromJson(QString &json) {
 
 void
 SWGTag::fromJsonObject(QJsonObject &pJson) {
-    setValue(&id, pJson["id"], "qint64", "");
-setValue(&name, pJson["name"], "QString", "QString");
+    ::Swagger::setValue(&id, pJson["id"], "qint64", "");
+    ::Swagger::setValue(&name, pJson["name"], "QString", "QString");
 }
 
 QString
@@ -90,12 +91,10 @@ SWGTag::asJson ()
 QJsonObject*
 SWGTag::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
+    
     obj->insert("id", QJsonValue(id));
 
-    
     toJsonValue(QString("name"), name, obj, QString("QString"));
-    
-        
 
     return obj;
 }

--- a/samples/client/petstore/qt5cpp/client/SWGTag.h
+++ b/samples/client/petstore/qt5cpp/client/SWGTag.h
@@ -56,12 +56,14 @@ public:
 
     qint64 getId();
     void setId(qint64 id);
-QString* getName();
+
+    QString* getName();
     void setName(QString* name);
+
 
 private:
     qint64 id;
-QString* name;
+    QString* name;
 };
 
 } /* namespace Swagger */

--- a/samples/client/petstore/qt5cpp/client/SWGUser.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGUser.cpp
@@ -51,34 +51,40 @@ SWGUser::~SWGUser() {
 void
 SWGUser::init() {
     id = 0L;
-username = new QString("");
-first_name = new QString("");
-last_name = new QString("");
-email = new QString("");
-password = new QString("");
-phone = new QString("");
-user_status = 0;
+    username = new QString("");
+    first_name = new QString("");
+    last_name = new QString("");
+    email = new QString("");
+    password = new QString("");
+    phone = new QString("");
+    user_status = 0;
 }
 
 void
 SWGUser::cleanup() {
     
-if(username != NULL) {
+
+    if(username != nullptr) {
         delete username;
     }
-if(first_name != NULL) {
+
+    if(first_name != nullptr) {
         delete first_name;
     }
-if(last_name != NULL) {
+
+    if(last_name != nullptr) {
         delete last_name;
     }
-if(email != NULL) {
+
+    if(email != nullptr) {
         delete email;
     }
-if(password != NULL) {
+
+    if(password != nullptr) {
         delete password;
     }
-if(phone != NULL) {
+
+    if(phone != nullptr) {
         delete phone;
     }
 
@@ -95,14 +101,14 @@ SWGUser::fromJson(QString &json) {
 
 void
 SWGUser::fromJsonObject(QJsonObject &pJson) {
-    setValue(&id, pJson["id"], "qint64", "");
-setValue(&username, pJson["username"], "QString", "QString");
-setValue(&first_name, pJson["first_name"], "QString", "QString");
-setValue(&last_name, pJson["last_name"], "QString", "QString");
-setValue(&email, pJson["email"], "QString", "QString");
-setValue(&password, pJson["password"], "QString", "QString");
-setValue(&phone, pJson["phone"], "QString", "QString");
-setValue(&user_status, pJson["user_status"], "qint32", "");
+    ::Swagger::setValue(&id, pJson["id"], "qint64", "");
+    ::Swagger::setValue(&username, pJson["username"], "QString", "QString");
+    ::Swagger::setValue(&first_name, pJson["first_name"], "QString", "QString");
+    ::Swagger::setValue(&last_name, pJson["last_name"], "QString", "QString");
+    ::Swagger::setValue(&email, pJson["email"], "QString", "QString");
+    ::Swagger::setValue(&password, pJson["password"], "QString", "QString");
+    ::Swagger::setValue(&phone, pJson["phone"], "QString", "QString");
+    ::Swagger::setValue(&user_status, pJson["user_status"], "qint32", "");
 }
 
 QString
@@ -118,38 +124,22 @@ SWGUser::asJson ()
 QJsonObject*
 SWGUser::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
+    
     obj->insert("id", QJsonValue(id));
 
-    
     toJsonValue(QString("username"), username, obj, QString("QString"));
-    
-        
 
-    
     toJsonValue(QString("first_name"), first_name, obj, QString("QString"));
-    
-        
 
-    
     toJsonValue(QString("last_name"), last_name, obj, QString("QString"));
-    
-        
 
-    
     toJsonValue(QString("email"), email, obj, QString("QString"));
-    
-        
 
-    
     toJsonValue(QString("password"), password, obj, QString("QString"));
-    
-        
 
-    
     toJsonValue(QString("phone"), phone, obj, QString("QString"));
-    
-        
-obj->insert("user_status", QJsonValue(user_status));
+
+    obj->insert("user_status", QJsonValue(user_status));
 
     return obj;
 }

--- a/samples/client/petstore/qt5cpp/client/SWGUser.h
+++ b/samples/client/petstore/qt5cpp/client/SWGUser.h
@@ -56,30 +56,38 @@ public:
 
     qint64 getId();
     void setId(qint64 id);
-QString* getUsername();
+
+    QString* getUsername();
     void setUsername(QString* username);
-QString* getFirstName();
+
+    QString* getFirstName();
     void setFirstName(QString* first_name);
-QString* getLastName();
+
+    QString* getLastName();
     void setLastName(QString* last_name);
-QString* getEmail();
+
+    QString* getEmail();
     void setEmail(QString* email);
-QString* getPassword();
+
+    QString* getPassword();
     void setPassword(QString* password);
-QString* getPhone();
+
+    QString* getPhone();
     void setPhone(QString* phone);
-qint32 getUserStatus();
+
+    qint32 getUserStatus();
     void setUserStatus(qint32 user_status);
+
 
 private:
     qint64 id;
-QString* username;
-QString* first_name;
-QString* last_name;
-QString* email;
-QString* password;
-QString* phone;
-qint32 user_status;
+    QString* username;
+    QString* first_name;
+    QString* last_name;
+    QString* email;
+    QString* password;
+    QString* phone;
+    qint32 user_status;
 };
 
 } /* namespace Swagger */


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Modified the mustache files to take into account arrays that are not based on complex types bur languages specific types as explained in #3410 