### PR TITLE
#3908 make a copy of vendorExtensions map instead of copying the reference

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
@@ -123,7 +123,7 @@ public class CodegenParameter {
             output.items = this.items;
         }
         if(this.vendorExtensions != null){
-        	output.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);
+            output.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);
         }
         output.hasValidation = this.hasValidation;
         output.isBinary = this.isBinary;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
@@ -122,7 +122,9 @@ public class CodegenParameter {
         if (this.items != null) {
             output.items = this.items;
         }
-        output.vendorExtensions = this.vendorExtensions;
+        if(this.vendorExtensions != null){
+        	output.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);
+        }
         output.hasValidation = this.hasValidation;
         output.isBinary = this.isBinary;
         output.isByteArray = this.isByteArray;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -1,5 +1,7 @@
 package io.swagger.codegen;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -283,9 +285,24 @@ public class CodegenProperty implements Cloneable {
     @Override
     public CodegenProperty clone() {
         try {
-            return (CodegenProperty) super.clone();
+        	CodegenProperty cp = (CodegenProperty) super.clone();
+        	if (this._enum != null) {
+                cp._enum = new ArrayList<String>(this._enum);
+            }
+            if (this.allowableValues != null) {
+                cp.allowableValues = new HashMap<String, Object>(this.allowableValues);
+            }
+            if (this.items != null) {
+                cp.items = this.items;
+            }
+        	if(this.vendorExtensions != null){
+                cp.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);
+            }
+        	return cp;
         } catch (CloneNotSupportedException e) {
             throw new IllegalStateException(e);
         }
     }
+    
+    
 }


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.
### Description of the PR

In the method copy of the class CodegenParameter, we make a copy of vendorExtensions map instead of copying the reference to prevent unwanted instance modification of a copied instance.
