### PR TITLE
add file response support

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
@@ -14,7 +14,7 @@ public class CodegenOperation {
     public Boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams,
             returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMapContainer,
             isListContainer, isMultipart, hasMore = Boolean.TRUE,
-            isResponseBinary = Boolean.FALSE, hasReference = Boolean.FALSE,
+            isResponseBinary = Boolean.FALSE, isResponseFile = Boolean.FALSE, hasReference = Boolean.FALSE,
             isRestfulIndex, isRestfulShow, isRestfulCreate, isRestfulUpdate, isRestfulDestroy,
             isRestful;
     public String path, operationId, returnType, httpMethod, returnBaseType,
@@ -215,6 +215,8 @@ public class CodegenOperation {
             return false;
         if (isResponseBinary != null ? !isResponseBinary.equals(that.isResponseBinary) : that.isResponseBinary != null)
             return false;
+        if (isResponseFile != null ? !isResponseFile.equals(that.isResponseFile) : that.isResponseFile != null)
+            return false;
         if (hasReference != null ? !hasReference.equals(that.hasReference) : that.hasReference != null)
             return false;
         if (path != null ? !path.equals(that.path) : that.path != null)
@@ -297,6 +299,7 @@ public class CodegenOperation {
         result = 31 * result + (isMultipart != null ? isMultipart.hashCode() : 0);
         result = 31 * result + (hasMore != null ? hasMore.hashCode() : 0);
         result = 31 * result + (isResponseBinary != null ? isResponseBinary.hashCode() : 0);
+        result = 31 * result + (isResponseFile != null ? isResponseFile.hashCode() : 0);
         result = 31 * result + (hasReference != null ? hasReference.hashCode() : 0);
         result = 31 * result + (path != null ? path.hashCode() : 0);
         result = 31 * result + (operationId != null ? operationId.hashCode() : 0);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -37,7 +37,7 @@ public class CodegenProperty implements Cloneable {
     public Boolean hasMore, required, secondaryParam;
     public Boolean hasMoreNonReadOnly; // for model constructor, true if next properyt is not readonly
     public Boolean isPrimitiveType, isContainer, isNotContainer;
-    public Boolean isString, isInteger, isLong, isFloat, isDouble, isByteArray, isBinary, isBoolean, isDate, isDateTime;
+    public Boolean isString, isInteger, isLong, isFloat, isDouble, isByteArray, isBinary, isFile, isBoolean, isDate, isDateTime;
     public Boolean isListContainer, isMapContainer;
     public boolean isEnum;
     public Boolean isReadOnly = false;
@@ -108,6 +108,7 @@ public class CodegenProperty implements Cloneable {
         result = prime * result + ((isDouble == null) ? 0 : isDouble.hashCode());
         result = prime * result + ((isByteArray == null) ? 0 : isByteArray.hashCode());
         result = prime * result + ((isBinary == null) ? 0 : isBinary.hashCode());
+        result = prime * result + ((isFile == null) ? 0 : isFile.hashCode());
         result = prime * result + ((isBoolean == null) ? 0 : isBoolean.hashCode());
         result = prime * result + ((isDate == null) ? 0 : isDate.hashCode());
         result = prime * result + ((isDateTime == null) ? 0 : isDateTime.hashCode());
@@ -262,6 +263,9 @@ public class CodegenProperty implements Cloneable {
             return false;
         }
         if (this.isBinary != other.isBinary && (this.isBinary == null || !this.isBinary.equals(other.isBinary))) {
+            return false;
+        }
+        if (this.isFile != other.isFile && (this.isFile == null || !this.isFile.equals(other.isFile))) {
             return false;
         }
         if (this.isListContainer != other.isListContainer && (this.isListContainer == null || !this.isListContainer.equals(other.isListContainer))) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
@@ -16,6 +16,7 @@ public class CodegenResponse {
     public Boolean isMapContainer;
     public Boolean isListContainer;
     public Boolean isBinary = Boolean.FALSE;
+    public Boolean isFile = Boolean.FALSE;
     public Object schema;
     public String jsonSchema;
 
@@ -63,6 +64,8 @@ public class CodegenResponse {
             return false;
         if (isBinary != null ? !isBinary.equals(that.isBinary) : that.isBinary != null)
             return false;
+        if (isFile != null ? !isFile.equals(that.isFile) : that.isFile != null)
+            return false;
         if (schema != null ? !schema.equals(that.schema) : that.schema != null)
             return false;
         return jsonSchema != null ? jsonSchema.equals(that.jsonSchema) : that.jsonSchema == null;
@@ -85,6 +88,7 @@ public class CodegenResponse {
         result = 31 * result + (isMapContainer != null ? isMapContainer.hashCode() : 0);
         result = 31 * result + (isListContainer != null ? isListContainer.hashCode() : 0);
         result = 31 * result + (isBinary != null ? isBinary.hashCode() : 0);
+        result = 31 * result + (isFile != null ? isFile.hashCode() : 0);
         result = 31 * result + (schema != null ? schema.hashCode() : 0);
         result = 31 * result + (jsonSchema != null ? jsonSchema.hashCode() : 0);
         return result;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -36,6 +36,7 @@ import io.swagger.models.properties.DateProperty;
 import io.swagger.models.properties.DateTimeProperty;
 import io.swagger.models.properties.DecimalProperty;
 import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.FileProperty;
 import io.swagger.models.properties.FloatProperty;
 import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.LongProperty;
@@ -765,6 +766,7 @@ public class DefaultCodegen {
         typeMapping.put("integer", "Integer");
         typeMapping.put("ByteArray", "byte[]");
         typeMapping.put("binary", "byte[]");
+        typeMapping.put("file", "File");
 
 
         instantiationTypes = new HashMap<String, String>();
@@ -1069,6 +1071,8 @@ public class DefaultCodegen {
             datatype = "ByteArray";
         } else if (p instanceof BinaryProperty) {
             datatype = "binary";
+        } else if (p instanceof FileProperty) {
+            datatype = "file";
         } else if (p instanceof BooleanProperty) {
             datatype = "boolean";
         } else if (p instanceof DateProperty) {
@@ -1536,6 +1540,9 @@ public class DefaultCodegen {
         if (p instanceof BinaryProperty) {
             property.isBinary = true;
         }
+        if (p instanceof FileProperty) {
+            property.isFile = true;
+        }
         if (p instanceof UUIDProperty) {
             property.isString = true;
         }
@@ -1964,6 +1971,9 @@ public class DefaultCodegen {
                 if (r.isBinary && r.isDefault){
                     op.isResponseBinary = Boolean.TRUE;
                 }
+                if (r.isFile && r.isDefault){
+                    op.isResponseFile = Boolean.TRUE;
+                }
             }
             op.responses.get(op.responses.size() - 1).hasMore = false;
 
@@ -2163,6 +2173,7 @@ public class DefaultCodegen {
             }
             r.dataType = cm.datatype;
             r.isBinary = isDataTypeBinary(cm.datatype);
+            r.isFile = isDataTypeFile(cm.datatype);
             if (cm.isContainer != null) {
                 r.simpleType = false;
                 r.containerType = cm.containerType;
@@ -2345,6 +2356,7 @@ public class DefaultCodegen {
                         p.dataType = cp.datatype;
                         p.isPrimitiveType = cp.isPrimitiveType;
                         p.isBinary = isDataTypeBinary(cp.datatype);
+                        p.isFile = isDataTypeFile(cp.datatype);
                     }
 
                     // set boolean flag (e.g. isString)
@@ -2412,6 +2424,8 @@ public class DefaultCodegen {
             p.example = "BINARY_DATA_HERE";
         } else if (Boolean.TRUE.equals(p.isByteArray)) {
             p.example = "B";
+        } else if (Boolean.TRUE.equals(p.isFile)) {
+            p.example = "/path/to/file.txt";
         } else if (Boolean.TRUE.equals(p.isDate)) {
             p.example = "2013-10-20";
         } else if (Boolean.TRUE.equals(p.isDateTime)) {
@@ -2460,6 +2474,10 @@ public class DefaultCodegen {
 
     public boolean isDataTypeBinary(String dataType) {
         return dataType.toLowerCase().startsWith("byte");
+    }
+
+    public boolean isDataTypeFile(String dataType) {
+        return dataType.toLowerCase().equals("file");
     }
 
     /**
@@ -3256,6 +3274,9 @@ public class DefaultCodegen {
             parameter.isPrimitiveType = true;
         } else if (Boolean.TRUE.equals(property.isBinary)) {
             parameter.isByteArray = true;
+            parameter.isPrimitiveType = true;
+        } else if (Boolean.TRUE.equals(property.isFile)) {
+            parameter.isFile = true;
             parameter.isPrimitiveType = true;
         } else if (Boolean.TRUE.equals(property.isDate)) {
             parameter.isDate = true;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -1,5 +1,7 @@
 package io.swagger.codegen.languages;
 
+import io.swagger.models.properties.FileProperty;
+import io.swagger.models.properties.Property;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +28,8 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
 
     public TypeScriptNodeClientCodegen() {
         super();
+
+        typeMapping.put("file", "Buffer");
 
         // clear import mapping (from default generator) as TS does not use it
         // at the moment
@@ -90,6 +94,19 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
     @Override
     public String getHelp() {
         return "Generates a TypeScript nodejs client library.";
+    }
+
+    @Override
+    public boolean isDataTypeFile(final String dataType) {
+        return dataType != null && dataType.equals("Buffer");
+    }
+
+    @Override
+    public String getTypeDeclaration(Property p) {
+        if (p instanceof FileProperty) {
+            return "Buffer";
+        }
+        return super.getTypeDeclaration(p);
     }
 
 

--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -235,7 +235,12 @@ export class {{classname}} {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
+{{^isResponseFile}}
             json: true,
+{{/isResponseFile}}
+{{#isResponseFile}}
+            encoding: null,
+{{/isResponseFile}}
 {{#bodyParam}}
             body: {{paramName}},
 {{/bodyParam}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -43,7 +43,7 @@ public class CodegenTest {
 
         final CodegenParameter file = op.formParams.get(1);
         Assert.assertTrue(file.isFormParam);
-        Assert.assertEquals(file.dataType, "file");
+        Assert.assertEquals(file.dataType, "File");
         Assert.assertNull(file.required);
         Assert.assertTrue(file.isFile);
         Assert.assertNull(file.hasMore);
@@ -186,6 +186,19 @@ public class CodegenTest {
         Assert.assertEquals(op.bodyParam.dataType, "byte[]");
         Assert.assertTrue(op.bodyParam.isBinary);
         Assert.assertTrue(op.responses.get(0).isBinary);
+    }
+
+    @Test(description = "return file when response format is file")
+    public void fileResponeseTest() {
+        final Swagger model = parseAndPrepareSwagger("src/test/resources/2_0/fileResponseTest.json");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        final String path = "/tests/fileResponse";
+        final Operation p = model.getPaths().get(path).getGet();
+        final CodegenOperation op = codegen.fromOperation(path, "get", p, model.getDefinitions());
+
+        Assert.assertEquals(op.returnType, "File");
+        Assert.assertTrue(op.responses.get(0).isFile);
+        Assert.assertTrue(op.isResponseFile);
     }
     
     @Test(description = "discriminator is present")

--- a/modules/swagger-codegen/src/test/resources/2_0/fileResponseTest.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/fileResponseTest.json
@@ -1,0 +1,33 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "File Response Test",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "basePath": "/v2",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/tests/fileResponse": {
+      "get": {
+        "operationId": "fileresponsetest",
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "OutputFileData",
+            "schema": {
+              "type": "file"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

 - Closes #4034
 - Add file response support for typescript-node client generator

Sorry for late action. I did try to treat both `binary` and `file` as `Buffer in Node.js`
However I could not find a good solution for it so I just make a PR for `file`.