### PR TITLE
Add constructFromObject to Javascript enum generation.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/partial_model_enum_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/partial_model_enum_class.mustache
@@ -20,5 +20,14 @@
   {{/allowableValues}}
   };
 
+  /**
+   * Returns a <code>{{classname}}</code> enum value from a Javascript object name.
+   * @param {Object} data The plain JavaScript object containing the name of the enum value.
+   * @return {{=< >=}}{module:<#invokerPackage><invokerPackage>/</invokerPackage><#modelPackage><modelPackage>/</modelPackage><classname>}<={{ }}=> The enum <code>{{classname}}</code> value.
+   */
+  exports.constructFromObject = function(object) {
+    return exports[object];
+  }
+
   return exports;
 }));

--- a/samples/client/petstore/javascript-promise/src/model/EnumClass.js
+++ b/samples/client/petstore/javascript-promise/src/model/EnumClass.js
@@ -62,6 +62,15 @@
      */
     "(xyz)": "(xyz)"  };
 
+  /**
+   * Returns a <code>EnumClass</code> enum value from a Javascript object name.
+   * @param {Object} data The plain JavaScript object containing the name of the enum value.
+   * @return {module:model/EnumClass} The enum <code>EnumClass</code> value.
+   */
+  exports.constructFromObject = function(object) {
+    return exports[object];
+  }
+
   return exports;
 }));
 

--- a/samples/client/petstore/javascript/src/model/EnumClass.js
+++ b/samples/client/petstore/javascript/src/model/EnumClass.js
@@ -62,6 +62,15 @@
      */
     "(xyz)": "(xyz)"  };
 
+  /**
+   * Returns a <code>EnumClass</code> enum value from a Javascript object name.
+   * @param {Object} data The plain JavaScript object containing the name of the enum value.
+   * @return {module:model/EnumClass} The enum <code>EnumClass</code> value.
+   */
+  exports.constructFromObject = function(object) {
+    return exports[object];
+  }
+
   return exports;
 }));
 


### PR DESCRIPTION
Generated code calls constructFromObject on enum types, but enum did not define the necessary function. Returns the value of the enum.