### PR TITLE
[aspnet5] Fix broken template directory for deprecated lang

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNet5ServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNet5ServerCodegen.java
@@ -10,6 +10,8 @@ public class AspNet5ServerCodegen extends AspNetCoreServerCodegen {
 
     public AspNet5ServerCodegen() {
         super();
+
+        embeddedTemplateDir = templateDir = "aspnetcore";
     }
 
     @Override


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

When I opened #4011, I seem to have forgotten to point the deprecated aspnet5 generator to the renamed aspnetcore directory.

This is a one-line change to point to that renamed directory.

This can be tested by running the same code in `./bin/aspnetcore-petstore-server.sh` but changing the language to the deprecated `aspnet5`.

See #4121.


