### PR TITLE
[Python] Add support for request timeout

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -99,6 +99,7 @@ class {{classname}}(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -213,6 +214,7 @@ class {{classname}}(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 {{/operation}}
 {{/operations}}

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -96,7 +96,8 @@ class ApiClient(object):
                    path_params=None, query_params=None, header_params=None,
                    body=None, post_params=None, files=None,
                    response_type=None, auth_settings=None, callback=None,
-                   _return_http_data_only=None, collection_formats=None, _preload_content=True):
+                   _return_http_data_only=None, collection_formats=None, _preload_content=True,
+                   _request_timeout=None):
 
         # header parameters
         header_params = header_params or {}
@@ -144,7 +145,9 @@ class ApiClient(object):
         response_data = self.request(method, url,
                                      query_params=query_params,
                                      headers=header_params,
-                                     post_params=post_params, body=body, _preload_content=_preload_content)
+                                     post_params=post_params, body=body,
+                                     _preload_content=_preload_content,
+                                     _request_timeout=_request_timeout)
 
         self.last_response = response_data
 
@@ -279,7 +282,8 @@ class ApiClient(object):
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, callback=None,
-                 _return_http_data_only=None, collection_formats=None, _preload_content=True):
+                 _return_http_data_only=None, collection_formats=None, _preload_content=True,
+                 _request_timeout=None):
         """
         Makes the HTTP request (synchronous) and return the deserialized data.
         To make an async request, define a function for callback.
@@ -303,21 +307,23 @@ class ApiClient(object):
         :param _return_http_data_only: response data without head status code and headers
         :param collection_formats: dict of collection formats for path, query,
             header, and post parameters.
+        :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
+                                 reading/decoding response data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of (connection, read) timeouts.
         :return:
             If provide parameter callback,
             the request will be called asynchronously.
             The method will return the request thread.
             If parameter callback is None,
             then the method will return the response directly.
-        :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
-                                 reading/decoding response data. Default is True.
         """
         if callback is None:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,
                                    response_type, auth_settings, callback,
-                                   _return_http_data_only, collection_formats, _preload_content)
+                                   _return_http_data_only, collection_formats, _preload_content, _request_timeout)
         else:
             thread = threading.Thread(target=self.__call_api,
                                       args=(resource_path, method,
@@ -326,12 +332,12 @@ class ApiClient(object):
                                             post_params, files,
                                             response_type, auth_settings,
                                             callback, _return_http_data_only,
-                                            collection_formats, _preload_content))
+                                            collection_formats, _preload_content, _request_timeout))
         thread.start()
         return thread
 
     def request(self, method, url, query_params=None, headers=None,
-                post_params=None, body=None, _preload_content=True):
+                post_params=None, body=None, _preload_content=True, _request_timeout=None):
         """
         Makes the HTTP request using RESTClient.
         """
