### PR TITLE
bugfix: issue-4051

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -363,6 +363,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             return name;
         }
 
+        if(startsWithTwoUppercaseLetters(name)){
+            name = name.substring(0, 2).toLowerCase() + name.substring(2);
+        }
+
         // camelize (lower first character) the variable name
         // pet_id => petId
         name = camelize(name, true);
@@ -373,6 +377,14 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
 
         return name;
+    }
+
+    private boolean startsWithTwoUppercaseLetters(String name) {
+        boolean startsWithTwoUppercaseLetters = false;
+        if(name.length() > 1) {
+            startsWithTwoUppercaseLetters = name.substring(0, 2).equals(name.substring(0, 2).toUpperCase());
+        }
+        return startsWithTwoUppercaseLetters;
     }
 
     @Override
@@ -933,10 +945,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             delim = ".";
         }
         return sb.toString();
-    }
-
-    public String toRegularExpression(String pattern) {
-        return escapeText(pattern);
     }
 
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -946,5 +946,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
         return sb.toString();
     }
+    
+    public String toRegularExpression(String pattern) {
+        return escapeText(pattern);
+    }
 
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -360,6 +360,32 @@ public class JavaModelTest {
         Assert.assertTrue(property.isNotContainer);
     }
 
+    @Test(description = "convert a model starting with two upper-case letter property names")
+    public void firstTwoUpperCaseLetterNamesTest() {
+        final Model model = new ModelImpl()
+                .description("a model with a property name starting with two upper-case letters")
+                .property("ATTName", new StringProperty())
+                .required("ATTName");
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty property = cm.vars.get(0);
+        Assert.assertEquals(property.baseName, "ATTName");
+        Assert.assertEquals(property.getter, "getAtTName");
+        Assert.assertEquals(property.setter, "setAtTName");
+        Assert.assertEquals(property.datatype, "String");
+        Assert.assertEquals(property.name, "atTName");
+        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.baseType, "String");
+        Assert.assertNull(property.hasMore);
+        Assert.assertTrue(property.required);
+        Assert.assertTrue(property.isNotContainer);
+    }
+
     @Test(description = "convert hyphens per issue 503")
     public void hyphensTest() {
         final Model model = new ModelImpl()


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.
### Description of the PR

The fix converts the first two letters of a property name to lower case if the property name started with two upper case letters.
Another way to handle the problem jackson has with uppercase properties would be to put the JsonProperty annotation to the getter methods.
