### PR TITLE
[ObjC] Fix deprecated JSONModel API usage

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/model-body.mustache
@@ -43,7 +43,7 @@
  * This method is used by `JSONModel`.
  */
 + (JSONKeyMapper *)keyMapper {
-  return [[JSONKeyMapper alloc] initWithDictionary:@{ {{#vars}}@"{{baseName}}": @"{{name}}"{{#hasMore}}, {{/hasMore}}{{/vars}} }];
+  return [[JSONKeyMapper alloc] initWithModelToJSONDictionary:@{ {{#vars}}@"{{name}}": @"{{baseName}}"{{#hasMore}}, {{/hasMore}}{{/vars}} }];
 }
 
 /**

--- a/modules/swagger-codegen/src/main/resources/objc/podspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/podspec.mustache
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 {{#useCoreData}}    s.resources      = '{{podName}}/**/*.{xcdatamodeld,xcdatamodel}'{{/useCoreData}}
 
     s.dependency 'AFNetworking', '~> 3'
-    s.dependency 'JSONModel', '~> 1.2'
+    s.dependency 'JSONModel', '~> 1.4'
     s.dependency 'ISO8601', '~> 0.5'
 end
 

--- a/samples/client/petstore/objc/default/SwaggerClient/Model/SWGCategory.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Model/SWGCategory.m
@@ -17,7 +17,7 @@
  * This method is used by `JSONModel`.
  */
 + (JSONKeyMapper *)keyMapper {
-  return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"name": @"name" }];
+  return [[JSONKeyMapper alloc] initWithModelToJSONDictionary:@{ @"_id": @"id", @"name": @"name" }];
 }
 
 /**

--- a/samples/client/petstore/objc/default/SwaggerClient/Model/SWGOrder.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Model/SWGOrder.m
@@ -17,7 +17,7 @@
  * This method is used by `JSONModel`.
  */
 + (JSONKeyMapper *)keyMapper {
-  return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"petId": @"petId", @"quantity": @"quantity", @"shipDate": @"shipDate", @"status": @"status", @"complete": @"complete" }];
+  return [[JSONKeyMapper alloc] initWithModelToJSONDictionary:@{ @"_id": @"id", @"petId": @"petId", @"quantity": @"quantity", @"shipDate": @"shipDate", @"status": @"status", @"complete": @"complete" }];
 }
 
 /**

--- a/samples/client/petstore/objc/default/SwaggerClient/Model/SWGPet.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Model/SWGPet.m
@@ -17,7 +17,7 @@
  * This method is used by `JSONModel`.
  */
 + (JSONKeyMapper *)keyMapper {
-  return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"category": @"category", @"name": @"name", @"photoUrls": @"photoUrls", @"tags": @"tags", @"status": @"status" }];
+  return [[JSONKeyMapper alloc] initWithModelToJSONDictionary:@{ @"_id": @"id", @"category": @"category", @"name": @"name", @"photoUrls": @"photoUrls", @"tags": @"tags", @"status": @"status" }];
 }
 
 /**

--- a/samples/client/petstore/objc/default/SwaggerClient/Model/SWGTag.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Model/SWGTag.m
@@ -17,7 +17,7 @@
  * This method is used by `JSONModel`.
  */
 + (JSONKeyMapper *)keyMapper {
-  return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"name": @"name" }];
+  return [[JSONKeyMapper alloc] initWithModelToJSONDictionary:@{ @"_id": @"id", @"name": @"name" }];
 }
 
 /**

--- a/samples/client/petstore/objc/default/SwaggerClient/Model/SWGUser.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Model/SWGUser.m
@@ -17,7 +17,7 @@
  * This method is used by `JSONModel`.
  */
 + (JSONKeyMapper *)keyMapper {
-  return [[JSONKeyMapper alloc] initWithDictionary:@{ @"id": @"_id", @"username": @"username", @"firstName": @"firstName", @"lastName": @"lastName", @"email": @"email", @"password": @"password", @"phone": @"phone", @"userStatus": @"userStatus" }];
+  return [[JSONKeyMapper alloc] initWithModelToJSONDictionary:@{ @"_id": @"id", @"username": @"username", @"firstName": @"firstName", @"lastName": @"lastName", @"email": @"email", @"password": @"password", @"phone": @"phone", @"userStatus": @"userStatus" }];
 }
 
 /**


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Replaced deprecated call `-[JSONKeyMapper initWithDictionary:]` with `-[JSONKeyMapper initWithModelToJSONDictionary:]`, inverting keys and values of dictionary as required.