### PR TITLE
[Typescript] Add Error to the list of reserved words that must be escaped 

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -55,7 +55,8 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 "Array",
                 "Date",
                 "number",
-                "any"
+                "any",
+		"Error"
         ));
         instantiationTypes.put("array", "Array");
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -56,7 +56,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 "Date",
                 "number",
                 "any",
-		"Error"
+		        "Error"
         ));
         instantiationTypes.put("array", "Array");
 
@@ -175,6 +175,11 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 return modelName;
             }
 
+            if(languageSpecificPrimitives.contains(name)){
+                String modelName = camelize("model_" + name);
+                LOGGER.warn(name + " (model name matches existing language type) cannot be used as a model name. Renamed to " + modelName);
+                return modelName;
+            }
             // camelize the model name
             // phone_number => PhoneNumber
             return camelize(name);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -56,7 +56,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 "Date",
                 "number",
                 "any",
-		        "Error"
+                "Error"
         ));
         instantiationTypes.put("array", "Array");
 
@@ -175,7 +175,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 return modelName;
             }
 
-            if(languageSpecificPrimitives.contains(name)){
+            if (languageSpecificPrimitives.contains(name)) {
                 String modelName = camelize("model_" + name);
                 LOGGER.warn(name + " (model name matches existing language type) cannot be used as a model name. Renamed to " + modelName);
                 return modelName;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)



This fixes a part of #2456.  I made this change from the github editor, but can do the rest of the checklist steps tonight at my home.