### PR TITLE
DART: multi-word class names work properly now, fixes #4117

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -141,7 +141,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         config.additionalProperties().put("generatedDate", DateTime.now().toString());
         config.additionalProperties().put("generatorClass", config.getClass().toString());
         config.additionalProperties().put("inputSpec", config.getInputSpec());
-        
+
         if (swagger.getInfo() != null) {
             Info info = swagger.getInfo();
             if (info.getTitle() != null) {
@@ -405,6 +405,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     operation.put("classname", config.toApiName(tag));
                     operation.put("classVarName", config.toApiVarName(tag));
                     operation.put("importPath", config.toApiImport(tag));
+                    operation.put("classFilename", config.toApiFilename(tag));
 
                     if(!config.vendorExtensions().isEmpty()) {
                     	operation.put("vendorExtensions", config.vendorExtensions());

--- a/modules/swagger-codegen/src/main/resources/dart/apilib.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/apilib.mustache
@@ -16,7 +16,7 @@ part 'auth/api_key_auth.dart';
 part 'auth/oauth.dart';
 part 'auth/http_basic_auth.dart';
 
-{{#apiInfo}}{{#apis}}part 'api/{{classVarName}}_api.dart';
+{{#apiInfo}}{{#apis}}part 'api/{{classFilename}}.dart';
 {{/apis}}{{/apiInfo}}
 {{#models}}{{#model}}part 'model/{{classFilename}}.dart';
 {{/model}}{{/models}}


### PR DESCRIPTION
Fixes #4117. I'm not sure if this is a proper fix. I tested it for dart only.