### PR TITLE
jaxrs-cxf-cdi :: Add a basic JAX-RS Application and CDI fixes

### DIFF
--- a/bin/jaxrs-cxf-cdi-petstore-server.sh
+++ b/bin/jaxrs-cxf-cdi-petstore-server.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf-cdi -o samples/server/petstore/jaxrs-cxf-cdi -DhideGenerationTimestamp=true"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf-cdi -o samples/server/petstore/jaxrs-cxf-cdi -DhideGenerationTimestamp=true"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
@@ -1,12 +1,22 @@
 package io.swagger.codegen.languages;
 
-import io.swagger.codegen.*;
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenProperty;
+import io.swagger.codegen.SupportingFile;
 
 import java.io.File;
 
+/**
+ * Generates a Java JAXRS Server according to JAXRS 2.0 specification, assuming an
+ * Apache CXF runtime and a Java EE runtime with CDI enabled.
+ * Similar to the original JAXRS generator, this creates API and Service classes
+ * in /src/gen/java and a sample ServiceImpl in /src/main/java. The API uses CDI
+ * to get an instance of ServiceImpl that implements the Service interface.
+ */
 public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen {
+    /**
+     * Default constructor
+     */
     public JavaJAXRSCXFCDIServerCodegen() {
         outputFolder = "generated-code/JavaJaxRS-CXF-CDI";
         artifactId = "swagger-jaxrs-cxf-cdi-server";
@@ -20,7 +30,8 @@ public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen {
         typeMapping.put("DateTime", "java.util.Date");
 
         // Updated template directory
-        embeddedTemplateDir = templateDir = JAXRS_TEMPLATE_DIRECTORY_NAME + File.separator + "cxf-cdi";
+        embeddedTemplateDir = templateDir = JAXRS_TEMPLATE_DIRECTORY_NAME
+                + File.separator + "cxf-cdi";
     }
 
     @Override
@@ -44,7 +55,8 @@ public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen {
                 (implFolder + '/' + invokerPackage).replace(".", "/"), "RestApplication.java"));
 
         // Make CDI work in containers with implicit archive scanning disabled
-        writeOptional(outputFolder, new SupportingFile("beans.mustache", "src/main/webapp/WEB-INF", "beans.xml"));
+        writeOptional(outputFolder, new SupportingFile("beans.mustache",
+                "src/main/webapp/WEB-INF", "beans.xml"));
     }
 
     @Override
@@ -57,7 +69,8 @@ public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen {
 
     @Override
     public String getHelp() {
-        return "Generates a Java JAXRS Server according to JAXRS 2.0 specification, assuming an Apache CXF runtime and a Java EE runtime with CDI enabled.";
+        return "Generates a Java JAXRS Server according to JAXRS 2.0 specification, assuming an "
+                + "Apache CXF runtime and a Java EE runtime with CDI enabled.";
     }
 
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
@@ -31,8 +31,20 @@ public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen {
     @Override
     public void processOpts() {
         super.processOpts();
+
         supportingFiles.clear(); // Don't need extra files provided by AbstractJAX-RS & Java Codegen
+
+        // writeOptional means these files are only written if they don't already exist
+
+        // POM
         writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
+
+        // RestApplication into src/main/java
+        writeOptional(outputFolder, new SupportingFile("RestApplication.mustache",
+                (implFolder + '/' + invokerPackage).replace(".", "/"), "RestApplication.java"));
+
+        // Make CDI work in containers with implicit archive scanning disabled
+        writeOptional(outputFolder, new SupportingFile("beans.mustache", "src/main/webapp/WEB-INF", "beans.xml"));
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/RestApplication.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/RestApplication.mustache
@@ -1,0 +1,9 @@
+package {{invokerPackage}};
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RestApplication extends Application {
+  // Add implementation-specific details here
+}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/beans.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/beans.mustache
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://java.sun.com/xml/ns/javaee
+        http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+
+  <!--
+    This is just an empty file so that CDI archive scanning kicks in when
+    implicit archive scanning is disabled (such as on IBM Bluemix)
+  -->
+
+</beans>

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/PetApi.java
@@ -3,78 +3,164 @@ package io.swagger.api;
 import java.io.File;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
+import io.swagger.api.PetApiService;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
-import java.util.Map;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 
-import org.apache.cxf.jaxrs.ext.multipart.*;
+import io.swagger.annotations.*;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 
-@Path("/")
-@Api(value = "/", description = "")
-public interface PetApi  {
+import java.util.List;
+
+@Path("/pet")
+@RequestScoped
+
+@Api(description = "the pet API")
+
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
+
+public class PetApi  {
+
+  @Context SecurityContext securityContext;
+
+  @Inject PetApiService delegate;
+
 
     @POST
     
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Add a new pet to the store", tags={ "pet",  })
-    public void  addPet(Pet body);
+    @ApiOperation(value = "Add a new pet to the store", notes = "", response = void.class, authorizations = {
+        @Authorization(value = "petstore_auth", scopes = {
+            @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+            @AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 405, message = "Invalid input", response = void.class) })
+    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) Pet body) {
+    	return delegate.addPet(body, securityContext);
+    }
 
     @DELETE
     @Path("/{petId}")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Deletes a pet", tags={ "pet",  })
-    public void  deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
+    @ApiOperation(value = "Deletes a pet", notes = "", response = void.class, authorizations = {
+        @Authorization(value = "petstore_auth", scopes = {
+            @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+            @AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid pet value", response = void.class) })
+    public Response deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathParam("petId") Long petId, @ApiParam(value = "" )@HeaderParam("api_key") String apiKey) {
+    	return delegate.deletePet(petId, apiKey, securityContext);
+    }
 
     @GET
     @Path("/findByStatus")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Finds Pets by status", tags={ "pet",  })
-    public Pet  findPetsByStatus(@QueryParam("status")List<String> status);
+    @ApiOperation(value = "Finds Pets by status", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "petstore_auth", scopes = {
+            @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+            @AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class, responseContainer = "List") })
+    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true, allowableValues="available, pending, sold")  @QueryParam("status") List<String> status) {
+    	return delegate.findPetsByStatus(status, securityContext);
+    }
 
     @GET
     @Path("/findByTags")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Finds Pets by tags", tags={ "pet",  })
-    public Pet  findPetsByTags(@QueryParam("tags")List<String> tags);
+    @ApiOperation(value = "Finds Pets by tags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "petstore_auth", scopes = {
+            @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+            @AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class, responseContainer = "List") })
+    public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true)  @QueryParam("tags") List<String> tags) {
+    	return delegate.findPetsByTags(tags, securityContext);
+    }
 
     @GET
     @Path("/{petId}")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Find pet by ID", tags={ "pet",  })