@@ -339,11 +345,13 @@ class ApiClient(object):
             return self.rest_client.GET(url,
                                         query_params=query_params,
                                         _preload_content=_preload_content,
+                                        _request_timeout=_request_timeout,
                                         headers=headers)
         elif method == "HEAD":
             return self.rest_client.HEAD(url,
                                          query_params=query_params,
                                          _preload_content=_preload_content,
+                                         _request_timeout=_request_timeout,
                                          headers=headers)
         elif method == "OPTIONS":
             return self.rest_client.OPTIONS(url,
@@ -351,6 +359,7 @@ class ApiClient(object):
                                             headers=headers,
                                             post_params=post_params,
                                             _preload_content=_preload_content,
+                                            _request_timeout=_request_timeout,
                                             body=body)
         elif method == "POST":
             return self.rest_client.POST(url,
@@ -358,6 +367,7 @@ class ApiClient(object):
                                          headers=headers,
                                          post_params=post_params,
                                          _preload_content=_preload_content,
+                                         _request_timeout=_request_timeout,
                                          body=body)
         elif method == "PUT":
             return self.rest_client.PUT(url,
@@ -365,6 +375,7 @@ class ApiClient(object):
                                         headers=headers,
                                         post_params=post_params,
                                         _preload_content=_preload_content,
+                                        _request_timeout=_request_timeout,
                                         body=body)
         elif method == "PATCH":
             return self.rest_client.PATCH(url,
@@ -372,12 +383,14 @@ class ApiClient(object):
                                           headers=headers,
                                           post_params=post_params,
                                           _preload_content=_preload_content,
+                                          _request_timeout=_request_timeout,
                                           body=body)
         elif method == "DELETE":
             return self.rest_client.DELETE(url,
                                            query_params=query_params,
                                            headers=headers,
                                            _preload_content=_preload_content,
+                                           _request_timeout=_request_timeout,
                                            body=body)
         else:
             raise ValueError(

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -85,7 +85,7 @@ class RESTClientObject(object):
         )
 
     def request(self, method, url, query_params=None, headers=None,
-                body=None, post_params=None, _preload_content=True):
+                body=None, post_params=None, _preload_content=True, _request_timeout=None):
         """
         :param method: http request method
         :param url: http request url
@@ -97,6 +97,8 @@ class RESTClientObject(object):
                             and `multipart/form-data`
         :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
                                  reading/decoding response data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of (connection, read) timeouts.
         """
         method = method.upper()
         assert method in ['GET', 'HEAD', 'DELETE', 'POST', 'PUT', 'PATCH', 'OPTIONS']
@@ -108,6 +110,13 @@ class RESTClientObject(object):
 
         post_params = post_params or {}
         headers = headers or {}
+
+        timeout = None
+        if _request_timeout:
+            if isinstance(_request_timeout, (int, ) if PY3 else (int, long)):
+                timeout = urllib3.Timeout(total=_request_timeout)
+            elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
+                timeout = urllib3.Timeout(connect=_request_timeout[0], read=_request_timeout[1])
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'
@@ -124,12 +133,14 @@ class RESTClientObject(object):
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,
                                                   preload_content=_preload_content,
+                                                  timeout=timeout,
                                                   headers=headers)
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':
                     r = self.pool_manager.request(method, url,
                                                   fields=post_params,
                                                   encode_multipart=False,
                                                   preload_content=_preload_content,
+                                                  timeout=timeout,
                                                   headers=headers)
                 elif headers['Content-Type'] == 'multipart/form-data':
                     # must del headers['Content-Type'], or the correct Content-Type
@@ -139,6 +150,7 @@ class RESTClientObject(object):
                                                   fields=post_params,
                                                   encode_multipart=True,
                                                   preload_content=_preload_content,
+                                                  timeout=timeout,
                                                   headers=headers)
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is provided
@@ -148,6 +160,7 @@ class RESTClientObject(object):
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,
                                                   preload_content=_preload_content,
+                                                  timeout=timeout,
                                                   headers=headers)
                 else:
                     # Cannot generate the request from given parameters
@@ -159,6 +172,7 @@ class RESTClientObject(object):
                 r = self.pool_manager.request(method, url,
                                               fields=query_params,
                                               preload_content=_preload_content,
+                                              timeout=timeout,
                                               headers=headers)
         except urllib3.exceptions.SSLError as e:
             msg = "{0}\n{1}".format(type(e).__name__, str(e))
@@ -180,55 +194,66 @@ class RESTClientObject(object):
 
         return r
 
-    def GET(self, url, headers=None, query_params=None, _preload_content=True):
+    def GET(self, url, headers=None, query_params=None, _preload_content=True, _request_timeout=None):
         return self.request("GET", url,
                             headers=headers,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             query_params=query_params)
 
-    def HEAD(self, url, headers=None, query_params=None, _preload_content=True):
+    def HEAD(self, url, headers=None, query_params=None, _preload_content=True, _request_timeout=None):
         return self.request("HEAD", url,
                             headers=headers,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             query_params=query_params)
 
