### PR TITLE
Support _preload_content flag in python client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -98,6 +98,7 @@ class {{classname}}(object):
         all_params = [{{#allParams}}'{{paramName}}'{{#hasMore}}, {{/hasMore}}{{/allParams}}]
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -211,6 +212,7 @@ class {{classname}}(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 {{/operation}}
 {{/operations}}

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -85,7 +85,7 @@ class RESTClientObject(object):
         )
 
     def request(self, method, url, query_params=None, headers=None,
-                body=None, post_params=None):
+                body=None, post_params=None, _preload_content=True):
         """
         :param method: http request method
         :param url: http request url
@@ -95,6 +95,8 @@ class RESTClientObject(object):
         :param post_params: request post parameters,
                             `application/x-www-form-urlencoded`
                             and `multipart/form-data`
+        :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
+                                 reading/decoding response data. Default is True.
         """
         method = method.upper()
         assert method in ['GET', 'HEAD', 'DELETE', 'POST', 'PUT', 'PATCH', 'OPTIONS']
@@ -121,11 +123,13 @@ class RESTClientObject(object):
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,
+                                                  preload_content=_preload_content,
                                                   headers=headers)
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':
                     r = self.pool_manager.request(method, url,
                                                   fields=post_params,
                                                   encode_multipart=False,
+                                                  preload_content=_preload_content,
                                                   headers=headers)
                 elif headers['Content-Type'] == 'multipart/form-data':
                     # must del headers['Content-Type'], or the correct Content-Type
@@ -134,6 +138,7 @@ class RESTClientObject(object):
                     r = self.pool_manager.request(method, url,
                                                   fields=post_params,
                                                   encode_multipart=True,
+                                                  preload_content=_preload_content,
                                                   headers=headers)
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is provided
@@ -142,6 +147,7 @@ class RESTClientObject(object):
                     request_body = body
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,
+                                                  preload_content=_preload_content,
                                                   headers=headers)
                 else:
                     # Cannot generate the request from given parameters
@@ -152,68 +158,77 @@ class RESTClientObject(object):
             else:
                 r = self.pool_manager.request(method, url,
                                               fields=query_params,
+                                              preload_content=_preload_content,
                                               headers=headers)
         except urllib3.exceptions.SSLError as e:
             msg = "{0}\n{1}".format(type(e).__name__, str(e))
             raise ApiException(status=0, reason=msg)
 
-        r = RESTResponse(r)
+        if _preload_content:
+            r = RESTResponse(r)
 
-        # In the python 3, the response.data is bytes.
-        # we need to decode it to string.
-        if PY3:
-            r.data = r.data.decode('utf8')
+            # In the python 3, the response.data is bytes.
+            # we need to decode it to string.
+            if PY3:
+                r.data = r.data.decode('utf8')
 
-        # log response body
-        logger.debug("response body: %s", r.data)
+            # log response body
+            logger.debug("response body: %s", r.data)
 
         if r.status not in range(200, 206):
             raise ApiException(http_resp=r)
 
         return r
 
-    def GET(self, url, headers=None, query_params=None):
+    def GET(self, url, headers=None, query_params=None, _preload_content=True):
         return self.request("GET", url,
                             headers=headers,
+                            _preload_content=_preload_content,
                             query_params=query_params)
 
-    def HEAD(self, url, headers=None, query_params=None):
+    def HEAD(self, url, headers=None, query_params=None, _preload_content=True):
         return self.request("HEAD", url,
                             headers=headers,
+                            _preload_content=_preload_content,
                             query_params=query_params)
 
-    def OPTIONS(self, url, headers=None, query_params=None, post_params=None, body=None):
+    def OPTIONS(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
         return self.request("OPTIONS", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
+                            _preload_content=_preload_content,
                             body=body)
 
-    def DELETE(self, url, headers=None, query_params=None, body=None):
+    def DELETE(self, url, headers=None, query_params=None, body=None, _preload_content=True):
         return self.request("DELETE", url,
                             headers=headers,
                             query_params=query_params,
+                            _preload_content=_preload_content,
                             body=body)
 
-    def POST(self, url, headers=None, query_params=None, post_params=None, body=None):
+    def POST(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
         return self.request("POST", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
+                            _preload_content=_preload_content,
                             body=body)
 
-    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None):
+    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
         return self.request("PUT", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
+                            _preload_content=_preload_content,
                             body=body)
 
-    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None):
+    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
         return self.request("PATCH", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
+                            _preload_content=_preload_content,
                             body=body)
 
 

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -186,8 +186,8 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
- - **Accept**: application/json
+ - **Content-Type**: */*
+ - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -102,6 +102,7 @@ class FakeApi(object):
         all_params = ['body']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -157,6 +158,7 @@ class FakeApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):
@@ -236,6 +238,7 @@ class FakeApi(object):
         all_params = ['number', 'double', 'pattern_without_delimiter', 'byte', 'integer', 'int32', 'int64', 'float', 'string', 'binary', 'date', 'date_time', 'password', 'param_callback']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -352,6 +355,7 @@ class FakeApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def test_enum_parameters(self, **kwargs):
@@ -419,6 +423,7 @@ class FakeApi(object):
         all_params = ['enum_form_string_array', 'enum_form_string', 'enum_header_string_array', 'enum_header_string', 'enum_query_string_array', 'enum_query_string', 'enum_query_integer', 'enum_query_double']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -466,13 +471,13 @@ class FakeApi(object):
 
         # HTTP header `Accept`
         header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/json'])
+            select_header_accept(['*/*'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
         header_params['Content-Type'] = self.api_client.\