-    public Pet  getPetById(@PathParam("petId") Long petId);
+    @ApiOperation(value = "Find pet by ID", notes = "Returns a single pet", response = Pet.class, authorizations = {
+        @Authorization(value = "api_key")
+    }, tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+    public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId) {
+    	return delegate.getPetById(petId, securityContext);
+    }
 
     @PUT
     
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Update an existing pet", tags={ "pet",  })
-    public void  updatePet(Pet body);
+    @ApiOperation(value = "Update an existing pet", notes = "", response = void.class, authorizations = {
+        @Authorization(value = "petstore_auth", scopes = {
+            @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+            @AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = void.class),
+        @ApiResponse(code = 405, message = "Validation exception", response = void.class) })
+    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) Pet body) {
+    	return delegate.updatePet(body, securityContext);
+    }
 
     @POST
     @Path("/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Updates a pet in the store with form data", tags={ "pet",  })
-    public void  updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
+    @ApiOperation(value = "Updates a pet in the store with form data", notes = "", response = void.class, authorizations = {
+        @Authorization(value = "petstore_auth", scopes = {
+            @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+            @AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 405, message = "Invalid input", response = void.class) })
+    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status) {
+    	return delegate.updatePetWithForm(petId, name, status, securityContext);
+    }
 
     @POST
     @Path("/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "uploads an image", tags={ "pet" })
-    public ModelApiResponse  uploadFile(@PathParam("petId") Long petId, @Multipart(value = "additionalMetadata", required = false)  String additionalMetadata,  @Multipart(value = "file", required = false) InputStream fileInputStream,
-   @Multipart(value = "file" , required = false) Attachment fileDetail);
+    @ApiOperation(value = "uploads an image", notes = "", response = ModelApiResponse.class, authorizations = {
+        @Authorization(value = "petstore_auth", scopes = {
+            @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),
+            @AuthorizationScope(scope = "read:pets", description = "read your pets")
+        })
+    }, tags={ "pet" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
+    public Response uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId, @Multipart(value = "additionalMetadata", required = false)  String additionalMetadata,  @Multipart(value = "file", required = false) InputStream fileInputStream, @Multipart(value = "file" , required = false) Attachment fileDetail) {
+    	return delegate.uploadFile(petId, additionalMetadata, inputStream, fileDetail, securityContext);
+    }
 }
