### PR TITLE
Update TypeScript Fetch TypeScript version to 2.0.7

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -38,7 +38,6 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         supportingFiles.add(new SupportingFile("README.md", "", "README.md"));
         supportingFiles.add(new SupportingFile("package.json.mustache", "", "package.json"));
-        supportingFiles.add(new SupportingFile("typings.json.mustache", "", "typings.json"));
         supportingFiles.add(new SupportingFile("tsconfig.json.mustache", "", "tsconfig.json"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
 

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
@@ -41,7 +41,7 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
      * {{{description}}}
      */
 {{/description}}
-    "{{name}}"{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
+    "{{baseName}}"{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
 {{/vars}}
 }
 

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/gitignore
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/gitignore
@@ -1,3 +1,2 @@
 wwwroot/*.js
 node_modules
-typings

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/package.json.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/package.json.mustache
@@ -6,14 +6,16 @@
   "browser": "./dist/api.js",
   "typings": "./dist/api.d.ts",
   "dependencies": {
-    {{^supportsES6}}"core-js": "^2.4.0",
-    {{/supportsES6}}"isomorphic-fetch": "^2.2.1"
+    "@types/node": "6.0.46",
+    "@types/isomorphic-fetch": "0.0.31",{{^supportsES6}}
+    "@types/core-js": "0.9.34",
+    "core-js": "2.4.1",{{/supportsES6}}
+    "isomorphic-fetch": "2.2.1"
   },
   "scripts" : {
-    "prepublish" : "typings install && tsc"
+    "prepublish" : "tsc"
   },
   "devDependencies": {
-    "typescript": "^1.8.10",
-    "typings": "^1.0.4"
+    "typescript": "^2.0.7"
   }
 }

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/tsconfig.json.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/tsconfig.json.mustache
@@ -9,9 +9,6 @@
   },
   "exclude": [
     "dist",
-    "node_modules",
-    "typings/browser",
-    "typings/main",
-    "typings/main.d.ts"
+    "node_modules"
   ]
 }

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/typings.json.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/typings.json.mustache
@@ -1,9 +1,0 @@
-{
-  "version": false,
-  "dependencies": {},
-  "globalDependencies": { {{^supportsES6}}
-    "core-js": "registry:dt/core-js#0.0.0+20160317120654",{{/supportsES6}}
-    "node": "registry:dt/node#4.0.0+20160423143914",
-    "isomorphic-fetch": "registry:dt/isomorphic-fetch#0.0.0+20160505171433"
-  }
-}


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)
* Update TypeScript Fetch TypeScript version to 2.0.7
* Fix support for underscore casing in POST body