-    def OPTIONS(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
+    def OPTIONS(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True,
+                _request_timeout=None):
         return self.request("OPTIONS", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
-    def DELETE(self, url, headers=None, query_params=None, body=None, _preload_content=True):
+    def DELETE(self, url, headers=None, query_params=None, body=None, _preload_content=True, _request_timeout=None):
         return self.request("DELETE", url,
                             headers=headers,
                             query_params=query_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
-    def POST(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
+    def POST(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True,
+             _request_timeout=None):
         return self.request("POST", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
-    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
+    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True,
+            _request_timeout=None):
         return self.request("PUT", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
-    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
+    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True,
+              _request_timeout=None):
         return self.request("PATCH", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -96,7 +96,8 @@ class ApiClient(object):
                    path_params=None, query_params=None, header_params=None,
                    body=None, post_params=None, files=None,
                    response_type=None, auth_settings=None, callback=None,
-                   _return_http_data_only=None, collection_formats=None, _preload_content=True):
+                   _return_http_data_only=None, collection_formats=None, _preload_content=True,
+                   _request_timeout=None):
 
         # header parameters
         header_params = header_params or {}
@@ -144,7 +145,9 @@ class ApiClient(object):
         response_data = self.request(method, url,
                                      query_params=query_params,
                                      headers=header_params,
-                                     post_params=post_params, body=body, _preload_content=_preload_content)
+                                     post_params=post_params, body=body,
+                                     _preload_content=_preload_content,
+                                     _request_timeout=_request_timeout)
 
         self.last_response = response_data
 
@@ -279,7 +282,8 @@ class ApiClient(object):
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, callback=None,
-                 _return_http_data_only=None, collection_formats=None, _preload_content=True):
+                 _return_http_data_only=None, collection_formats=None, _preload_content=True,
+                 _request_timeout=None):
         """
         Makes the HTTP request (synchronous) and return the deserialized data.
         To make an async request, define a function for callback.
@@ -303,21 +307,23 @@ class ApiClient(object):
         :param _return_http_data_only: response data without head status code and headers
         :param collection_formats: dict of collection formats for path, query,
             header, and post parameters.
+        :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
+                                 reading/decoding response data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of (connection, read) timeouts.
         :return:
             If provide parameter callback,
             the request will be called asynchronously.
             The method will return the request thread.
             If parameter callback is None,
             then the method will return the response directly.
-        :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
-                                 reading/decoding response data. Default is True.
         """
         if callback is None:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,
                                    response_type, auth_settings, callback,
-                                   _return_http_data_only, collection_formats, _preload_content)
+                                   _return_http_data_only, collection_formats, _preload_content, _request_timeout)
         else:
             thread = threading.Thread(target=self.__call_api,
                                       args=(resource_path, method,
@@ -326,12 +332,12 @@ class ApiClient(object):
                                             post_params, files,
                                             response_type, auth_settings,
                                             callback, _return_http_data_only,
-                                            collection_formats, _preload_content))
+                                            collection_formats, _preload_content, _request_timeout))
         thread.start()
         return thread
 
     def request(self, method, url, query_params=None, headers=None,
-                post_params=None, body=None, _preload_content=True):
+                post_params=None, body=None, _preload_content=True, _request_timeout=None):
         """
         Makes the HTTP request using RESTClient.
         """
