### PR TITLE
[csharp] Don't duplicate parent properties in derived classes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2848,6 +2848,7 @@ public class DefaultCodegen {
                 if (Boolean.TRUE.equals(cp.isReadOnly)) {
                     m.readOnlyVars.add(cp);
                 } else { // else add to readWriteVars (list of properties)
+                    // FIXME: readWriteVars can contain duplicated properties. Debug/breakpoint here while running C# generator (Dog and Cat models)
                     m.readWriteVars.add(cp);
                 }
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -47,6 +47,9 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
     public CSharpClientCodegen() {
         super();
+
+        supportsInheritance = true;
+
         modelTemplateFiles.put("model.mustache", ".cs");
         apiTemplateFiles.put("api.mustache", ".cs");
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -24,12 +24,11 @@ import org.slf4j.LoggerFactory;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class CSharpClientCodegen extends AbstractCSharpCodegen {
-    @SuppressWarnings({"unused", "hiding"})
+    @SuppressWarnings({"hiding"})
     private static final Logger LOGGER = LoggerFactory.getLogger(CSharpClientCodegen.class);
     private static final String NET45 = "v4.5";
     private static final String NET35 = "v3.5";
     private static final String UWP = "uwp";
-    private static final String DATA_TYPE_WITH_ENUM_EXTENSION = "plainDatatypeWithEnum";
 
     protected String packageGuid = "{" + java.util.UUID.randomUUID().toString().toUpperCase() + "}";
     protected String clientPackage = "IO.Swagger.Client";
@@ -48,6 +47,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     public CSharpClientCodegen() {
         super();
 
+        // TODO: This needs to be moved to base, which requires testing the change on all derived generators
         supportsInheritance = true;
 
         modelTemplateFiles.put("model.mustache", ".cs");
@@ -352,10 +352,48 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     @Override
     public CodegenModel fromModel(String name, Model model, Map<String, Model> allDefinitions) {
         CodegenModel codegenModel = super.fromModel(name, model, allDefinitions);
-        if (allDefinitions != null && codegenModel != null && codegenModel.parent != null && codegenModel.hasEnums) {
+        if (allDefinitions != null && codegenModel != null && codegenModel.parent != null) {
             final Model parentModel = allDefinitions.get(toModelName(codegenModel.parent));
-            final CodegenModel parentCodegenModel = super.fromModel(codegenModel.parent, parentModel);
-            codegenModel = this.reconcileInlineEnums(codegenModel, parentCodegenModel);
+            if(parentModel != null) {
+                final CodegenModel parentCodegenModel = super.fromModel(codegenModel.parent, parentModel);
+                if (codegenModel.hasEnums) {
+                    codegenModel = this.reconcileInlineEnums(codegenModel, parentCodegenModel);
+                }
+
+                Map<String, CodegenProperty> propertyHash = new HashMap<>(codegenModel.vars.size());
+                for (final CodegenProperty property : codegenModel.vars) {
+                    propertyHash.put(property.name, property);
+                }
+
+                CodegenProperty last = null;
+                for (final CodegenProperty property : parentCodegenModel.vars) {
+                    // helper list of parentVars simplifies templating
+                    if (!propertyHash.containsKey(property.name)) {
+                        final CodegenProperty parentVar = property.clone();
+                        parentVar.isInherited = true;
+                        parentVar.hasMore = true;
+                        last = parentVar;
+                        LOGGER.info("adding parent variable %s", property.name);
+                        codegenModel.parentVars.add(parentVar);
+                    }
+                }
+
+                if (last != null) {
+                    last.hasMore = false;
+                }
+            }
+        }
+
+        // Cleanup possible duplicates. Currently, readWriteVars can contain the same property twice. May or may not be isolated to C#.
+        if(codegenModel != null && codegenModel.readWriteVars != null && codegenModel.readWriteVars.size() > 1) {
+            int length = codegenModel.readWriteVars.size() - 1;
+            for (int i = length; i > (length / 2); i --) {
+                final CodegenProperty codegenProperty = codegenModel.readWriteVars.get(i);
+                // If the property at current index is found earlier in the list, remove this last instance.
+                if(codegenModel.readWriteVars.indexOf(codegenProperty) < i) {
+                    codegenModel.readWriteVars.remove(i);
+                }
+            }
         }
 
         return codegenModel;

--- a/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
@@ -47,9 +47,10 @@
     {{#hasOnlyReadOnly}}
         [JsonConstructorAttribute]
     {{/hasOnlyReadOnly}}
-        public {{classname}}({{#readWriteVars}}{{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} = null{{^-last}}, {{/-last}}{{/readWriteVars}})
+        public {{classname}}({{#readWriteVars}}{{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} = null{{^-last}}, {{/-last}}{{/readWriteVars}}){{#parent}} : base({{#parentVars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/parentVars}}){{/parent}}
         {
             {{#vars}}
+            {{^isInherited}}
             {{^isReadOnly}}
             {{#required}}
             // to ensure "{{name}}" is required (not null)
@@ -63,8 +64,10 @@
             }
             {{/required}}
             {{/isReadOnly}}
+            {{/isInherited}}
             {{/vars}}
             {{#vars}}
+            {{^isInherited}}
             {{^isReadOnly}}
             {{^required}}
             {{#defaultValue}}// use default value if no "{{name}}" provided
@@ -82,10 +85,12 @@ this.{{name}} = {{name}};
             {{/defaultValue}}
             {{/required}}
             {{/isReadOnly}}
+            {{/isInherited}}
             {{/vars}}
         }
-        
+
         {{#vars}}
+        {{^isInherited}}
         {{^isEnum}}
         /// <summary>
         /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
@@ -93,8 +98,8 @@ this.{{name}} = {{name}};
         /// <value>{{description}}</value>{{/description}}
         [DataMember(Name="{{baseName}}", EmitDefaultValue={{emitDefaultValue}})]
         public {{{datatype}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
-        {{/isEnum}}
-        {{/vars}}
+
+        {{/isEnum}}{{/isInherited}}{{/vars}}
         /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
@@ -103,13 +108,14 @@ this.{{name}} = {{name}};
         {
             var sb = new StringBuilder();
             sb.Append("class {{classname}} {\n");
+            {{#parent}}sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");{{/parent}}
             {{#vars}}
             sb.Append("  {{name}}: ").Append({{name}}).Append("\n");
             {{/vars}}
             sb.Append("}\n");
             return sb.ToString();
         }
-  
+
         /// <summary>
         /// Returns the JSON string presentation of the object
         /// </summary>
@@ -189,7 +195,8 @@ this.{{name}} = {{name}};
 
 {{/generatePropertyChanged}}
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        { {{#vars}}{{#hasValidation}}{{#maxLength}}
+        { {{#parent}}{{^isArrayModel}}{{#parentVars}}
+            foreach(var x in base.Validate(validationContext)) yield return x;{{/parentVars}}{{/isArrayModel}}{{/parent}}{{#vars}}{{#hasValidation}}{{#maxLength}}
             // {{{name}}} ({{{datatype}}}) maxLength
             if(this.{{{name}}} != null && this.{{{name}}}.Length > {{maxLength}})
             {


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.
### Description of the PR

referring to #3829, this sets parent properties only on base types in the C# client generator.  It looks like there's a similar solution in the NancyFX generator, but it didn't port correctly to `AbstractCSharpCodegen`.

I'd like to move logic from this PR into `AbstractCSharpCodegen` to be shared across generators, but I'd need to look more into how NancyFX is doing its inheritance (because it doesn't have `supportsInheritance = true` set).

One of my main concerns is that the code block I have commented "Cleanup possible duplicates." may or may not indicate a bug elsewhere (wherever `readWriteVars` is used). Without this cleanup block, when `supportsInheritance = true` and I debug `./bin/csharp-petstore.sh`, I get `readWriteVars` containing duplicates for all parent properties .  My assumption is that the `name` property of these codegen properties isn't being compared in a case-insensitive way, or post-processing of property names isn't being done before the sorting. I spent some time trying to track this down and couldn't find it. 

I was wondering if someone could:
- verify this code generates the correct C# code?
- remove the "Cleanup possible duplicates" block and `supportsInheritance = true;` to see if readWriteVars does indeed include duplicates?

I plan to take another look, but it may be a week or so before I get around to it.
