### PR TITLE
[Spring] add back setter to read-only attributes in Spring models

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
@@ -27,7 +27,6 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{/vars}}
   {{#vars}}
-  {{^isReadOnly}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
     return this;
@@ -47,7 +46,6 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   }
   {{/isMapContainer}}
 
-  {{/isReadOnly}}
    /**
   {{#description}}
    * {{{description}}}
@@ -70,12 +68,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
-  {{^isReadOnly}}
 
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
   }
-  {{/isReadOnly}}
 
   {{/vars}}
 

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/FakeApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Client;
-import java.time.OffsetDateTime;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.math.BigDecimal;
 
 import io.swagger.annotations.*;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
 
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/HasOnlyReadOnly.java
@@ -17,6 +17,11 @@ public class HasOnlyReadOnly   {
   @JsonProperty("foo")
   private String foo = null;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
    /**
    * Get bar
    * @return bar
@@ -26,6 +31,15 @@ public class HasOnlyReadOnly   {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
    /**
    * Get foo
    * @return foo
@@ -33,6 +47,10 @@ public class HasOnlyReadOnly   {
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/Name.java
@@ -42,6 +42,11 @@ public class Name   {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
    /**
    * Get snakeCase
    * @return snakeCase
@@ -49,6 +54,10 @@ public class Name   {
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -69,6 +78,11 @@ public class Name   {
     this.property = property;
   }
 
+  public Name _123Number(Integer _123Number) {
+    this._123Number = _123Number;
+    return this;
+  }
+
    /**
    * Get _123Number
    * @return _123Number
@@ -76,6 +90,10 @@ public class Name   {
   @ApiModelProperty(value = "")
   public Integer get123Number() {
     return _123Number;
+  }
+
+  public void set123Number(Integer _123Number) {
+    this._123Number = _123Number;
   }
 
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/ReadOnlyFirst.java
@@ -17,6 +17,11 @@ public class ReadOnlyFirst   {
   @JsonProperty("baz")
   private String baz = null;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
    /**
    * Get bar
    * @return bar
@@ -24,6 +29,10 @@ public class ReadOnlyFirst   {
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApi.java
@@ -2,8 +2,8 @@ package io.swagger.api;
 
 import io.swagger.model.Client;
 import org.joda.time.LocalDate;
-import java.math.BigDecimal;
 import org.joda.time.DateTime;
+import java.math.BigDecimal;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/FakeApiController.java
@@ -2,8 +2,8 @@ package io.swagger.api;
 
 import io.swagger.model.Client;
 import org.joda.time.LocalDate;
-import java.math.BigDecimal;
 import org.joda.time.DateTime;
+import java.math.BigDecimal;
 
 import io.swagger.annotations.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApiController.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
 
 import io.swagger.annotations.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/HasOnlyReadOnly.java
@@ -17,6 +17,11 @@ public class HasOnlyReadOnly   {
   @JsonProperty("foo")
   private String foo = null;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
    /**
    * Get bar
    * @return bar
@@ -26,6 +31,15 @@ public class HasOnlyReadOnly   {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
    /**
    * Get foo
    * @return foo
@@ -33,6 +47,10 @@ public class HasOnlyReadOnly   {
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/Name.java
@@ -42,6 +42,11 @@ public class Name   {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
    /**
    * Get snakeCase
    * @return snakeCase
@@ -49,6 +54,10 @@ public class Name   {
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -69,6 +78,11 @@ public class Name   {
     this.property = property;
   }
 
+  public Name _123Number(Integer _123Number) {
+    this._123Number = _123Number;
+    return this;
+  }
+
    /**
    * Get _123Number
    * @return _123Number
@@ -76,6 +90,10 @@ public class Name   {
   @ApiModelProperty(value = "")
   public Integer get123Number() {
     return _123Number;
+  }
+
+  public void set123Number(Integer _123Number) {
+    this._123Number = _123Number;
   }
 
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/ReadOnlyFirst.java
@@ -17,6 +17,11 @@ public class ReadOnlyFirst   {
   @JsonProperty("baz")
   private String baz = null;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
    /**
    * Get bar
    * @return bar
@@ -24,6 +29,10 @@ public class ReadOnlyFirst   {
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApi.java
@@ -2,8 +2,8 @@ package io.swagger.api;
 
 import io.swagger.model.Client;
 import org.joda.time.LocalDate;
-import java.math.BigDecimal;
 import org.joda.time.DateTime;
+import java.math.BigDecimal;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/FakeApiController.java
@@ -2,8 +2,8 @@ package io.swagger.api;
 
 import io.swagger.model.Client;
 import org.joda.time.LocalDate;
-import java.math.BigDecimal;
 import org.joda.time.DateTime;
+import java.math.BigDecimal;
 
 import io.swagger.annotations.*;
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
 
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApiController.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
 import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
 
 import io.swagger.annotations.*;
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/model/HasOnlyReadOnly.java
@@ -17,6 +17,11 @@ public class HasOnlyReadOnly   {
   @JsonProperty("foo")
   private String foo = null;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
    /**
    * Get bar
    * @return bar
@@ -26,6 +31,15 @@ public class HasOnlyReadOnly   {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
    /**
    * Get foo
    * @return foo
@@ -33,6 +47,10 @@ public class HasOnlyReadOnly   {
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/model/Name.java
@@ -42,6 +42,11 @@ public class Name   {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
    /**
    * Get snakeCase
    * @return snakeCase
@@ -49,6 +54,10 @@ public class Name   {
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -69,6 +78,11 @@ public class Name   {
     this.property = property;
   }
 
+  public Name _123Number(Integer _123Number) {
+    this._123Number = _123Number;
+    return this;
+  }
+
    /**
    * Get _123Number
    * @return _123Number
@@ -76,6 +90,10 @@ public class Name   {
   @ApiModelProperty(value = "")
   public Integer get123Number() {
     return _123Number;
+  }
+
+  public void set123Number(Integer _123Number) {
+    this._123Number = _123Number;
   }
 
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/model/ReadOnlyFirst.java
@@ -17,6 +17,11 @@ public class ReadOnlyFirst   {
   @JsonProperty("baz")
   private String baz = null;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
    /**
    * Get bar
    * @return bar
@@ -24,6 +29,10 @@ public class ReadOnlyFirst   {
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add back setter to read-only attributes in Spring models

For https://github.com/swagger-api/swagger-codegen/issues/3793

