### PR TITLE
[dart] updated intl library version

### DIFF
--- a/modules/swagger-codegen/src/main/resources/dart/pubspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/pubspec.mustache
@@ -4,7 +4,7 @@ description: {{pubDescription}}
 dependencies:
   http: '>=0.11.1 <0.12.0'
   dartson: "^0.2.4"
-  intl: "^0.12.4+2"
+  intl: any
 
 dev_dependencies:
   guinness: '^0.1.17'


### PR DESCRIPTION
The version of the "intl" library is now more than a year old and is starting to conflict with other libraries' dependencies, in our case with angular 2 for dart. Only date parsing, i.e. a very limited subset of "intl" features, is used in the generated libraries. We find it unlikely, that this feature would be changed in a major way in future, and therefore and to avoid this problem in future, we find it justified to set the version constraint to "any".
