### PR TITLE
Fix sanitizeTag to retain numbers and underscore in tag names

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3171,7 +3171,12 @@ public class DefaultCodegen {
                 buf.append(StringUtils.capitalize(part));
             }
         }
-        return buf.toString().replaceAll("[^a-zA-Z ]", "");
+        String returnTag = buf.toString().replaceAll("[^a-zA-Z0-9_]", "");
+        if (returnTag.matches("\\d.*")) {
+            return "_" + returnTag;
+        } else {
+            return returnTag;
+        }
     }
 
     /**

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -13,6 +13,17 @@ import java.util.List;
 
 public class CodegenTest {
 
+    @Test(description = "test sanitizeTag")
+    public void sanitizeTagTest() {
+        final DefaultCodegen codegen = new DefaultCodegen();
+        Assert.assertEquals(codegen.sanitizeTag("foo"), "Foo");
+        Assert.assertEquals(codegen.sanitizeTag("foo bar"), "FooBar");
+        Assert.assertEquals(codegen.sanitizeTag("foo_bar"), "Foo_bar");
+        Assert.assertEquals(codegen.sanitizeTag("foo1 bar2"), "Foo1Bar2");
+        Assert.assertEquals(codegen.sanitizeTag("foo bar 1"), "FooBar1");
+        Assert.assertEquals(codegen.sanitizeTag("1foo"), "_1foo");
+    }
+
     @Test(description = "read a file upload param from a 2.0 spec")
     public void fileUploadParamTest() {
         final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/petstore.json");


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)

**I've run bin/run-all-petstore but there are lots of unrelated changes, and in a glance I could not see any change related to this PR. I am just guessing petstore samples are out of date. Let me know if you want me to add those (huge) changes.**

- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

I've changed the pattern sanitizeTag uses to remove invalid characters and also added underscore to tags starting with a number. Also added some test cases.

fixes #2657