### PR TITLE
[Obj-c] Generated code documentation fixes

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-header.mustache
@@ -72,7 +72,7 @@ extern NSString *const {{classPrefix}}ResponseObjectErrorKey;
 /**
  * Sets the client reachability, this may be overridden by the reachability manager if reachability changes
  *
- * @param The client reachability.
+ * @param status The client reachability status.
  */
 +(void) setReachabilityStatus:(AFNetworkReachabilityStatus) status;
 

--- a/modules/swagger-codegen/src/main/resources/objc/Configuration-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/Configuration-header.mustache
@@ -100,7 +100,7 @@
 /**
  * Sets the prefix for API key
  *
- * @param apiKeyPrefix API key prefix.
+ * @param prefix API key prefix.
  * @param identifier   API key identifier.
  */
 - (void) setApiKeyPrefix:(NSString *)prefix forApiKeyPrefixIdentifier:(NSString *)identifier;
@@ -140,7 +140,7 @@
 /**
 * Removes header from defaultHeaders
 *
-* @param Header name.
+* @param key Header name.
 */
 -(void) removeDefaultHeaderForKey:(NSString*)key;
 
@@ -153,7 +153,7 @@
 -(void) setDefaultHeaderValue:(NSString*) value forKey:(NSString*)key;
 
 /**
-* @param Header key name.
+* @param key Header key name.
 */
 -(NSString*) defaultHeaderForKey:(NSString*)key;
 

--- a/modules/swagger-codegen/src/main/resources/objc/ResponseDeserializer-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ResponseDeserializer-header.mustache
@@ -28,7 +28,7 @@ extern NSInteger const {{classPrefix}}UnknownResponseObjectErrorCode;
  * Deserializes the given data to Objective-C object.
  *
  * @param data The data will be deserialized.
- * @param class The type of objective-c object.
+ * @param className The type of objective-c object.
  * @param error The error
  */
 - (id) deserialize:(id) data class:(NSString *) className error:(NSError**)error;

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGApiClient.h
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGApiClient.h
@@ -98,7 +98,7 @@ extern NSString *const SWGResponseObjectErrorKey;
 /**
  * Sets the client reachability, this may be overridden by the reachability manager if reachability changes
  *
- * @param The client reachability.
+ * @param status The client reachability status.
  */
 +(void) setReachabilityStatus:(AFNetworkReachabilityStatus) status;
 

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGConfiguration.h
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGConfiguration.h
@@ -122,7 +122,7 @@
 /**
  * Sets the prefix for API key
  *
- * @param apiKeyPrefix API key prefix.
+ * @param prefix API key prefix.
  * @param identifier   API key identifier.
  */
 - (void) setApiKeyPrefix:(NSString *)prefix forApiKeyPrefixIdentifier:(NSString *)identifier;
@@ -162,7 +162,7 @@
 /**
 * Removes header from defaultHeaders
 *
-* @param Header name.
+* @param key Header name.
 */
 -(void) removeDefaultHeaderForKey:(NSString*)key;
 
@@ -175,7 +175,7 @@
 -(void) setDefaultHeaderValue:(NSString*) value forKey:(NSString*)key;
 
 /**
-* @param Header key name.
+* @param key Header key name.
 */
 -(NSString*) defaultHeaderForKey:(NSString*)key;
 

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGResponseDeserializer.h
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGResponseDeserializer.h
@@ -50,7 +50,7 @@ extern NSInteger const SWGUnknownResponseObjectErrorCode;
  * Deserializes the given data to Objective-C object.
  *
  * @param data The data will be deserialized.
- * @param class The type of objective-c object.
+ * @param className The type of objective-c object.
  * @param error The error
  */
 - (id) deserialize:(id) data class:(NSString *) className error:(NSError**)error;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixes for misplaced and missed parameter names in Obj-C code. 
That is minor fix, so I decide not to open a new issue.