### PR TITLE
[Java] Fix outputFolder in java-related server stub generators

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
@@ -10,6 +10,8 @@ public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen
 {
 	public JavaJAXRSCXFCDIServerCodegen()
 	{
+        outputFolder = "generated-code/JavaJaxRS-CXF-CDI";
+
 		artifactId = "swagger-jaxrs-cxf-cdi-server";
 
 		sourceFolder = "src" + File.separator + "gen" + File.separator + "java";

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
@@ -6,55 +6,46 @@ import io.swagger.codegen.CodegenProperty;
 
 import java.io.File;
 
-public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen
-{
-	public JavaJAXRSCXFCDIServerCodegen()
-	{
+public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen {
+    public JavaJAXRSCXFCDIServerCodegen() {
         outputFolder = "generated-code/JavaJaxRS-CXF-CDI";
+        artifactId = "swagger-jaxrs-cxf-cdi-server";
+        sourceFolder = "src" + File.separator + "gen" + File.separator + "java";
 
-		artifactId = "swagger-jaxrs-cxf-cdi-server";
+        // Three API templates to support CDI injection
+        apiTemplateFiles.put("apiService.mustache", ".java");
+        apiTemplateFiles.put("apiServiceImpl.mustache", ".java");
 
-		sourceFolder = "src" + File.separator + "gen" + File.separator + "java";
+        // Use standard types
+        typeMapping.put("DateTime", "java.util.Date");
 
-		// Three API templates to support CDI injection
-		apiTemplateFiles.put("apiService.mustache", ".java");
-	  apiTemplateFiles.put("apiServiceImpl.mustache", ".java");
+        // Updated template directory
+        embeddedTemplateDir = templateDir = JAXRS_TEMPLATE_DIRECTORY_NAME + File.separator + "cxf-cdi";
+    }
 
-		// Use standard types
-		typeMapping.put("DateTime", "java.util.Date");
+    @Override
+    public String getName() {
+        return "jaxrs-cxf-cdi";
+    }
 
-		// Updated template directory
-	  embeddedTemplateDir = templateDir = JAXRS_TEMPLATE_DIRECTORY_NAME + File.separator + "cxf-cdi";
-	}
+    @Override
+    public void processOpts() {
+        super.processOpts();
+        supportingFiles.clear(); // Don't need extra files provided by AbstractJAX-RS & Java Codegen
+        writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
+    }
 
-	@Override
-	public String getName()
-	{
-		return "jaxrs-cxf-cdi";
-	}
+    @Override
+    public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
+        super.postProcessModelProperty(model, property);
 
-	@Override
-	public void processOpts()
-	{
-		super.processOpts();
+        // Reinstate JsonProperty
+        model.imports.add("JsonProperty");
+    }
 
-		supportingFiles.clear(); // Don't need extra files provided by AbstractJAX-RS & Java Codegen
-
-		writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
-	}
-
-	@Override
-	public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
-		super.postProcessModelProperty(model, property);
-
-		// Reinstate JsonProperty
-		model.imports.add("JsonProperty");
-	}
-
-	@Override
-	public String getHelp()
-	{
-		return "Generates a Java JAXRS Server according to JAXRS 2.0 specification, assuming an Apache CXF runtime and a Java EE runtime with CDI enabled.";
-	}
+    @Override
+    public String getHelp() {
+        return "Generates a Java JAXRS Server according to JAXRS 2.0 specification, assuming an Apache CXF runtime and a Java EE runtime with CDI enabled.";
+    }
 
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaMSF4JServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaMSF4JServerCodegen.java
@@ -18,7 +18,7 @@ public class JavaMSF4JServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
     public JavaMSF4JServerCodegen() {
         super();
-        outputFolder = "generated-code/JavaJaxRS-Jersey";
+        outputFolder = "generated-code/JavaJaxRS-MSF4J";
         apiTemplateFiles.put("apiService.mustache", ".java");
         apiTemplateFiles.put("apiServiceImpl.mustache", ".java");
         apiTemplateFiles.put("apiServiceFactory.mustache", ".java");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaResteasyServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaResteasyServerCodegen.java
@@ -16,7 +16,7 @@ public class JavaResteasyServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
         artifactId = "swagger-jaxrs-resteasy-server";
 
-        outputFolder = "generated-code/javaJaxRS";
+        outputFolder = "generated-code/JavaJaxRS-Resteasy";
         apiTemplateFiles.put("apiService.mustache", ".java");
         apiTemplateFiles.put("apiServiceImpl.mustache", ".java");
         apiTemplateFiles.put("apiServiceFactory.mustache", ".java");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

 Fix outputFolder in Java-related server stub generators