-

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/PetApiService.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/PetApiService.java
@@ -16,7 +16,7 @@ import java.io.InputStream;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-16T23:03:38.470+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
 public interface PetApiService {
       public Response addPet(Pet body, SecurityContext securityContext);
       public Response deletePet(Long petId, String apiKey, SecurityContext securityContext);

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/StoreApi.java
@@ -2,49 +2,83 @@ package io.swagger.api;
 
 import java.util.Map;
 import io.swagger.model.Order;
+import io.swagger.api.StoreApiService;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
-import java.util.Map;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 
-import org.apache.cxf.jaxrs.ext.multipart.*;
+import io.swagger.annotations.*;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 
-@Path("/")
-@Api(value = "/", description = "")
-public interface StoreApi  {
+import java.util.List;
+
+@Path("/store")
+@RequestScoped
+
+@Api(description = "the store API")
+
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
+
+public class StoreApi  {
+
+  @Context SecurityContext securityContext;
+
+  @Inject StoreApiService delegate;
+
 
     @DELETE
     @Path("/order/{orderId}")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Delete purchase order by ID", tags={ "store",  })
-    public void  deleteOrder(@PathParam("orderId") String orderId);
+    @ApiOperation(value = "Delete purchase order by ID", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", response = void.class, tags={ "store",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = void.class) })
+    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("orderId") String orderId) {
+    	return delegate.deleteOrder(orderId, securityContext);
+    }
 
     @GET
     @Path("/inventory")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Returns pet inventories by status", tags={ "store",  })
-    public Integer  getInventory();
+    @ApiOperation(value = "Returns pet inventories by status", notes = "Returns a map of status codes to quantities", response = Integer.class, responseContainer = "Map", authorizations = {
+        @Authorization(value = "api_key")
+    }, tags={ "store",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
+    public Response getInventory() {
+    	return delegate.getInventory(securityContext);
+    }
 
     @GET
     @Path("/order/{orderId}")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Find purchase order by ID", tags={ "store",  })
-    public Order  getOrderById(@PathParam("orderId") Long orderId);
+    @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("orderId") Long orderId) {
+    	return delegate.getOrderById(orderId, securityContext);
+    }
 
     @POST
     @Path("/order")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Place an order for a pet", tags={ "store" })
-    public Order  placeOrder(Order body);
+    @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) Order body) {
+    	return delegate.placeOrder(body, securityContext);
+    }
 }
-

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/StoreApiService.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/StoreApiService.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-16T23:03:38.470+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
 public interface StoreApiService {
       public Response deleteOrder(String orderId, SecurityContext securityContext);
       public Response getInventory(SecurityContext securityContext);

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/UserApi.java
@@ -2,77 +2,126 @@ package io.swagger.api;
 
 import java.util.List;
 import io.swagger.model.User;
+import io.swagger.api.UserApiService;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
-import java.util.Map;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 
-import org.apache.cxf.jaxrs.ext.multipart.*;
+import io.swagger.annotations.*;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 
-@Path("/")
-@Api(value = "/", description = "")
-public interface UserApi  {
+import java.util.List;
+
+@Path("/user")
+@RequestScoped
+
+@Api(description = "the user API")
+
+
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
+
+public class UserApi  {
+
+  @Context SecurityContext securityContext;
+
+  @Inject UserApiService delegate;
+
 
     @POST
     
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Create user", tags={ "user",  })
-    public void  createUser(User body);
+    @ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = void.class, tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = void.class) })
+    public Response createUser(@ApiParam(value = "Created user object" ,required=true) User body) {
+    	return delegate.createUser(body, securityContext);
+    }
 
     @POST
     @Path("/createWithArray")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Creates list of users with given input array", tags={ "user",  })
-    public void  createUsersWithArrayInput(List<User> body);
+    @ApiOperation(value = "Creates list of users with given input array", notes = "", response = void.class, tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = void.class) })
+    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) List<User> body) {
+    	return delegate.createUsersWithArrayInput(body, securityContext);
+    }
 
     @POST
     @Path("/createWithList")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Creates list of users with given input array", tags={ "user",  })
-    public void  createUsersWithListInput(List<User> body);
+    @ApiOperation(value = "Creates list of users with given input array", notes = "", response = void.class, tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = void.class) })
+    public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) List<User> body) {
+    	return delegate.createUsersWithListInput(body, securityContext);
+    }
 
     @DELETE
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Delete user", tags={ "user",  })
-    public void  deleteUser(@PathParam("username") String username);
+    @ApiOperation(value = "Delete user", notes = "This can only be done by the logged in user.", response = void.class, tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = void.class),
+        @ApiResponse(code = 404, message = "User not found", response = void.class) })
+    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username) {
+    	return delegate.deleteUser(username, securityContext);
+    }
 
     @GET
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Get user by user name", tags={ "user",  })
-    public User  getUserByName(@PathParam("username") String username);
+    @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = User.class),
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
+        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ",required=true) @PathParam("username") String username) {
+    	return delegate.getUserByName(username, securityContext);
+    }
 
     @GET
     @Path("/login")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Logs user into the system", tags={ "user",  })
-    public String  loginUser(@QueryParam("username")String username, @QueryParam("password")String password);
+    @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = String.class),
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+    public Response loginUser(@ApiParam(value = "The user name for login",required=true)  @QueryParam("username") String username, @ApiParam(value = "The password for login in clear text",required=true)  @QueryParam("password") String password) {
+    	return delegate.loginUser(username, password, securityContext);
+    }
 
     @GET
     @Path("/logout")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Logs out current logged in user session", tags={ "user",  })
-    public void  logoutUser();
+    @ApiOperation(value = "Logs out current logged in user session", notes = "", response = void.class, tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = void.class) })
+    public Response logoutUser() {
+    	return delegate.logoutUser(securityContext);
+    }
 
     @PUT
     @Path("/{username}")
     
     @Produces({ "application/xml", "application/json" })
-    @ApiOperation(value = "Updated user", tags={ "user" })
-    public void  updateUser(@PathParam("username") String username, User body);
+    @ApiOperation(value = "Updated user", notes = "This can only be done by the logged in user.", response = void.class, tags={ "user" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid user supplied", response = void.class),
+        @ApiResponse(code = 404, message = "User not found", response = void.class) })
+    public Response updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathParam("username") String username, @ApiParam(value = "Updated user object" ,required=true) User body) {
+    	return delegate.updateUser(username, body, securityContext);
+    }
 }
