### PR TITLE
Select application/json content-type in python generated client, if */* is in the list of content-types

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -462,7 +462,7 @@ class ApiClient(object):
 
         content_types = list(map(lambda x: x.lower(), content_types))
 
-        if 'application/json' in content_types:
+        if 'application/json' in content_types or '*/*' in content_types:
             return 'application/json'
         else:
             return content_types[0]

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -462,7 +462,7 @@ class ApiClient(object):
 
         content_types = list(map(lambda x: x.lower(), content_types))
 
-        if 'application/json' in content_types:
+        if 'application/json' in content_types or '*/*' in content_types:
             return 'application/json'
         else:
             return content_types[0]


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

select_header_content_type in generated python client's api_client prefers application/json if it is in the list of content types. But the list may content */* that means server accepts any content-type. In that case we should still prefer application/json content type.
