### PR TITLE
ISSUE-1388 - Do not NPE when array properties items are not specified

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -422,6 +422,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (p instanceof ArrayProperty) {
             ArrayProperty ap = (ArrayProperty) p;
             Property inner = ap.getItems();
+            if (inner == null) {
+              return null;
+            }
             return getSwaggerType(p) + "<" + getTypeDeclaration(inner) + ">";
         } else if (p instanceof MapProperty) {
             MapProperty mp = (MapProperty) p;
@@ -441,6 +444,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 pattern = "new java.util.ArrayList<%s>()";
             } else {
                 pattern = "new ArrayList<%s>()";
+            }
+            if (ap.getItems() == null) {
+              return null;
             }
             return String.format(pattern, getTypeDeclaration(ap.getItems()));
         } else if (p instanceof MapProperty) {


### PR DESCRIPTION
### Description of the PR

Do not NPE on an array type with no "items". Just return null.
