### PR TITLE
[csharp] Use default rather than null in ctor

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2192,7 +2192,7 @@ public class DefaultCodegen {
         p.jsonSchema = Json.pretty(param);
 
         if (System.getProperty("debugParser") != null) {
-            LOGGER.info("working on Parameter " + param);
+            LOGGER.info("working on Parameter " + param.getName());
         }
 
         // move the defaultValue for headers, forms and params
@@ -2212,7 +2212,7 @@ public class DefaultCodegen {
             String collectionFormat = null;
             String type = qp.getType();
             if (null == type) {
-                LOGGER.warn("Type is NULL for Serializable Parameter: " + param);
+                LOGGER.warn("Type is NULL for Serializable Parameter: " + param.getName());
             }
             if ("array".equals(type)) { // for array parameter
                 Property inner = qp.getItems();

--- a/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
@@ -47,7 +47,7 @@
     {{#hasOnlyReadOnly}}
         [JsonConstructorAttribute]
     {{/hasOnlyReadOnly}}
-        public {{classname}}({{#readWriteVars}}{{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} = null{{^-last}}, {{/-last}}{{/readWriteVars}})
+        public {{classname}}({{#readWriteVars}}{{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} = {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}default({{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}}){{/defaultValue}}{{^-last}}, {{/-last}}{{/readWriteVars}})
         {
             {{#vars}}
             {{^isReadOnly}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

See #3608

This improves the defaults on constructor parameters by using `defaults(type)` rather than `null` for all inputs.

~~There seems to have been some weird usage of nullable types, possibly on parameters that aren't defined in the target swagger definition as nullable although I'm not 100% sure and didn't spend a lot of time investigating this.~~
Edit: I looked more closely and the nullable types seem to only occur when a primitive or enum is not marked as required. I had actually [previously explained this behavior for properties](https://github.com/swagger-api/swagger-codegen/issues/2885#issuecomment-220203786), but wasn't thinking broadly enough when I made comment about constructor parameters above.

This PR changes constructor parameters in models to:

1. Default to a default if present
2. Set to `default(TheType)` if no default value is defined

## Examples

### Old Behavior: Dog

```
public Dog(string ClassName = null, string Color = null, string Breed = null)
{
    // to ensure "ClassName" is required (not null)
    if (ClassName == null)
    {
        throw new InvalidDataException("ClassName is a required property for Dog and cannot be null");
    }
    else
    {
        this.ClassName = ClassName;
    }
    // use default value if no "Color" provided
    if (Color == null)
    {
        this.Color = "red";
    }
    else
    {
        this.Color = Color;
    }
    this.Breed = Breed;
}
```

### New Behavior: Dog

```
 public Dog(string ClassName = default(string), string Color = "red", string Breed = default(string))
{
    // to ensure "ClassName" is required (not null)
    if (ClassName == null)
    {
        throw new InvalidDataException("ClassName is a required property for Dog and cannot be null");
    }
    else
    {
        this.ClassName = ClassName;
    }
    // use default value if no "Color" provided
    if (Color == null)
    {
        this.Color = "red";
    }
    else
    {
        this.Color = Color;
    }
    this.Breed = Breed;
}
```

### New Behavior: Other constructor examples

```
public Cat(string ClassName = default(string), 
            string Color = "red", 
            bool? Declawed = default(bool?)
) { }

public EnumArrays(JustSymbolEnum? JustSymbol = default(JustSymbolEnum?), 
            List<ArrayEnumEnum> ArrayEnum = default(List<ArrayEnumEnum>)
) { }

public Pet(long? Id = default(long?), 
           Category Category = default(Category), 
           string Name = default(string), 
           List<string> PhotoUrls = default(List<string>), 
           List<Tag> Tags = default(List<Tag>), 
           StatusEnum? Status = default(StatusEnum?)
) { }
```

I didn't include regenerated samples in this PR.

## Question

If this looks good, should I go ahead and update aspnetcore and NancyFx generators to do the same for models?