-

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/UserApiService.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/api/UserApiService.java
@@ -15,7 +15,7 @@ import java.io.InputStream;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
-@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-16T23:03:38.470+08:00")
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
 public interface UserApiService {
       public Response createUser(User body, SecurityContext securityContext);
       public Response createUsersWithArrayInput(List<User> body, SecurityContext securityContext);

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/Category.java
@@ -4,52 +4,71 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 
-import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@XmlAccessorType(XmlAccessType.FIELD)
- @XmlType(name = "Category", propOrder =
-    { "id", "name"
-})
+/**
+ * A category for a pet
+ **/
 
-@XmlRootElement(name="Category")
-@ApiModel(description="A category for a pet")
-public class Category  {
+import io.swagger.annotations.*;
+import java.util.Objects;
+@ApiModel(description = "A category for a pet")
+
+public class Category   {
   
-
-  @XmlElement(name="id")
-  @ApiModelProperty(example = "null", value = "")
   private Long id = null;
-
-  @XmlElement(name="name")
-  @ApiModelProperty(example = "null", value = "")
   private String name = null;
 
- /**
-   * Get id
-   * @return id
-  **/
+  /**
+   **/
+  public Category id(Long id) {
+    this.id = id;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("id")
   public Long getId() {
     return id;
   }
   public void setId(Long id) {
     this.id = id;
   }
- /**
-   * Get name
-   * @return name
-  **/
+
+  /**
+   **/
+  public Category name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("name")
   public String getName() {
     return name;
   }
   public void setName(String name) {
     this.name = name;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Category category = (Category) o;
+    return Objects.equals(id, category.id) &&
+        Objects.equals(name, category.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name);
   }
 
   @Override
@@ -67,7 +86,7 @@ public class Category  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private static String toIndentedString(Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -4,66 +4,90 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 
-import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@XmlAccessorType(XmlAccessType.FIELD)
- @XmlType(name = "ModelApiResponse", propOrder =
-    { "code", "type", "message"
-})
+/**
+ * Describes the result of uploading an image resource
+ **/
 
-@XmlRootElement(name="ModelApiResponse")
-@ApiModel(description="Describes the result of uploading an image resource")
-public class ModelApiResponse  {
+import io.swagger.annotations.*;
+import java.util.Objects;
+@ApiModel(description = "Describes the result of uploading an image resource")
+
+public class ModelApiResponse   {
   
-
-  @XmlElement(name="code")
-  @ApiModelProperty(example = "null", value = "")
   private Integer code = null;
-
-  @XmlElement(name="type")
-  @ApiModelProperty(example = "null", value = "")
   private String type = null;
-
-  @XmlElement(name="message")
-  @ApiModelProperty(example = "null", value = "")
   private String message = null;
 
- /**
-   * Get code
-   * @return code
-  **/
+  /**
+   **/
+  public ModelApiResponse code(Integer code) {
+    this.code = code;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("code")
   public Integer getCode() {
     return code;
   }
   public void setCode(Integer code) {
     this.code = code;
   }
- /**
-   * Get type
-   * @return type
-  **/
+
+  /**
+   **/
+  public ModelApiResponse type(String type) {
+    this.type = type;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("type")
   public String getType() {
     return type;
   }
   public void setType(String type) {
     this.type = type;
   }
- /**
-   * Get message
-   * @return message
-  **/
+
+  /**
+   **/
+  public ModelApiResponse message(String message) {
+    this.message = message;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("message")
   public String getMessage() {
     return message;
   }
   public void setMessage(String message) {
     this.message = message;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ModelApiResponse _apiResponse = (ModelApiResponse) o;
+    return Objects.equals(code, _apiResponse.code) &&
+        Objects.equals(type, _apiResponse.type) &&
+        Objects.equals(message, _apiResponse.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(code, type, message);
   }
 
   @Override
@@ -82,7 +106,7 @@ public class ModelApiResponse  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private static String toIndentedString(Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/Order.java
@@ -4,141 +4,165 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 
-import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@XmlAccessorType(XmlAccessType.FIELD)
- @XmlType(name = "Order", propOrder =
-    { "id", "petId", "quantity", "shipDate", "status", "complete"
-})
+/**
+ * An order for a pets from the pet store
+ **/
 
-@XmlRootElement(name="Order")
-@ApiModel(description="An order for a pets from the pet store")
-public class Order  {
+import io.swagger.annotations.*;
+import java.util.Objects;
+@ApiModel(description = "An order for a pets from the pet store")
+
+public class Order   {
   
-
-  @XmlElement(name="id")
-  @ApiModelProperty(example = "null", value = "")
   private Long id = null;
-
-  @XmlElement(name="petId")
-  @ApiModelProperty(example = "null", value = "")
   private Long petId = null;
-
-  @XmlElement(name="quantity")
-  @ApiModelProperty(example = "null", value = "")
   private Integer quantity = null;
-
-  @XmlElement(name="shipDate")
-  @ApiModelProperty(example = "null", value = "")
   private java.util.Date shipDate = null;
 
-@XmlType(name="StatusEnum")
-@XmlEnum(String.class)
-public enum StatusEnum {
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
 
-    @XmlEnumValue("placed") PLACED(String.valueOf("placed")), @XmlEnumValue("approved") APPROVED(String.valueOf("approved")), @XmlEnumValue("delivered") DELIVERED(String.valueOf("delivered"));
-
-
-    private String value;
-
-    StatusEnum (String v) {
-        value = v;
-    }
-
+@XmlType(name="Order")
+@XmlEnum
+public enum Order {
+    {values&#x3D;[placed, approved, delivered], enumVars&#x3D;[{name&#x3D;PLACED, value&#x3D;&quot;placed&quot;}, {name&#x3D;APPROVED, value&#x3D;&quot;approved&quot;}, {name&#x3D;DELIVERED, value&#x3D;&quot;delivered&quot;}]}, 
+    
     public String value() {
-        return value;
+        return name();
     }
 
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static StatusEnum fromValue(String v) {
-        for (StatusEnum b : StatusEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
-        }
-        return null;
+    public static Order fromValue(String v) {
+        return valueOf(v);
     }
 }
-
-
-  @XmlElement(name="status")
-  @ApiModelProperty(example = "null", value = "Order Status")
   private StatusEnum status = null;
-
-  @XmlElement(name="complete")
-  @ApiModelProperty(example = "null", value = "")
   private Boolean complete = false;
 
- /**
-   * Get id
-   * @return id
-  **/
+  /**
+   **/
+  public Order id(Long id) {
+    this.id = id;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("id")
   public Long getId() {
     return id;
   }
   public void setId(Long id) {
     this.id = id;
   }
- /**
-   * Get petId
-   * @return petId
-  **/
+
+  /**
+   **/
+  public Order petId(Long petId) {
+    this.petId = petId;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("petId")
   public Long getPetId() {
     return petId;
   }
   public void setPetId(Long petId) {
     this.petId = petId;
   }
- /**
-   * Get quantity
-   * @return quantity
-  **/
+
+  /**
+   **/
+  public Order quantity(Integer quantity) {
+    this.quantity = quantity;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("quantity")
   public Integer getQuantity() {
     return quantity;
   }
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
- /**
-   * Get shipDate
-   * @return shipDate
-  **/
+
+  /**
+   **/
+  public Order shipDate(java.util.Date shipDate) {
+    this.shipDate = shipDate;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("shipDate")
   public java.util.Date getShipDate() {
     return shipDate;
   }
   public void setShipDate(java.util.Date shipDate) {
     this.shipDate = shipDate;
   }
- /**
+
+  /**
    * Order Status
-   * @return status
-  **/
+   **/
+  public Order status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "Order Status")
+  @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
   }
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
- /**
-   * Get complete
-   * @return complete
-  **/
+
+  /**
+   **/
+  public Order complete(Boolean complete) {
+    this.complete = complete;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("complete")
   public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {
     this.complete = complete;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Order order = (Order) o;
+    return Objects.equals(id, order.id) &&
+        Objects.equals(petId, order.petId) &&
+        Objects.equals(quantity, order.quantity) &&
+        Objects.equals(shipDate, order.shipDate) &&
+        Objects.equals(status, order.status) &&
+        Objects.equals(complete, order.complete);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, petId, quantity, shipDate, status, complete);
   }
 
   @Override
@@ -160,7 +184,7 @@ public enum StatusEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private static String toIndentedString(Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/Pet.java
@@ -8,141 +8,165 @@ import io.swagger.model.Tag;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@XmlAccessorType(XmlAccessType.FIELD)
- @XmlType(name = "Pet", propOrder =
-    { "id", "category", "name", "photoUrls", "tags", "status"
-})
+/**
+ * A pet for sale in the pet store
+ **/
 
-@XmlRootElement(name="Pet")
-@ApiModel(description="A pet for sale in the pet store")
-public class Pet  {
+import io.swagger.annotations.*;
+import java.util.Objects;
+@ApiModel(description = "A pet for sale in the pet store")
+
+public class Pet   {
   
-
-  @XmlElement(name="id")
-  @ApiModelProperty(example = "null", value = "")
   private Long id = null;
-
-  @XmlElement(name="category")
-  @ApiModelProperty(example = "null", value = "")
   private Category category = null;
-
-  @XmlElement(name="name")
-  @ApiModelProperty(example = "doggie", required = true, value = "")
   private String name = null;
-
-  @XmlElement(name="photoUrls")
-  @ApiModelProperty(example = "null", required = true, value = "")
   private List<String> photoUrls = new ArrayList<String>();
-
-  @XmlElement(name="tags")
-  @ApiModelProperty(example = "null", value = "")
   private List<Tag> tags = new ArrayList<Tag>();
 
-@XmlType(name="StatusEnum")
-@XmlEnum(String.class)
-public enum StatusEnum {
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
 
-    @XmlEnumValue("available") AVAILABLE(String.valueOf("available")), @XmlEnumValue("pending") PENDING(String.valueOf("pending")), @XmlEnumValue("sold") SOLD(String.valueOf("sold"));
-
-
-    private String value;
-
-    StatusEnum (String v) {
-        value = v;
-    }
-
+@XmlType(name="Pet")
+@XmlEnum
+public enum Pet {
+    {values&#x3D;[available, pending, sold], enumVars&#x3D;[{name&#x3D;AVAILABLE, value&#x3D;&quot;available&quot;}, {name&#x3D;PENDING, value&#x3D;&quot;pending&quot;}, {name&#x3D;SOLD, value&#x3D;&quot;sold&quot;}]}, 
+    
     public String value() {
-        return value;
+        return name();
     }
 
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static StatusEnum fromValue(String v) {
-        for (StatusEnum b : StatusEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
-        }
-        return null;
+    public static Pet fromValue(String v) {
+        return valueOf(v);
     }
 }
-
-
-  @XmlElement(name="status")
-  @ApiModelProperty(example = "null", value = "pet status in the store")
   private StatusEnum status = null;
 
- /**
-   * Get id
-   * @return id
-  **/
+  /**
+   **/
+  public Pet id(Long id) {
+    this.id = id;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("id")
   public Long getId() {
     return id;
   }
   public void setId(Long id) {
     this.id = id;
   }
- /**
-   * Get category
-   * @return category
-  **/
+
+  /**
+   **/
+  public Pet category(Category category) {
+    this.category = category;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("category")
   public Category getCategory() {
     return category;
   }
   public void setCategory(Category category) {
     this.category = category;
   }
- /**
-   * Get name
-   * @return name
-  **/
+
+  /**
+   **/
+  public Pet name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty("name")
   public String getName() {
     return name;
   }
   public void setName(String name) {
     this.name = name;
   }
- /**
-   * Get photoUrls
-   * @return photoUrls
-  **/
+
+  /**
+   **/
+  public Pet photoUrls(List<String> photoUrls) {
+    this.photoUrls = photoUrls;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", required = true, value = "")
+  @JsonProperty("photoUrls")
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
- /**
-   * Get tags
-   * @return tags
-  **/
+
+  /**
+   **/
+  public Pet tags(List<Tag> tags) {
+    this.tags = tags;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("tags")
   public List<Tag> getTags() {
     return tags;
   }
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
- /**
+
+  /**
    * pet status in the store
-   * @return status
-  **/
+   **/
+  public Pet status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "pet status in the store")
+  @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
   }
   public void setStatus(StatusEnum status) {
     this.status = status;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Pet pet = (Pet) o;
+    return Objects.equals(id, pet.id) &&
+        Objects.equals(category, pet.category) &&
+        Objects.equals(name, pet.name) &&
+        Objects.equals(photoUrls, pet.photoUrls) &&
+        Objects.equals(tags, pet.tags) &&
+        Objects.equals(status, pet.status);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, category, name, photoUrls, tags, status);
   }
 
   @Override
@@ -164,7 +188,7 @@ public enum StatusEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private static String toIndentedString(Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/Tag.java
@@ -4,52 +4,71 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 
-import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@XmlAccessorType(XmlAccessType.FIELD)
- @XmlType(name = "Tag", propOrder =
-    { "id", "name"
-})
+/**
+ * A tag for a pet
+ **/
 
-@XmlRootElement(name="Tag")
-@ApiModel(description="A tag for a pet")
-public class Tag  {
+import io.swagger.annotations.*;
+import java.util.Objects;
+@ApiModel(description = "A tag for a pet")
+
+public class Tag   {
   
-
-  @XmlElement(name="id")
-  @ApiModelProperty(example = "null", value = "")
   private Long id = null;
-
-  @XmlElement(name="name")
-  @ApiModelProperty(example = "null", value = "")
   private String name = null;
 
- /**
-   * Get id
-   * @return id
-  **/
+  /**
+   **/
+  public Tag id(Long id) {
+    this.id = id;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("id")
   public Long getId() {
     return id;
   }
   public void setId(Long id) {
     this.id = id;
   }
- /**
-   * Get name
-   * @return name
-  **/
+
+  /**
+   **/
+  public Tag name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("name")
   public String getName() {
     return name;
   }
   public void setName(String name) {
     this.name = name;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Tag tag = (Tag) o;
+    return Objects.equals(id, tag.id) &&
+        Objects.equals(name, tag.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name);
   }
 
   @Override
@@ -67,7 +86,7 @@ public class Tag  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private static String toIndentedString(Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/io/swagger/model/User.java
@@ -4,136 +4,186 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 
-import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@XmlAccessorType(XmlAccessType.FIELD)
- @XmlType(name = "User", propOrder =
-    { "id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus"
-})
+/**
+ * A User who is purchasing from the pet store
+ **/
 
-@XmlRootElement(name="User")
-@ApiModel(description="A User who is purchasing from the pet store")
-public class User  {
+import io.swagger.annotations.*;
+import java.util.Objects;
+@ApiModel(description = "A User who is purchasing from the pet store")
+
+public class User   {
   
-
-  @XmlElement(name="id")
-  @ApiModelProperty(example = "null", value = "")
   private Long id = null;
-
-  @XmlElement(name="username")
-  @ApiModelProperty(example = "null", value = "")
   private String username = null;
-
-  @XmlElement(name="firstName")
-  @ApiModelProperty(example = "null", value = "")
   private String firstName = null;
-
-  @XmlElement(name="lastName")
-  @ApiModelProperty(example = "null", value = "")
   private String lastName = null;
-
-  @XmlElement(name="email")
-  @ApiModelProperty(example = "null", value = "")
   private String email = null;
-
-  @XmlElement(name="password")
-  @ApiModelProperty(example = "null", value = "")
   private String password = null;
-
-  @XmlElement(name="phone")
-  @ApiModelProperty(example = "null", value = "")
   private String phone = null;
-
-  @XmlElement(name="userStatus")
-  @ApiModelProperty(example = "null", value = "User Status")
   private Integer userStatus = null;
 
- /**
-   * Get id
-   * @return id
-  **/
+  /**
+   **/
+  public User id(Long id) {
+    this.id = id;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("id")
   public Long getId() {
     return id;
   }
   public void setId(Long id) {
     this.id = id;
   }
- /**
-   * Get username
-   * @return username
-  **/
+
+  /**
+   **/
+  public User username(String username) {
+    this.username = username;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("username")
   public String getUsername() {
     return username;
   }
   public void setUsername(String username) {
     this.username = username;
   }
- /**
-   * Get firstName
-   * @return firstName
-  **/
+
+  /**
+   **/
+  public User firstName(String firstName) {
+    this.firstName = firstName;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("firstName")
   public String getFirstName() {
     return firstName;
   }
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
- /**
-   * Get lastName
-   * @return lastName
-  **/
+
+  /**
+   **/
+  public User lastName(String lastName) {
+    this.lastName = lastName;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("lastName")
   public String getLastName() {
     return lastName;
   }
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
- /**
-   * Get email
-   * @return email
-  **/
+
+  /**
+   **/
+  public User email(String email) {
+    this.email = email;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("email")
   public String getEmail() {
     return email;
   }
   public void setEmail(String email) {
     this.email = email;
   }
- /**
-   * Get password
-   * @return password
-  **/
+
+  /**
+   **/
+  public User password(String password) {
+    this.password = password;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("password")
   public String getPassword() {
     return password;
   }
   public void setPassword(String password) {
     this.password = password;
   }
- /**
-   * Get phone
-   * @return phone
-  **/
+
+  /**
+   **/
+  public User phone(String phone) {
+    this.phone = phone;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "")
+  @JsonProperty("phone")
   public String getPhone() {
     return phone;
   }
   public void setPhone(String phone) {
     this.phone = phone;
   }
- /**
+
+  /**
    * User Status
-   * @return userStatus
-  **/
+   **/
+  public User userStatus(Integer userStatus) {
+    this.userStatus = userStatus;
+    return this;
+  }
+
+  
+  @ApiModelProperty(example = "null", value = "User Status")
+  @JsonProperty("userStatus")
   public Integer getUserStatus() {
     return userStatus;
   }
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    User user = (User) o;
+    return Objects.equals(id, user.id) &&
+        Objects.equals(username, user.username) &&
+        Objects.equals(firstName, user.firstName) &&
+        Objects.equals(lastName, user.lastName) &&
+        Objects.equals(email, user.email) &&
+        Objects.equals(password, user.password) &&
+        Objects.equals(phone, user.phone) &&
+        Objects.equals(userStatus, user.userStatus);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, username, firstName, lastName, email, password, phone, userStatus);
   }
 
   @Override
@@ -157,7 +207,7 @@ public class User  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private static String toIndentedString(Object o) {
+  private String toIndentedString(Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/io/swagger/api/RestApplication.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/io/swagger/api/RestApplication.java
@@ -1,0 +1,9 @@
+package io.swagger.api;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RestApplication extends Application {
+  // Add implementation-specific details here
+}

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/io/swagger/api/impl/PetApiServiceImpl.java
@@ -1,72 +1,63 @@
 package io.swagger.api.impl;
 
 import io.swagger.api.*;
+import io.swagger.model.*;
+
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
 import java.io.File;
 import io.swagger.model.ModelApiResponse;
 import io.swagger.model.Pet;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
-import javax.ws.rs.*;
+
+import java.io.InputStream;
+
+import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.core.Response;
-import org.apache.cxf.jaxrs.model.wadl.Description;
-import org.apache.cxf.jaxrs.model.wadl.DocTarget;
+import javax.ws.rs.core.SecurityContext;
 
-import org.apache.cxf.jaxrs.ext.multipart.*;
-
-import io.swagger.annotations.Api;
-
-public class PetApiServiceImpl implements PetApi {
-    public void  addPet(Pet body) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public void  deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public Pet  findPetsByStatus(List<String> status) {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
-    public Pet  findPetsByTags(List<String> tags) {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
-    public Pet  getPetById(@PathParam("petId") Long petId) {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
-    public void  updatePet(Pet body) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public void  updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public ModelApiResponse  uploadFile(@PathParam("petId") Long petId, @Multipart(value = "additionalMetadata", required = false)  String additionalMetadata,  @Multipart(value = "file", required = false) InputStream fileInputStream,
-   @Multipart(value = "file" , required = false) Attachment fileDetail) {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
+@RequestScoped
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
+public class PetApiServiceImpl implements PetApiService {
+      @Override
+      public Response addPet(Pet body, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response deletePet(Long petId, String apiKey, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response findPetsByStatus(List<String> status, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response findPetsByTags(List<String> tags, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response getPetById(Long petId, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response updatePet(Pet body, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response updatePetWithForm(Long petId, String name, String status, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response uploadFile(Long petId, String additionalMetadata, InputStream fileInputStream, Attachment fileDetail, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
 }
-

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/io/swagger/api/impl/StoreApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/io/swagger/api/impl/StoreApiServiceImpl.java
@@ -1,46 +1,42 @@
 package io.swagger.api.impl;
 
 import io.swagger.api.*;
+import io.swagger.model.*;
+
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
 import java.util.Map;
 import io.swagger.model.Order;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
-import javax.ws.rs.*;
+
+import java.io.InputStream;
+
+import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.core.Response;
-import org.apache.cxf.jaxrs.model.wadl.Description;
-import org.apache.cxf.jaxrs.model.wadl.DocTarget;
+import javax.ws.rs.core.SecurityContext;
 
-import org.apache.cxf.jaxrs.ext.multipart.*;
-
-import io.swagger.annotations.Api;
-
-public class StoreApiServiceImpl implements StoreApi {
-    public void  deleteOrder(@PathParam("orderId") String orderId) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public Integer  getInventory() {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
-    public Order  getOrderById(@PathParam("orderId") Long orderId) {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
-    public Order  placeOrder(Order body) {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
+@RequestScoped
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
+public class StoreApiServiceImpl implements StoreApiService {
+      @Override
+      public Response deleteOrder(String orderId, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response getInventory(SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response getOrderById(Long orderId, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response placeOrder(Order body, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
 }
-

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/io/swagger/api/impl/UserApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/main/java/io/swagger/api/impl/UserApiServiceImpl.java
@@ -1,70 +1,62 @@
 package io.swagger.api.impl;
 
 import io.swagger.api.*;
+import io.swagger.model.*;
+
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+
 import java.util.List;
 import io.swagger.model.User;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
-import javax.ws.rs.*;
+
+import java.io.InputStream;
+
+import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.core.Response;
-import org.apache.cxf.jaxrs.model.wadl.Description;
-import org.apache.cxf.jaxrs.model.wadl.DocTarget;
+import javax.ws.rs.core.SecurityContext;
 
-import org.apache.cxf.jaxrs.ext.multipart.*;
-
-import io.swagger.annotations.Api;
-
-public class UserApiServiceImpl implements UserApi {
-    public void  createUser(User body) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public void  createUsersWithArrayInput(List<User> body) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public void  createUsersWithListInput(List<User> body) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public void  deleteUser(@PathParam("username") String username) {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public User  getUserByName(@PathParam("username") String username) {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
-    public String  loginUser(String username, String password) {
-        // TODO: Implement...
-        
-        return null;
-    }
-    
-    public void  logoutUser() {
-        // TODO: Implement...
-        
-        
-    }
-    
-    public void  updateUser(@PathParam("username") String username, User body) {
-        // TODO: Implement...
-        
-        
-    }
-    
+@RequestScoped
+@javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavaJAXRSCXFCDIServerCodegen", date = "2016-11-17T08:53:42.205Z")
+public class UserApiServiceImpl implements UserApiService {
+      @Override
+      public Response createUser(User body, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response createUsersWithArrayInput(List<User> body, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response createUsersWithListInput(List<User> body, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response deleteUser(String username, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response getUserByName(String username, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response loginUser(String username, String password, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response logoutUser(SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
+      @Override
+      public Response updateUser(String username, User body, SecurityContext securityContext) {
+      // do some magic!
+      return Response.ok().entity("magic!").build();
+  }
 }
-

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/main/webapp/WEB-INF/beans.xml
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://java.sun.com/xml/ns/javaee
+        http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+
+  <!--
+    This is just an empty file so that CDI archive scanning kicks in when
+    implicit archive scanning is disabled (such as on IBM Bluemix)
+  -->
+
+</beans>

--- a/samples/server/petstore/jaxrs-cxf-cdi/swagger.json
+++ b/samples/server/petstore/jaxrs-cxf-cdi/swagger.json
@@ -637,11 +637,6 @@
     }
   },
   "securityDefinitions" : {
-    "api_key" : {
-      "type" : "apiKey",
-      "name" : "api_key",
-      "in" : "header"
-    },
     "petstore_auth" : {
       "type" : "oauth2",
       "authorizationUrl" : "http://petstore.swagger.io/api/oauth/dialog",
@@ -650,6 +645,11 @@
         "write:pets" : "modify pets in your account",
         "read:pets" : "read your pets"
       }
+    },
+    "api_key" : {
+      "type" : "apiKey",
+      "name" : "api_key",
+      "in" : "header"
     }
   },
   "definitions" : {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add a JAX-RS application, and beans.xml, so that this works on typical JavaEE 7.0 servers.  For example, code generated by this generator will now work directly upon deployment to IBM WAS Liberty, and IBM Bluemix.


