### PR TITLE
fix[dart]: send ISO8601 dates

### DIFF
--- a/modules/swagger-codegen/src/main/resources/dart/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/api_client.mustache
@@ -17,7 +17,6 @@ class ApiClient {
 
   final dson = new Dartson.JSON()
                    ..addTransformer(new DateTimeParser(), DateTime);
-  final DateFormat _dateFormatter = new DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   final _RegList = new RegExp(r'^List<(.*)>$');
   final _RegMap = new RegExp(r'^Map<String,(.*)>$');
@@ -31,24 +30,6 @@ class ApiClient {
 
   void addDefaultHeader(String key, String value) {
      _defaultHeaderMap[key] = value;
-  }
-
-  /// Format the given Date object into string.
-  String formatDate(DateTime date) {
-    return _dateFormatter.format(date);
-  }
-
-  /// Format the given parameter object into string.
-  String parameterToString(Object param) {
-    if (param == null) {
-      return '';
-    } else if (param is DateTime) {
-      return formatDate(param);
-    } else if (param is List) {
-      return (param).join(',');
-    } else {
-      return param.toString();
-    }
   }
 
   dynamic _deserialize(dynamic value, String targetType) {

--- a/modules/swagger-codegen/src/main/resources/dart/api_helper.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/api_helper.mustache
@@ -11,7 +11,7 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
   if (name == null || name.isEmpty || value == null) return params;
 
   if (value is! List) {
-    params.add(new QueryParam(name, '$value'));
+    params.add(new QueryParam(name, _parameterToString(value)));
     return params;
   }
 
@@ -23,11 +23,22 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
                      : collectionFormat; // default: csv
 
   if (collectionFormat == "multi") {
-    return values.map((v) => new QueryParam(name, '$v'));
+    return values.map((v) => new QueryParam(name, _parameterToString(v)));
   }
 
   String delimiter = _delimiters[collectionFormat] ?? ",";
 
-  params.add(new QueryParam(name, values.join(delimiter)));
+  params.add(new QueryParam(name, values.map((v)=>_parameterToString(v)).join(delimiter)));
   return params;
+}
+
+/// Format the given parameter object into string.
+String _parameterToString(dynamic value) {
+  if (value == null) {
+    return '';
+  } else if (value is DateTime) {
+    return value.toUtc().toIso8601String();
+  } else {
+    return value.toString();
+  }
 }

--- a/modules/swagger-codegen/src/main/resources/dart/apilib.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/apilib.mustache
@@ -6,7 +6,6 @@ import 'package:http/browser_client.dart';{{/browserClient}}
 import 'package:http/http.dart';
 import 'package:dartson/dartson.dart';
 import 'package:dartson/transformers/date_time.dart';
-import 'package:intl/intl.dart';
 
 part 'api_client.dart';
 part 'api_helper.dart';

--- a/modules/swagger-codegen/src/main/resources/dart/pubspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/pubspec.mustache
@@ -4,7 +4,6 @@ description: {{pubDescription}}
 dependencies:
   http: '>=0.11.1 <0.12.0'
   dartson: "^0.2.4"
-  intl: ">=0.12.4"
 
 dev_dependencies:
   guinness: '^0.1.17'

--- a/samples/client/petstore/dart/swagger/lib/api.dart
+++ b/samples/client/petstore/dart/swagger/lib/api.dart
@@ -6,7 +6,6 @@ import 'package:http/browser_client.dart';
 import 'package:http/http.dart';
 import 'package:dartson/dartson.dart';
 import 'package:dartson/transformers/date_time.dart';
-import 'package:intl/intl.dart';
 
 part 'api_client.dart';
 part 'api_helper.dart';

--- a/samples/client/petstore/dart/swagger/lib/api_client.dart
+++ b/samples/client/petstore/dart/swagger/lib/api_client.dart
@@ -17,7 +17,6 @@ class ApiClient {
 
   final dson = new Dartson.JSON()
                    ..addTransformer(new DateTimeParser(), DateTime);
-  final DateFormat _dateFormatter = new DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   final _RegList = new RegExp(r'^List<(.*)>$');
   final _RegMap = new RegExp(r'^Map<String,(.*)>$');
@@ -30,24 +29,6 @@ class ApiClient {
 
   void addDefaultHeader(String key, String value) {
      _defaultHeaderMap[key] = value;
-  }
-
-  /// Format the given Date object into string.
-  String formatDate(DateTime date) {
-    return _dateFormatter.format(date);
-  }
-
-  /// Format the given parameter object into string.
-  String parameterToString(Object param) {
-    if (param == null) {
-      return '';
-    } else if (param is DateTime) {
-      return formatDate(param);
-    } else if (param is List) {
-      return (param).join(',');
-    } else {
-      return param.toString();
-    }
   }
 
   dynamic _deserialize(dynamic value, String targetType) {

--- a/samples/client/petstore/dart/swagger/lib/api_helper.dart
+++ b/samples/client/petstore/dart/swagger/lib/api_helper.dart
@@ -11,7 +11,7 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
   if (name == null || name.isEmpty || value == null) return params;
 
   if (value is! List) {
-    params.add(new QueryParam(name, '$value'));
+    params.add(new QueryParam(name, _parameterToString(value)));
     return params;
   }
 
@@ -23,11 +23,22 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
                      : collectionFormat; // default: csv
 
   if (collectionFormat == "multi") {
-    return values.map((v) => new QueryParam(name, '$v'));
+    return values.map((v) => new QueryParam(name, _parameterToString(v)));
   }
 
   String delimiter = _delimiters[collectionFormat] ?? ",";
 
-  params.add(new QueryParam(name, values.join(delimiter)));
+  params.add(new QueryParam(name, values.map((v)=>_parameterToString(v)).join(delimiter)));
   return params;
+}
+
+/// Format the given parameter object into string.
+String _parameterToString(dynamic value) {
+  if (value == null) {
+    return '';
+  } else if (value is DateTime) {
+    return value.toUtc().toIso8601String();
+  } else {
+    return value.toString();
+  }
 }

--- a/samples/client/petstore/dart/swagger/pubspec.yaml
+++ b/samples/client/petstore/dart/swagger/pubspec.yaml
@@ -4,7 +4,6 @@ description: Swagger API client
 dependencies:
   http: '>=0.11.1 <0.12.0'
   dartson: "^0.2.4"
-  intl: ">=0.12.4"
 
 dev_dependencies:
   guinness: '^0.1.17'


### PR DESCRIPTION
Dates for parameters were sent by using DateTime#toString. This would give us a date of the format "2016-11-08 14:33:37.270". Now I changed it to use DateTime#toIso8601String to give us a value like "2016-11-08T14:34:29.520". There were functions to format the date correctly, but those were not used anymore, which is why I assume that ISO8601 should have been used in the first place.

In other news, I decided not to use the provided code which relied on the intl package to format a ISO 8601, but a function from the DateTime class in core, thereby eliminating the necessity for using the external "intl" library.