-            select_header_content_type(['application/json'])
+            select_header_content_type(['*/*'])
 
         # Authentication setting
         auth_settings = []
@@ -488,4 +493,5 @@ class FakeApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/pet_api.py
@@ -102,6 +102,7 @@ class PetApi(object):
         all_params = ['body']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -157,6 +158,7 @@ class PetApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def delete_pet(self, pet_id, **kwargs):
@@ -212,6 +214,7 @@ class PetApi(object):
         all_params = ['pet_id', 'api_key']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -269,6 +272,7 @@ class PetApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def find_pets_by_status(self, status, **kwargs):
@@ -322,6 +326,7 @@ class PetApi(object):
         all_params = ['status']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -378,6 +383,7 @@ class PetApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def find_pets_by_tags(self, tags, **kwargs):
@@ -431,6 +437,7 @@ class PetApi(object):
         all_params = ['tags']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -487,6 +494,7 @@ class PetApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def get_pet_by_id(self, pet_id, **kwargs):
@@ -540,6 +548,7 @@ class PetApi(object):
         all_params = ['pet_id']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -595,6 +604,7 @@ class PetApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def update_pet(self, body, **kwargs):
@@ -648,6 +658,7 @@ class PetApi(object):
         all_params = ['body']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -703,6 +714,7 @@ class PetApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def update_pet_with_form(self, pet_id, **kwargs):
@@ -760,6 +772,7 @@ class PetApi(object):
         all_params = ['pet_id', 'name', 'status']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -819,6 +832,7 @@ class PetApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def upload_file(self, pet_id, **kwargs):
@@ -876,6 +890,7 @@ class PetApi(object):
         all_params = ['pet_id', 'additional_metadata', 'file']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -935,4 +950,5 @@ class PetApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/store_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/store_api.py
@@ -102,6 +102,7 @@ class StoreApi(object):
         all_params = ['order_id']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -159,6 +160,7 @@ class StoreApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def get_inventory(self, **kwargs):
@@ -210,6 +212,7 @@ class StoreApi(object):
         all_params = []
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -260,6 +263,7 @@ class StoreApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def get_order_by_id(self, order_id, **kwargs):
@@ -313,6 +317,7 @@ class StoreApi(object):
         all_params = ['order_id']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -372,6 +377,7 @@ class StoreApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def place_order(self, body, **kwargs):
@@ -425,6 +431,7 @@ class StoreApi(object):
         all_params = ['body']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -480,4 +487,5 @@ class StoreApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/user_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/user_api.py
@@ -102,6 +102,7 @@ class UserApi(object):
         all_params = ['body']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -157,6 +158,7 @@ class UserApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def create_users_with_array_input(self, body, **kwargs):
@@ -210,6 +212,7 @@ class UserApi(object):
         all_params = ['body']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -265,6 +268,7 @@ class UserApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def create_users_with_list_input(self, body, **kwargs):
@@ -318,6 +322,7 @@ class UserApi(object):
         all_params = ['body']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -373,6 +378,7 @@ class UserApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def delete_user(self, username, **kwargs):
@@ -426,6 +432,7 @@ class UserApi(object):
         all_params = ['username']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -481,6 +488,7 @@ class UserApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def get_user_by_name(self, username, **kwargs):
@@ -534,6 +542,7 @@ class UserApi(object):
         all_params = ['username']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -589,6 +598,7 @@ class UserApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def login_user(self, username, password, **kwargs):
@@ -644,6 +654,7 @@ class UserApi(object):
         all_params = ['username', 'password']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -704,6 +715,7 @@ class UserApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def logout_user(self, **kwargs):
@@ -755,6 +767,7 @@ class UserApi(object):
         all_params = []
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -805,6 +818,7 @@ class UserApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)
 
     def update_user(self, username, body, **kwargs):
