### PR TITLE
[ObjC] AFNetworking pinnedCertificates API usage fix

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/ApiClient-body.mustache
@@ -483,7 +483,7 @@ static NSString * {{classPrefix}}__fileNameForResponse(NSURLResponse *response) 
 
     if (config.sslCaCert) {
         NSData *certData = [NSData dataWithContentsOfFile:config.sslCaCert];
-        [securityPolicy setPinnedCertificates:@[certData]];
+        [securityPolicy setPinnedCertificates:[NSSet setWithObject:certData]];
     }
 
     if (config.verifySSL) {

--- a/modules/swagger-codegen/src/main/resources/objc/podspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/podspec.mustache
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     s.public_header_files = '{{podName}}/**/*.h'
 {{#useCoreData}}    s.resources      = '{{podName}}/**/*.{xcdatamodeld,xcdatamodel}'{{/useCoreData}}
 
-    s.dependency 'AFNetworking', '~> 3'
+    s.dependency 'AFNetworking', '~> 3.1'
     s.dependency 'JSONModel', '~> 1.2'
     s.dependency 'ISO8601', '~> 0.5'
 end

--- a/samples/client/petstore/objc/default/SwaggerClient.podspec
+++ b/samples/client/petstore/objc/default/SwaggerClient.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     s.public_header_files = 'SwaggerClient/**/*.h'
 
 
-    s.dependency 'AFNetworking', '~> 3'
+    s.dependency 'AFNetworking', '~> 3.1'
     s.dependency 'JSONModel', '~> 1.2'
     s.dependency 'ISO8601', '~> 0.5'
 end

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGApiClient.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGApiClient.m
@@ -483,7 +483,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
     if (config.sslCaCert) {
         NSData *certData = [NSData dataWithContentsOfFile:config.sslCaCert];
-        [securityPolicy setPinnedCertificates:@[certData]];
+        [securityPolicy setPinnedCertificates:[NSSet setWithObject:certData]];
     }
 
     if (config.verifySSL) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Current version of generated code produces a warning: `Incompatible pointer types sending 'NSArray *' to parameter of type 'NSSet<NSData *> * _Nullable'`

This PR updates AFNetworking API usage according to this commit: https://github.com/AFNetworking/AFNetworking/commit/352f8515498c748c260561cbd3a990a00b0b05ab
