### PR TITLE
Add two override points inside AlamofireRequestBuilder in the Swift 3 template.

### DIFF
--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -30,6 +30,25 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         return Alamofire.SessionManager(configuration: configuration)
     }
 
+    /**
+     May be overridden by a subclass if you want to control the Content-Type
+     that is given to an uploaded form part.
+
+     Return nil to use the default behavior (inferring the Content-Type from
+     the file extension).  Return the desired Content-Type otherwise.
+     */
+    open func contentTypeForFormPart(fileURL: URL) -> String? {
+        return nil
+    }
+
+    /**
+     May be overridden by a subclass if you want to control the request
+     configuration (e.g. to override the cache policy).
+     */
+    open func makeRequest(manager: SessionManager, method: HTTPMethod, encoding: ParameterEncoding) -> DataRequest {
+        return manager.request(URLString, method: method, parameters: parameters, encoding: encoding)
+    }
+
     override open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
         let managerId:String = UUID().uuidString
         // Create a new manager for each request to customize its request header
@@ -47,7 +66,12 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 for (k, v) in self.parameters! {
                     switch v {
                     case let fileURL as URL:
-                        mpForm.append(fileURL, withName: k)
+                        if let mimeType = self.contentTypeForFormPart(fileURL: fileURL) {
+                            mpForm.append(fileURL, withName: k, fileName: fileURL.lastPathComponent, mimeType: mimeType)
+                        }
+                        else {
+                            mpForm.append(fileURL, withName: k)
+                        }
                         break
                     case let string as String:
                         mpForm.append(string.data(using: String.Encoding.utf8)!, withName: k)
@@ -72,7 +96,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 }
             })
         } else {
-            let request = manager.request(URLString, method: xMethod!, parameters: parameters, encoding: encoding)
+            let request = makeRequest(manager: manager, method: xMethod!, encoding: encoding)
             if let onProgressReady = self.onProgressReady {
                 onProgressReady(request.progress)
             }
@@ -100,7 +124,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if stringResponse.result.isFailure {
                     completion(
                         nil,
-                        ErrorResponse.Error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
+                        ErrorResponse.Error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error as Error!)
                     )
                     return
                 }