@@ -860,6 +874,7 @@ class UserApi(object):
         all_params = ['username', 'body']
         all_params.append('callback')
         all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -920,4 +935,5 @@ class UserApi(object):
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
+                                            _preload_content=params.get('_preload_content', True),
                                             collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -105,7 +105,7 @@ class RESTClientObject(object):
         )
 
     def request(self, method, url, query_params=None, headers=None,
-                body=None, post_params=None):
+                body=None, post_params=None, _preload_content=True):
         """
         :param method: http request method
         :param url: http request url
@@ -115,6 +115,8 @@ class RESTClientObject(object):
         :param post_params: request post parameters,
                             `application/x-www-form-urlencoded`
                             and `multipart/form-data`
+        :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
+                                 reading/decoding response data. Default is True.
         """
         method = method.upper()
         assert method in ['GET', 'HEAD', 'DELETE', 'POST', 'PUT', 'PATCH', 'OPTIONS']
@@ -141,11 +143,13 @@ class RESTClientObject(object):
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,
+                                                  preload_content=_preload_content,
                                                   headers=headers)
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':
                     r = self.pool_manager.request(method, url,
                                                   fields=post_params,
                                                   encode_multipart=False,
+                                                  preload_content=_preload_content,
                                                   headers=headers)
                 elif headers['Content-Type'] == 'multipart/form-data':
                     # must del headers['Content-Type'], or the correct Content-Type
@@ -154,6 +158,7 @@ class RESTClientObject(object):
                     r = self.pool_manager.request(method, url,
                                                   fields=post_params,
                                                   encode_multipart=True,
+                                                  preload_content=_preload_content,
                                                   headers=headers)
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is provided
@@ -162,6 +167,7 @@ class RESTClientObject(object):
                     request_body = body
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,
+                                                  preload_content=_preload_content,
                                                   headers=headers)
                 else:
                     # Cannot generate the request from given parameters
@@ -172,68 +178,77 @@ class RESTClientObject(object):
             else:
                 r = self.pool_manager.request(method, url,
                                               fields=query_params,
+                                              preload_content=_preload_content,
                                               headers=headers)
         except urllib3.exceptions.SSLError as e:
             msg = "{0}\n{1}".format(type(e).__name__, str(e))
             raise ApiException(status=0, reason=msg)
 
-        r = RESTResponse(r)
+        if _preload_content:
+            r = RESTResponse(r)
 
-        # In the python 3, the response.data is bytes.
-        # we need to decode it to string.
-        if PY3:
-            r.data = r.data.decode('utf8')
+            # In the python 3, the response.data is bytes.
+            # we need to decode it to string.
+            if PY3:
+                r.data = r.data.decode('utf8')
 
-        # log response body
-        logger.debug("response body: %s", r.data)
+            # log response body
+            logger.debug("response body: %s", r.data)
 
         if r.status not in range(200, 206):
             raise ApiException(http_resp=r)
 
         return r
 
-    def GET(self, url, headers=None, query_params=None):
+    def GET(self, url, headers=None, query_params=None, _preload_content=True):
         return self.request("GET", url,
                             headers=headers,
+                            _preload_content=_preload_content,
                             query_params=query_params)
 
-    def HEAD(self, url, headers=None, query_params=None):
+    def HEAD(self, url, headers=None, query_params=None, _preload_content=True):
         return self.request("HEAD", url,
                             headers=headers,
+                            _preload_content=_preload_content,
                             query_params=query_params)
 
-    def OPTIONS(self, url, headers=None, query_params=None, post_params=None, body=None):
+    def OPTIONS(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
         return self.request("OPTIONS", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
+                            _preload_content=_preload_content,
                             body=body)
 
-    def DELETE(self, url, headers=None, query_params=None, body=None):
+    def DELETE(self, url, headers=None, query_params=None, body=None, _preload_content=True):
         return self.request("DELETE", url,
                             headers=headers,
                             query_params=query_params,
+                            _preload_content=_preload_content,
                             body=body)
 
-    def POST(self, url, headers=None, query_params=None, post_params=None, body=None):
+    def POST(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
         return self.request("POST", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
+                            _preload_content=_preload_content,
                             body=body)
 
-    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None):
+    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
         return self.request("PUT", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
+                            _preload_content=_preload_content,
                             body=body)
 
-    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None):
+    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
         return self.request("PATCH", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
+                            _preload_content=_preload_content,
                             body=body)
 
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
In order to support streaming responses, we need the API Client not to read response content and return a Response object. urllib3 has a flag called preload_content that if set to False, it will return a urllib3.HTTPResponse. This PR add support for this flag in rest client and api client and generated api classes. The flag is optional and defaulted to True to keep current behavior.