@@ -339,11 +345,13 @@ class ApiClient(object):
             return self.rest_client.GET(url,
                                         query_params=query_params,
                                         _preload_content=_preload_content,
+                                        _request_timeout=_request_timeout,
                                         headers=headers)
         elif method == "HEAD":
             return self.rest_client.HEAD(url,
                                          query_params=query_params,
                                          _preload_content=_preload_content,
+                                         _request_timeout=_request_timeout,
                                          headers=headers)
         elif method == "OPTIONS":
             return self.rest_client.OPTIONS(url,
@@ -351,6 +359,7 @@ class ApiClient(object):
                                             headers=headers,
                                             post_params=post_params,
                                             _preload_content=_preload_content,
+                                            _request_timeout=_request_timeout,
                                             body=body)
         elif method == "POST":
             return self.rest_client.POST(url,
@@ -358,6 +367,7 @@ class ApiClient(object):
                                          headers=headers,
                                          post_params=post_params,
                                          _preload_content=_preload_content,
+                                         _request_timeout=_request_timeout,
                                          body=body)
         elif method == "PUT":
             return self.rest_client.PUT(url,
@@ -365,6 +375,7 @@ class ApiClient(object):
                                         headers=headers,
                                         post_params=post_params,
                                         _preload_content=_preload_content,
+                                        _request_timeout=_request_timeout,
                                         body=body)
         elif method == "PATCH":
             return self.rest_client.PATCH(url,
@@ -372,12 +383,14 @@ class ApiClient(object):
                                           headers=headers,
                                           post_params=post_params,
                                           _preload_content=_preload_content,
+                                          _request_timeout=_request_timeout,
                                           body=body)
         elif method == "DELETE":
             return self.rest_client.DELETE(url,
                                            query_params=query_params,
                                            headers=headers,
                                            _preload_content=_preload_content,
+                                           _request_timeout=_request_timeout,
                                            body=body)
         else:
             raise ValueError(

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -103,6 +103,7 @@ class FakeApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -159,6 +160,7 @@ class FakeApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def test_endpoint_parameters(self, number, double, pattern_without_delimiter, byte, **kwargs):
@@ -239,6 +241,7 @@ class FakeApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -356,6 +359,7 @@ class FakeApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def test_enum_parameters(self, **kwargs):
@@ -424,6 +428,7 @@ class FakeApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -494,4 +499,5 @@ class FakeApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/pet_api.py
@@ -103,6 +103,7 @@ class PetApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -159,6 +160,7 @@ class PetApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def delete_pet(self, pet_id, **kwargs):
@@ -215,6 +217,7 @@ class PetApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -273,6 +276,7 @@ class PetApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def find_pets_by_status(self, status, **kwargs):
@@ -327,6 +331,7 @@ class PetApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -384,6 +389,7 @@ class PetApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def find_pets_by_tags(self, tags, **kwargs):
@@ -438,6 +444,7 @@ class PetApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -495,6 +502,7 @@ class PetApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def get_pet_by_id(self, pet_id, **kwargs):
@@ -549,6 +557,7 @@ class PetApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -605,6 +614,7 @@ class PetApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def update_pet(self, body, **kwargs):
@@ -659,6 +669,7 @@ class PetApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -715,6 +726,7 @@ class PetApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def update_pet_with_form(self, pet_id, **kwargs):
@@ -773,6 +785,7 @@ class PetApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -833,6 +846,7 @@ class PetApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def upload_file(self, pet_id, **kwargs):
@@ -891,6 +905,7 @@ class PetApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -951,4 +966,5 @@ class PetApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/store_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/store_api.py
@@ -103,6 +103,7 @@ class StoreApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -161,6 +162,7 @@ class StoreApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def get_inventory(self, **kwargs):
@@ -213,6 +215,7 @@ class StoreApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -264,6 +267,7 @@ class StoreApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def get_order_by_id(self, order_id, **kwargs):
@@ -318,6 +322,7 @@ class StoreApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -378,6 +383,7 @@ class StoreApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def place_order(self, body, **kwargs):
@@ -432,6 +438,7 @@ class StoreApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -488,4 +495,5 @@ class StoreApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/apis/user_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/user_api.py
@@ -103,6 +103,7 @@ class UserApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -159,6 +160,7 @@ class UserApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def create_users_with_array_input(self, body, **kwargs):
@@ -213,6 +215,7 @@ class UserApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -269,6 +272,7 @@ class UserApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def create_users_with_list_input(self, body, **kwargs):
@@ -323,6 +327,7 @@ class UserApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -379,6 +384,7 @@ class UserApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def delete_user(self, username, **kwargs):
@@ -433,6 +439,7 @@ class UserApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -489,6 +496,7 @@ class UserApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def get_user_by_name(self, username, **kwargs):
@@ -543,6 +551,7 @@ class UserApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -599,6 +608,7 @@ class UserApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def login_user(self, username, password, **kwargs):
@@ -655,6 +665,7 @@ class UserApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -716,6 +727,7 @@ class UserApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def logout_user(self, **kwargs):
@@ -768,6 +780,7 @@ class UserApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -819,6 +832,7 @@ class UserApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)
 
     def update_user(self, username, body, **kwargs):