@@ -159,6 +183,13 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if response.result.isFailure {
                     completion(nil, ErrorResponse.Error(response.response?.statusCode ?? 500, response.data, response.result.error!))
                     return
+                }
+
+                // handle HTTP 204 No Content
+                // NSNull would crash decoders
+                if response.response?.statusCode == 204 && response.result.value is NSNull{
+                    completion(nil, nil)
+                    return;
                 }
 
                 if () is T {

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -44,6 +44,15 @@ class Decoders {
         decoders[key] = { decoder($0) as AnyObject }
     }
 
+    static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> T {
+        let key = discriminator;
+        if let decoder = decoders[key] {
+            return decoder(source) as! T
+        } else {
+            fatalError("Source \(source) is not convertible to type \(clazz): Maybe swagger file is insufficient")
+        }
+    }
+
     static func decode<T>(clazz: [T].Type, source: AnyObject) -> [T] {
         let array = source as! [AnyObject]
         return array.map { Decoders.decode(clazz: T.self, source: $0) }
@@ -146,6 +155,7 @@ class Decoders {
         // Decoder for AdditionalPropertiesClass
         Decoders.addDecoder(clazz: AdditionalPropertiesClass.self) { (source: AnyObject) -> AdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = AdditionalPropertiesClass()
             instance.mapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_property"] as AnyObject?)
             instance.mapOfMapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_of_map_property"] as AnyObject?)
@@ -160,6 +170,11 @@ class Decoders {
         // Decoder for Animal
         Decoders.addDecoder(clazz: Animal.self) { (source: AnyObject) -> Animal in
             let sourceDictionary = source as! [AnyHashable: Any]
+            // Check discriminator to support inheritance
+            if let discriminator = sourceDictionary["className"] as? String, discriminator != "Animal"{
+                return Decoders.decode(clazz: Animal.self, discriminator: discriminator, source: source)
+            }
+
             let instance = Animal()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -185,6 +200,7 @@ class Decoders {
         // Decoder for ApiResponse
         Decoders.addDecoder(clazz: ApiResponse.self) { (source: AnyObject) -> ApiResponse in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ApiResponse()
             instance.code = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["code"] as AnyObject?)
             instance.type = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["type"] as AnyObject?)
@@ -200,6 +216,7 @@ class Decoders {
         // Decoder for ArrayOfArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfArrayOfNumberOnly.self) { (source: AnyObject) -> ArrayOfArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayOfArrayOfNumberOnly()
             instance.arrayArrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayArrayNumber"] as AnyObject?)
             return instance
@@ -213,6 +230,7 @@ class Decoders {
         // Decoder for ArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfNumberOnly.self) { (source: AnyObject) -> ArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayOfNumberOnly()
             instance.arrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayNumber"] as AnyObject?)
             return instance
@@ -226,6 +244,7 @@ class Decoders {
         // Decoder for ArrayTest
         Decoders.addDecoder(clazz: ArrayTest.self) { (source: AnyObject) -> ArrayTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayTest()
             instance.arrayOfString = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_of_string"] as AnyObject?)
             instance.arrayArrayOfInteger = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_array_of_integer"] as AnyObject?)
@@ -241,6 +260,7 @@ class Decoders {
         // Decoder for Cat
         Decoders.addDecoder(clazz: Cat.self) { (source: AnyObject) -> Cat in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Cat()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -256,6 +276,7 @@ class Decoders {
         // Decoder for Category
         Decoders.addDecoder(clazz: Category.self) { (source: AnyObject) -> Category in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Category()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"] as AnyObject?)
@@ -270,6 +291,7 @@ class Decoders {
         // Decoder for Client
         Decoders.addDecoder(clazz: Client.self) { (source: AnyObject) -> Client in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Client()
             instance.client = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["client"] as AnyObject?)
             return instance
@@ -283,6 +305,7 @@ class Decoders {
         // Decoder for Dog
         Decoders.addDecoder(clazz: Dog.self) { (source: AnyObject) -> Dog in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Dog()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -298,6 +321,7 @@ class Decoders {
         // Decoder for EnumArrays
         Decoders.addDecoder(clazz: EnumArrays.self) { (source: AnyObject) -> EnumArrays in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = EnumArrays()
             if let justSymbol = sourceDictionary["just_symbol"] as? String { 
                 instance.justSymbol = EnumArrays.JustSymbol(rawValue: (justSymbol))
@@ -333,6 +357,7 @@ class Decoders {
         // Decoder for EnumTest
         Decoders.addDecoder(clazz: EnumTest.self) { (source: AnyObject) -> EnumTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = EnumTest()
             if let enumString = sourceDictionary["enum_string"] as? String { 
                 instance.enumString = EnumTest.EnumString(rawValue: (enumString))
@@ -357,6 +382,7 @@ class Decoders {
         // Decoder for FormatTest
         Decoders.addDecoder(clazz: FormatTest.self) { (source: AnyObject) -> FormatTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = FormatTest()
             instance.integer = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["integer"] as AnyObject?)
             instance.int32 = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["int32"] as AnyObject?)
@@ -382,6 +408,7 @@ class Decoders {
         // Decoder for HasOnlyReadOnly
         Decoders.addDecoder(clazz: HasOnlyReadOnly.self) { (source: AnyObject) -> HasOnlyReadOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = HasOnlyReadOnly()
             instance.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
             instance.foo = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["foo"] as AnyObject?)
@@ -396,6 +423,7 @@ class Decoders {
         // Decoder for List
         Decoders.addDecoder(clazz: List.self) { (source: AnyObject) -> List in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = List()
             instance._123List = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["123-list"] as AnyObject?)
             return instance
@@ -409,6 +437,7 @@ class Decoders {
         // Decoder for MapTest
         Decoders.addDecoder(clazz: MapTest.self) { (source: AnyObject) -> MapTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = MapTest()
             instance.mapMapOfString = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_map_of_string"] as AnyObject?)
             if let mapOfEnumString = sourceDictionary["map_of_enum_string"] as? [String:String] { //TODO: handle enum map scenario
@@ -425,6 +454,7 @@ class Decoders {
         // Decoder for MixedPropertiesAndAdditionalPropertiesClass
         Decoders.addDecoder(clazz: MixedPropertiesAndAdditionalPropertiesClass.self) { (source: AnyObject) -> MixedPropertiesAndAdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = MixedPropertiesAndAdditionalPropertiesClass()
             instance.uuid = Decoders.decodeOptional(clazz: UUID.self, source: sourceDictionary["uuid"] as AnyObject?)
             instance.dateTime = Decoders.decodeOptional(clazz: Date.self, source: sourceDictionary["dateTime"] as AnyObject?)
@@ -440,6 +470,7 @@ class Decoders {
         // Decoder for Model200Response
         Decoders.addDecoder(clazz: Model200Response.self) { (source: AnyObject) -> Model200Response in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Model200Response()
             instance.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
             instance._class = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["class"] as AnyObject?)
@@ -454,6 +485,7 @@ class Decoders {
         // Decoder for Name
         Decoders.addDecoder(clazz: Name.self) { (source: AnyObject) -> Name in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Name()
             instance.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
             instance.snakeCase = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["snake_case"] as AnyObject?)
@@ -470,6 +502,7 @@ class Decoders {
         // Decoder for NumberOnly
         Decoders.addDecoder(clazz: NumberOnly.self) { (source: AnyObject) -> NumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = NumberOnly()
             instance.justNumber = Decoders.decodeOptional(clazz: Double.self, source: sourceDictionary["JustNumber"] as AnyObject?)
             return instance
@@ -483,6 +516,7 @@ class Decoders {
         // Decoder for Order
         Decoders.addDecoder(clazz: Order.self) { (source: AnyObject) -> Order in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Order()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.petId = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["petId"] as AnyObject?)
@@ -504,6 +538,7 @@ class Decoders {
         // Decoder for Pet
         Decoders.addDecoder(clazz: Pet.self) { (source: AnyObject) -> Pet in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Pet()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.category = Decoders.decodeOptional(clazz: Category.self, source: sourceDictionary["category"] as AnyObject?)
@@ -525,6 +560,7 @@ class Decoders {
         // Decoder for ReadOnlyFirst
         Decoders.addDecoder(clazz: ReadOnlyFirst.self) { (source: AnyObject) -> ReadOnlyFirst in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ReadOnlyFirst()
             instance.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
             instance.baz = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["baz"] as AnyObject?)
@@ -539,6 +575,7 @@ class Decoders {
         // Decoder for Return
         Decoders.addDecoder(clazz: Return.self) { (source: AnyObject) -> Return in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Return()
             instance._return = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["return"] as AnyObject?)
             return instance
@@ -552,6 +589,7 @@ class Decoders {
         // Decoder for SpecialModelName
         Decoders.addDecoder(clazz: SpecialModelName.self) { (source: AnyObject) -> SpecialModelName in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = SpecialModelName()
             instance.specialPropertyName = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["$special[property.name]"] as AnyObject?)
             return instance
@@ -565,6 +603,7 @@ class Decoders {
         // Decoder for Tag
         Decoders.addDecoder(clazz: Tag.self) { (source: AnyObject) -> Tag in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Tag()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"] as AnyObject?)
@@ -579,6 +618,7 @@ class Decoders {
         // Decoder for User
         Decoders.addDecoder(clazz: User.self) { (source: AnyObject) -> User in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = User()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.username = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["username"] as AnyObject?)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -15,7 +15,7 @@ open class AdditionalPropertiesClass: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_property"] = self.mapProperty?.encodeToJSON()
         nillableDictionary["map_of_map_property"] = self.mapOfMapProperty?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -15,7 +15,7 @@ open class Animal: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["className"] = self.className
         nillableDictionary["color"] = self.color

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -16,7 +16,7 @@ open class ApiResponse: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["code"] = self.code?.encodeToJSON()
         nillableDictionary["type"] = self.type

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,7 +14,7 @@ open class ArrayOfArrayOfNumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayArrayNumber"] = self.arrayArrayNumber?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -14,7 +14,7 @@ open class ArrayOfNumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayNumber"] = self.arrayNumber?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -16,7 +16,7 @@ open class ArrayTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["array_of_string"] = self.arrayOfString?.encodeToJSON()
         nillableDictionary["array_array_of_integer"] = self.arrayArrayOfInteger?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -8,18 +8,14 @@
 import Foundation
 
 
-open class Cat: JSONEncodable {
-    public var className: String?
-    public var color: String?
+open class Cat: Animal {
     public var declawed: Bool?
 
-    public init() {}
+    
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        var nillableDictionary = [String:Any?]()
-        nillableDictionary["className"] = self.className
-        nillableDictionary["color"] = self.color
+    override open func encodeToJSON() -> Any {
+        var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["declawed"] = self.declawed
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -15,7 +15,7 @@ open class Category: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -14,7 +14,7 @@ open class Client: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["client"] = self.client
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -8,18 +8,14 @@
 import Foundation
 
 
-open class Dog: JSONEncodable {
-    public var className: String?
-    public var color: String?
+open class Dog: Animal {
     public var breed: String?
 
-    public init() {}
+    
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        var nillableDictionary = [String:Any?]()
-        nillableDictionary["className"] = self.className
-        nillableDictionary["color"] = self.color
+    override open func encodeToJSON() -> Any {
+        var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["breed"] = self.breed
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -23,7 +23,7 @@ open class EnumArrays: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["just_symbol"] = self.justSymbol?.rawValue
         nillableDictionary["array_enum"] = self.arrayEnum?.map({$0.rawValue}).encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -28,7 +28,7 @@ open class EnumTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["enum_string"] = self.enumString?.rawValue
         nillableDictionary["enum_integer"] = self.enumInteger?.rawValue

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -26,7 +26,7 @@ open class FormatTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["integer"] = self.integer?.encodeToJSON()
         nillableDictionary["int32"] = self.int32?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -15,7 +15,7 @@ open class HasOnlyReadOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["foo"] = self.foo

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -14,7 +14,7 @@ open class List: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["123-list"] = self._123List
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -19,7 +19,7 @@ open class MapTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_map_of_string"] = self.mapMapOfString?.encodeToJSON()//TODO: handle enum map scenario
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -16,7 +16,7 @@ open class MixedPropertiesAndAdditionalPropertiesClass: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["uuid"] = self.uuid?.encodeToJSON()
         nillableDictionary["dateTime"] = self.dateTime?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -16,7 +16,7 @@ open class Model200Response: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["class"] = self._class

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -18,7 +18,7 @@ open class Name: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["snake_case"] = self.snakeCase?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -14,7 +14,7 @@ open class NumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["JustNumber"] = self.justNumber
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -25,7 +25,7 @@ open class Order: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["petId"] = self.petId?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -25,7 +25,7 @@ open class Pet: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["category"] = self.category?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -15,7 +15,7 @@ open class ReadOnlyFirst: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["baz"] = self.baz

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -15,7 +15,7 @@ open class Return: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["return"] = self._return?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -14,7 +14,7 @@ open class SpecialModelName: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["$special[property.name]"] = self.specialPropertyName?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -15,7 +15,7 @@ open class Tag: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -22,7 +22,7 @@ open class User: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["username"] = self.username

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -30,6 +30,25 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         return Alamofire.SessionManager(configuration: configuration)
     }
 
+    /**
+     May be overridden by a subclass if you want to control the Content-Type
+     that is given to an uploaded form part.
+
+     Return nil to use the default behavior (inferring the Content-Type from
+     the file extension).  Return the desired Content-Type otherwise.
+     */
+    open func contentTypeForFormPart(fileURL: URL) -> String? {
+        return nil
+    }
+
+    /**
+     May be overridden by a subclass if you want to control the request
+     configuration (e.g. to override the cache policy).
+     */
+    open func makeRequest(manager: SessionManager, method: HTTPMethod, encoding: ParameterEncoding) -> DataRequest {
+        return manager.request(URLString, method: method, parameters: parameters, encoding: encoding)
+    }
+
     override open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) {
         let managerId:String = UUID().uuidString
         // Create a new manager for each request to customize its request header
@@ -47,7 +66,12 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 for (k, v) in self.parameters! {
                     switch v {
                     case let fileURL as URL:
-                        mpForm.append(fileURL, withName: k)
+                        if let mimeType = self.contentTypeForFormPart(fileURL: fileURL) {
+                            mpForm.append(fileURL, withName: k, fileName: fileURL.lastPathComponent, mimeType: mimeType)
+                        }
+                        else {
+                            mpForm.append(fileURL, withName: k)
+                        }
                         break
                     case let string as String:
                         mpForm.append(string.data(using: String.Encoding.utf8)!, withName: k)
@@ -72,7 +96,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 }
             })
         } else {
-            let request = manager.request(URLString, method: xMethod!, parameters: parameters, encoding: encoding)
+            let request = makeRequest(manager: manager, method: xMethod!, encoding: encoding)
             if let onProgressReady = self.onProgressReady {
                 onProgressReady(request.progress)
             }
@@ -100,7 +124,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if stringResponse.result.isFailure {
                     completion(
                         nil,
-                        ErrorResponse.Error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
+                        ErrorResponse.Error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error as Error!)
                     )
                     return
                 }
@@ -159,6 +183,13 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if response.result.isFailure {
                     completion(nil, ErrorResponse.Error(response.response?.statusCode ?? 500, response.data, response.result.error!))
                     return
+                }
+
+                // handle HTTP 204 No Content
+                // NSNull would crash decoders
+                if response.response?.statusCode == 204 && response.result.value is NSNull{
+                    completion(nil, nil)
+                    return;
                 }
 
                 if () is T {

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -44,6 +44,15 @@ class Decoders {
         decoders[key] = { decoder($0) as AnyObject }
     }
 
+    static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> T {
+        let key = discriminator;
+        if let decoder = decoders[key] {
+            return decoder(source) as! T
+        } else {
+            fatalError("Source \(source) is not convertible to type \(clazz): Maybe swagger file is insufficient")
+        }
+    }
+
     static func decode<T>(clazz: [T].Type, source: AnyObject) -> [T] {
         let array = source as! [AnyObject]
         return array.map { Decoders.decode(clazz: T.self, source: $0) }
@@ -146,6 +155,7 @@ class Decoders {
         // Decoder for AdditionalPropertiesClass
         Decoders.addDecoder(clazz: AdditionalPropertiesClass.self) { (source: AnyObject) -> AdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = AdditionalPropertiesClass()
             instance.mapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_property"] as AnyObject?)
             instance.mapOfMapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_of_map_property"] as AnyObject?)
@@ -160,6 +170,11 @@ class Decoders {
         // Decoder for Animal
         Decoders.addDecoder(clazz: Animal.self) { (source: AnyObject) -> Animal in
             let sourceDictionary = source as! [AnyHashable: Any]
+            // Check discriminator to support inheritance
+            if let discriminator = sourceDictionary["className"] as? String, discriminator != "Animal"{
+                return Decoders.decode(clazz: Animal.self, discriminator: discriminator, source: source)
+            }
+
             let instance = Animal()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -185,6 +200,7 @@ class Decoders {
         // Decoder for ApiResponse
         Decoders.addDecoder(clazz: ApiResponse.self) { (source: AnyObject) -> ApiResponse in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ApiResponse()
             instance.code = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["code"] as AnyObject?)
             instance.type = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["type"] as AnyObject?)
@@ -200,6 +216,7 @@ class Decoders {
         // Decoder for ArrayOfArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfArrayOfNumberOnly.self) { (source: AnyObject) -> ArrayOfArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayOfArrayOfNumberOnly()
             instance.arrayArrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayArrayNumber"] as AnyObject?)
             return instance
@@ -213,6 +230,7 @@ class Decoders {
         // Decoder for ArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfNumberOnly.self) { (source: AnyObject) -> ArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayOfNumberOnly()
             instance.arrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayNumber"] as AnyObject?)
             return instance
@@ -226,6 +244,7 @@ class Decoders {
         // Decoder for ArrayTest
         Decoders.addDecoder(clazz: ArrayTest.self) { (source: AnyObject) -> ArrayTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayTest()
             instance.arrayOfString = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_of_string"] as AnyObject?)
             instance.arrayArrayOfInteger = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_array_of_integer"] as AnyObject?)
@@ -241,6 +260,7 @@ class Decoders {
         // Decoder for Cat
         Decoders.addDecoder(clazz: Cat.self) { (source: AnyObject) -> Cat in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Cat()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -256,6 +276,7 @@ class Decoders {
         // Decoder for Category
         Decoders.addDecoder(clazz: Category.self) { (source: AnyObject) -> Category in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Category()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"] as AnyObject?)
@@ -270,6 +291,7 @@ class Decoders {
         // Decoder for Client
         Decoders.addDecoder(clazz: Client.self) { (source: AnyObject) -> Client in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Client()
             instance.client = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["client"] as AnyObject?)
             return instance
@@ -283,6 +305,7 @@ class Decoders {
         // Decoder for Dog
         Decoders.addDecoder(clazz: Dog.self) { (source: AnyObject) -> Dog in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Dog()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -298,6 +321,7 @@ class Decoders {
         // Decoder for EnumArrays
         Decoders.addDecoder(clazz: EnumArrays.self) { (source: AnyObject) -> EnumArrays in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = EnumArrays()
             if let justSymbol = sourceDictionary["just_symbol"] as? String { 
                 instance.justSymbol = EnumArrays.JustSymbol(rawValue: (justSymbol))
@@ -333,6 +357,7 @@ class Decoders {
         // Decoder for EnumTest
         Decoders.addDecoder(clazz: EnumTest.self) { (source: AnyObject) -> EnumTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = EnumTest()
             if let enumString = sourceDictionary["enum_string"] as? String { 
                 instance.enumString = EnumTest.EnumString(rawValue: (enumString))
@@ -357,6 +382,7 @@ class Decoders {
         // Decoder for FormatTest
         Decoders.addDecoder(clazz: FormatTest.self) { (source: AnyObject) -> FormatTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = FormatTest()
             instance.integer = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["integer"] as AnyObject?)
             instance.int32 = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["int32"] as AnyObject?)
@@ -382,6 +408,7 @@ class Decoders {
         // Decoder for HasOnlyReadOnly
         Decoders.addDecoder(clazz: HasOnlyReadOnly.self) { (source: AnyObject) -> HasOnlyReadOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = HasOnlyReadOnly()
             instance.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
             instance.foo = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["foo"] as AnyObject?)
@@ -396,6 +423,7 @@ class Decoders {
         // Decoder for List
         Decoders.addDecoder(clazz: List.self) { (source: AnyObject) -> List in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = List()
             instance._123List = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["123-list"] as AnyObject?)
             return instance
@@ -409,6 +437,7 @@ class Decoders {
         // Decoder for MapTest
         Decoders.addDecoder(clazz: MapTest.self) { (source: AnyObject) -> MapTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = MapTest()
             instance.mapMapOfString = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_map_of_string"] as AnyObject?)
             if let mapOfEnumString = sourceDictionary["map_of_enum_string"] as? [String:String] { //TODO: handle enum map scenario
@@ -425,6 +454,7 @@ class Decoders {
         // Decoder for MixedPropertiesAndAdditionalPropertiesClass
         Decoders.addDecoder(clazz: MixedPropertiesAndAdditionalPropertiesClass.self) { (source: AnyObject) -> MixedPropertiesAndAdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = MixedPropertiesAndAdditionalPropertiesClass()
             instance.uuid = Decoders.decodeOptional(clazz: UUID.self, source: sourceDictionary["uuid"] as AnyObject?)
             instance.dateTime = Decoders.decodeOptional(clazz: Date.self, source: sourceDictionary["dateTime"] as AnyObject?)
@@ -440,6 +470,7 @@ class Decoders {
         // Decoder for Model200Response
         Decoders.addDecoder(clazz: Model200Response.self) { (source: AnyObject) -> Model200Response in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Model200Response()
             instance.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
             instance._class = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["class"] as AnyObject?)
@@ -454,6 +485,7 @@ class Decoders {
         // Decoder for Name
         Decoders.addDecoder(clazz: Name.self) { (source: AnyObject) -> Name in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Name()
             instance.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
             instance.snakeCase = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["snake_case"] as AnyObject?)
@@ -470,6 +502,7 @@ class Decoders {
         // Decoder for NumberOnly
         Decoders.addDecoder(clazz: NumberOnly.self) { (source: AnyObject) -> NumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = NumberOnly()
             instance.justNumber = Decoders.decodeOptional(clazz: Double.self, source: sourceDictionary["JustNumber"] as AnyObject?)
             return instance
@@ -483,6 +516,7 @@ class Decoders {
         // Decoder for Order
         Decoders.addDecoder(clazz: Order.self) { (source: AnyObject) -> Order in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Order()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.petId = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["petId"] as AnyObject?)
@@ -504,6 +538,7 @@ class Decoders {
         // Decoder for Pet
         Decoders.addDecoder(clazz: Pet.self) { (source: AnyObject) -> Pet in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Pet()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.category = Decoders.decodeOptional(clazz: Category.self, source: sourceDictionary["category"] as AnyObject?)
@@ -525,6 +560,7 @@ class Decoders {
         // Decoder for ReadOnlyFirst
         Decoders.addDecoder(clazz: ReadOnlyFirst.self) { (source: AnyObject) -> ReadOnlyFirst in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ReadOnlyFirst()
             instance.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
             instance.baz = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["baz"] as AnyObject?)
@@ -539,6 +575,7 @@ class Decoders {
         // Decoder for Return
         Decoders.addDecoder(clazz: Return.self) { (source: AnyObject) -> Return in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Return()
             instance._return = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["return"] as AnyObject?)
             return instance
@@ -552,6 +589,7 @@ class Decoders {
         // Decoder for SpecialModelName
         Decoders.addDecoder(clazz: SpecialModelName.self) { (source: AnyObject) -> SpecialModelName in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = SpecialModelName()
             instance.specialPropertyName = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["$special[property.name]"] as AnyObject?)
             return instance
@@ -565,6 +603,7 @@ class Decoders {
         // Decoder for Tag
         Decoders.addDecoder(clazz: Tag.self) { (source: AnyObject) -> Tag in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Tag()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"] as AnyObject?)
@@ -579,6 +618,7 @@ class Decoders {
         // Decoder for User
         Decoders.addDecoder(clazz: User.self) { (source: AnyObject) -> User in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = User()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.username = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["username"] as AnyObject?)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -15,7 +15,7 @@ open class AdditionalPropertiesClass: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_property"] = self.mapProperty?.encodeToJSON()
         nillableDictionary["map_of_map_property"] = self.mapOfMapProperty?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -15,7 +15,7 @@ open class Animal: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["className"] = self.className
         nillableDictionary["color"] = self.color

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -16,7 +16,7 @@ open class ApiResponse: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["code"] = self.code?.encodeToJSON()
         nillableDictionary["type"] = self.type

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,7 +14,7 @@ open class ArrayOfArrayOfNumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayArrayNumber"] = self.arrayArrayNumber?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -14,7 +14,7 @@ open class ArrayOfNumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayNumber"] = self.arrayNumber?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -16,7 +16,7 @@ open class ArrayTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["array_of_string"] = self.arrayOfString?.encodeToJSON()
         nillableDictionary["array_array_of_integer"] = self.arrayArrayOfInteger?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -8,18 +8,14 @@
 import Foundation
 
 
-open class Cat: JSONEncodable {
-    public var className: String?
-    public var color: String?
+open class Cat: Animal {
     public var declawed: Bool?
 
-    public init() {}
+    
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        var nillableDictionary = [String:Any?]()
-        nillableDictionary["className"] = self.className
-        nillableDictionary["color"] = self.color
+    override open func encodeToJSON() -> Any {
+        var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["declawed"] = self.declawed
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -15,7 +15,7 @@ open class Category: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -14,7 +14,7 @@ open class Client: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["client"] = self.client
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -8,18 +8,14 @@
 import Foundation
 
 
-open class Dog: JSONEncodable {
-    public var className: String?
-    public var color: String?
+open class Dog: Animal {
     public var breed: String?
 
-    public init() {}
+    
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        var nillableDictionary = [String:Any?]()
-        nillableDictionary["className"] = self.className
-        nillableDictionary["color"] = self.color
+    override open func encodeToJSON() -> Any {
+        var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["breed"] = self.breed
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -23,7 +23,7 @@ open class EnumArrays: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["just_symbol"] = self.justSymbol?.rawValue
         nillableDictionary["array_enum"] = self.arrayEnum?.map({$0.rawValue}).encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -28,7 +28,7 @@ open class EnumTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["enum_string"] = self.enumString?.rawValue
         nillableDictionary["enum_integer"] = self.enumInteger?.rawValue

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -26,7 +26,7 @@ open class FormatTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["integer"] = self.integer?.encodeToJSON()
         nillableDictionary["int32"] = self.int32?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -15,7 +15,7 @@ open class HasOnlyReadOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["foo"] = self.foo

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -14,7 +14,7 @@ open class List: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["123-list"] = self._123List
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -19,7 +19,7 @@ open class MapTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_map_of_string"] = self.mapMapOfString?.encodeToJSON()//TODO: handle enum map scenario
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -16,7 +16,7 @@ open class MixedPropertiesAndAdditionalPropertiesClass: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["uuid"] = self.uuid?.encodeToJSON()
         nillableDictionary["dateTime"] = self.dateTime?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -16,7 +16,7 @@ open class Model200Response: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["class"] = self._class

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -18,7 +18,7 @@ open class Name: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["snake_case"] = self.snakeCase?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -14,7 +14,7 @@ open class NumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["JustNumber"] = self.justNumber
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -25,7 +25,7 @@ open class Order: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["petId"] = self.petId?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -25,7 +25,7 @@ open class Pet: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["category"] = self.category?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -15,7 +15,7 @@ open class ReadOnlyFirst: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["baz"] = self.baz

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -15,7 +15,7 @@ open class Return: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["return"] = self._return?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -14,7 +14,7 @@ open class SpecialModelName: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["$special[property.name]"] = self.specialPropertyName?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -15,7 +15,7 @@ open class Tag: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -22,7 +22,7 @@ open class User: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["username"] = self.username


### PR DESCRIPTION
Add two override points inside AlamofireRequestBuilder in the Swift 3 template.

These allow the caller to control the request configuration (e.g. to override the cache policy) and to control the Content-Type that is given to an uploaded form part.
