### PR TITLE
add support for relative path in specs files for SpringMVC.   

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -217,15 +217,15 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         String contextRoot=strippedBasePath;
         String relativeBasePath="";
         
-		int slashPos = strippedBasePath.indexOf('/');
-		if (slashPos != -1)
-		{
-			contextRoot = strippedBasePath.substring(0, slashPos);
-			contextRoot = trimSlash(contextRoot);
+        int slashPos = strippedBasePath.indexOf('/');
+        if (slashPos != -1)
+        {
+            contextRoot = strippedBasePath.substring(0, slashPos);
+            contextRoot = trimSlash(contextRoot);
 
-			relativeBasePath = strippedBasePath.substring(slashPos);
-			relativeBasePath = "/"+trimSlash(relativeBasePath);
-		}
+            relativeBasePath = strippedBasePath.substring(slashPos);
+            relativeBasePath = "/"+trimSlash(relativeBasePath);
+        }
         
 		
         // resolve inline models

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -210,6 +210,24 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         String basePath = config.escapeText(hostBuilder.toString());
         String basePathWithoutHost = config.escapeText(swagger.getBasePath());
 
+		//when the basepath in spec looks like this:  context/basePath
+        //normally, the first part indicates the context root,  the second is the relative path.
+        String strippedBasePath=trimSlash(contextPath);
+
+        String contextRoot=strippedBasePath;
+        String relativeBasePath="";
+        
+		int slashPos = strippedBasePath.indexOf('/');
+		if (slashPos != -1)
+		{
+			contextRoot = strippedBasePath.substring(0, slashPos);
+			contextRoot = trimSlash(contextRoot);
+
+			relativeBasePath = strippedBasePath.substring(slashPos);
+			relativeBasePath = "/"+trimSlash(relativeBasePath);
+		}
+        
+		
         // resolve inline models
         InlineModelResolver inlineModelResolver = new InlineModelResolver();
         inlineModelResolver.flatten(swagger);
@@ -399,6 +417,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     operation.put("basePath", basePath);
                     operation.put("basePathWithoutHost", basePathWithoutHost);
                     operation.put("contextPath", contextPath);
+					
+					//
+					operation.put("contextRoot", contextRoot);
+                    operation.put("relativeBasePath", relativeBasePath);
+					
                     operation.put("baseName", tag);
                     operation.put("modelPackage", config.modelPackage());
                     operation.putAll(config.additionalProperties());
@@ -648,6 +671,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         return files;
     }
 
+	private String trimSlash(String contextPath)
+	{
+		return contextPath.replaceAll("(^/+|/+$)", "");
+	}
+	
     private File processTemplateToFile(Map<String, Object> templateData, String templateName, String outputFilename) throws IOException {
         if(ignoreProcessor.allowsFile(new File(outputFilename.replaceAll("//", "/")))) {
             String templateFile = getFullTemplateFile(config, templateName);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -210,7 +210,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         String basePath = config.escapeText(hostBuilder.toString());
         String basePathWithoutHost = config.escapeText(swagger.getBasePath());
 
-		//when the basepath in spec looks like this:  context/basePath
+        //when the basepath in spec looks like this:  context/basePath
         //normally, the first part indicates the context root,  the second is the relative path.
         String strippedBasePath=trimSlash(contextPath);
 
@@ -419,7 +419,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     operation.put("contextPath", contextPath);
 					
 					//
-					operation.put("contextRoot", contextRoot);
+                    operation.put("contextRoot", contextRoot);
                     operation.put("relativeBasePath", relativeBasePath);
 					
                     operation.put("baseName", tag);

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
@@ -37,7 +37,7 @@ public interface {{classname}} {
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
     @ApiResponses(value = { {{#responses}}
         @ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{returnType}}}.class){{#hasMore}},{{/hasMore}}{{/responses}} })
-    @RequestMapping(value = "{{{path}}}",{{#singleContentTypes}}
+    @RequestMapping(value = "{{{relativeBasePath}}}{{{path}}}",{{#singleContentTypes}}
         produces = "{{{vendorExtensions.x-accepts}}}",
         consumes = "{{{vendorExtensions.x-contentType}}}",{{/singleContentTypes}}{{^singleContentTypes}}{{#hasProduces}}
         produces = { {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }, {{/hasProduces}}{{#hasConsumes}}


### PR DESCRIPTION
### PR checklist
when we define basePath in spec like this   petstore/v2,   it normally means in the web container,   petstore is the context path,  v2  is global  relative path for all resource path.  so it is good to generate API with this relative path for @RequestMapping(value = "/v2/dogs"),   also it is better to define the controller level  mapping since controller is resource based.

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)


