### PR TITLE
update parser, core versions

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfiguratorUtils.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfiguratorUtils.java
@@ -33,7 +33,7 @@ public final class CodegenConfiguratorUtils {
     public static void applyImportMappingsKvp(String importMappings, CodegenConfigurator configurator) {
         final Map<String, String> map = createMapFromKeyValuePairs(importMappings);
         for (Map.Entry<String, String> entry : map.entrySet()) {
-            configurator.addImportMapping(entry.getKey(), entry.getValue());
+            configurator.addImportMapping(entry.getKey().trim(), entry.getValue().trim());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -780,10 +780,10 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>1.0.22</swagger-parser-version>
+        <swagger-parser-version>1.0.23-SNAPSHOT</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>2.3.4</felix-version>
-        <swagger-core-version>1.5.9</swagger-core-version>
+        <swagger-core-version>1.5.10</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>
         <junit-version>4.8.1</junit-version>


### PR DESCRIPTION
Fixes #4090 by updating to latest swagger-core (1.5.10) and parser snapshot (1.0.23-SNAPSHOT).  This should address the following issues:

#3614
#3347 
#3305
#1551
