### PR TITLE
fix NancyFX string parser

### DIFF
--- a/modules/swagger-codegen/src/main/resources/nancyfx/parameters.mustache
+++ b/modules/swagger-codegen/src/main/resources/nancyfx/parameters.mustache
@@ -134,7 +134,7 @@ namespace {{packageName}}.{{packageContext}}.Utils
         private static IDictionary<Type, Func<Parameter, object>> CreateParsers()
         {
             var parsers = ImmutableDictionary.CreateBuilder<Type, Func<Parameter, object>>();
-            parsers.Put(typeof(string), value => value);
+            parsers.Put(typeof(string), value => value.Value);
             parsers.Put(typeof(bool), SafeParse(bool.Parse));
             parsers.Put(typeof(bool?), SafeParse(bool.Parse));
             parsers.Put(typeof(byte), SafeParse(byte.Parse));

--- a/samples/server/petstore/nancyfx/IO.Swagger.sln
+++ b/samples/server/petstore/nancyfx/IO.Swagger.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{D198220E-91F6-402F-966F-8EF6105B1B75}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{1CE943E7-586D-4D9C-BE8B-3E005FDC39D1}"
 EndProject
 Global
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Debug|Any CPU = Debug|Any CPU
 Release|Any CPU = Release|Any CPU
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
-{D198220E-91F6-402F-966F-8EF6105B1B75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{D198220E-91F6-402F-966F-8EF6105B1B75}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{D198220E-91F6-402F-966F-8EF6105B1B75}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{D198220E-91F6-402F-966F-8EF6105B1B75}.Release|Any CPU.Build.0 = Release|Any CPU
+{1CE943E7-586D-4D9C-BE8B-3E005FDC39D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{1CE943E7-586D-4D9C-BE8B-3E005FDC39D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{1CE943E7-586D-4D9C-BE8B-3E005FDC39D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{1CE943E7-586D-4D9C-BE8B-3E005FDC39D1}.Release|Any CPU.Build.0 = Release|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/server/petstore/nancyfx/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/server/petstore/nancyfx/src/IO.Swagger/IO.Swagger.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
         <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{D198220E-91F6-402F-966F-8EF6105B1B75}</ProjectGuid>
+        <ProjectGuid>{1CE943E7-586D-4D9C-BE8B-3E005FDC39D1}</ProjectGuid>
         <OutputType>Library</OutputType>
         <AppDesignerFolder>Properties</AppDesignerFolder>
         <RootNamespace>IO.Swagger.v2</RootNamespace>

--- a/samples/server/petstore/nancyfx/src/IO.Swagger/Models/ApiResponse.cs
+++ b/samples/server/petstore/nancyfx/src/IO.Swagger/Models/ApiResponse.cs
@@ -8,7 +8,7 @@ using NodaTime;
 namespace IO.Swagger.v2.Models
 {
     /// <summary>
-    /// ApiResponse
+    /// Describes the result of uploading an image resource
     /// </summary>
     public sealed class ApiResponse:  IEquatable<ApiResponse>
     { 

--- a/samples/server/petstore/nancyfx/src/IO.Swagger/Models/Category.cs
+++ b/samples/server/petstore/nancyfx/src/IO.Swagger/Models/Category.cs
@@ -8,7 +8,7 @@ using NodaTime;
 namespace IO.Swagger.v2.Models
 {
     /// <summary>
-    /// Category
+    /// A category for a pet
     /// </summary>
     public sealed class Category:  IEquatable<Category>
     { 

--- a/samples/server/petstore/nancyfx/src/IO.Swagger/Models/Order.cs
+++ b/samples/server/petstore/nancyfx/src/IO.Swagger/Models/Order.cs
@@ -8,7 +8,7 @@ using NodaTime;
 namespace IO.Swagger.v2.Models
 {
     /// <summary>
-    /// Order
+    /// An order for a pets from the pet store
     /// </summary>
     public sealed class Order:  IEquatable<Order>
     { 

--- a/samples/server/petstore/nancyfx/src/IO.Swagger/Models/Pet.cs
+++ b/samples/server/petstore/nancyfx/src/IO.Swagger/Models/Pet.cs
@@ -8,7 +8,7 @@ using NodaTime;
 namespace IO.Swagger.v2.Models
 {
     /// <summary>
-    /// Pet
+    /// A pet for sale in the pet store
     /// </summary>
     public sealed class Pet:  IEquatable<Pet>
     { 

--- a/samples/server/petstore/nancyfx/src/IO.Swagger/Models/Tag.cs
+++ b/samples/server/petstore/nancyfx/src/IO.Swagger/Models/Tag.cs
@@ -8,7 +8,7 @@ using NodaTime;
 namespace IO.Swagger.v2.Models
 {
     /// <summary>
-    /// Tag
+    /// A tag for a pet
     /// </summary>
     public sealed class Tag:  IEquatable<Tag>
     { 

--- a/samples/server/petstore/nancyfx/src/IO.Swagger/Models/User.cs
+++ b/samples/server/petstore/nancyfx/src/IO.Swagger/Models/User.cs
@@ -8,7 +8,7 @@ using NodaTime;
 namespace IO.Swagger.v2.Models
 {
     /// <summary>
-    /// User
+    /// A User who is purchasing from the pet store
     /// </summary>
     public sealed class User:  IEquatable<User>
     { 

--- a/samples/server/petstore/nancyfx/src/IO.Swagger/Utils/Parameters.cs
+++ b/samples/server/petstore/nancyfx/src/IO.Swagger/Utils/Parameters.cs
@@ -134,7 +134,7 @@ namespace IO.Swagger.v2.Utils
         private static IDictionary<Type, Func<Parameter, object>> CreateParsers()
         {
             var parsers = ImmutableDictionary.CreateBuilder<Type, Func<Parameter, object>>();
-            parsers.Put(typeof(string), value => value);
+            parsers.Put(typeof(string), value => value.Value);
             parsers.Put(typeof(bool), SafeParse(bool.Parse));
             parsers.Put(typeof(bool?), SafeParse(bool.Parse));
             parsers.Put(typeof(byte), SafeParse(byte.Parse));


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)


parser needs to access the Value parameter to enable the direct cast at Util/Parameters.cs:line 102 when handling string parameters