### PR TITLE
Add gitUseID and gitRepoID flags to maven plugin

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -71,6 +71,18 @@ public class CodeGenMojo extends AbstractMojo {
     private String inputSpec;
 
     /**
+     * Git user ID, e.g. swagger-api.
+     */
+    @Parameter(name = "gitUserId", required = false)
+    private String gitUserId;
+
+    /**
+     * Git repo ID, e.g. swagger-codegen.
+     */
+    @Parameter(name = "gitRepoId", required = false)
+    private String gitRepoId;
+
+    /**
      * Folder containing the template files.
      */
     @Parameter(name = "templateDirectory")
@@ -193,6 +205,14 @@ public class CodeGenMojo extends AbstractMojo {
 
         if(isNotEmpty(inputSpec)) {
             configurator.setInputSpec(inputSpec);
+        }
+
+        if(isNotEmpty(gitUserId)) {
+            configurator.setGitUserId(gitUserId);
+        }
+
+        if(isNotEmpty(gitRepoId)) {
+            configurator.setGitRepoId(gitRepoId);
         }
 
         configurator.setLang(language);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Simply pass through gitUseID and gitRepoID to the generator.