@@ -875,6 +889,7 @@ class UserApi(object):
         all_params.append('callback')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
+        all_params.append('_request_timeout')
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -936,4 +951,5 @@ class UserApi(object):
                                             callback=params.get('callback'),
                                             _return_http_data_only=params.get('_return_http_data_only'),
                                             _preload_content=params.get('_preload_content', True),
+                                            _request_timeout=params.get('_request_timeout'),
                                             collection_formats=collection_formats)

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -105,7 +105,7 @@ class RESTClientObject(object):
         )
 
     def request(self, method, url, query_params=None, headers=None,
-                body=None, post_params=None, _preload_content=True):
+                body=None, post_params=None, _preload_content=True, _request_timeout=None):
         """
         :param method: http request method
         :param url: http request url
@@ -117,6 +117,8 @@ class RESTClientObject(object):
                             and `multipart/form-data`
         :param _preload_content: if False, the urllib3.HTTPResponse object will be returned without
                                  reading/decoding response data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of (connection, read) timeouts.
         """
         method = method.upper()
         assert method in ['GET', 'HEAD', 'DELETE', 'POST', 'PUT', 'PATCH', 'OPTIONS']
@@ -128,6 +130,13 @@ class RESTClientObject(object):
 
         post_params = post_params or {}
         headers = headers or {}
+
+        timeout = None
+        if _request_timeout:
+            if isinstance(_request_timeout, (int, ) if PY3 else (int, long)):
+                timeout = urllib3.Timeout(total=_request_timeout)
+            elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
+                timeout = urllib3.Timeout(connect=_request_timeout[0], read=_request_timeout[1])
 
         if 'Content-Type' not in headers:
             headers['Content-Type'] = 'application/json'
@@ -144,12 +153,14 @@ class RESTClientObject(object):
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,
                                                   preload_content=_preload_content,
+                                                  timeout=timeout,
                                                   headers=headers)
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':
                     r = self.pool_manager.request(method, url,
                                                   fields=post_params,
                                                   encode_multipart=False,
                                                   preload_content=_preload_content,
+                                                  timeout=timeout,
                                                   headers=headers)
                 elif headers['Content-Type'] == 'multipart/form-data':
                     # must del headers['Content-Type'], or the correct Content-Type
@@ -159,6 +170,7 @@ class RESTClientObject(object):
                                                   fields=post_params,
                                                   encode_multipart=True,
                                                   preload_content=_preload_content,
+                                                  timeout=timeout,
                                                   headers=headers)
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is provided
@@ -168,6 +180,7 @@ class RESTClientObject(object):
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,
                                                   preload_content=_preload_content,
+                                                  timeout=timeout,
                                                   headers=headers)
                 else:
                     # Cannot generate the request from given parameters
@@ -179,6 +192,7 @@ class RESTClientObject(object):
                 r = self.pool_manager.request(method, url,
                                               fields=query_params,
                                               preload_content=_preload_content,
+                                              timeout=timeout,
                                               headers=headers)
         except urllib3.exceptions.SSLError as e:
             msg = "{0}\n{1}".format(type(e).__name__, str(e))
@@ -200,55 +214,66 @@ class RESTClientObject(object):
 
         return r
 
-    def GET(self, url, headers=None, query_params=None, _preload_content=True):
+    def GET(self, url, headers=None, query_params=None, _preload_content=True, _request_timeout=None):
         return self.request("GET", url,
                             headers=headers,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             query_params=query_params)
 
