### PR TITLE
[ruby] Make sure super is always called for ApiError class.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api_error.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_error.mustache
@@ -13,12 +13,14 @@ module {{moduleName}}
     #   ApiError.new(:code => 404, :message => "Not Found")
     def initialize(arg = nil)
       if arg.is_a? Hash
+        if arg.key?(:message) || arg.key?('message')
+          super(arg[:message] || arg['message'])
+        else
+          super arg
+        end
+
         arg.each do |k, v|
-          if k.to_s == 'message'
-            super v
-          else
-            instance_variable_set "@#{k}", v
-          end
+          instance_variable_set "@#{k}", v
         end
       else
         super arg

--- a/samples/client/petstore/ruby/lib/petstore/api_error.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_error.rb
@@ -32,12 +32,14 @@ module Petstore
     #   ApiError.new(:code => 404, :message => "Not Found")
     def initialize(arg = nil)
       if arg.is_a? Hash
+        if arg.key?(:message) || arg.key?('message')
+          super(arg[:message] || arg['message'])
+        else
+          super arg
+        end
+
         arg.each do |k, v|
-          if k.to_s == 'message'
-            super v
-          else
-            instance_variable_set "@#{k}", v
-          end
+          instance_variable_set "@#{k}", v
         end
       else
         super arg

--- a/samples/client/petstore/ruby/spec/api_error_spec.rb
+++ b/samples/client/petstore/ruby/spec/api_error_spec.rb
@@ -1,0 +1,15 @@
+require File.dirname(__FILE__) + '/spec_helper'
+
+describe Petstore::ApiClient do
+  describe '#initialize' do
+    it "should save the message if one is given" do
+      err = Petstore::ApiError.new(message: "Hello")
+      expect(err.message).to eq("Hello")
+    end
+
+    it "should save the hash as message if no message is given" do
+      err = Petstore::ApiError.new(code: 500, response_body: "server error")
+      expect(err.message).to eq("{:code=>500, :response_body=>\"server error\"}")
+    end
+  end
+end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Rewrite the logic in ruby client's `ApiError` class to always call `super` so that some information is guaranteed to be included.

https://github.com/swagger-api/swagger-codegen/issues/4167

