### PR TITLE
Throw an Error object instead of a string

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
@@ -58,7 +58,7 @@
 <#allParams><#required>
       // verify the required parameter '<paramName>' is set
       if (<paramName> == undefined || <paramName> == null) {
-        throw "Missing the required parameter '<paramName>' when calling <operationId>";
+        throw new Error("Missing the required parameter '<paramName>' when calling <operationId>");
       }
 </required></allParams>
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
I am unable to run `./bin/javascript-petstore.sh` and `./bin/security/javascript-petstore.sh` on Windows 10
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Don't throw string literals but Error objects in JavaScript.

Fixes: #4054