-    def HEAD(self, url, headers=None, query_params=None, _preload_content=True):
+    def HEAD(self, url, headers=None, query_params=None, _preload_content=True, _request_timeout=None):
         return self.request("HEAD", url,
                             headers=headers,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             query_params=query_params)
 
-    def OPTIONS(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
+    def OPTIONS(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True,
+                _request_timeout=None):
         return self.request("OPTIONS", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
-    def DELETE(self, url, headers=None, query_params=None, body=None, _preload_content=True):
+    def DELETE(self, url, headers=None, query_params=None, body=None, _preload_content=True, _request_timeout=None):
         return self.request("DELETE", url,
                             headers=headers,
                             query_params=query_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
-    def POST(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
+    def POST(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True,
+             _request_timeout=None):
         return self.request("POST", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
-    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
+    def PUT(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True,
+            _request_timeout=None):
         return self.request("PUT", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
-    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True):
+    def PATCH(self, url, headers=None, query_params=None, post_params=None, body=None, _preload_content=True,
+              _request_timeout=None):
         return self.request("PATCH", url,
                             headers=headers,
                             query_params=query_params,
                             post_params=post_params,
                             _preload_content=_preload_content,
+                            _request_timeout=_request_timeout,
                             body=body)
 
 

--- a/samples/client/petstore/python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/tests/test_pet_api.py
@@ -15,7 +15,37 @@ from petstore_api.rest import ApiException
 
 from .util import id_gen
 
+import json
+
+import urllib3
+
 HOST = 'http://petstore.swagger.io/v2'
+
+
+class TimeoutWithEqual(urllib3.Timeout):
+    def __init__(self, *arg, **kwargs):
+        super(TimeoutWithEqual, self).__init__(*arg, **kwargs)
+
+    def __eq__(self, other):
+        return self._read == other._read and self._connect == other._connect and self.total == other.total
+
+
+class MockPoolManager(object):
+    def __init__(self, tc):
+        self._tc = tc
+        self._reqs = []
+
+    def expect_request(self, *args, **kwargs):
+        self._reqs.append((args, kwargs))
+
+    def request(self, *args, **kwargs):
+        self._tc.assertTrue(len(self._reqs)>0)
+        r = self._reqs.pop(0)
+        self._tc.maxDiff = None
+        self._tc.assertEqual(r[0], args)
+        self._tc.assertEqual(r[1], kwargs)
+        return urllib3.HTTPResponse(status=200, body=b'test')
+
 
 class PetApiTests(unittest.TestCase):
 
@@ -64,6 +94,28 @@ class PetApiTests(unittest.TestCase):
 
         resp.close()
         resp.release_conn()
+
+    def test_timeout(self):
+        mock_pool = MockPoolManager(self)
+        self.api_client.rest_client.pool_manager = mock_pool
+
+        mock_pool.expect_request('POST', 'http://petstore.swagger.io/v2/pet',
+                                 body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
+                                 headers={'Content-Type': 'application/json',
+                                          'Authorization': 'Bearer ',
+                                          'Accept': 'application/json',
+                                          'User-Agent': 'Swagger-Codegen/1.0.0/python'},
+                                 preload_content=True, timeout=TimeoutWithEqual(total=5))
+        mock_pool.expect_request('POST', 'http://petstore.swagger.io/v2/pet',
+                                 body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
+                                 headers={'Content-Type': 'application/json',
+                                          'Authorization': 'Bearer ',
+                                          'Accept': 'application/json',
+                                          'User-Agent': 'Swagger-Codegen/1.0.0/python'},
+                                 preload_content=True, timeout=TimeoutWithEqual(connect=1, read=2))
+
+        self.pet_api.add_pet(body=self.pet, _request_timeout=5)
+        self.pet_api.add_pet(body=self.pet, _request_timeout=(1, 2))
 
     def test_create_api_instance(self):
         pet_api = petstore_api.PetApi()


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Similar to #4166 adding support for a timeout flag called _request_timeout.

fixes #4169 