### PR TITLE
[html2] Add missing enums to parameters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/index.mustache
@@ -6,580 +6,431 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta charset="UTF-8" />
+  {{>js_jquery}}
+  {{>js_prettify}}
+  {{>js_bootstrap}}
+  {{>marked}}
+  <script>
+    $( document ).ready(function() {
+      marked.setOptions({
+        renderer: new marked.Renderer(),
+        gfm: true,
+        tables: true,
+        breaks: false,
+        pedantic: false,
+        sanitize: false,
+        smartLists: true,
+        smartypants: false
+      });
+
+      var textFile = null;
+
+      /// Function to be used to download a text json schema
+      function makeTextFile(text) {
+
+        var data = new Blob([text], {type: 'text/plain'});
+
+        // If we are replacing a previously generated file we need to
+        // manually revoke the object URL to avoid memory leaks.
+        if (textFile !== null) {
+          window.URL.revokeObjectURL(textFile);
+        }
+
+        textFile = window.URL.createObjectURL(data);
+
+        var a = document.createElement("a");
+        document.body.appendChild(a);
+        a.style = "display: none";
+        a.href = textFile;
+        a.download = 'schema.txt';
+        a.click();
+
+        return textFile;
+      };
+
+      /// TODO: Implement resizing for expanding within iframe
+      function callResize() {
+        window.parent.postMessage('resize', "*");
+      }
+
+      function processMarked() {
+        $(".marked").each(function() {
+          $(this).html(marked($(this).html()));
+        });
+      }
 
 
-{{>js_jquery}}
-
-{{>js_prettify}}
-{{>js_bootstrap}}
-{{>marked}}
-
-<script>
-
-$( document ).ready(function() {
-  marked.setOptions({
-    renderer: new marked.Renderer(),
-    gfm: true,
-    tables: true,
-    breaks: false,
-    pedantic: false,
-    sanitize: false,
-    smartLists: true,
-    smartypants: false
-  });
-
-  var textFile = null;
-
-  /// Function to be used to download a text json schema
-  function makeTextFile(text) {
-
-    var data = new Blob([text], {type: 'text/plain'});
-
-    // If we are replacing a previously generated file we need to
-    // manually revoke the object URL to avoid memory leaks.
-    if (textFile !== null) {
-      window.URL.revokeObjectURL(textFile);
-    }
-
-    textFile = window.URL.createObjectURL(data);
-
-    var a = document.createElement("a");
-    document.body.appendChild(a);
-    a.style = "display: none";
-    a.href = textFile;
-    a.download = 'schema.txt';
-    a.click();
-
-    return textFile;
-  };
-
-  /// TODO: Implement resizing for expanding within iframe
-  function callResize() {
-    window.parent.postMessage('resize', "*");
-  }
-
-  function processMarked() {
-    $(".marked").each(function() {
-      $(this).html(marked($(this).html()));
-    });
-  }
+      // load google web fonts
+      loadGoogleFontCss();
 
 
-  // load google web fonts
-  loadGoogleFontCss();
+      // Bootstrap Scrollspy
+      $(this).scrollspy({ target: '#scrollingNav', offset: 18 });
+
+      // Content-Scroll on Navigation click.
+      $('.sidenav').find('a').on('click', function(e) {
+          e.preventDefault();
+          var id = $(this).attr('href');
+          if ($(id).length > 0)
+              $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 400);
+          window.location.hash = $(this).attr('href');
+      });
+
+      // Quickjump on Pageload to hash position.
+      if(window.location.hash) {
+          var id = window.location.hash;
+          if ($(id).length > 0)
+              $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 0);
+      }
 
 
-  // Bootstrap Scrollspy
-  $(this).scrollspy({ target: '#scrollingNav', offset: 18 });
-
-  // Content-Scroll on Navigation click.
-  $('.sidenav').find('a').on('click', function(e) {
-      e.preventDefault();
-      var id = $(this).attr('href');
-      if ($(id).length > 0)
-          $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 400);
-      window.location.hash = $(this).attr('href');
-  });
-
-  // Quickjump on Pageload to hash position.
-  if(window.location.hash) {
-      var id = window.location.hash;
-      if ($(id).length > 0)
-          $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 0);
-  }
+      function initDynamic() {
+        // tabs
+        $('.nav-tabs-examples a').click(function (e) {
+            e.preventDefault();
+            $(this).tab('show');
+        });
 
 
-  function initDynamic() {
-    // tabs
-    $('.nav-tabs-examples a').click(function (e) {
-        e.preventDefault();
-        $(this).tab('show');
-    });
+        $('.nav-tabs-examples').find('a:first').tab('show');
 
+        // call scrollspy refresh method
+        $(window).scrollspy('refresh');
+      }
 
-    $('.nav-tabs-examples').find('a:first').tab('show');
+      initDynamic();
 
-    // call scrollspy refresh method
-    $(window).scrollspy('refresh');
-  }
+      // Pre- / Code-Format
+      prettyPrint();
 
-  initDynamic();
+      //Convert elements with "marked" class to markdown
+      processMarked();
 
-  // Pre- / Code-Format
-  prettyPrint();
-
-  //Convert elements with "marked" class to markdown
-  processMarked();
-
-  /**
-   * Load google fonts.
-   */
-  function loadGoogleFontCss() {
-    WebFont.load({
-      active: function() {
-        // Update scrollspy
-        $(window).scrollspy('refresh')
-      },
-      google: {
-        families: ['Source Code Pro', 'Source Sans Pro:n4,n6,n7']
+      /**
+       * Load google fonts.
+       */
+      function loadGoogleFontCss() {
+        WebFont.load({
+          active: function() {
+            // Update scrollspy
+            $(window).scrollspy('refresh')
+          },
+          google: {
+            families: ['Source Code Pro', 'Source Sans Pro:n4,n6,n7']
+          }
+        });
       }
     });
-  }
-});
-</script>
-
-<style type="text/css">
-{{>css_bootstrap}}
-{{>css_prettify}}
-
-{{>styles}}
-
-</style>
-
-
+  </script>
+  <style type="text/css">
+  {{>css_bootstrap}}
+  {{>css_prettify}}
+  {{>styles}}
+  </style>
 </head>
 <body>
   <script>
-
-  // Script section to load models into a JS Var
-
-  var defs = {}
-
-  {{#models}}
-  {{#model}}
-  defs.{{name}} = {{{modelJson}}};
-  {{/model}}
-  {{/models}}
+    // Script section to load models into a JS Var
+    var defs = {}
+    {{#models}}
+    {{#model}}
+    defs.{{name}} = {{{modelJson}}};
+    {{/model}}
+    {{/models}}
   </script>
 
-<div class="container-fluid">
+  <div class="container-fluid">
     <div class="row-fluid">
-        <div id="sidenav" class="span2">
-            <nav id="scrollingNav">
-                <ul class="sidenav nav nav-list">
+      <div id="sidenav" class="span2">
+        <nav id="scrollingNav">
+          <ul class="sidenav nav nav-list">
+            <!-- Logo Area -->
+              <!--<div style="width: 80%; background-color: #4c8eca; color: white; padding: 20px; text-align: center; margin-bottom: 20px; ">
 
+              API Docs 2
 
-                    <!-- Logo Area -->
-                    <!--<div style="width: 80%; background-color: #4c8eca; color: white; padding: 20px; text-align: center; margin-bottom: 20px; ">
+              </div>
+            -->
+            <li class="nav-fixed nav-header active" data-group="_"><a href="#api-_">API Summary</a></li>
 
-                    API Docs 2
-
-                    </div>
-                    -->
-                    <li class="nav-fixed nav-header active" data-group="_"><a href="#api-_">API Summary</a></li>
-
-                    {{#apiInfo}}
-
-                        {{#apis}}
-                            {{#operations}}
-                                <li class="nav-header" data-group="{{baseName}}"><a href="#api-{{baseName}}">API Methods - {{baseName}}</a></li>
-                                {{#operation}}
-                                    <li data-group="{{baseName}}" data-name="{{nickname}}" class="">
-                                        <a href="#api-{{baseName}}-{{nickname}}">{{nickname}}</a>
-                                    </li>
-                                {{/operation}}
-                            {{/operations}}
-                        {{/apis}}
-
-                    {{/apiInfo}}
-
-
-
-                </ul>
-            </nav>
+            {{#apiInfo}}
+              {{#apis}}
+                {{#operations}}
+                  <li class="nav-header" data-group="{{baseName}}"><a href="#api-{{baseName}}">API Methods - {{baseName}}</a></li>
+                  {{#operation}}
+                    <li data-group="{{baseName}}" data-name="{{nickname}}" class="">
+                      <a href="#api-{{baseName}}-{{nickname}}">{{nickname}}</a>
+                    </li>
+                  {{/operation}}
+                {{/operations}}
+              {{/apis}}
+            {{/apiInfo}}
+          </ul>
+        </nav>
+      </div>
+      <div id="content">
+        <div id="project">
+          <div class="pull-left">
+            <h1>{{{appName}}}</h1>
+          </div>
+          <div class="clearfix"></div>
         </div>
-        <div id="content">
-            <div id="project">
-                <div class="pull-left">
-                    <h1>{{{appName}}}</h1>
-                </div>
-                <div class="clearfix"></div>
-            </div>
-            <div id="header">
-                <div id="api-_">
-                    <h2 id="welcome-to-apidoc">API and SDK Documentation</h2>
-
-                    {{#version}}
-                        <div class="app-desc">Version: {{{version}}}</div>
-                    {{/version}}
-
-
-                    <hr>
-
-                    <p class="marked">{{appDescription}}</p>
-                </div>
-            </div>
-            <div id="sections">
-
-                {{#apiInfo}}
-
-                    {{#apis}}
-                        {{#operations}}
-                            <section id="api-{{baseName}}">
-                                <h1>{{baseName}}</h1>
-                                {{#operation}}
-
-
-
-
-
-
-
-                                    <div id="api-{{baseName}}-{{nickname}}">
-
-                                        <article id="api-{{baseName}}-{{nickname}}-0" data-group="User" data-name="{{nickname}}" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>{{nickname}}</h1>
-                                                <p>{{summary}}</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">{{notes}}</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="{{httpMethod}}"><code><span class="pln">{{path}}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-{{baseName}}-{{nickname}}-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-{{baseName}}-{{nickname}}-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-{{baseName}}-{{nickname}}-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-{{baseName}}-{{nickname}}-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-{{baseName}}-{{nickname}}-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-{{baseName}}-{{nickname}}-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-{{baseName}}-{{nickname}}-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-{{baseName}}-{{nickname}}-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-{{baseName}}-{{nickname}}-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-{{baseName}}-{{nickname}}-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">{{httpMethod}}</span>{{#authMethods}}{{#isApiKey}}{{#isKeyInHeader}} -H "{{keyParamName}}: [[apiKey]]" {{/isKeyInHeader}}{{/isApiKey}}{{#isBasic}} -H "Authorization: Basic [[basicHash]]" {{/isBasic}}{{/authMethods}} "{{basePath}}{{path}}{{#hasQueryParams}}?{{#queryParams}}{{^-first}}&{{/-first}}{{paramName}}={{vendorExtensions.x-eg}}{{/queryParams}}{{/hasQueryParams}}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-{{>sample_java}}
-                                                  </code></pre>
+        <div id="header">
+          <div id="api-_">
+            <h2 id="welcome-to-apidoc">API and SDK Documentation</h2>
+            {{#version}}
+              <div class="app-desc">Version: {{{version}}}</div>
+            {{/version}}
+            <hr>
+            <p class="marked">{{appDescription}}</p>
           </div>
-
-
-                                                <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-{{>sample_android}}
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-{{>sample_objc}}
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-{{>sample_js}}
-                                                    </code></pre>
-                                                </div>
-
-                                                <!--<div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-{{>sample_csharp}}
-                                                    </code></pre>
-                                                </div>
-
-
-                                                <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-{{>sample_php}}
-                                                  </code></pre>
-          </div>
-
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                            {{#hasPathParams}}
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                    {{#pathParams}}
-                                                        {{>param}}
-                                                    {{/pathParams}}
-                                                </table>
-                                            {{/hasPathParams}}
-
-                                            {{#hasHeaderParams}}
-                                                <div class="methodsubtabletitle">Header parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                    {{#headerParams}}
-                                                        {{>param}}
-                                                    {{/headerParams}}
-
-                                                </table>
-                                            {{/hasHeaderParams}}
-
-
-                                            {{#hasBodyParam}}
-                                                <div class="methodsubtabletitle">Body parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                    {{#bodyParams}}
-                                                        {{>paramB}}
-                                                    {{/bodyParams}}
-
-                                                </table>
-                                            {{/hasBodyParam}}
-
-                                            {{#hasFormParams}}
-                                                <div class="methodsubtabletitle">Form parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                    {{#formParams}}
-                                                        {{>param}}
-                                                    {{/formParams}}
-
-                                                </table>
-                                            {{/hasFormParams}}
-
-                                            {{#hasQueryParams}}
-                                                <div class="methodsubtabletitle">Query parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                    {{#queryParams}}
-                                                        {{>param}}
-                                                    {{/queryParams}}
-                                                </table>
-                                            {{/hasQueryParams}}
-
-                                            <h2>Responses</h2>
-                                            {{#responses}}
-
-                                                <h3> Status: {{code}} - {{message}} </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-{{baseName}}-{{nickname}}-schema">Schema</a>
-                                                    </li>
-
-                                                    {{#examples}}
-                                                        <li class="">
-                                                            <a href="#examples-{{baseName}}-{{nickname}}-example">Response Example</a>
-                                                        </li>
-                                                    {{/examples}}
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-{{baseName}}-{{nickname}}-schema">
-
-
-
-
-                                                        <div id='examples-{{baseName}}-{{nickname}}-schema-{{code}}' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {{{jsonSchema}}};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-{{baseName}}-{{nickname}}-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-{{baseName}}-{{nickname}}-schema-{{code}}');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-{{baseName}}-{{nickname}}-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-                                                    {{#examples}}
-                                                        <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-example">
-                                                            <pre class="prettyprint"><code class="json">{{example}}</code></pre>
-                                                        </div>
-                                                    {{/examples}}
-
-
-                                                </div>
-
-
-
-                                            {{/responses}}
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-                                {{/operation}}
-                            </section>
-
-                        {{/operations}}
-                    {{/apis}}
-
-                {{/apiInfo}}
-
-
-
-
-            </div>
-
-
-
-
-
-
-            <div id="footer">
-                <div id="api-_footer">
-                    <p>Suggestions, contact, support and error reporting;
-                        {{#infoUrl}}
-                            <div class="app-desc">Information URL: <a href="{{{infoUrl}}}">{{{infoUrl}}}</a></div>
-                        {{/infoUrl}}
-                        {{#infoEmail}}
-                            <div class="app-desc">Contact Info: <a href="{{{infoEmail}}}">{{{infoEmail}}}</a></div>
-                        {{/infoEmail}}
-                    </p>
-                    {{#licenseInfo}}
-                        <div class="license-info">{{{licenseInfo}}}</div>
-                    {{/licenseInfo}}
-                    {{#licenseUrl}}
-                        <div class="license-url">{{{licenseUrl}}}</div>
-                    {{/licenseUrl}}
-                </div>
-            </div>
-            <div id="generator">
-                <div class="content">
-                    Generated {{generatedDate}}
-                </div>
-            </div>
         </div>
+        <div id="sections">
+          {{#apiInfo}}
+            {{#apis}}
+              {{#operations}}
+                <section id="api-{{baseName}}">
+                  <h1>{{baseName}}</h1>
+                  {{#operation}}
+                    <div id="api-{{baseName}}-{{nickname}}">
+                      <article id="api-{{baseName}}-{{nickname}}-0" data-group="User" data-name="{{nickname}}" data-version="0">
+                        <div class="pull-left">
+                          <h1>{{nickname}}</h1>
+                          <p>{{summary}}</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">{{notes}}</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="{{httpMethod}}"><code><span class="pln">{{path}}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-{{baseName}}-{{nickname}}-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-java">Java</a></li>
+                          <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-{{baseName}}-{{nickname}}-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">{{httpMethod}}</span>{{#authMethods}}{{#isApiKey}}{{#isKeyInHeader}} -H "{{keyParamName}}: [[apiKey]]" {{/isKeyInHeader}}{{/isApiKey}}{{#isBasic}} -H "Authorization: Basic [[basicHash]]" {{/isBasic}}{{/authMethods}} "{{basePath}}{{path}}{{#hasQueryParams}}?{{#queryParams}}{{^-first}}&{{/-first}}{{paramName}}={{vendorExtensions.x-eg}}{{/queryParams}}{{/hasQueryParams}}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  {{>sample_java}}
+                            </code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  {{>sample_android}}
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  {{>sample_objc}}
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  {{>sample_js}}
+                              </code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  {{>sample_csharp}}
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  {{>sample_php}}
+                              </code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Parameters</h2>
+
+                          {{#hasPathParams}}
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                {{#pathParams}}
+                                  {{>param}}
+                                {{/pathParams}}
+                            </table>
+                          {{/hasPathParams}}
+
+                          {{#hasHeaderParams}}
+                            <div class="methodsubtabletitle">Header parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                              {{#headerParams}}
+                                  {{>param}}
+                              {{/headerParams}}
+                            </table>
+                          {{/hasHeaderParams}}
+
+                          {{#hasBodyParam}}
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                              {{#bodyParams}}
+                                {{>paramB}}
+                              {{/bodyParams}}
+                            </table>
+                          {{/hasBodyParam}}
+
+                          {{#hasFormParams}}
+                            <div class="methodsubtabletitle">Form parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                              {{#formParams}}
+                                  {{>param}}
+                              {{/formParams}}
+                            </table>
+                          {{/hasFormParams}}
+
+                          {{#hasQueryParams}}
+                            <div class="methodsubtabletitle">Query parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                              {{#queryParams}}
+                                {{>param}}
+                              {{/queryParams}}
+                            </table>
+                          {{/hasQueryParams}}
+
+                          <h2>Responses</h2>
+                          {{#responses}}
+                            <h3> Status: {{code}} - {{message}} </h3>
+
+                            {{#schema}}
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-{{baseName}}-{{nickname}}-schema">Schema</a>
+                                </li>
+
+                                {{#examples}}
+                                  <li class="">
+                                    <a href="#examples-{{baseName}}-{{nickname}}-example">Response Example</a>
+                                  </li>
+                                {{/examples}}
+                              </ul>
+
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-{{baseName}}-{{nickname}}-schema">
+                                  <div id='examples-{{baseName}}-{{nickname}}-schema-{{code}}' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
+
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {{{jsonSchema}}};
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-{{baseName}}-{{nickname}}-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-{{baseName}}-{{nickname}}-schema-{{code}}');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-{{baseName}}-{{nickname}}-schema-data' type='hidden' value=''></input>
+                                </div>
+                                {{#examples}}
+                                  <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-example">
+                                    <pre class="prettyprint"><code class="json">{{example}}</code></pre>
+                                  </div>
+                                {{/examples}}
+                              </div>
+                            {{/schema}}
+                          {{/responses}}
+                        </article>
+                      </div>
+                      <hr>
+                    {{/operation}}
+                  </section>
+                {{/operations}}
+              {{/apis}}
+            {{/apiInfo}}
+          </div>
+          <div id="footer">
+            <div id="api-_footer">
+              <p>Suggestions, contact, support and error reporting;
+                {{#infoUrl}}
+                  <div class="app-desc">Information URL: <a href="{{{infoUrl}}}">{{{infoUrl}}}</a></div>
+                {{/infoUrl}}
+                {{#infoEmail}}
+                  <div class="app-desc">Contact Info: <a href="{{{infoEmail}}}">{{{infoEmail}}}</a></div>
+                {{/infoEmail}}
+              </p>
+              {{#licenseInfo}}
+                <div class="license-info">{{{licenseInfo}}}</div>
+              {{/licenseInfo}}
+              {{#licenseUrl}}
+                <div class="license-url">{{{licenseUrl}}}</div>
+              {{/licenseUrl}}
+            </div>
+          </div>
+          <div id="generator">
+            <div class="content">
+              Generated {{generatedDate}}
+            </div>
+          </div>
+      </div>
     </div>
-</div>
-
-
-
-
-
-
-{{>js_jsonschemaview}}
-{{>js_jsonref}}
-{{>js_webfontloader}}
-
-
-
-
-<script>
-$(document).ready(function () {
-$('.nav-tabs-examples').find('a:first').tab('show');
-$(this).scrollspy({ target: '#scrollingNav', offset: 18 });
-});
-</script>
+  </div>
+  {{>js_jsonschemaview}}
+  {{>js_jsonref}}
+  {{>js_webfontloader}}
+  <script>
+  $(document).ready(function () {
+    $('.nav-tabs-examples').find('a:first').tab('show');
+    $(this).scrollspy({ target: '#scrollingNav', offset: 18 });
+  });
+  </script>
 </body>
-
 </html>

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/js_jsonschemaview.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/js_jsonschemaview.mustache
@@ -251,10 +251,10 @@ var JSONSchemaView = (function () {
       }
 
       if (this.schema['enum']) {
-        var formatter = new JSONFormatter(this.schema['enum'], this.open - 1);
-        var formatterEl = formatter.render();
-        formatterEl.classList.add('inner');
-        element.querySelector('.enums.inner').appendChild(formatterEl);
+        var tempDiv = document.createElement('span');;
+        tempDiv.classList.add('inner');
+        tempDiv.innerHTML = '<code>' + this.schema['enum'].join('</code>, <code>') + '</code>';
+        element.querySelector('.enums.inner').appendChild(tempDiv);
       }
 
       if (this.isArray) {

--- a/samples/html2/index.html
+++ b/samples/html2/index.html
@@ -6,17 +6,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta charset="UTF-8" />
-
-
-<script>
+  <script>
 /*! jQuery v3.1.0 | (c) jQuery Foundation | jquery.org/license */
 !function(a,b){"use strict";"object"==typeof module&&"object"==typeof module.exports?module.exports=a.document?b(a,!0):function(a){if(!a.document)throw new Error("jQuery requires a window with a document");return b(a)}:b(a)}("undefined"!=typeof window?window:this,function(a,b){"use strict";var c=[],d=a.document,e=Object.getPrototypeOf,f=c.slice,g=c.concat,h=c.push,i=c.indexOf,j={},k=j.toString,l=j.hasOwnProperty,m=l.toString,n=m.call(Object),o={};function p(a,b){b=b||d;var c=b.createElement("script");c.text=a,b.head.appendChild(c).parentNode.removeChild(c)}var q="3.1.0",r=function(a,b){return new r.fn.init(a,b)},s=/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g,t=/^-ms-/,u=/-([a-z])/g,v=function(a,b){return b.toUpperCase()};r.fn=r.prototype={jquery:q,constructor:r,length:0,toArray:function(){return f.call(this)},get:function(a){return null!=a?a<0?this[a+this.length]:this[a]:f.call(this)},pushStack:function(a){var b=r.merge(this.constructor(),a);return b.prevObject=this,b},each:function(a){return r.each(this,a)},map:function(a){return this.pushStack(r.map(this,function(b,c){return a.call(b,c,b)}))},slice:function(){return this.pushStack(f.apply(this,arguments))},first:function(){return this.eq(0)},last:function(){return this.eq(-1)},eq:function(a){var b=this.length,c=+a+(a<0?b:0);return this.pushStack(c>=0&&c<b?[this[c]]:[])},end:function(){return this.prevObject||this.constructor()},push:h,sort:c.sort,splice:c.splice},r.extend=r.fn.extend=function(){var a,b,c,d,e,f,g=arguments[0]||{},h=1,i=arguments.length,j=!1;for("boolean"==typeof g&&(j=g,g=arguments[h]||{},h++),"object"==typeof g||r.isFunction(g)||(g={}),h===i&&(g=this,h--);h<i;h++)if(null!=(a=arguments[h]))for(b in a)c=g[b],d=a[b],g!==d&&(j&&d&&(r.isPlainObject(d)||(e=r.isArray(d)))?(e?(e=!1,f=c&&r.isArray(c)?c:[]):f=c&&r.isPlainObject(c)?c:{},g[b]=r.extend(j,f,d)):void 0!==d&&(g[b]=d));return g},r.extend({expando:"jQuery"+(q+Math.random()).replace(/\D/g,""),isReady:!0,error:function(a){throw new Error(a)},noop:function(){},isFunction:function(a){return"function"===r.type(a)},isArray:Array.isArray,isWindow:function(a){return null!=a&&a===a.window},isNumeric:function(a){var b=r.type(a);return("number"===b||"string"===b)&&!isNaN(a-parseFloat(a))},isPlainObject:function(a){var b,c;return!(!a||"[object Object]"!==k.call(a))&&(!(b=e(a))||(c=l.call(b,"constructor")&&b.constructor,"function"==typeof c&&m.call(c)===n))},isEmptyObject:function(a){var b;for(b in a)return!1;return!0},type:function(a){return null==a?a+"":"object"==typeof a||"function"==typeof a?j[k.call(a)]||"object":typeof a},globalEval:function(a){p(a)},camelCase:function(a){return a.replace(t,"ms-").replace(u,v)},nodeName:function(a,b){return a.nodeName&&a.nodeName.toLowerCase()===b.toLowerCase()},each:function(a,b){var c,d=0;if(w(a)){for(c=a.length;d<c;d++)if(b.call(a[d],d,a[d])===!1)break}else for(d in a)if(b.call(a[d],d,a[d])===!1)break;return a},trim:function(a){return null==a?"":(a+"").replace(s,"")},makeArray:function(a,b){var c=b||[];return null!=a&&(w(Object(a))?r.merge(c,"string"==typeof a?[a]:a):h.call(c,a)),c},inArray:function(a,b,c){return null==b?-1:i.call(b,a,c)},merge:function(a,b){for(var c=+b.length,d=0,e=a.length;d<c;d++)a[e++]=b[d];return a.length=e,a},grep:function(a,b,c){for(var d,e=[],f=0,g=a.length,h=!c;f<g;f++)d=!b(a[f],f),d!==h&&e.push(a[f]);return e},map:function(a,b,c){var d,e,f=0,h=[];if(w(a))for(d=a.length;f<d;f++)e=b(a[f],f,c),null!=e&&h.push(e);else for(f in a)e=b(a[f],f,c),null!=e&&h.push(e);return g.apply([],h)},guid:1,proxy:function(a,b){var c,d,e;if("string"==typeof b&&(c=a[b],b=a,a=c),r.isFunction(a))return d=f.call(arguments,2),e=function(){return a.apply(b||this,d.concat(f.call(arguments)))},e.guid=a.guid=a.guid||r.guid++,e},now:Date.now,support:o}),"function"==typeof Symbol&&(r.fn[Symbol.iterator]=c[Symbol.iterator]),r.each("Boolean Number String Function Array Date RegExp Object Error Symbol".split(" "),function(a,b){j["[object "+b+"]"]=b.toLowerCase()});function w(a){var b=!!a&&"length"in a&&a.length,c=r.type(a);return"function"!==c&&!r.isWindow(a)&&("array"===c||0===b||"number"==typeof b&&b>0&&b-1 in a)}var x=function(a){var b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u="sizzle"+1*new Date,v=a.document,w=0,x=0,y=ha(),z=ha(),A=ha(),B=function(a,b){return a===b&&(l=!0),0},C={}.hasOwnProperty,D=[],E=D.pop,F=D.push,G=D.push,H=D.slice,I=function(a,b){for(var c=0,d=a.length;c<d;c++)if(a[c]===b)return c;return-1},J="checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped",K="[\\x20\\t\\r\\n\\f]",L="(?:\\\\.|[\\w-]|[^\0-\\xa0])+",M="\\["+K+"*("+L+")(?:"+K+"*([*^$|!~]?=)"+K+"*(?:'((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\"|("+L+"))|)"+K+"*\\]",N=":("+L+")(?:\\((('((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\")|((?:\\\\.|[^\\\\()[\\]]|"+M+")*)|.*)\\)|)",O=new RegExp(K+"+","g"),P=new RegExp("^"+K+"+|((?:^|[^\\\\])(?:\\\\.)*)"+K+"+$","g"),Q=new RegExp("^"+K+"*,"+K+"*"),R=new RegExp("^"+K+"*([>+~]|"+K+")"+K+"*"),S=new RegExp("="+K+"*([^\\]'\"]*?)"+K+"*\\]","g"),T=new RegExp(N),U=new RegExp("^"+L+"$"),V={ID:new RegExp("^#("+L+")"),CLASS:new RegExp("^\\.("+L+")"),TAG:new RegExp("^("+L+"|[*])"),ATTR:new RegExp("^"+M),PSEUDO:new RegExp("^"+N),CHILD:new RegExp("^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\("+K+"*(even|odd|(([+-]|)(\\d*)n|)"+K+"*(?:([+-]|)"+K+"*(\\d+)|))"+K+"*\\)|)","i"),bool:new RegExp("^(?:"+J+")$","i"),needsContext:new RegExp("^"+K+"*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\("+K+"*((?:-\\d)?\\d*)"+K+"*\\)|)(?=[^-]|$)","i")},W=/^(?:input|select|textarea|button)$/i,X=/^h\d$/i,Y=/^[^{]+\{\s*\[native \w/,Z=/^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,$=/[+~]/,_=new RegExp("\\\\([\\da-f]{1,6}"+K+"?|("+K+")|.)","ig"),aa=function(a,b,c){var d="0x"+b-65536;return d!==d||c?b:d<0?String.fromCharCode(d+65536):String.fromCharCode(d>>10|55296,1023&d|56320)},ba=/([\0-\x1f\x7f]|^-?\d)|^-$|[^\x80-\uFFFF\w-]/g,ca=function(a,b){return b?"\0"===a?"\ufffd":a.slice(0,-1)+"\\"+a.charCodeAt(a.length-1).toString(16)+" ":"\\"+a},da=function(){m()},ea=ta(function(a){return a.disabled===!0},{dir:"parentNode",next:"legend"});try{G.apply(D=H.call(v.childNodes),v.childNodes),D[v.childNodes.length].nodeType}catch(fa){G={apply:D.length?function(a,b){F.apply(a,H.call(b))}:function(a,b){var c=a.length,d=0;while(a[c++]=b[d++]);a.length=c-1}}}function ga(a,b,d,e){var f,h,j,k,l,o,r,s=b&&b.ownerDocument,w=b?b.nodeType:9;if(d=d||[],"string"!=typeof a||!a||1!==w&&9!==w&&11!==w)return d;if(!e&&((b?b.ownerDocument||b:v)!==n&&m(b),b=b||n,p)){if(11!==w&&(l=Z.exec(a)))if(f=l[1]){if(9===w){if(!(j=b.getElementById(f)))return d;if(j.id===f)return d.push(j),d}else if(s&&(j=s.getElementById(f))&&t(b,j)&&j.id===f)return d.push(j),d}else{if(l[2])return G.apply(d,b.getElementsByTagName(a)),d;if((f=l[3])&&c.getElementsByClassName&&b.getElementsByClassName)return G.apply(d,b.getElementsByClassName(f)),d}if(c.qsa&&!A[a+" "]&&(!q||!q.test(a))){if(1!==w)s=b,r=a;else if("object"!==b.nodeName.toLowerCase()){(k=b.getAttribute("id"))?k=k.replace(ba,ca):b.setAttribute("id",k=u),o=g(a),h=o.length;while(h--)o[h]="#"+k+" "+sa(o[h]);r=o.join(","),s=$.test(a)&&qa(b.parentNode)||b}if(r)try{return G.apply(d,s.querySelectorAll(r)),d}catch(x){}finally{k===u&&b.removeAttribute("id")}}}return i(a.replace(P,"$1"),b,d,e)}function ha(){var a=[];function b(c,e){return a.push(c+" ")>d.cacheLength&&delete b[a.shift()],b[c+" "]=e}return b}function ia(a){return a[u]=!0,a}function ja(a){var b=n.createElement("fieldset");try{return!!a(b)}catch(c){return!1}finally{b.parentNode&&b.parentNode.removeChild(b),b=null}}function ka(a,b){var c=a.split("|"),e=c.length;while(e--)d.attrHandle[c[e]]=b}function la(a,b){var c=b&&a,d=c&&1===a.nodeType&&1===b.nodeType&&a.sourceIndex-b.sourceIndex;if(d)return d;if(c)while(c=c.nextSibling)if(c===b)return-1;return a?1:-1}function ma(a){return function(b){var c=b.nodeName.toLowerCase();return"input"===c&&b.type===a}}function na(a){return function(b){var c=b.nodeName.toLowerCase();return("input"===c||"button"===c)&&b.type===a}}function oa(a){return function(b){return"label"in b&&b.disabled===a||"form"in b&&b.disabled===a||"form"in b&&b.disabled===!1&&(b.isDisabled===a||b.isDisabled!==!a&&("label"in b||!ea(b))!==a)}}function pa(a){return ia(function(b){return b=+b,ia(function(c,d){var e,f=a([],c.length,b),g=f.length;while(g--)c[e=f[g]]&&(c[e]=!(d[e]=c[e]))})})}function qa(a){return a&&"undefined"!=typeof a.getElementsByTagName&&a}c=ga.support={},f=ga.isXML=function(a){var b=a&&(a.ownerDocument||a).documentElement;return!!b&&"HTML"!==b.nodeName},m=ga.setDocument=function(a){var b,e,g=a?a.ownerDocument||a:v;return g!==n&&9===g.nodeType&&g.documentElement?(n=g,o=n.documentElement,p=!f(n),v!==n&&(e=n.defaultView)&&e.top!==e&&(e.addEventListener?e.addEventListener("unload",da,!1):e.attachEvent&&e.attachEvent("onunload",da)),c.attributes=ja(function(a){return a.className="i",!a.getAttribute("className")}),c.getElementsByTagName=ja(function(a){return a.appendChild(n.createComment("")),!a.getElementsByTagName("*").length}),c.getElementsByClassName=Y.test(n.getElementsByClassName),c.getById=ja(function(a){return o.appendChild(a).id=u,!n.getElementsByName||!n.getElementsByName(u).length}),c.getById?(d.find.ID=function(a,b){if("undefined"!=typeof b.getElementById&&p){var c=b.getElementById(a);return c?[c]:[]}},d.filter.ID=function(a){var b=a.replace(_,aa);return function(a){return a.getAttribute("id")===b}}):(delete d.find.ID,d.filter.ID=function(a){var b=a.replace(_,aa);return function(a){var c="undefined"!=typeof a.getAttributeNode&&a.getAttributeNode("id");return c&&c.value===b}}),d.find.TAG=c.getElementsByTagName?function(a,b){return"undefined"!=typeof b.getElementsByTagName?b.getElementsByTagName(a):c.qsa?b.querySelectorAll(a):void 0}:function(a,b){var c,d=[],e=0,f=b.getElementsByTagName(a);if("*"===a){while(c=f[e++])1===c.nodeType&&d.push(c);return d}return f},d.find.CLASS=c.getElementsByClassName&&function(a,b){if("undefined"!=typeof b.getElementsByClassName&&p)return b.getElementsByClassName(a)},r=[],q=[],(c.qsa=Y.test(n.querySelectorAll))&&(ja(function(a){o.appendChild(a).innerHTML="<a id='"+u+"'></a><select id='"+u+"-\r\\' msallowcapture=''><option selected=''></option></select>",a.querySelectorAll("[msallowcapture^='']").length&&q.push("[*^$]="+K+"*(?:''|\"\")"),a.querySelectorAll("[selected]").length||q.push("\\["+K+"*(?:value|"+J+")"),a.querySelectorAll("[id~="+u+"-]").length||q.push("~="),a.querySelectorAll(":checked").length||q.push(":checked"),a.querySelectorAll("a#"+u+"+*").length||q.push(".#.+[+~]")}),ja(function(a){a.innerHTML="<a href='' disabled='disabled'></a><select disabled='disabled'><option/></select>";var b=n.createElement("input");b.setAttribute("type","hidden"),a.appendChild(b).setAttribute("name","D"),a.querySelectorAll("[name=d]").length&&q.push("name"+K+"*[*^$|!~]?="),2!==a.querySelectorAll(":enabled").length&&q.push(":enabled",":disabled"),o.appendChild(a).disabled=!0,2!==a.querySelectorAll(":disabled").length&&q.push(":enabled",":disabled"),a.querySelectorAll("*,:x"),q.push(",.*:")})),(c.matchesSelector=Y.test(s=o.matches||o.webkitMatchesSelector||o.mozMatchesSelector||o.oMatchesSelector||o.msMatchesSelector))&&ja(function(a){c.disconnectedMatch=s.call(a,"*"),s.call(a,"[s!='']:x"),r.push("!=",N)}),q=q.length&&new RegExp(q.join("|")),r=r.length&&new RegExp(r.join("|")),b=Y.test(o.compareDocumentPosition),t=b||Y.test(o.contains)?function(a,b){var c=9===a.nodeType?a.documentElement:a,d=b&&b.parentNode;return a===d||!(!d||1!==d.nodeType||!(c.contains?c.contains(d):a.compareDocumentPosition&&16&a.compareDocumentPosition(d)))}:function(a,b){if(b)while(b=b.parentNode)if(b===a)return!0;return!1},B=b?function(a,b){if(a===b)return l=!0,0;var d=!a.compareDocumentPosition-!b.compareDocumentPosition;return d?d:(d=(a.ownerDocument||a)===(b.ownerDocument||b)?a.compareDocumentPosition(b):1,1&d||!c.sortDetached&&b.compareDocumentPosition(a)===d?a===n||a.ownerDocument===v&&t(v,a)?-1:b===n||b.ownerDocument===v&&t(v,b)?1:k?I(k,a)-I(k,b):0:4&d?-1:1)}:function(a,b){if(a===b)return l=!0,0;var c,d=0,e=a.parentNode,f=b.parentNode,g=[a],h=[b];if(!e||!f)return a===n?-1:b===n?1:e?-1:f?1:k?I(k,a)-I(k,b):0;if(e===f)return la(a,b);c=a;while(c=c.parentNode)g.unshift(c);c=b;while(c=c.parentNode)h.unshift(c);while(g[d]===h[d])d++;return d?la(g[d],h[d]):g[d]===v?-1:h[d]===v?1:0},n):n},ga.matches=function(a,b){return ga(a,null,null,b)},ga.matchesSelector=function(a,b){if((a.ownerDocument||a)!==n&&m(a),b=b.replace(S,"='$1']"),c.matchesSelector&&p&&!A[b+" "]&&(!r||!r.test(b))&&(!q||!q.test(b)))try{var d=s.call(a,b);if(d||c.disconnectedMatch||a.document&&11!==a.document.nodeType)return d}catch(e){}return ga(b,n,null,[a]).length>0},ga.contains=function(a,b){return(a.ownerDocument||a)!==n&&m(a),t(a,b)},ga.attr=function(a,b){(a.ownerDocument||a)!==n&&m(a);var e=d.attrHandle[b.toLowerCase()],f=e&&C.call(d.attrHandle,b.toLowerCase())?e(a,b,!p):void 0;return void 0!==f?f:c.attributes||!p?a.getAttribute(b):(f=a.getAttributeNode(b))&&f.specified?f.value:null},ga.escape=function(a){return(a+"").replace(ba,ca)},ga.error=function(a){throw new Error("Syntax error, unrecognized expression: "+a)},ga.uniqueSort=function(a){var b,d=[],e=0,f=0;if(l=!c.detectDuplicates,k=!c.sortStable&&a.slice(0),a.sort(B),l){while(b=a[f++])b===a[f]&&(e=d.push(f));while(e--)a.splice(d[e],1)}return k=null,a},e=ga.getText=function(a){var b,c="",d=0,f=a.nodeType;if(f){if(1===f||9===f||11===f){if("string"==typeof a.textContent)return a.textContent;for(a=a.firstChild;a;a=a.nextSibling)c+=e(a)}else if(3===f||4===f)return a.nodeValue}else while(b=a[d++])c+=e(b);return c},d=ga.selectors={cacheLength:50,createPseudo:ia,match:V,attrHandle:{},find:{},relative:{">":{dir:"parentNode",first:!0}," ":{dir:"parentNode"},"+":{dir:"previousSibling",first:!0},"~":{dir:"previousSibling"}},preFilter:{ATTR:function(a){return a[1]=a[1].replace(_,aa),a[3]=(a[3]||a[4]||a[5]||"").replace(_,aa),"~="===a[2]&&(a[3]=" "+a[3]+" "),a.slice(0,4)},CHILD:function(a){return a[1]=a[1].toLowerCase(),"nth"===a[1].slice(0,3)?(a[3]||ga.error(a[0]),a[4]=+(a[4]?a[5]+(a[6]||1):2*("even"===a[3]||"odd"===a[3])),a[5]=+(a[7]+a[8]||"odd"===a[3])):a[3]&&ga.error(a[0]),a},PSEUDO:function(a){var b,c=!a[6]&&a[2];return V.CHILD.test(a[0])?null:(a[3]?a[2]=a[4]||a[5]||"":c&&T.test(c)&&(b=g(c,!0))&&(b=c.indexOf(")",c.length-b)-c.length)&&(a[0]=a[0].slice(0,b),a[2]=c.slice(0,b)),a.slice(0,3))}},filter:{TAG:function(a){var b=a.replace(_,aa).toLowerCase();return"*"===a?function(){return!0}:function(a){return a.nodeName&&a.nodeName.toLowerCase()===b}},CLASS:function(a){var b=y[a+" "];return b||(b=new RegExp("(^|"+K+")"+a+"("+K+"|$)"))&&y(a,function(a){return b.test("string"==typeof a.className&&a.className||"undefined"!=typeof a.getAttribute&&a.getAttribute("class")||"")})},ATTR:function(a,b,c){return function(d){var e=ga.attr(d,a);return null==e?"!="===b:!b||(e+="","="===b?e===c:"!="===b?e!==c:"^="===b?c&&0===e.indexOf(c):"*="===b?c&&e.indexOf(c)>-1:"$="===b?c&&e.slice(-c.length)===c:"~="===b?(" "+e.replace(O," ")+" ").indexOf(c)>-1:"|="===b&&(e===c||e.slice(0,c.length+1)===c+"-"))}},CHILD:function(a,b,c,d,e){var f="nth"!==a.slice(0,3),g="last"!==a.slice(-4),h="of-type"===b;return 1===d&&0===e?function(a){return!!a.parentNode}:function(b,c,i){var j,k,l,m,n,o,p=f!==g?"nextSibling":"previousSibling",q=b.parentNode,r=h&&b.nodeName.toLowerCase(),s=!i&&!h,t=!1;if(q){if(f){while(p){m=b;while(m=m[p])if(h?m.nodeName.toLowerCase()===r:1===m.nodeType)return!1;o=p="only"===a&&!o&&"nextSibling"}return!0}if(o=[g?q.firstChild:q.lastChild],g&&s){m=q,l=m[u]||(m[u]={}),k=l[m.uniqueID]||(l[m.uniqueID]={}),j=k[a]||[],n=j[0]===w&&j[1],t=n&&j[2],m=n&&q.childNodes[n];while(m=++n&&m&&m[p]||(t=n=0)||o.pop())if(1===m.nodeType&&++t&&m===b){k[a]=[w,n,t];break}}else if(s&&(m=b,l=m[u]||(m[u]={}),k=l[m.uniqueID]||(l[m.uniqueID]={}),j=k[a]||[],n=j[0]===w&&j[1],t=n),t===!1)while(m=++n&&m&&m[p]||(t=n=0)||o.pop())if((h?m.nodeName.toLowerCase()===r:1===m.nodeType)&&++t&&(s&&(l=m[u]||(m[u]={}),k=l[m.uniqueID]||(l[m.uniqueID]={}),k[a]=[w,t]),m===b))break;return t-=e,t===d||t%d===0&&t/d>=0}}},PSEUDO:function(a,b){var c,e=d.pseudos[a]||d.setFilters[a.toLowerCase()]||ga.error("unsupported pseudo: "+a);return e[u]?e(b):e.length>1?(c=[a,a,"",b],d.setFilters.hasOwnProperty(a.toLowerCase())?ia(function(a,c){var d,f=e(a,b),g=f.length;while(g--)d=I(a,f[g]),a[d]=!(c[d]=f[g])}):function(a){return e(a,0,c)}):e}},pseudos:{not:ia(function(a){var b=[],c=[],d=h(a.replace(P,"$1"));return d[u]?ia(function(a,b,c,e){var f,g=d(a,null,e,[]),h=a.length;while(h--)(f=g[h])&&(a[h]=!(b[h]=f))}):function(a,e,f){return b[0]=a,d(b,null,f,c),b[0]=null,!c.pop()}}),has:ia(function(a){return function(b){return ga(a,b).length>0}}),contains:ia(function(a){return a=a.replace(_,aa),function(b){return(b.textContent||b.innerText||e(b)).indexOf(a)>-1}}),lang:ia(function(a){return U.test(a||"")||ga.error("unsupported lang: "+a),a=a.replace(_,aa).toLowerCase(),function(b){var c;do if(c=p?b.lang:b.getAttribute("xml:lang")||b.getAttribute("lang"))return c=c.toLowerCase(),c===a||0===c.indexOf(a+"-");while((b=b.parentNode)&&1===b.nodeType);return!1}}),target:function(b){var c=a.location&&a.location.hash;return c&&c.slice(1)===b.id},root:function(a){return a===o},focus:function(a){return a===n.activeElement&&(!n.hasFocus||n.hasFocus())&&!!(a.type||a.href||~a.tabIndex)},enabled:oa(!1),disabled:oa(!0),checked:function(a){var b=a.nodeName.toLowerCase();return"input"===b&&!!a.checked||"option"===b&&!!a.selected},selected:function(a){return a.parentNode&&a.parentNode.selectedIndex,a.selected===!0},empty:function(a){for(a=a.firstChild;a;a=a.nextSibling)if(a.nodeType<6)return!1;return!0},parent:function(a){return!d.pseudos.empty(a)},header:function(a){return X.test(a.nodeName)},input:function(a){return W.test(a.nodeName)},button:function(a){var b=a.nodeName.toLowerCase();return"input"===b&&"button"===a.type||"button"===b},text:function(a){var b;return"input"===a.nodeName.toLowerCase()&&"text"===a.type&&(null==(b=a.getAttribute("type"))||"text"===b.toLowerCase())},first:pa(function(){return[0]}),last:pa(function(a,b){return[b-1]}),eq:pa(function(a,b,c){return[c<0?c+b:c]}),even:pa(function(a,b){for(var c=0;c<b;c+=2)a.push(c);return a}),odd:pa(function(a,b){for(var c=1;c<b;c+=2)a.push(c);return a}),lt:pa(function(a,b,c){for(var d=c<0?c+b:c;--d>=0;)a.push(d);return a}),gt:pa(function(a,b,c){for(var d=c<0?c+b:c;++d<b;)a.push(d);return a})}},d.pseudos.nth=d.pseudos.eq;for(b in{radio:!0,checkbox:!0,file:!0,password:!0,image:!0})d.pseudos[b]=ma(b);for(b in{submit:!0,reset:!0})d.pseudos[b]=na(b);function ra(){}ra.prototype=d.filters=d.pseudos,d.setFilters=new ra,g=ga.tokenize=function(a,b){var c,e,f,g,h,i,j,k=z[a+" "];if(k)return b?0:k.slice(0);h=a,i=[],j=d.preFilter;while(h){c&&!(e=Q.exec(h))||(e&&(h=h.slice(e[0].length)||h),i.push(f=[])),c=!1,(e=R.exec(h))&&(c=e.shift(),f.push({value:c,type:e[0].replace(P," ")}),h=h.slice(c.length));for(g in d.filter)!(e=V[g].exec(h))||j[g]&&!(e=j[g](e))||(c=e.shift(),f.push({value:c,type:g,matches:e}),h=h.slice(c.length));if(!c)break}return b?h.length:h?ga.error(a):z(a,i).slice(0)};function sa(a){for(var b=0,c=a.length,d="";b<c;b++)d+=a[b].value;return d}function ta(a,b,c){var d=b.dir,e=b.next,f=e||d,g=c&&"parentNode"===f,h=x++;return b.first?function(b,c,e){while(b=b[d])if(1===b.nodeType||g)return a(b,c,e)}:function(b,c,i){var j,k,l,m=[w,h];if(i){while(b=b[d])if((1===b.nodeType||g)&&a(b,c,i))return!0}else while(b=b[d])if(1===b.nodeType||g)if(l=b[u]||(b[u]={}),k=l[b.uniqueID]||(l[b.uniqueID]={}),e&&e===b.nodeName.toLowerCase())b=b[d]||b;else{if((j=k[f])&&j[0]===w&&j[1]===h)return m[2]=j[2];if(k[f]=m,m[2]=a(b,c,i))return!0}}}function ua(a){return a.length>1?function(b,c,d){var e=a.length;while(e--)if(!a[e](b,c,d))return!1;return!0}:a[0]}function va(a,b,c){for(var d=0,e=b.length;d<e;d++)ga(a,b[d],c);return c}function wa(a,b,c,d,e){for(var f,g=[],h=0,i=a.length,j=null!=b;h<i;h++)(f=a[h])&&(c&&!c(f,d,e)||(g.push(f),j&&b.push(h)));return g}function xa(a,b,c,d,e,f){return d&&!d[u]&&(d=xa(d)),e&&!e[u]&&(e=xa(e,f)),ia(function(f,g,h,i){var j,k,l,m=[],n=[],o=g.length,p=f||va(b||"*",h.nodeType?[h]:h,[]),q=!a||!f&&b?p:wa(p,m,a,h,i),r=c?e||(f?a:o||d)?[]:g:q;if(c&&c(q,r,h,i),d){j=wa(r,n),d(j,[],h,i),k=j.length;while(k--)(l=j[k])&&(r[n[k]]=!(q[n[k]]=l))}if(f){if(e||a){if(e){j=[],k=r.length;while(k--)(l=r[k])&&j.push(q[k]=l);e(null,r=[],j,i)}k=r.length;while(k--)(l=r[k])&&(j=e?I(f,l):m[k])>-1&&(f[j]=!(g[j]=l))}}else r=wa(r===g?r.splice(o,r.length):r),e?e(null,g,r,i):G.apply(g,r)})}function ya(a){for(var b,c,e,f=a.length,g=d.relative[a[0].type],h=g||d.relative[" "],i=g?1:0,k=ta(function(a){return a===b},h,!0),l=ta(function(a){return I(b,a)>-1},h,!0),m=[function(a,c,d){var e=!g&&(d||c!==j)||((b=c).nodeType?k(a,c,d):l(a,c,d));return b=null,e}];i<f;i++)if(c=d.relative[a[i].type])m=[ta(ua(m),c)];else{if(c=d.filter[a[i].type].apply(null,a[i].matches),c[u]){for(e=++i;e<f;e++)if(d.relative[a[e].type])break;return xa(i>1&&ua(m),i>1&&sa(a.slice(0,i-1).concat({value:" "===a[i-2].type?"*":""})).replace(P,"$1"),c,i<e&&ya(a.slice(i,e)),e<f&&ya(a=a.slice(e)),e<f&&sa(a))}m.push(c)}return ua(m)}function za(a,b){var c=b.length>0,e=a.length>0,f=function(f,g,h,i,k){var l,o,q,r=0,s="0",t=f&&[],u=[],v=j,x=f||e&&d.find.TAG("*",k),y=w+=null==v?1:Math.random()||.1,z=x.length;for(k&&(j=g===n||g||k);s!==z&&null!=(l=x[s]);s++){if(e&&l){o=0,g||l.ownerDocument===n||(m(l),h=!p);while(q=a[o++])if(q(l,g||n,h)){i.push(l);break}k&&(w=y)}c&&((l=!q&&l)&&r--,f&&t.push(l))}if(r+=s,c&&s!==r){o=0;while(q=b[o++])q(t,u,g,h);if(f){if(r>0)while(s--)t[s]||u[s]||(u[s]=E.call(i));u=wa(u)}G.apply(i,u),k&&!f&&u.length>0&&r+b.length>1&&ga.uniqueSort(i)}return k&&(w=y,j=v),t};return c?ia(f):f}return h=ga.compile=function(a,b){var c,d=[],e=[],f=A[a+" "];if(!f){b||(b=g(a)),c=b.length;while(c--)f=ya(b[c]),f[u]?d.push(f):e.push(f);f=A(a,za(e,d)),f.selector=a}return f},i=ga.select=function(a,b,e,f){var i,j,k,l,m,n="function"==typeof a&&a,o=!f&&g(a=n.selector||a);if(e=e||[],1===o.length){if(j=o[0]=o[0].slice(0),j.length>2&&"ID"===(k=j[0]).type&&c.getById&&9===b.nodeType&&p&&d.relative[j[1].type]){if(b=(d.find.ID(k.matches[0].replace(_,aa),b)||[])[0],!b)return e;n&&(b=b.parentNode),a=a.slice(j.shift().value.length)}i=V.needsContext.test(a)?0:j.length;while(i--){if(k=j[i],d.relative[l=k.type])break;if((m=d.find[l])&&(f=m(k.matches[0].replace(_,aa),$.test(j[0].type)&&qa(b.parentNode)||b))){if(j.splice(i,1),a=f.length&&sa(j),!a)return G.apply(e,f),e;break}}}return(n||h(a,o))(f,b,!p,e,!b||$.test(a)&&qa(b.parentNode)||b),e},c.sortStable=u.split("").sort(B).join("")===u,c.detectDuplicates=!!l,m(),c.sortDetached=ja(function(a){return 1&a.compareDocumentPosition(n.createElement("fieldset"))}),ja(function(a){return a.innerHTML="<a href='#'></a>","#"===a.firstChild.getAttribute("href")})||ka("type|href|height|width",function(a,b,c){if(!c)return a.getAttribute(b,"type"===b.toLowerCase()?1:2)}),c.attributes&&ja(function(a){return a.innerHTML="<input/>",a.firstChild.setAttribute("value",""),""===a.firstChild.getAttribute("value")})||ka("value",function(a,b,c){if(!c&&"input"===a.nodeName.toLowerCase())return a.defaultValue}),ja(function(a){return null==a.getAttribute("disabled")})||ka(J,function(a,b,c){var d;if(!c)return a[b]===!0?b.toLowerCase():(d=a.getAttributeNode(b))&&d.specified?d.value:null}),ga}(a);r.find=x,r.expr=x.selectors,r.expr[":"]=r.expr.pseudos,r.uniqueSort=r.unique=x.uniqueSort,r.text=x.getText,r.isXMLDoc=x.isXML,r.contains=x.contains,r.escapeSelector=x.escape;var y=function(a,b,c){var d=[],e=void 0!==c;while((a=a[b])&&9!==a.nodeType)if(1===a.nodeType){if(e&&r(a).is(c))break;d.push(a)}return d},z=function(a,b){for(var c=[];a;a=a.nextSibling)1===a.nodeType&&a!==b&&c.push(a);return c},A=r.expr.match.needsContext,B=/^<([a-z][^\/\0>:\x20\t\r\n\f]*)[\x20\t\r\n\f]*\/?>(?:<\/\1>|)$/i,C=/^.[^:#\[\.,]*$/;function D(a,b,c){if(r.isFunction(b))return r.grep(a,function(a,d){return!!b.call(a,d,a)!==c});if(b.nodeType)return r.grep(a,function(a){return a===b!==c});if("string"==typeof b){if(C.test(b))return r.filter(b,a,c);b=r.filter(b,a)}return r.grep(a,function(a){return i.call(b,a)>-1!==c&&1===a.nodeType})}r.filter=function(a,b,c){var d=b[0];return c&&(a=":not("+a+")"),1===b.length&&1===d.nodeType?r.find.matchesSelector(d,a)?[d]:[]:r.find.matches(a,r.grep(b,function(a){return 1===a.nodeType}))},r.fn.extend({find:function(a){var b,c,d=this.length,e=this;if("string"!=typeof a)return this.pushStack(r(a).filter(function(){for(b=0;b<d;b++)if(r.contains(e[b],this))return!0}));for(c=this.pushStack([]),b=0;b<d;b++)r.find(a,e[b],c);return d>1?r.uniqueSort(c):c},filter:function(a){return this.pushStack(D(this,a||[],!1))},not:function(a){return this.pushStack(D(this,a||[],!0))},is:function(a){return!!D(this,"string"==typeof a&&A.test(a)?r(a):a||[],!1).length}});var E,F=/^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]+))$/,G=r.fn.init=function(a,b,c){var e,f;if(!a)return this;if(c=c||E,"string"==typeof a){if(e="<"===a[0]&&">"===a[a.length-1]&&a.length>=3?[null,a,null]:F.exec(a),!e||!e[1]&&b)return!b||b.jquery?(b||c).find(a):this.constructor(b).find(a);if(e[1]){if(b=b instanceof r?b[0]:b,r.merge(this,r.parseHTML(e[1],b&&b.nodeType?b.ownerDocument||b:d,!0)),B.test(e[1])&&r.isPlainObject(b))for(e in b)r.isFunction(this[e])?this[e](b[e]):this.attr(e,b[e]);return this}return f=d.getElementById(e[2]),f&&(this[0]=f,this.length=1),this}return a.nodeType?(this[0]=a,this.length=1,this):r.isFunction(a)?void 0!==c.ready?c.ready(a):a(r):r.makeArray(a,this)};G.prototype=r.fn,E=r(d);var H=/^(?:parents|prev(?:Until|All))/,I={children:!0,contents:!0,next:!0,prev:!0};r.fn.extend({has:function(a){var b=r(a,this),c=b.length;return this.filter(function(){for(var a=0;a<c;a++)if(r.contains(this,b[a]))return!0})},closest:function(a,b){var c,d=0,e=this.length,f=[],g="string"!=typeof a&&r(a);if(!A.test(a))for(;d<e;d++)for(c=this[d];c&&c!==b;c=c.parentNode)if(c.nodeType<11&&(g?g.index(c)>-1:1===c.nodeType&&r.find.matchesSelector(c,a))){f.push(c);break}return this.pushStack(f.length>1?r.uniqueSort(f):f)},index:function(a){return a?"string"==typeof a?i.call(r(a),this[0]):i.call(this,a.jquery?a[0]:a):this[0]&&this[0].parentNode?this.first().prevAll().length:-1},add:function(a,b){return this.pushStack(r.uniqueSort(r.merge(this.get(),r(a,b))))},addBack:function(a){return this.add(null==a?this.prevObject:this.prevObject.filter(a))}});function J(a,b){while((a=a[b])&&1!==a.nodeType);return a}r.each({parent:function(a){var b=a.parentNode;return b&&11!==b.nodeType?b:null},parents:function(a){return y(a,"parentNode")},parentsUntil:function(a,b,c){return y(a,"parentNode",c)},next:function(a){return J(a,"nextSibling")},prev:function(a){return J(a,"previousSibling")},nextAll:function(a){return y(a,"nextSibling")},prevAll:function(a){return y(a,"previousSibling")},nextUntil:function(a,b,c){return y(a,"nextSibling",c)},prevUntil:function(a,b,c){return y(a,"previousSibling",c)},siblings:function(a){return z((a.parentNode||{}).firstChild,a)},children:function(a){return z(a.firstChild)},contents:function(a){return a.contentDocument||r.merge([],a.childNodes)}},function(a,b){r.fn[a]=function(c,d){var e=r.map(this,b,c);return"Until"!==a.slice(-5)&&(d=c),d&&"string"==typeof d&&(e=r.filter(d,e)),this.length>1&&(I[a]||r.uniqueSort(e),H.test(a)&&e.reverse()),this.pushStack(e)}});var K=/\S+/g;function L(a){var b={};return r.each(a.match(K)||[],function(a,c){b[c]=!0}),b}r.Callbacks=function(a){a="string"==typeof a?L(a):r.extend({},a);var b,c,d,e,f=[],g=[],h=-1,i=function(){for(e=a.once,d=b=!0;g.length;h=-1){c=g.shift();while(++h<f.length)f[h].apply(c[0],c[1])===!1&&a.stopOnFalse&&(h=f.length,c=!1)}a.memory||(c=!1),b=!1,e&&(f=c?[]:"")},j={add:function(){return f&&(c&&!b&&(h=f.length-1,g.push(c)),function d(b){r.each(b,function(b,c){r.isFunction(c)?a.unique&&j.has(c)||f.push(c):c&&c.length&&"string"!==r.type(c)&&d(c)})}(arguments),c&&!b&&i()),this},remove:function(){return r.each(arguments,function(a,b){var c;while((c=r.inArray(b,f,c))>-1)f.splice(c,1),c<=h&&h--}),this},has:function(a){return a?r.inArray(a,f)>-1:f.length>0},empty:function(){return f&&(f=[]),this},disable:function(){return e=g=[],f=c="",this},disabled:function(){return!f},lock:function(){return e=g=[],c||b||(f=c=""),this},locked:function(){return!!e},fireWith:function(a,c){return e||(c=c||[],c=[a,c.slice?c.slice():c],g.push(c),b||i()),this},fire:function(){return j.fireWith(this,arguments),this},fired:function(){return!!d}};return j};function M(a){return a}function N(a){throw a}function O(a,b,c){var d;try{a&&r.isFunction(d=a.promise)?d.call(a).done(b).fail(c):a&&r.isFunction(d=a.then)?d.call(a,b,c):b.call(void 0,a)}catch(a){c.call(void 0,a)}}r.extend({Deferred:function(b){var c=[["notify","progress",r.Callbacks("memory"),r.Callbacks("memory"),2],["resolve","done",r.Callbacks("once memory"),r.Callbacks("once memory"),0,"resolved"],["reject","fail",r.Callbacks("once memory"),r.Callbacks("once memory"),1,"rejected"]],d="pending",e={state:function(){return d},always:function(){return f.done(arguments).fail(arguments),this},"catch":function(a){return e.then(null,a)},pipe:function(){var a=arguments;return r.Deferred(function(b){r.each(c,function(c,d){var e=r.isFunction(a[d[4]])&&a[d[4]];f[d[1]](function(){var a=e&&e.apply(this,arguments);a&&r.isFunction(a.promise)?a.promise().progress(b.notify).done(b.resolve).fail(b.reject):b[d[0]+"With"](this,e?[a]:arguments)})}),a=null}).promise()},then:function(b,d,e){var f=0;function g(b,c,d,e){return function(){var h=this,i=arguments,j=function(){var a,j;if(!(b<f)){if(a=d.apply(h,i),a===c.promise())throw new TypeError("Thenable self-resolution");j=a&&("object"==typeof a||"function"==typeof a)&&a.then,r.isFunction(j)?e?j.call(a,g(f,c,M,e),g(f,c,N,e)):(f++,j.call(a,g(f,c,M,e),g(f,c,N,e),g(f,c,M,c.notifyWith))):(d!==M&&(h=void 0,i=[a]),(e||c.resolveWith)(h,i))}},k=e?j:function(){try{j()}catch(a){r.Deferred.exceptionHook&&r.Deferred.exceptionHook(a,k.stackTrace),b+1>=f&&(d!==N&&(h=void 0,i=[a]),c.rejectWith(h,i))}};b?k():(r.Deferred.getStackHook&&(k.stackTrace=r.Deferred.getStackHook()),a.setTimeout(k))}}return r.Deferred(function(a){c[0][3].add(g(0,a,r.isFunction(e)?e:M,a.notifyWith)),c[1][3].add(g(0,a,r.isFunction(b)?b:M)),c[2][3].add(g(0,a,r.isFunction(d)?d:N))}).promise()},promise:function(a){return null!=a?r.extend(a,e):e}},f={};return r.each(c,function(a,b){var g=b[2],h=b[5];e[b[1]]=g.add,h&&g.add(function(){d=h},c[3-a][2].disable,c[0][2].lock),g.add(b[3].fire),f[b[0]]=function(){return f[b[0]+"With"](this===f?void 0:this,arguments),this},f[b[0]+"With"]=g.fireWith}),e.promise(f),b&&b.call(f,f),f},when:function(a){var b=arguments.length,c=b,d=Array(c),e=f.call(arguments),g=r.Deferred(),h=function(a){return function(c){d[a]=this,e[a]=arguments.length>1?f.call(arguments):c,--b||g.resolveWith(d,e)}};if(b<=1&&(O(a,g.done(h(c)).resolve,g.reject),"pending"===g.state()||r.isFunction(e[c]&&e[c].then)))return g.then();while(c--)O(e[c],h(c),g.reject);return g.promise()}});var P=/^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;r.Deferred.exceptionHook=function(b,c){a.console&&a.console.warn&&b&&P.test(b.name)&&a.console.warn("jQuery.Deferred exception: "+b.message,b.stack,c)},r.readyException=function(b){a.setTimeout(function(){throw b})};var Q=r.Deferred();r.fn.ready=function(a){return Q.then(a)["catch"](function(a){r.readyException(a)}),this},r.extend({isReady:!1,readyWait:1,holdReady:function(a){a?r.readyWait++:r.ready(!0)},ready:function(a){(a===!0?--r.readyWait:r.isReady)||(r.isReady=!0,a!==!0&&--r.readyWait>0||Q.resolveWith(d,[r]))}}),r.ready.then=Q.then;function R(){d.removeEventListener("DOMContentLoaded",R),a.removeEventListener("load",R),r.ready()}"complete"===d.readyState||"loading"!==d.readyState&&!d.documentElement.doScroll?a.setTimeout(r.ready):(d.addEventListener("DOMContentLoaded",R),a.addEventListener("load",R));var S=function(a,b,c,d,e,f,g){var h=0,i=a.length,j=null==c;if("object"===r.type(c)){e=!0;for(h in c)S(a,b,h,c[h],!0,f,g)}else if(void 0!==d&&(e=!0,
 r.isFunction(d)||(g=!0),j&&(g?(b.call(a,d),b=null):(j=b,b=function(a,b,c){return j.call(r(a),c)})),b))for(;h<i;h++)b(a[h],c,g?d:d.call(a[h],h,b(a[h],c)));return e?a:j?b.call(a):i?b(a[0],c):f},T=function(a){return 1===a.nodeType||9===a.nodeType||!+a.nodeType};function U(){this.expando=r.expando+U.uid++}U.uid=1,U.prototype={cache:function(a){var b=a[this.expando];return b||(b={},T(a)&&(a.nodeType?a[this.expando]=b:Object.defineProperty(a,this.expando,{value:b,configurable:!0}))),b},set:function(a,b,c){var d,e=this.cache(a);if("string"==typeof b)e[r.camelCase(b)]=c;else for(d in b)e[r.camelCase(d)]=b[d];return e},get:function(a,b){return void 0===b?this.cache(a):a[this.expando]&&a[this.expando][r.camelCase(b)]},access:function(a,b,c){return void 0===b||b&&"string"==typeof b&&void 0===c?this.get(a,b):(this.set(a,b,c),void 0!==c?c:b)},remove:function(a,b){var c,d=a[this.expando];if(void 0!==d){if(void 0!==b){r.isArray(b)?b=b.map(r.camelCase):(b=r.camelCase(b),b=b in d?[b]:b.match(K)||[]),c=b.length;while(c--)delete d[b[c]]}(void 0===b||r.isEmptyObject(d))&&(a.nodeType?a[this.expando]=void 0:delete a[this.expando])}},hasData:function(a){var b=a[this.expando];return void 0!==b&&!r.isEmptyObject(b)}};var V=new U,W=new U,X=/^(?:\{[\w\W]*\}|\[[\w\W]*\])$/,Y=/[A-Z]/g;function Z(a,b,c){var d;if(void 0===c&&1===a.nodeType)if(d="data-"+b.replace(Y,"-$&").toLowerCase(),c=a.getAttribute(d),"string"==typeof c){try{c="true"===c||"false"!==c&&("null"===c?null:+c+""===c?+c:X.test(c)?JSON.parse(c):c)}catch(e){}W.set(a,b,c)}else c=void 0;return c}r.extend({hasData:function(a){return W.hasData(a)||V.hasData(a)},data:function(a,b,c){return W.access(a,b,c)},removeData:function(a,b){W.remove(a,b)},_data:function(a,b,c){return V.access(a,b,c)},_removeData:function(a,b){V.remove(a,b)}}),r.fn.extend({data:function(a,b){var c,d,e,f=this[0],g=f&&f.attributes;if(void 0===a){if(this.length&&(e=W.get(f),1===f.nodeType&&!V.get(f,"hasDataAttrs"))){c=g.length;while(c--)g[c]&&(d=g[c].name,0===d.indexOf("data-")&&(d=r.camelCase(d.slice(5)),Z(f,d,e[d])));V.set(f,"hasDataAttrs",!0)}return e}return"object"==typeof a?this.each(function(){W.set(this,a)}):S(this,function(b){var c;if(f&&void 0===b){if(c=W.get(f,a),void 0!==c)return c;if(c=Z(f,a),void 0!==c)return c}else this.each(function(){W.set(this,a,b)})},null,b,arguments.length>1,null,!0)},removeData:function(a){return this.each(function(){W.remove(this,a)})}}),r.extend({queue:function(a,b,c){var d;if(a)return b=(b||"fx")+"queue",d=V.get(a,b),c&&(!d||r.isArray(c)?d=V.access(a,b,r.makeArray(c)):d.push(c)),d||[]},dequeue:function(a,b){b=b||"fx";var c=r.queue(a,b),d=c.length,e=c.shift(),f=r._queueHooks(a,b),g=function(){r.dequeue(a,b)};"inprogress"===e&&(e=c.shift(),d--),e&&("fx"===b&&c.unshift("inprogress"),delete f.stop,e.call(a,g,f)),!d&&f&&f.empty.fire()},_queueHooks:function(a,b){var c=b+"queueHooks";return V.get(a,c)||V.access(a,c,{empty:r.Callbacks("once memory").add(function(){V.remove(a,[b+"queue",c])})})}}),r.fn.extend({queue:function(a,b){var c=2;return"string"!=typeof a&&(b=a,a="fx",c--),arguments.length<c?r.queue(this[0],a):void 0===b?this:this.each(function(){var c=r.queue(this,a,b);r._queueHooks(this,a),"fx"===a&&"inprogress"!==c[0]&&r.dequeue(this,a)})},dequeue:function(a){return this.each(function(){r.dequeue(this,a)})},clearQueue:function(a){return this.queue(a||"fx",[])},promise:function(a,b){var c,d=1,e=r.Deferred(),f=this,g=this.length,h=function(){--d||e.resolveWith(f,[f])};"string"!=typeof a&&(b=a,a=void 0),a=a||"fx";while(g--)c=V.get(f[g],a+"queueHooks"),c&&c.empty&&(d++,c.empty.add(h));return h(),e.promise(b)}});var $=/[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,_=new RegExp("^(?:([+-])=|)("+$+")([a-z%]*)$","i"),aa=["Top","Right","Bottom","Left"],ba=function(a,b){return a=b||a,"none"===a.style.display||""===a.style.display&&r.contains(a.ownerDocument,a)&&"none"===r.css(a,"display")},ca=function(a,b,c,d){var e,f,g={};for(f in b)g[f]=a.style[f],a.style[f]=b[f];e=c.apply(a,d||[]);for(f in b)a.style[f]=g[f];return e};function da(a,b,c,d){var e,f=1,g=20,h=d?function(){return d.cur()}:function(){return r.css(a,b,"")},i=h(),j=c&&c[3]||(r.cssNumber[b]?"":"px"),k=(r.cssNumber[b]||"px"!==j&&+i)&&_.exec(r.css(a,b));if(k&&k[3]!==j){j=j||k[3],c=c||[],k=+i||1;do f=f||".5",k/=f,r.style(a,b,k+j);while(f!==(f=h()/i)&&1!==f&&--g)}return c&&(k=+k||+i||0,e=c[1]?k+(c[1]+1)*c[2]:+c[2],d&&(d.unit=j,d.start=k,d.end=e)),e}var ea={};function fa(a){var b,c=a.ownerDocument,d=a.nodeName,e=ea[d];return e?e:(b=c.body.appendChild(c.createElement(d)),e=r.css(b,"display"),b.parentNode.removeChild(b),"none"===e&&(e="block"),ea[d]=e,e)}function ga(a,b){for(var c,d,e=[],f=0,g=a.length;f<g;f++)d=a[f],d.style&&(c=d.style.display,b?("none"===c&&(e[f]=V.get(d,"display")||null,e[f]||(d.style.display="")),""===d.style.display&&ba(d)&&(e[f]=fa(d))):"none"!==c&&(e[f]="none",V.set(d,"display",c)));for(f=0;f<g;f++)null!=e[f]&&(a[f].style.display=e[f]);return a}r.fn.extend({show:function(){return ga(this,!0)},hide:function(){return ga(this)},toggle:function(a){return"boolean"==typeof a?a?this.show():this.hide():this.each(function(){ba(this)?r(this).show():r(this).hide()})}});var ha=/^(?:checkbox|radio)$/i,ia=/<([a-z][^\/\0>\x20\t\r\n\f]+)/i,ja=/^$|\/(?:java|ecma)script/i,ka={option:[1,"<select multiple='multiple'>","</select>"],thead:[1,"<table>","</table>"],col:[2,"<table><colgroup>","</colgroup></table>"],tr:[2,"<table><tbody>","</tbody></table>"],td:[3,"<table><tbody><tr>","</tr></tbody></table>"],_default:[0,"",""]};ka.optgroup=ka.option,ka.tbody=ka.tfoot=ka.colgroup=ka.caption=ka.thead,ka.th=ka.td;function la(a,b){var c="undefined"!=typeof a.getElementsByTagName?a.getElementsByTagName(b||"*"):"undefined"!=typeof a.querySelectorAll?a.querySelectorAll(b||"*"):[];return void 0===b||b&&r.nodeName(a,b)?r.merge([a],c):c}function ma(a,b){for(var c=0,d=a.length;c<d;c++)V.set(a[c],"globalEval",!b||V.get(b[c],"globalEval"))}var na=/<|&#?\w+;/;function oa(a,b,c,d,e){for(var f,g,h,i,j,k,l=b.createDocumentFragment(),m=[],n=0,o=a.length;n<o;n++)if(f=a[n],f||0===f)if("object"===r.type(f))r.merge(m,f.nodeType?[f]:f);else if(na.test(f)){g=g||l.appendChild(b.createElement("div")),h=(ia.exec(f)||["",""])[1].toLowerCase(),i=ka[h]||ka._default,g.innerHTML=i[1]+r.htmlPrefilter(f)+i[2],k=i[0];while(k--)g=g.lastChild;r.merge(m,g.childNodes),g=l.firstChild,g.textContent=""}else m.push(b.createTextNode(f));l.textContent="",n=0;while(f=m[n++])if(d&&r.inArray(f,d)>-1)e&&e.push(f);else if(j=r.contains(f.ownerDocument,f),g=la(l.appendChild(f),"script"),j&&ma(g),c){k=0;while(f=g[k++])ja.test(f.type||"")&&c.push(f)}return l}!function(){var a=d.createDocumentFragment(),b=a.appendChild(d.createElement("div")),c=d.createElement("input");c.setAttribute("type","radio"),c.setAttribute("checked","checked"),c.setAttribute("name","t"),b.appendChild(c),o.checkClone=b.cloneNode(!0).cloneNode(!0).lastChild.checked,b.innerHTML="<textarea>x</textarea>",o.noCloneChecked=!!b.cloneNode(!0).lastChild.defaultValue}();var pa=d.documentElement,qa=/^key/,ra=/^(?:mouse|pointer|contextmenu|drag|drop)|click/,sa=/^([^.]*)(?:\.(.+)|)/;function ta(){return!0}function ua(){return!1}function va(){try{return d.activeElement}catch(a){}}function wa(a,b,c,d,e,f){var g,h;if("object"==typeof b){"string"!=typeof c&&(d=d||c,c=void 0);for(h in b)wa(a,h,c,d,b[h],f);return a}if(null==d&&null==e?(e=c,d=c=void 0):null==e&&("string"==typeof c?(e=d,d=void 0):(e=d,d=c,c=void 0)),e===!1)e=ua;else if(!e)return a;return 1===f&&(g=e,e=function(a){return r().off(a),g.apply(this,arguments)},e.guid=g.guid||(g.guid=r.guid++)),a.each(function(){r.event.add(this,b,e,d,c)})}r.event={global:{},add:function(a,b,c,d,e){var f,g,h,i,j,k,l,m,n,o,p,q=V.get(a);if(q){c.handler&&(f=c,c=f.handler,e=f.selector),e&&r.find.matchesSelector(pa,e),c.guid||(c.guid=r.guid++),(i=q.events)||(i=q.events={}),(g=q.handle)||(g=q.handle=function(b){return"undefined"!=typeof r&&r.event.triggered!==b.type?r.event.dispatch.apply(a,arguments):void 0}),b=(b||"").match(K)||[""],j=b.length;while(j--)h=sa.exec(b[j])||[],n=p=h[1],o=(h[2]||"").split(".").sort(),n&&(l=r.event.special[n]||{},n=(e?l.delegateType:l.bindType)||n,l=r.event.special[n]||{},k=r.extend({type:n,origType:p,data:d,handler:c,guid:c.guid,selector:e,needsContext:e&&r.expr.match.needsContext.test(e),namespace:o.join(".")},f),(m=i[n])||(m=i[n]=[],m.delegateCount=0,l.setup&&l.setup.call(a,d,o,g)!==!1||a.addEventListener&&a.addEventListener(n,g)),l.add&&(l.add.call(a,k),k.handler.guid||(k.handler.guid=c.guid)),e?m.splice(m.delegateCount++,0,k):m.push(k),r.event.global[n]=!0)}},remove:function(a,b,c,d,e){var f,g,h,i,j,k,l,m,n,o,p,q=V.hasData(a)&&V.get(a);if(q&&(i=q.events)){b=(b||"").match(K)||[""],j=b.length;while(j--)if(h=sa.exec(b[j])||[],n=p=h[1],o=(h[2]||"").split(".").sort(),n){l=r.event.special[n]||{},n=(d?l.delegateType:l.bindType)||n,m=i[n]||[],h=h[2]&&new RegExp("(^|\\.)"+o.join("\\.(?:.*\\.|)")+"(\\.|$)"),g=f=m.length;while(f--)k=m[f],!e&&p!==k.origType||c&&c.guid!==k.guid||h&&!h.test(k.namespace)||d&&d!==k.selector&&("**"!==d||!k.selector)||(m.splice(f,1),k.selector&&m.delegateCount--,l.remove&&l.remove.call(a,k));g&&!m.length&&(l.teardown&&l.teardown.call(a,o,q.handle)!==!1||r.removeEvent(a,n,q.handle),delete i[n])}else for(n in i)r.event.remove(a,n+b[j],c,d,!0);r.isEmptyObject(i)&&V.remove(a,"handle events")}},dispatch:function(a){var b=r.event.fix(a),c,d,e,f,g,h,i=new Array(arguments.length),j=(V.get(this,"events")||{})[b.type]||[],k=r.event.special[b.type]||{};for(i[0]=b,c=1;c<arguments.length;c++)i[c]=arguments[c];if(b.delegateTarget=this,!k.preDispatch||k.preDispatch.call(this,b)!==!1){h=r.event.handlers.call(this,b,j),c=0;while((f=h[c++])&&!b.isPropagationStopped()){b.currentTarget=f.elem,d=0;while((g=f.handlers[d++])&&!b.isImmediatePropagationStopped())b.rnamespace&&!b.rnamespace.test(g.namespace)||(b.handleObj=g,b.data=g.data,e=((r.event.special[g.origType]||{}).handle||g.handler).apply(f.elem,i),void 0!==e&&(b.result=e)===!1&&(b.preventDefault(),b.stopPropagation()))}return k.postDispatch&&k.postDispatch.call(this,b),b.result}},handlers:function(a,b){var c,d,e,f,g=[],h=b.delegateCount,i=a.target;if(h&&i.nodeType&&("click"!==a.type||isNaN(a.button)||a.button<1))for(;i!==this;i=i.parentNode||this)if(1===i.nodeType&&(i.disabled!==!0||"click"!==a.type)){for(d=[],c=0;c<h;c++)f=b[c],e=f.selector+" ",void 0===d[e]&&(d[e]=f.needsContext?r(e,this).index(i)>-1:r.find(e,this,null,[i]).length),d[e]&&d.push(f);d.length&&g.push({elem:i,handlers:d})}return h<b.length&&g.push({elem:this,handlers:b.slice(h)}),g},addProp:function(a,b){Object.defineProperty(r.Event.prototype,a,{enumerable:!0,configurable:!0,get:r.isFunction(b)?function(){if(this.originalEvent)return b(this.originalEvent)}:function(){if(this.originalEvent)return this.originalEvent[a]},set:function(b){Object.defineProperty(this,a,{enumerable:!0,configurable:!0,writable:!0,value:b})}})},fix:function(a){return a[r.expando]?a:new r.Event(a)},special:{load:{noBubble:!0},focus:{trigger:function(){if(this!==va()&&this.focus)return this.focus(),!1},delegateType:"focusin"},blur:{trigger:function(){if(this===va()&&this.blur)return this.blur(),!1},delegateType:"focusout"},click:{trigger:function(){if("checkbox"===this.type&&this.click&&r.nodeName(this,"input"))return this.click(),!1},_default:function(a){return r.nodeName(a.target,"a")}},beforeunload:{postDispatch:function(a){void 0!==a.result&&a.originalEvent&&(a.originalEvent.returnValue=a.result)}}}},r.removeEvent=function(a,b,c){a.removeEventListener&&a.removeEventListener(b,c)},r.Event=function(a,b){return this instanceof r.Event?(a&&a.type?(this.originalEvent=a,this.type=a.type,this.isDefaultPrevented=a.defaultPrevented||void 0===a.defaultPrevented&&a.returnValue===!1?ta:ua,this.target=a.target&&3===a.target.nodeType?a.target.parentNode:a.target,this.currentTarget=a.currentTarget,this.relatedTarget=a.relatedTarget):this.type=a,b&&r.extend(this,b),this.timeStamp=a&&a.timeStamp||r.now(),void(this[r.expando]=!0)):new r.Event(a,b)},r.Event.prototype={constructor:r.Event,isDefaultPrevented:ua,isPropagationStopped:ua,isImmediatePropagationStopped:ua,isSimulated:!1,preventDefault:function(){var a=this.originalEvent;this.isDefaultPrevented=ta,a&&!this.isSimulated&&a.preventDefault()},stopPropagation:function(){var a=this.originalEvent;this.isPropagationStopped=ta,a&&!this.isSimulated&&a.stopPropagation()},stopImmediatePropagation:function(){var a=this.originalEvent;this.isImmediatePropagationStopped=ta,a&&!this.isSimulated&&a.stopImmediatePropagation(),this.stopPropagation()}},r.each({altKey:!0,bubbles:!0,cancelable:!0,changedTouches:!0,ctrlKey:!0,detail:!0,eventPhase:!0,metaKey:!0,pageX:!0,pageY:!0,shiftKey:!0,view:!0,"char":!0,charCode:!0,key:!0,keyCode:!0,button:!0,buttons:!0,clientX:!0,clientY:!0,offsetX:!0,offsetY:!0,pointerId:!0,pointerType:!0,screenX:!0,screenY:!0,targetTouches:!0,toElement:!0,touches:!0,which:function(a){var b=a.button;return null==a.which&&qa.test(a.type)?null!=a.charCode?a.charCode:a.keyCode:!a.which&&void 0!==b&&ra.test(a.type)?1&b?1:2&b?3:4&b?2:0:a.which}},r.event.addProp),r.each({mouseenter:"mouseover",mouseleave:"mouseout",pointerenter:"pointerover",pointerleave:"pointerout"},function(a,b){r.event.special[a]={delegateType:b,bindType:b,handle:function(a){var c,d=this,e=a.relatedTarget,f=a.handleObj;return e&&(e===d||r.contains(d,e))||(a.type=f.origType,c=f.handler.apply(this,arguments),a.type=b),c}}}),r.fn.extend({on:function(a,b,c,d){return wa(this,a,b,c,d)},one:function(a,b,c,d){return wa(this,a,b,c,d,1)},off:function(a,b,c){var d,e;if(a&&a.preventDefault&&a.handleObj)return d=a.handleObj,r(a.delegateTarget).off(d.namespace?d.origType+"."+d.namespace:d.origType,d.selector,d.handler),this;if("object"==typeof a){for(e in a)this.off(e,b,a[e]);return this}return b!==!1&&"function"!=typeof b||(c=b,b=void 0),c===!1&&(c=ua),this.each(function(){r.event.remove(this,a,c,b)})}});var xa=/<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi,ya=/<script|<style|<link/i,za=/checked\s*(?:[^=]|=\s*.checked.)/i,Aa=/^true\/(.*)/,Ba=/^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;function Ca(a,b){return r.nodeName(a,"table")&&r.nodeName(11!==b.nodeType?b:b.firstChild,"tr")?a.getElementsByTagName("tbody")[0]||a:a}function Da(a){return a.type=(null!==a.getAttribute("type"))+"/"+a.type,a}function Ea(a){var b=Aa.exec(a.type);return b?a.type=b[1]:a.removeAttribute("type"),a}function Fa(a,b){var c,d,e,f,g,h,i,j;if(1===b.nodeType){if(V.hasData(a)&&(f=V.access(a),g=V.set(b,f),j=f.events)){delete g.handle,g.events={};for(e in j)for(c=0,d=j[e].length;c<d;c++)r.event.add(b,e,j[e][c])}W.hasData(a)&&(h=W.access(a),i=r.extend({},h),W.set(b,i))}}function Ga(a,b){var c=b.nodeName.toLowerCase();"input"===c&&ha.test(a.type)?b.checked=a.checked:"input"!==c&&"textarea"!==c||(b.defaultValue=a.defaultValue)}function Ha(a,b,c,d){b=g.apply([],b);var e,f,h,i,j,k,l=0,m=a.length,n=m-1,q=b[0],s=r.isFunction(q);if(s||m>1&&"string"==typeof q&&!o.checkClone&&za.test(q))return a.each(function(e){var f=a.eq(e);s&&(b[0]=q.call(this,e,f.html())),Ha(f,b,c,d)});if(m&&(e=oa(b,a[0].ownerDocument,!1,a,d),f=e.firstChild,1===e.childNodes.length&&(e=f),f||d)){for(h=r.map(la(e,"script"),Da),i=h.length;l<m;l++)j=e,l!==n&&(j=r.clone(j,!0,!0),i&&r.merge(h,la(j,"script"))),c.call(a[l],j,l);if(i)for(k=h[h.length-1].ownerDocument,r.map(h,Ea),l=0;l<i;l++)j=h[l],ja.test(j.type||"")&&!V.access(j,"globalEval")&&r.contains(k,j)&&(j.src?r._evalUrl&&r._evalUrl(j.src):p(j.textContent.replace(Ba,""),k))}return a}function Ia(a,b,c){for(var d,e=b?r.filter(b,a):a,f=0;null!=(d=e[f]);f++)c||1!==d.nodeType||r.cleanData(la(d)),d.parentNode&&(c&&r.contains(d.ownerDocument,d)&&ma(la(d,"script")),d.parentNode.removeChild(d));return a}r.extend({htmlPrefilter:function(a){return a.replace(xa,"<$1></$2>")},clone:function(a,b,c){var d,e,f,g,h=a.cloneNode(!0),i=r.contains(a.ownerDocument,a);if(!(o.noCloneChecked||1!==a.nodeType&&11!==a.nodeType||r.isXMLDoc(a)))for(g=la(h),f=la(a),d=0,e=f.length;d<e;d++)Ga(f[d],g[d]);if(b)if(c)for(f=f||la(a),g=g||la(h),d=0,e=f.length;d<e;d++)Fa(f[d],g[d]);else Fa(a,h);return g=la(h,"script"),g.length>0&&ma(g,!i&&la(a,"script")),h},cleanData:function(a){for(var b,c,d,e=r.event.special,f=0;void 0!==(c=a[f]);f++)if(T(c)){if(b=c[V.expando]){if(b.events)for(d in b.events)e[d]?r.event.remove(c,d):r.removeEvent(c,d,b.handle);c[V.expando]=void 0}c[W.expando]&&(c[W.expando]=void 0)}}}),r.fn.extend({detach:function(a){return Ia(this,a,!0)},remove:function(a){return Ia(this,a)},text:function(a){return S(this,function(a){return void 0===a?r.text(this):this.empty().each(function(){1!==this.nodeType&&11!==this.nodeType&&9!==this.nodeType||(this.textContent=a)})},null,a,arguments.length)},append:function(){return Ha(this,arguments,function(a){if(1===this.nodeType||11===this.nodeType||9===this.nodeType){var b=Ca(this,a);b.appendChild(a)}})},prepend:function(){return Ha(this,arguments,function(a){if(1===this.nodeType||11===this.nodeType||9===this.nodeType){var b=Ca(this,a);b.insertBefore(a,b.firstChild)}})},before:function(){return Ha(this,arguments,function(a){this.parentNode&&this.parentNode.insertBefore(a,this)})},after:function(){return Ha(this,arguments,function(a){this.parentNode&&this.parentNode.insertBefore(a,this.nextSibling)})},empty:function(){for(var a,b=0;null!=(a=this[b]);b++)1===a.nodeType&&(r.cleanData(la(a,!1)),a.textContent="");return this},clone:function(a,b){return a=null!=a&&a,b=null==b?a:b,this.map(function(){return r.clone(this,a,b)})},html:function(a){return S(this,function(a){var b=this[0]||{},c=0,d=this.length;if(void 0===a&&1===b.nodeType)return b.innerHTML;if("string"==typeof a&&!ya.test(a)&&!ka[(ia.exec(a)||["",""])[1].toLowerCase()]){a=r.htmlPrefilter(a);try{for(;c<d;c++)b=this[c]||{},1===b.nodeType&&(r.cleanData(la(b,!1)),b.innerHTML=a);b=0}catch(e){}}b&&this.empty().append(a)},null,a,arguments.length)},replaceWith:function(){var a=[];return Ha(this,arguments,function(b){var c=this.parentNode;r.inArray(this,a)<0&&(r.cleanData(la(this)),c&&c.replaceChild(b,this))},a)}}),r.each({appendTo:"append",prependTo:"prepend",insertBefore:"before",insertAfter:"after",replaceAll:"replaceWith"},function(a,b){r.fn[a]=function(a){for(var c,d=[],e=r(a),f=e.length-1,g=0;g<=f;g++)c=g===f?this:this.clone(!0),r(e[g])[b](c),h.apply(d,c.get());return this.pushStack(d)}});var Ja=/^margin/,Ka=new RegExp("^("+$+")(?!px)[a-z%]+$","i"),La=function(b){var c=b.ownerDocument.defaultView;return c&&c.opener||(c=a),c.getComputedStyle(b)};!function(){function b(){if(i){i.style.cssText="box-sizing:border-box;position:relative;display:block;margin:auto;border:1px;padding:1px;top:1%;width:50%",i.innerHTML="",pa.appendChild(h);var b=a.getComputedStyle(i);c="1%"!==b.top,g="2px"===b.marginLeft,e="4px"===b.width,i.style.marginRight="50%",f="4px"===b.marginRight,pa.removeChild(h),i=null}}var c,e,f,g,h=d.createElement("div"),i=d.createElement("div");i.style&&(i.style.backgroundClip="content-box",i.cloneNode(!0).style.backgroundClip="",o.clearCloneStyle="content-box"===i.style.backgroundClip,h.style.cssText="border:0;width:8px;height:0;top:0;left:-9999px;padding:0;margin-top:1px;position:absolute",h.appendChild(i),r.extend(o,{pixelPosition:function(){return b(),c},boxSizingReliable:function(){return b(),e},pixelMarginRight:function(){return b(),f},reliableMarginLeft:function(){return b(),g}}))}();function Ma(a,b,c){var d,e,f,g,h=a.style;return c=c||La(a),c&&(g=c.getPropertyValue(b)||c[b],""!==g||r.contains(a.ownerDocument,a)||(g=r.style(a,b)),!o.pixelMarginRight()&&Ka.test(g)&&Ja.test(b)&&(d=h.width,e=h.minWidth,f=h.maxWidth,h.minWidth=h.maxWidth=h.width=g,g=c.width,h.width=d,h.minWidth=e,h.maxWidth=f)),void 0!==g?g+"":g}function Na(a,b){return{get:function(){return a()?void delete this.get:(this.get=b).apply(this,arguments)}}}var Oa=/^(none|table(?!-c[ea]).+)/,Pa={position:"absolute",visibility:"hidden",display:"block"},Qa={letterSpacing:"0",fontWeight:"400"},Ra=["Webkit","Moz","ms"],Sa=d.createElement("div").style;function Ta(a){if(a in Sa)return a;var b=a[0].toUpperCase()+a.slice(1),c=Ra.length;while(c--)if(a=Ra[c]+b,a in Sa)return a}function Ua(a,b,c){var d=_.exec(b);return d?Math.max(0,d[2]-(c||0))+(d[3]||"px"):b}function Va(a,b,c,d,e){for(var f=c===(d?"border":"content")?4:"width"===b?1:0,g=0;f<4;f+=2)"margin"===c&&(g+=r.css(a,c+aa[f],!0,e)),d?("content"===c&&(g-=r.css(a,"padding"+aa[f],!0,e)),"margin"!==c&&(g-=r.css(a,"border"+aa[f]+"Width",!0,e))):(g+=r.css(a,"padding"+aa[f],!0,e),"padding"!==c&&(g+=r.css(a,"border"+aa[f]+"Width",!0,e)));return g}function Wa(a,b,c){var d,e=!0,f=La(a),g="border-box"===r.css(a,"boxSizing",!1,f);if(a.getClientRects().length&&(d=a.getBoundingClientRect()[b]),d<=0||null==d){if(d=Ma(a,b,f),(d<0||null==d)&&(d=a.style[b]),Ka.test(d))return d;e=g&&(o.boxSizingReliable()||d===a.style[b]),d=parseFloat(d)||0}return d+Va(a,b,c||(g?"border":"content"),e,f)+"px"}r.extend({cssHooks:{opacity:{get:function(a,b){if(b){var c=Ma(a,"opacity");return""===c?"1":c}}}},cssNumber:{animationIterationCount:!0,columnCount:!0,fillOpacity:!0,flexGrow:!0,flexShrink:!0,fontWeight:!0,lineHeight:!0,opacity:!0,order:!0,orphans:!0,widows:!0,zIndex:!0,zoom:!0},cssProps:{"float":"cssFloat"},style:function(a,b,c,d){if(a&&3!==a.nodeType&&8!==a.nodeType&&a.style){var e,f,g,h=r.camelCase(b),i=a.style;return b=r.cssProps[h]||(r.cssProps[h]=Ta(h)||h),g=r.cssHooks[b]||r.cssHooks[h],void 0===c?g&&"get"in g&&void 0!==(e=g.get(a,!1,d))?e:i[b]:(f=typeof c,"string"===f&&(e=_.exec(c))&&e[1]&&(c=da(a,b,e),f="number"),null!=c&&c===c&&("number"===f&&(c+=e&&e[3]||(r.cssNumber[h]?"":"px")),o.clearCloneStyle||""!==c||0!==b.indexOf("background")||(i[b]="inherit"),g&&"set"in g&&void 0===(c=g.set(a,c,d))||(i[b]=c)),void 0)}},css:function(a,b,c,d){var e,f,g,h=r.camelCase(b);return b=r.cssProps[h]||(r.cssProps[h]=Ta(h)||h),g=r.cssHooks[b]||r.cssHooks[h],g&&"get"in g&&(e=g.get(a,!0,c)),void 0===e&&(e=Ma(a,b,d)),"normal"===e&&b in Qa&&(e=Qa[b]),""===c||c?(f=parseFloat(e),c===!0||isFinite(f)?f||0:e):e}}),r.each(["height","width"],function(a,b){r.cssHooks[b]={get:function(a,c,d){if(c)return!Oa.test(r.css(a,"display"))||a.getClientRects().length&&a.getBoundingClientRect().width?Wa(a,b,d):ca(a,Pa,function(){return Wa(a,b,d)})},set:function(a,c,d){var e,f=d&&La(a),g=d&&Va(a,b,d,"border-box"===r.css(a,"boxSizing",!1,f),f);return g&&(e=_.exec(c))&&"px"!==(e[3]||"px")&&(a.style[b]=c,c=r.css(a,b)),Ua(a,c,g)}}}),r.cssHooks.marginLeft=Na(o.reliableMarginLeft,function(a,b){if(b)return(parseFloat(Ma(a,"marginLeft"))||a.getBoundingClientRect().left-ca(a,{marginLeft:0},function(){return a.getBoundingClientRect().left}))+"px"}),r.each({margin:"",padding:"",border:"Width"},function(a,b){r.cssHooks[a+b]={expand:function(c){for(var d=0,e={},f="string"==typeof c?c.split(" "):[c];d<4;d++)e[a+aa[d]+b]=f[d]||f[d-2]||f[0];return e}},Ja.test(a)||(r.cssHooks[a+b].set=Ua)}),r.fn.extend({css:function(a,b){return S(this,function(a,b,c){var d,e,f={},g=0;if(r.isArray(b)){for(d=La(a),e=b.length;g<e;g++)f[b[g]]=r.css(a,b[g],!1,d);return f}return void 0!==c?r.style(a,b,c):r.css(a,b)},a,b,arguments.length>1)}});function Xa(a,b,c,d,e){return new Xa.prototype.init(a,b,c,d,e)}r.Tween=Xa,Xa.prototype={constructor:Xa,init:function(a,b,c,d,e,f){this.elem=a,this.prop=c,this.easing=e||r.easing._default,this.options=b,this.start=this.now=this.cur(),this.end=d,this.unit=f||(r.cssNumber[c]?"":"px")},cur:function(){var a=Xa.propHooks[this.prop];return a&&a.get?a.get(this):Xa.propHooks._default.get(this)},run:function(a){var b,c=Xa.propHooks[this.prop];return this.options.duration?this.pos=b=r.easing[this.easing](a,this.options.duration*a,0,1,this.options.duration):this.pos=b=a,this.now=(this.end-this.start)*b+this.start,this.options.step&&this.options.step.call(this.elem,this.now,this),c&&c.set?c.set(this):Xa.propHooks._default.set(this),this}},Xa.prototype.init.prototype=Xa.prototype,Xa.propHooks={_default:{get:function(a){var b;return 1!==a.elem.nodeType||null!=a.elem[a.prop]&&null==a.elem.style[a.prop]?a.elem[a.prop]:(b=r.css(a.elem,a.prop,""),b&&"auto"!==b?b:0)},set:function(a){r.fx.step[a.prop]?r.fx.step[a.prop](a):1!==a.elem.nodeType||null==a.elem.style[r.cssProps[a.prop]]&&!r.cssHooks[a.prop]?a.elem[a.prop]=a.now:r.style(a.elem,a.prop,a.now+a.unit)}}},Xa.propHooks.scrollTop=Xa.propHooks.scrollLeft={set:function(a){a.elem.nodeType&&a.elem.parentNode&&(a.elem[a.prop]=a.now)}},r.easing={linear:function(a){return a},swing:function(a){return.5-Math.cos(a*Math.PI)/2},_default:"swing"},r.fx=Xa.prototype.init,r.fx.step={};var Ya,Za,$a=/^(?:toggle|show|hide)$/,_a=/queueHooks$/;function ab(){Za&&(a.requestAnimationFrame(ab),r.fx.tick())}function bb(){return a.setTimeout(function(){Ya=void 0}),Ya=r.now()}function cb(a,b){var c,d=0,e={height:a};for(b=b?1:0;d<4;d+=2-b)c=aa[d],e["margin"+c]=e["padding"+c]=a;return b&&(e.opacity=e.width=a),e}function db(a,b,c){for(var d,e=(gb.tweeners[b]||[]).concat(gb.tweeners["*"]),f=0,g=e.length;f<g;f++)if(d=e[f].call(c,b,a))return d}function eb(a,b,c){var d,e,f,g,h,i,j,k,l="width"in b||"height"in b,m=this,n={},o=a.style,p=a.nodeType&&ba(a),q=V.get(a,"fxshow");c.queue||(g=r._queueHooks(a,"fx"),null==g.unqueued&&(g.unqueued=0,h=g.empty.fire,g.empty.fire=function(){g.unqueued||h()}),g.unqueued++,m.always(function(){m.always(function(){g.unqueued--,r.queue(a,"fx").length||g.empty.fire()})}));for(d in b)if(e=b[d],$a.test(e)){if(delete b[d],f=f||"toggle"===e,e===(p?"hide":"show")){if("show"!==e||!q||void 0===q[d])continue;p=!0}n[d]=q&&q[d]||r.style(a,d)}if(i=!r.isEmptyObject(b),i||!r.isEmptyObject(n)){l&&1===a.nodeType&&(c.overflow=[o.overflow,o.overflowX,o.overflowY],j=q&&q.display,null==j&&(j=V.get(a,"display")),k=r.css(a,"display"),"none"===k&&(j?k=j:(ga([a],!0),j=a.style.display||j,k=r.css(a,"display"),ga([a]))),("inline"===k||"inline-block"===k&&null!=j)&&"none"===r.css(a,"float")&&(i||(m.done(function(){o.display=j}),null==j&&(k=o.display,j="none"===k?"":k)),o.display="inline-block")),c.overflow&&(o.overflow="hidden",m.always(function(){o.overflow=c.overflow[0],o.overflowX=c.overflow[1],o.overflowY=c.overflow[2]})),i=!1;for(d in n)i||(q?"hidden"in q&&(p=q.hidden):q=V.access(a,"fxshow",{display:j}),f&&(q.hidden=!p),p&&ga([a],!0),m.done(function(){p||ga([a]),V.remove(a,"fxshow");for(d in n)r.style(a,d,n[d])})),i=db(p?q[d]:0,d,m),d in q||(q[d]=i.start,p&&(i.end=i.start,i.start=0))}}function fb(a,b){var c,d,e,f,g;for(c in a)if(d=r.camelCase(c),e=b[d],f=a[c],r.isArray(f)&&(e=f[1],f=a[c]=f[0]),c!==d&&(a[d]=f,delete a[c]),g=r.cssHooks[d],g&&"expand"in g){f=g.expand(f),delete a[d];for(c in f)c in a||(a[c]=f[c],b[c]=e)}else b[d]=e}function gb(a,b,c){var d,e,f=0,g=gb.prefilters.length,h=r.Deferred().always(function(){delete i.elem}),i=function(){if(e)return!1;for(var b=Ya||bb(),c=Math.max(0,j.startTime+j.duration-b),d=c/j.duration||0,f=1-d,g=0,i=j.tweens.length;g<i;g++)j.tweens[g].run(f);return h.notifyWith(a,[j,f,c]),f<1&&i?c:(h.resolveWith(a,[j]),!1)},j=h.promise({elem:a,props:r.extend({},b),opts:r.extend(!0,{specialEasing:{},easing:r.easing._default},c),originalProperties:b,originalOptions:c,startTime:Ya||bb(),duration:c.duration,tweens:[],createTween:function(b,c){var d=r.Tween(a,j.opts,b,c,j.opts.specialEasing[b]||j.opts.easing);return j.tweens.push(d),d},stop:function(b){var c=0,d=b?j.tweens.length:0;if(e)return this;for(e=!0;c<d;c++)j.tweens[c].run(1);return b?(h.notifyWith(a,[j,1,0]),h.resolveWith(a,[j,b])):h.rejectWith(a,[j,b]),this}}),k=j.props;for(fb(k,j.opts.specialEasing);f<g;f++)if(d=gb.prefilters[f].call(j,a,k,j.opts))return r.isFunction(d.stop)&&(r._queueHooks(j.elem,j.opts.queue).stop=r.proxy(d.stop,d)),d;return r.map(k,db,j),r.isFunction(j.opts.start)&&j.opts.start.call(a,j),r.fx.timer(r.extend(i,{elem:a,anim:j,queue:j.opts.queue})),j.progress(j.opts.progress).done(j.opts.done,j.opts.complete).fail(j.opts.fail).always(j.opts.always)}r.Animation=r.extend(gb,{tweeners:{"*":[function(a,b){var c=this.createTween(a,b);return da(c.elem,a,_.exec(b),c),c}]},tweener:function(a,b){r.isFunction(a)?(b=a,a=["*"]):a=a.match(K);for(var c,d=0,e=a.length;d<e;d++)c=a[d],gb.tweeners[c]=gb.tweeners[c]||[],gb.tweeners[c].unshift(b)},prefilters:[eb],prefilter:function(a,b){b?gb.prefilters.unshift(a):gb.prefilters.push(a)}}),r.speed=function(a,b,c){var e=a&&"object"==typeof a?r.extend({},a):{complete:c||!c&&b||r.isFunction(a)&&a,duration:a,easing:c&&b||b&&!r.isFunction(b)&&b};return r.fx.off||d.hidden?e.duration=0:e.duration="number"==typeof e.duration?e.duration:e.duration in r.fx.speeds?r.fx.speeds[e.duration]:r.fx.speeds._default,null!=e.queue&&e.queue!==!0||(e.queue="fx"),e.old=e.complete,e.complete=function(){r.isFunction(e.old)&&e.old.call(this),e.queue&&r.dequeue(this,e.queue)},e},r.fn.extend({fadeTo:function(a,b,c,d){return this.filter(ba).css("opacity",0).show().end().animate({opacity:b},a,c,d)},animate:function(a,b,c,d){var e=r.isEmptyObject(a),f=r.speed(b,c,d),g=function(){var b=gb(this,r.extend({},a),f);(e||V.get(this,"finish"))&&b.stop(!0)};return g.finish=g,e||f.queue===!1?this.each(g):this.queue(f.queue,g)},stop:function(a,b,c){var d=function(a){var b=a.stop;delete a.stop,b(c)};return"string"!=typeof a&&(c=b,b=a,a=void 0),b&&a!==!1&&this.queue(a||"fx",[]),this.each(function(){var b=!0,e=null!=a&&a+"queueHooks",f=r.timers,g=V.get(this);if(e)g[e]&&g[e].stop&&d(g[e]);else for(e in g)g[e]&&g[e].stop&&_a.test(e)&&d(g[e]);for(e=f.length;e--;)f[e].elem!==this||null!=a&&f[e].queue!==a||(f[e].anim.stop(c),b=!1,f.splice(e,1));!b&&c||r.dequeue(this,a)})},finish:function(a){return a!==!1&&(a=a||"fx"),this.each(function(){var b,c=V.get(this),d=c[a+"queue"],e=c[a+"queueHooks"],f=r.timers,g=d?d.length:0;for(c.finish=!0,r.queue(this,a,[]),e&&e.stop&&e.stop.call(this,!0),b=f.length;b--;)f[b].elem===this&&f[b].queue===a&&(f[b].anim.stop(!0),f.splice(b,1));for(b=0;b<g;b++)d[b]&&d[b].finish&&d[b].finish.call(this);delete c.finish})}}),r.each(["toggle","show","hide"],function(a,b){var c=r.fn[b];r.fn[b]=function(a,d,e){return null==a||"boolean"==typeof a?c.apply(this,arguments):this.animate(cb(b,!0),a,d,e)}}),r.each({slideDown:cb("show"),slideUp:cb("hide"),slideToggle:cb("toggle"),fadeIn:{opacity:"show"},fadeOut:{opacity:"hide"},fadeToggle:{opacity:"toggle"}},function(a,b){r.fn[a]=function(a,c,d){return this.animate(b,a,c,d)}}),r.timers=[],r.fx.tick=function(){var a,b=0,c=r.timers;for(Ya=r.now();b<c.length;b++)a=c[b],a()||c[b]!==a||c.splice(b--,1);c.length||r.fx.stop(),Ya=void 0},r.fx.timer=function(a){r.timers.push(a),a()?r.fx.start():r.timers.pop()},r.fx.interval=13,r.fx.start=function(){Za||(Za=a.requestAnimationFrame?a.requestAnimationFrame(ab):a.setInterval(r.fx.tick,r.fx.interval))},r.fx.stop=function(){a.cancelAnimationFrame?a.cancelAnimationFrame(Za):a.clearInterval(Za),Za=null},r.fx.speeds={slow:600,fast:200,_default:400},r.fn.delay=function(b,c){return b=r.fx?r.fx.speeds[b]||b:b,c=c||"fx",this.queue(c,function(c,d){var e=a.setTimeout(c,b);d.stop=function(){a.clearTimeout(e)}})},function(){var a=d.createElement("input"),b=d.createElement("select"),c=b.appendChild(d.createElement("option"));a.type="checkbox",o.checkOn=""!==a.value,o.optSelected=c.selected,a=d.createElement("input"),a.value="t",a.type="radio",o.radioValue="t"===a.value}();var hb,ib=r.expr.attrHandle;r.fn.extend({attr:function(a,b){return S(this,r.attr,a,b,arguments.length>1)},removeAttr:function(a){return this.each(function(){r.removeAttr(this,a)})}}),r.extend({attr:function(a,b,c){var d,e,f=a.nodeType;if(3!==f&&8!==f&&2!==f)return"undefined"==typeof a.getAttribute?r.prop(a,b,c):(1===f&&r.isXMLDoc(a)||(e=r.attrHooks[b.toLowerCase()]||(r.expr.match.bool.test(b)?hb:void 0)),void 0!==c?null===c?void r.removeAttr(a,b):e&&"set"in e&&void 0!==(d=e.set(a,c,b))?d:(a.setAttribute(b,c+""),c):e&&"get"in e&&null!==(d=e.get(a,b))?d:(d=r.find.attr(a,b),null==d?void 0:d))},attrHooks:{type:{set:function(a,b){if(!o.radioValue&&"radio"===b&&r.nodeName(a,"input")){var c=a.value;return a.setAttribute("type",b),c&&(a.value=c),b}}}},removeAttr:function(a,b){var c,d=0,e=b&&b.match(K);
 if(e&&1===a.nodeType)while(c=e[d++])a.removeAttribute(c)}}),hb={set:function(a,b,c){return b===!1?r.removeAttr(a,c):a.setAttribute(c,c),c}},r.each(r.expr.match.bool.source.match(/\w+/g),function(a,b){var c=ib[b]||r.find.attr;ib[b]=function(a,b,d){var e,f,g=b.toLowerCase();return d||(f=ib[g],ib[g]=e,e=null!=c(a,b,d)?g:null,ib[g]=f),e}});var jb=/^(?:input|select|textarea|button)$/i,kb=/^(?:a|area)$/i;r.fn.extend({prop:function(a,b){return S(this,r.prop,a,b,arguments.length>1)},removeProp:function(a){return this.each(function(){delete this[r.propFix[a]||a]})}}),r.extend({prop:function(a,b,c){var d,e,f=a.nodeType;if(3!==f&&8!==f&&2!==f)return 1===f&&r.isXMLDoc(a)||(b=r.propFix[b]||b,e=r.propHooks[b]),void 0!==c?e&&"set"in e&&void 0!==(d=e.set(a,c,b))?d:a[b]=c:e&&"get"in e&&null!==(d=e.get(a,b))?d:a[b]},propHooks:{tabIndex:{get:function(a){var b=r.find.attr(a,"tabindex");return b?parseInt(b,10):jb.test(a.nodeName)||kb.test(a.nodeName)&&a.href?0:-1}}},propFix:{"for":"htmlFor","class":"className"}}),o.optSelected||(r.propHooks.selected={get:function(a){var b=a.parentNode;return b&&b.parentNode&&b.parentNode.selectedIndex,null},set:function(a){var b=a.parentNode;b&&(b.selectedIndex,b.parentNode&&b.parentNode.selectedIndex)}}),r.each(["tabIndex","readOnly","maxLength","cellSpacing","cellPadding","rowSpan","colSpan","useMap","frameBorder","contentEditable"],function(){r.propFix[this.toLowerCase()]=this});var lb=/[\t\r\n\f]/g;function mb(a){return a.getAttribute&&a.getAttribute("class")||""}r.fn.extend({addClass:function(a){var b,c,d,e,f,g,h,i=0;if(r.isFunction(a))return this.each(function(b){r(this).addClass(a.call(this,b,mb(this)))});if("string"==typeof a&&a){b=a.match(K)||[];while(c=this[i++])if(e=mb(c),d=1===c.nodeType&&(" "+e+" ").replace(lb," ")){g=0;while(f=b[g++])d.indexOf(" "+f+" ")<0&&(d+=f+" ");h=r.trim(d),e!==h&&c.setAttribute("class",h)}}return this},removeClass:function(a){var b,c,d,e,f,g,h,i=0;if(r.isFunction(a))return this.each(function(b){r(this).removeClass(a.call(this,b,mb(this)))});if(!arguments.length)return this.attr("class","");if("string"==typeof a&&a){b=a.match(K)||[];while(c=this[i++])if(e=mb(c),d=1===c.nodeType&&(" "+e+" ").replace(lb," ")){g=0;while(f=b[g++])while(d.indexOf(" "+f+" ")>-1)d=d.replace(" "+f+" "," ");h=r.trim(d),e!==h&&c.setAttribute("class",h)}}return this},toggleClass:function(a,b){var c=typeof a;return"boolean"==typeof b&&"string"===c?b?this.addClass(a):this.removeClass(a):r.isFunction(a)?this.each(function(c){r(this).toggleClass(a.call(this,c,mb(this),b),b)}):this.each(function(){var b,d,e,f;if("string"===c){d=0,e=r(this),f=a.match(K)||[];while(b=f[d++])e.hasClass(b)?e.removeClass(b):e.addClass(b)}else void 0!==a&&"boolean"!==c||(b=mb(this),b&&V.set(this,"__className__",b),this.setAttribute&&this.setAttribute("class",b||a===!1?"":V.get(this,"__className__")||""))})},hasClass:function(a){var b,c,d=0;b=" "+a+" ";while(c=this[d++])if(1===c.nodeType&&(" "+mb(c)+" ").replace(lb," ").indexOf(b)>-1)return!0;return!1}});var nb=/\r/g,ob=/[\x20\t\r\n\f]+/g;r.fn.extend({val:function(a){var b,c,d,e=this[0];{if(arguments.length)return d=r.isFunction(a),this.each(function(c){var e;1===this.nodeType&&(e=d?a.call(this,c,r(this).val()):a,null==e?e="":"number"==typeof e?e+="":r.isArray(e)&&(e=r.map(e,function(a){return null==a?"":a+""})),b=r.valHooks[this.type]||r.valHooks[this.nodeName.toLowerCase()],b&&"set"in b&&void 0!==b.set(this,e,"value")||(this.value=e))});if(e)return b=r.valHooks[e.type]||r.valHooks[e.nodeName.toLowerCase()],b&&"get"in b&&void 0!==(c=b.get(e,"value"))?c:(c=e.value,"string"==typeof c?c.replace(nb,""):null==c?"":c)}}}),r.extend({valHooks:{option:{get:function(a){var b=r.find.attr(a,"value");return null!=b?b:r.trim(r.text(a)).replace(ob," ")}},select:{get:function(a){for(var b,c,d=a.options,e=a.selectedIndex,f="select-one"===a.type,g=f?null:[],h=f?e+1:d.length,i=e<0?h:f?e:0;i<h;i++)if(c=d[i],(c.selected||i===e)&&!c.disabled&&(!c.parentNode.disabled||!r.nodeName(c.parentNode,"optgroup"))){if(b=r(c).val(),f)return b;g.push(b)}return g},set:function(a,b){var c,d,e=a.options,f=r.makeArray(b),g=e.length;while(g--)d=e[g],(d.selected=r.inArray(r.valHooks.option.get(d),f)>-1)&&(c=!0);return c||(a.selectedIndex=-1),f}}}}),r.each(["radio","checkbox"],function(){r.valHooks[this]={set:function(a,b){if(r.isArray(b))return a.checked=r.inArray(r(a).val(),b)>-1}},o.checkOn||(r.valHooks[this].get=function(a){return null===a.getAttribute("value")?"on":a.value})});var pb=/^(?:focusinfocus|focusoutblur)$/;r.extend(r.event,{trigger:function(b,c,e,f){var g,h,i,j,k,m,n,o=[e||d],p=l.call(b,"type")?b.type:b,q=l.call(b,"namespace")?b.namespace.split("."):[];if(h=i=e=e||d,3!==e.nodeType&&8!==e.nodeType&&!pb.test(p+r.event.triggered)&&(p.indexOf(".")>-1&&(q=p.split("."),p=q.shift(),q.sort()),k=p.indexOf(":")<0&&"on"+p,b=b[r.expando]?b:new r.Event(p,"object"==typeof b&&b),b.isTrigger=f?2:3,b.namespace=q.join("."),b.rnamespace=b.namespace?new RegExp("(^|\\.)"+q.join("\\.(?:.*\\.|)")+"(\\.|$)"):null,b.result=void 0,b.target||(b.target=e),c=null==c?[b]:r.makeArray(c,[b]),n=r.event.special[p]||{},f||!n.trigger||n.trigger.apply(e,c)!==!1)){if(!f&&!n.noBubble&&!r.isWindow(e)){for(j=n.delegateType||p,pb.test(j+p)||(h=h.parentNode);h;h=h.parentNode)o.push(h),i=h;i===(e.ownerDocument||d)&&o.push(i.defaultView||i.parentWindow||a)}g=0;while((h=o[g++])&&!b.isPropagationStopped())b.type=g>1?j:n.bindType||p,m=(V.get(h,"events")||{})[b.type]&&V.get(h,"handle"),m&&m.apply(h,c),m=k&&h[k],m&&m.apply&&T(h)&&(b.result=m.apply(h,c),b.result===!1&&b.preventDefault());return b.type=p,f||b.isDefaultPrevented()||n._default&&n._default.apply(o.pop(),c)!==!1||!T(e)||k&&r.isFunction(e[p])&&!r.isWindow(e)&&(i=e[k],i&&(e[k]=null),r.event.triggered=p,e[p](),r.event.triggered=void 0,i&&(e[k]=i)),b.result}},simulate:function(a,b,c){var d=r.extend(new r.Event,c,{type:a,isSimulated:!0});r.event.trigger(d,null,b)}}),r.fn.extend({trigger:function(a,b){return this.each(function(){r.event.trigger(a,b,this)})},triggerHandler:function(a,b){var c=this[0];if(c)return r.event.trigger(a,b,c,!0)}}),r.each("blur focus focusin focusout resize scroll click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup contextmenu".split(" "),function(a,b){r.fn[b]=function(a,c){return arguments.length>0?this.on(b,null,a,c):this.trigger(b)}}),r.fn.extend({hover:function(a,b){return this.mouseenter(a).mouseleave(b||a)}}),o.focusin="onfocusin"in a,o.focusin||r.each({focus:"focusin",blur:"focusout"},function(a,b){var c=function(a){r.event.simulate(b,a.target,r.event.fix(a))};r.event.special[b]={setup:function(){var d=this.ownerDocument||this,e=V.access(d,b);e||d.addEventListener(a,c,!0),V.access(d,b,(e||0)+1)},teardown:function(){var d=this.ownerDocument||this,e=V.access(d,b)-1;e?V.access(d,b,e):(d.removeEventListener(a,c,!0),V.remove(d,b))}}});var qb=a.location,rb=r.now(),sb=/\?/;r.parseXML=function(b){var c;if(!b||"string"!=typeof b)return null;try{c=(new a.DOMParser).parseFromString(b,"text/xml")}catch(d){c=void 0}return c&&!c.getElementsByTagName("parsererror").length||r.error("Invalid XML: "+b),c};var tb=/\[\]$/,ub=/\r?\n/g,vb=/^(?:submit|button|image|reset|file)$/i,wb=/^(?:input|select|textarea|keygen)/i;function xb(a,b,c,d){var e;if(r.isArray(b))r.each(b,function(b,e){c||tb.test(a)?d(a,e):xb(a+"["+("object"==typeof e&&null!=e?b:"")+"]",e,c,d)});else if(c||"object"!==r.type(b))d(a,b);else for(e in b)xb(a+"["+e+"]",b[e],c,d)}r.param=function(a,b){var c,d=[],e=function(a,b){var c=r.isFunction(b)?b():b;d[d.length]=encodeURIComponent(a)+"="+encodeURIComponent(null==c?"":c)};if(r.isArray(a)||a.jquery&&!r.isPlainObject(a))r.each(a,function(){e(this.name,this.value)});else for(c in a)xb(c,a[c],b,e);return d.join("&")},r.fn.extend({serialize:function(){return r.param(this.serializeArray())},serializeArray:function(){return this.map(function(){var a=r.prop(this,"elements");return a?r.makeArray(a):this}).filter(function(){var a=this.type;return this.name&&!r(this).is(":disabled")&&wb.test(this.nodeName)&&!vb.test(a)&&(this.checked||!ha.test(a))}).map(function(a,b){var c=r(this).val();return null==c?null:r.isArray(c)?r.map(c,function(a){return{name:b.name,value:a.replace(ub,"\r\n")}}):{name:b.name,value:c.replace(ub,"\r\n")}}).get()}});var yb=/%20/g,zb=/#.*$/,Ab=/([?&])_=[^&]*/,Bb=/^(.*?):[ \t]*([^\r\n]*)$/gm,Cb=/^(?:about|app|app-storage|.+-extension|file|res|widget):$/,Db=/^(?:GET|HEAD)$/,Eb=/^\/\//,Fb={},Gb={},Hb="*/".concat("*"),Ib=d.createElement("a");Ib.href=qb.href;function Jb(a){return function(b,c){"string"!=typeof b&&(c=b,b="*");var d,e=0,f=b.toLowerCase().match(K)||[];if(r.isFunction(c))while(d=f[e++])"+"===d[0]?(d=d.slice(1)||"*",(a[d]=a[d]||[]).unshift(c)):(a[d]=a[d]||[]).push(c)}}function Kb(a,b,c,d){var e={},f=a===Gb;function g(h){var i;return e[h]=!0,r.each(a[h]||[],function(a,h){var j=h(b,c,d);return"string"!=typeof j||f||e[j]?f?!(i=j):void 0:(b.dataTypes.unshift(j),g(j),!1)}),i}return g(b.dataTypes[0])||!e["*"]&&g("*")}function Lb(a,b){var c,d,e=r.ajaxSettings.flatOptions||{};for(c in b)void 0!==b[c]&&((e[c]?a:d||(d={}))[c]=b[c]);return d&&r.extend(!0,a,d),a}function Mb(a,b,c){var d,e,f,g,h=a.contents,i=a.dataTypes;while("*"===i[0])i.shift(),void 0===d&&(d=a.mimeType||b.getResponseHeader("Content-Type"));if(d)for(e in h)if(h[e]&&h[e].test(d)){i.unshift(e);break}if(i[0]in c)f=i[0];else{for(e in c){if(!i[0]||a.converters[e+" "+i[0]]){f=e;break}g||(g=e)}f=f||g}if(f)return f!==i[0]&&i.unshift(f),c[f]}function Nb(a,b,c,d){var e,f,g,h,i,j={},k=a.dataTypes.slice();if(k[1])for(g in a.converters)j[g.toLowerCase()]=a.converters[g];f=k.shift();while(f)if(a.responseFields[f]&&(c[a.responseFields[f]]=b),!i&&d&&a.dataFilter&&(b=a.dataFilter(b,a.dataType)),i=f,f=k.shift())if("*"===f)f=i;else if("*"!==i&&i!==f){if(g=j[i+" "+f]||j["* "+f],!g)for(e in j)if(h=e.split(" "),h[1]===f&&(g=j[i+" "+h[0]]||j["* "+h[0]])){g===!0?g=j[e]:j[e]!==!0&&(f=h[0],k.unshift(h[1]));break}if(g!==!0)if(g&&a["throws"])b=g(b);else try{b=g(b)}catch(l){return{state:"parsererror",error:g?l:"No conversion from "+i+" to "+f}}}return{state:"success",data:b}}r.extend({active:0,lastModified:{},etag:{},ajaxSettings:{url:qb.href,type:"GET",isLocal:Cb.test(qb.protocol),global:!0,processData:!0,async:!0,contentType:"application/x-www-form-urlencoded; charset=UTF-8",accepts:{"*":Hb,text:"text/plain",html:"text/html",xml:"application/xml, text/xml",json:"application/json, text/javascript"},contents:{xml:/\bxml\b/,html:/\bhtml/,json:/\bjson\b/},responseFields:{xml:"responseXML",text:"responseText",json:"responseJSON"},converters:{"* text":String,"text html":!0,"text json":JSON.parse,"text xml":r.parseXML},flatOptions:{url:!0,context:!0}},ajaxSetup:function(a,b){return b?Lb(Lb(a,r.ajaxSettings),b):Lb(r.ajaxSettings,a)},ajaxPrefilter:Jb(Fb),ajaxTransport:Jb(Gb),ajax:function(b,c){"object"==typeof b&&(c=b,b=void 0),c=c||{};var e,f,g,h,i,j,k,l,m,n,o=r.ajaxSetup({},c),p=o.context||o,q=o.context&&(p.nodeType||p.jquery)?r(p):r.event,s=r.Deferred(),t=r.Callbacks("once memory"),u=o.statusCode||{},v={},w={},x="canceled",y={readyState:0,getResponseHeader:function(a){var b;if(k){if(!h){h={};while(b=Bb.exec(g))h[b[1].toLowerCase()]=b[2]}b=h[a.toLowerCase()]}return null==b?null:b},getAllResponseHeaders:function(){return k?g:null},setRequestHeader:function(a,b){return null==k&&(a=w[a.toLowerCase()]=w[a.toLowerCase()]||a,v[a]=b),this},overrideMimeType:function(a){return null==k&&(o.mimeType=a),this},statusCode:function(a){var b;if(a)if(k)y.always(a[y.status]);else for(b in a)u[b]=[u[b],a[b]];return this},abort:function(a){var b=a||x;return e&&e.abort(b),A(0,b),this}};if(s.promise(y),o.url=((b||o.url||qb.href)+"").replace(Eb,qb.protocol+"//"),o.type=c.method||c.type||o.method||o.type,o.dataTypes=(o.dataType||"*").toLowerCase().match(K)||[""],null==o.crossDomain){j=d.createElement("a");try{j.href=o.url,j.href=j.href,o.crossDomain=Ib.protocol+"//"+Ib.host!=j.protocol+"//"+j.host}catch(z){o.crossDomain=!0}}if(o.data&&o.processData&&"string"!=typeof o.data&&(o.data=r.param(o.data,o.traditional)),Kb(Fb,o,c,y),k)return y;l=r.event&&o.global,l&&0===r.active++&&r.event.trigger("ajaxStart"),o.type=o.type.toUpperCase(),o.hasContent=!Db.test(o.type),f=o.url.replace(zb,""),o.hasContent?o.data&&o.processData&&0===(o.contentType||"").indexOf("application/x-www-form-urlencoded")&&(o.data=o.data.replace(yb,"+")):(n=o.url.slice(f.length),o.data&&(f+=(sb.test(f)?"&":"?")+o.data,delete o.data),o.cache===!1&&(f=f.replace(Ab,""),n=(sb.test(f)?"&":"?")+"_="+rb++ +n),o.url=f+n),o.ifModified&&(r.lastModified[f]&&y.setRequestHeader("If-Modified-Since",r.lastModified[f]),r.etag[f]&&y.setRequestHeader("If-None-Match",r.etag[f])),(o.data&&o.hasContent&&o.contentType!==!1||c.contentType)&&y.setRequestHeader("Content-Type",o.contentType),y.setRequestHeader("Accept",o.dataTypes[0]&&o.accepts[o.dataTypes[0]]?o.accepts[o.dataTypes[0]]+("*"!==o.dataTypes[0]?", "+Hb+"; q=0.01":""):o.accepts["*"]);for(m in o.headers)y.setRequestHeader(m,o.headers[m]);if(o.beforeSend&&(o.beforeSend.call(p,y,o)===!1||k))return y.abort();if(x="abort",t.add(o.complete),y.done(o.success),y.fail(o.error),e=Kb(Gb,o,c,y)){if(y.readyState=1,l&&q.trigger("ajaxSend",[y,o]),k)return y;o.async&&o.timeout>0&&(i=a.setTimeout(function(){y.abort("timeout")},o.timeout));try{k=!1,e.send(v,A)}catch(z){if(k)throw z;A(-1,z)}}else A(-1,"No Transport");function A(b,c,d,h){var j,m,n,v,w,x=c;k||(k=!0,i&&a.clearTimeout(i),e=void 0,g=h||"",y.readyState=b>0?4:0,j=b>=200&&b<300||304===b,d&&(v=Mb(o,y,d)),v=Nb(o,v,y,j),j?(o.ifModified&&(w=y.getResponseHeader("Last-Modified"),w&&(r.lastModified[f]=w),w=y.getResponseHeader("etag"),w&&(r.etag[f]=w)),204===b||"HEAD"===o.type?x="nocontent":304===b?x="notmodified":(x=v.state,m=v.data,n=v.error,j=!n)):(n=x,!b&&x||(x="error",b<0&&(b=0))),y.status=b,y.statusText=(c||x)+"",j?s.resolveWith(p,[m,x,y]):s.rejectWith(p,[y,x,n]),y.statusCode(u),u=void 0,l&&q.trigger(j?"ajaxSuccess":"ajaxError",[y,o,j?m:n]),t.fireWith(p,[y,x]),l&&(q.trigger("ajaxComplete",[y,o]),--r.active||r.event.trigger("ajaxStop")))}return y},getJSON:function(a,b,c){return r.get(a,b,c,"json")},getScript:function(a,b){return r.get(a,void 0,b,"script")}}),r.each(["get","post"],function(a,b){r[b]=function(a,c,d,e){return r.isFunction(c)&&(e=e||d,d=c,c=void 0),r.ajax(r.extend({url:a,type:b,dataType:e,data:c,success:d},r.isPlainObject(a)&&a))}}),r._evalUrl=function(a){return r.ajax({url:a,type:"GET",dataType:"script",cache:!0,async:!1,global:!1,"throws":!0})},r.fn.extend({wrapAll:function(a){var b;return this[0]&&(r.isFunction(a)&&(a=a.call(this[0])),b=r(a,this[0].ownerDocument).eq(0).clone(!0),this[0].parentNode&&b.insertBefore(this[0]),b.map(function(){var a=this;while(a.firstElementChild)a=a.firstElementChild;return a}).append(this)),this},wrapInner:function(a){return r.isFunction(a)?this.each(function(b){r(this).wrapInner(a.call(this,b))}):this.each(function(){var b=r(this),c=b.contents();c.length?c.wrapAll(a):b.append(a)})},wrap:function(a){var b=r.isFunction(a);return this.each(function(c){r(this).wrapAll(b?a.call(this,c):a)})},unwrap:function(a){return this.parent(a).not("body").each(function(){r(this).replaceWith(this.childNodes)}),this}}),r.expr.pseudos.hidden=function(a){return!r.expr.pseudos.visible(a)},r.expr.pseudos.visible=function(a){return!!(a.offsetWidth||a.offsetHeight||a.getClientRects().length)},r.ajaxSettings.xhr=function(){try{return new a.XMLHttpRequest}catch(b){}};var Ob={0:200,1223:204},Pb=r.ajaxSettings.xhr();o.cors=!!Pb&&"withCredentials"in Pb,o.ajax=Pb=!!Pb,r.ajaxTransport(function(b){var c,d;if(o.cors||Pb&&!b.crossDomain)return{send:function(e,f){var g,h=b.xhr();if(h.open(b.type,b.url,b.async,b.username,b.password),b.xhrFields)for(g in b.xhrFields)h[g]=b.xhrFields[g];b.mimeType&&h.overrideMimeType&&h.overrideMimeType(b.mimeType),b.crossDomain||e["X-Requested-With"]||(e["X-Requested-With"]="XMLHttpRequest");for(g in e)h.setRequestHeader(g,e[g]);c=function(a){return function(){c&&(c=d=h.onload=h.onerror=h.onabort=h.onreadystatechange=null,"abort"===a?h.abort():"error"===a?"number"!=typeof h.status?f(0,"error"):f(h.status,h.statusText):f(Ob[h.status]||h.status,h.statusText,"text"!==(h.responseType||"text")||"string"!=typeof h.responseText?{binary:h.response}:{text:h.responseText},h.getAllResponseHeaders()))}},h.onload=c(),d=h.onerror=c("error"),void 0!==h.onabort?h.onabort=d:h.onreadystatechange=function(){4===h.readyState&&a.setTimeout(function(){c&&d()})},c=c("abort");try{h.send(b.hasContent&&b.data||null)}catch(i){if(c)throw i}},abort:function(){c&&c()}}}),r.ajaxPrefilter(function(a){a.crossDomain&&(a.contents.script=!1)}),r.ajaxSetup({accepts:{script:"text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"},contents:{script:/\b(?:java|ecma)script\b/},converters:{"text script":function(a){return r.globalEval(a),a}}}),r.ajaxPrefilter("script",function(a){void 0===a.cache&&(a.cache=!1),a.crossDomain&&(a.type="GET")}),r.ajaxTransport("script",function(a){if(a.crossDomain){var b,c;return{send:function(e,f){b=r("<script>").prop({charset:a.scriptCharset,src:a.url}).on("load error",c=function(a){b.remove(),c=null,a&&f("error"===a.type?404:200,a.type)}),d.head.appendChild(b[0])},abort:function(){c&&c()}}}});var Qb=[],Rb=/(=)\?(?=&|$)|\?\?/;r.ajaxSetup({jsonp:"callback",jsonpCallback:function(){var a=Qb.pop()||r.expando+"_"+rb++;return this[a]=!0,a}}),r.ajaxPrefilter("json jsonp",function(b,c,d){var e,f,g,h=b.jsonp!==!1&&(Rb.test(b.url)?"url":"string"==typeof b.data&&0===(b.contentType||"").indexOf("application/x-www-form-urlencoded")&&Rb.test(b.data)&&"data");if(h||"jsonp"===b.dataTypes[0])return e=b.jsonpCallback=r.isFunction(b.jsonpCallback)?b.jsonpCallback():b.jsonpCallback,h?b[h]=b[h].replace(Rb,"$1"+e):b.jsonp!==!1&&(b.url+=(sb.test(b.url)?"&":"?")+b.jsonp+"="+e),b.converters["script json"]=function(){return g||r.error(e+" was not called"),g[0]},b.dataTypes[0]="json",f=a[e],a[e]=function(){g=arguments},d.always(function(){void 0===f?r(a).removeProp(e):a[e]=f,b[e]&&(b.jsonpCallback=c.jsonpCallback,Qb.push(e)),g&&r.isFunction(f)&&f(g[0]),g=f=void 0}),"script"}),o.createHTMLDocument=function(){var a=d.implementation.createHTMLDocument("").body;return a.innerHTML="<form></form><form></form>",2===a.childNodes.length}(),r.parseHTML=function(a,b,c){if("string"!=typeof a)return[];"boolean"==typeof b&&(c=b,b=!1);var e,f,g;return b||(o.createHTMLDocument?(b=d.implementation.createHTMLDocument(""),e=b.createElement("base"),e.href=d.location.href,b.head.appendChild(e)):b=d),f=B.exec(a),g=!c&&[],f?[b.createElement(f[1])]:(f=oa([a],b,g),g&&g.length&&r(g).remove(),r.merge([],f.childNodes))},r.fn.load=function(a,b,c){var d,e,f,g=this,h=a.indexOf(" ");return h>-1&&(d=r.trim(a.slice(h)),a=a.slice(0,h)),r.isFunction(b)?(c=b,b=void 0):b&&"object"==typeof b&&(e="POST"),g.length>0&&r.ajax({url:a,type:e||"GET",dataType:"html",data:b}).done(function(a){f=arguments,g.html(d?r("<div>").append(r.parseHTML(a)).find(d):a)}).always(c&&function(a,b){g.each(function(){c.apply(this,f||[a.responseText,b,a])})}),this},r.each(["ajaxStart","ajaxStop","ajaxComplete","ajaxError","ajaxSuccess","ajaxSend"],function(a,b){r.fn[b]=function(a){return this.on(b,a)}}),r.expr.pseudos.animated=function(a){return r.grep(r.timers,function(b){return a===b.elem}).length};function Sb(a){return r.isWindow(a)?a:9===a.nodeType&&a.defaultView}r.offset={setOffset:function(a,b,c){var d,e,f,g,h,i,j,k=r.css(a,"position"),l=r(a),m={};"static"===k&&(a.style.position="relative"),h=l.offset(),f=r.css(a,"top"),i=r.css(a,"left"),j=("absolute"===k||"fixed"===k)&&(f+i).indexOf("auto")>-1,j?(d=l.position(),g=d.top,e=d.left):(g=parseFloat(f)||0,e=parseFloat(i)||0),r.isFunction(b)&&(b=b.call(a,c,r.extend({},h))),null!=b.top&&(m.top=b.top-h.top+g),null!=b.left&&(m.left=b.left-h.left+e),"using"in b?b.using.call(a,m):l.css(m)}},r.fn.extend({offset:function(a){if(arguments.length)return void 0===a?this:this.each(function(b){r.offset.setOffset(this,a,b)});var b,c,d,e,f=this[0];if(f)return f.getClientRects().length?(d=f.getBoundingClientRect(),d.width||d.height?(e=f.ownerDocument,c=Sb(e),b=e.documentElement,{top:d.top+c.pageYOffset-b.clientTop,left:d.left+c.pageXOffset-b.clientLeft}):d):{top:0,left:0}},position:function(){if(this[0]){var a,b,c=this[0],d={top:0,left:0};return"fixed"===r.css(c,"position")?b=c.getBoundingClientRect():(a=this.offsetParent(),b=this.offset(),r.nodeName(a[0],"html")||(d=a.offset()),d={top:d.top+r.css(a[0],"borderTopWidth",!0),left:d.left+r.css(a[0],"borderLeftWidth",!0)}),{top:b.top-d.top-r.css(c,"marginTop",!0),left:b.left-d.left-r.css(c,"marginLeft",!0)}}},offsetParent:function(){return this.map(function(){var a=this.offsetParent;while(a&&"static"===r.css(a,"position"))a=a.offsetParent;return a||pa})}}),r.each({scrollLeft:"pageXOffset",scrollTop:"pageYOffset"},function(a,b){var c="pageYOffset"===b;r.fn[a]=function(d){return S(this,function(a,d,e){var f=Sb(a);return void 0===e?f?f[b]:a[d]:void(f?f.scrollTo(c?f.pageXOffset:e,c?e:f.pageYOffset):a[d]=e)},a,d,arguments.length)}}),r.each(["top","left"],function(a,b){r.cssHooks[b]=Na(o.pixelPosition,function(a,c){if(c)return c=Ma(a,b),Ka.test(c)?r(a).position()[b]+"px":c})}),r.each({Height:"height",Width:"width"},function(a,b){r.each({padding:"inner"+a,content:b,"":"outer"+a},function(c,d){r.fn[d]=function(e,f){var g=arguments.length&&(c||"boolean"!=typeof e),h=c||(e===!0||f===!0?"margin":"border");return S(this,function(b,c,e){var f;return r.isWindow(b)?0===d.indexOf("outer")?b["inner"+a]:b.document.documentElement["client"+a]:9===b.nodeType?(f=b.documentElement,Math.max(b.body["scroll"+a],f["scroll"+a],b.body["offset"+a],f["offset"+a],f["client"+a])):void 0===e?r.css(b,c,h):r.style(b,c,e,h)},b,g?e:void 0,g)}})}),r.fn.extend({bind:function(a,b,c){return this.on(a,null,b,c)},unbind:function(a,b){return this.off(a,null,b)},delegate:function(a,b,c,d){return this.on(b,a,c,d)},undelegate:function(a,b,c){return 1===arguments.length?this.off(a,"**"):this.off(b,a||"**",c)}}),r.parseJSON=JSON.parse,"function"==typeof define&&define.amd&&define("jquery",[],function(){return r});var Tb=a.jQuery,Ub=a.$;return r.noConflict=function(b){return a.$===r&&(a.$=Ub),b&&a.jQuery===r&&(a.jQuery=Tb),r},b||(a.jQuery=a.$=r),r});
 </script>
 
-
-<script>
+  <script>
 !function(){var q=null;window.PR_SHOULD_USE_CONTINUATION=!0;
 (function(){function S(a){function d(e){var b=e.charCodeAt(0);if(b!==92)return b;var a=e.charAt(1);return(b=r[a])?b:"0"<=a&&a<="7"?parseInt(e.substring(1),8):a==="u"||a==="x"?parseInt(e.substring(2),16):e.charCodeAt(1)}function g(e){if(e<32)return(e<16?"\\x0":"\\x")+e.toString(16);e=String.fromCharCode(e);return e==="\\"||e==="-"||e==="]"||e==="^"?"\\"+e:e}function b(e){var b=e.substring(1,e.length-1).match(/\\u[\dA-Fa-f]{4}|\\x[\dA-Fa-f]{2}|\\[0-3][0-7]{0,2}|\\[0-7]{1,2}|\\[\S\s]|[^\\]/g),e=[],a=
 b[0]==="^",c=["["];a&&c.push("^");for(var a=a?1:0,f=b.length;a<f;++a){var h=b[a];if(/\\[bdsw]/i.test(h))c.push(h);else{var h=d(h),l;a+2<f&&"-"===b[a+1]?(l=d(b[a+2]),a+=2):l=h;e.push([h,l]);l<65||h>122||(l<65||h>90||e.push([Math.max(65,h)|32,Math.min(l,90)|32]),l<97||h>122||e.push([Math.max(97,h)&-33,Math.min(l,122)&-33]))}}e.sort(function(e,a){return e[0]-a[0]||a[1]-e[1]});b=[];f=[];for(a=0;a<e.length;++a)h=e[a],h[0]<=f[1]+1?f[1]=Math.max(f[1],h[1]):b.push(f=h);for(a=0;a<b.length;++a)h=b[a],c.push(g(h[0])),
@@ -49,7 +46,7 @@ o.className&&e.test(o.className)){m=!0;break}if(!m){d.className+=" prettyprinted
 h={};g()}};typeof define==="function"&&define.amd&&define("google-code-prettify",[],function(){return Y})})();}()
 </script>
 
-<script>
+  <script>
 /*!
 * Bootstrap.js by @fat & @mdo
 * Copyright 2013 Twitter, Inc.
@@ -58,7 +55,7 @@ h={};g()}};typeof define==="function"&&define.amd&&define("google-code-prettify"
 !function(e){"use strict";e(function(){e.support.transition=function(){var e=function(){var e=document.createElement("bootstrap"),t={WebkitTransition:"webkitTransitionEnd",MozTransition:"transitionend",OTransition:"oTransitionEnd otransitionend",transition:"transitionend"},n;for(n in t)if(e.style[n]!==undefined)return t[n]}();return e&&{end:e}}()})}(window.jQuery),!function(e){"use strict";var t='[data-dismiss="alert"]',n=function(n){e(n).on("click",t,this.close)};n.prototype.close=function(t){function s(){i.trigger("closed").remove()}var n=e(this),r=n.attr("data-target"),i;r||(r=n.attr("href"),r=r&&r.replace(/.*(?=#[^\s]*$)/,"")),i=e(r),t&&t.preventDefault(),i.length||(i=n.hasClass("alert")?n:n.parent()),i.trigger(t=e.Event("close"));if(t.isDefaultPrevented())return;i.removeClass("in"),e.support.transition&&i.hasClass("fade")?i.on(e.support.transition.end,s):s()};var r=e.fn.alert;e.fn.alert=function(t){return this.each(function(){var r=e(this),i=r.data("alert");i||r.data("alert",i=new n(this)),typeof t=="string"&&i[t].call(r)})},e.fn.alert.Constructor=n,e.fn.alert.noConflict=function(){return e.fn.alert=r,this},e(document).on("click.alert.data-api",t,n.prototype.close)}(window.jQuery),!function(e){"use strict";var t=function(t,n){this.$element=e(t),this.options=e.extend({},e.fn.button.defaults,n)};t.prototype.setState=function(e){var t="disabled",n=this.$element,r=n.data(),i=n.is("input")?"val":"html";e+="Text",r.resetText||n.data("resetText",n[i]()),n[i](r[e]||this.options[e]),setTimeout(function(){e=="loadingText"?n.addClass(t).attr(t,t):n.removeClass(t).removeAttr(t)},0)},t.prototype.toggle=function(){var e=this.$element.closest('[data-toggle="buttons-radio"]');e&&e.find(".active").removeClass("active"),this.$element.toggleClass("active")};var n=e.fn.button;e.fn.button=function(n){return this.each(function(){var r=e(this),i=r.data("button"),s=typeof n=="object"&&n;i||r.data("button",i=new t(this,s)),n=="toggle"?i.toggle():n&&i.setState(n)})},e.fn.button.defaults={loadingText:"loading..."},e.fn.button.Constructor=t,e.fn.button.noConflict=function(){return e.fn.button=n,this},e(document).on("click.button.data-api","[data-toggle^=button]",function(t){var n=e(t.target);n.hasClass("btn")||(n=n.closest(".btn")),n.button("toggle")})}(window.jQuery),!function(e){"use strict";var t=function(t,n){this.$element=e(t),this.$indicators=this.$element.find(".carousel-indicators"),this.options=n,this.options.pause=="hover"&&this.$element.on("mouseenter",e.proxy(this.pause,this)).on("mouseleave",e.proxy(this.cycle,this))};t.prototype={cycle:function(t){return t||(this.paused=!1),this.interval&&clearInterval(this.interval),this.options.interval&&!this.paused&&(this.interval=setInterval(e.proxy(this.next,this),this.options.interval)),this},getActiveIndex:function(){return this.$active=this.$element.find(".item.active"),this.$items=this.$active.parent().children(),this.$items.index(this.$active)},to:function(t){var n=this.getActiveIndex(),r=this;if(t>this.$items.length-1||t<0)return;return this.sliding?this.$element.one("slid",function(){r.to(t)}):n==t?this.pause().cycle():this.slide(t>n?"next":"prev",e(this.$items[t]))},pause:function(t){return t||(this.paused=!0),this.$element.find(".next, .prev").length&&e.support.transition.end&&(this.$element.trigger(e.support.transition.end),this.cycle(!0)),clearInterval(this.interval),this.interval=null,this},next:function(){if(this.sliding)return;return this.slide("next")},prev:function(){if(this.sliding)return;return this.slide("prev")},slide:function(t,n){var r=this.$element.find(".item.active"),i=n||r[t](),s=this.interval,o=t=="next"?"left":"right",u=t=="next"?"first":"last",a=this,f;this.sliding=!0,s&&this.pause(),i=i.length?i:this.$element.find(".item")[u](),f=e.Event("slide",{relatedTarget:i[0],direction:o});if(i.hasClass("active"))return;this.$indicators.length&&(this.$indicators.find(".active").removeClass("active"),this.$element.one("slid",function(){var t=e(a.$indicators.children()[a.getActiveIndex()]);t&&t.addClass("active")}));if(e.support.transition&&this.$element.hasClass("slide")){this.$element.trigger(f);if(f.isDefaultPrevented())return;i.addClass(t),i[0].offsetWidth,r.addClass(o),i.addClass(o),this.$element.one(e.support.transition.end,function(){i.removeClass([t,o].join(" ")).addClass("active"),r.removeClass(["active",o].join(" ")),a.sliding=!1,setTimeout(function(){a.$element.trigger("slid")},0)})}else{this.$element.trigger(f);if(f.isDefaultPrevented())return;r.removeClass("active"),i.addClass("active"),this.sliding=!1,this.$element.trigger("slid")}return s&&this.cycle(),this}};var n=e.fn.carousel;e.fn.carousel=function(n){return this.each(function(){var r=e(this),i=r.data("carousel"),s=e.extend({},e.fn.carousel.defaults,typeof n=="object"&&n),o=typeof n=="string"?n:s.slide;i||r.data("carousel",i=new t(this,s)),typeof n=="number"?i.to(n):o?i[o]():s.interval&&i.pause().cycle()})},e.fn.carousel.defaults={interval:5e3,pause:"hover"},e.fn.carousel.Constructor=t,e.fn.carousel.noConflict=function(){return e.fn.carousel=n,this},e(document).on("click.carousel.data-api","[data-slide], [data-slide-to]",function(t){var n=e(this),r,i=e(n.attr("data-target")||(r=n.attr("href"))&&r.replace(/.*(?=#[^\s]+$)/,"")),s=e.extend({},i.data(),n.data()),o;i.carousel(s),(o=n.attr("data-slide-to"))&&i.data("carousel").pause().to(o).cycle(),t.preventDefault()})}(window.jQuery),!function(e){"use strict";var t=function(t,n){this.$element=e(t),this.options=e.extend({},e.fn.collapse.defaults,n),this.options.parent&&(this.$parent=e(this.options.parent)),this.options.toggle&&this.toggle()};t.prototype={constructor:t,dimension:function(){var e=this.$element.hasClass("width");return e?"width":"height"},show:function(){var t,n,r,i;if(this.transitioning||this.$element.hasClass("in"))return;t=this.dimension(),n=e.camelCase(["scroll",t].join("-")),r=this.$parent&&this.$parent.find("> .accordion-group > .in");if(r&&r.length){i=r.data("collapse");if(i&&i.transitioning)return;r.collapse("hide"),i||r.data("collapse",null)}this.$element[t](0),this.transition("addClass",e.Event("show"),"shown"),e.support.transition&&this.$element[t](this.$element[0][n])},hide:function(){var t;if(this.transitioning||!this.$element.hasClass("in"))return;t=this.dimension(),this.reset(this.$element[t]()),this.transition("removeClass",e.Event("hide"),"hidden"),this.$element[t](0)},reset:function(e){var t=this.dimension();return this.$element.removeClass("collapse")[t](e||"auto")[0].offsetWidth,this.$element[e!==null?"addClass":"removeClass"]("collapse"),this},transition:function(t,n,r){var i=this,s=function(){n.type=="show"&&i.reset(),i.transitioning=0,i.$element.trigger(r)};this.$element.trigger(n);if(n.isDefaultPrevented())return;this.transitioning=1,this.$element[t]("in"),e.support.transition&&this.$element.hasClass("collapse")?this.$element.one(e.support.transition.end,s):s()},toggle:function(){this[this.$element.hasClass("in")?"hide":"show"]()}};var n=e.fn.collapse;e.fn.collapse=function(n){return this.each(function(){var r=e(this),i=r.data("collapse"),s=e.extend({},e.fn.collapse.defaults,r.data(),typeof n=="object"&&n);i||r.data("collapse",i=new t(this,s)),typeof n=="string"&&i[n]()})},e.fn.collapse.defaults={toggle:!0},e.fn.collapse.Constructor=t,e.fn.collapse.noConflict=function(){return e.fn.collapse=n,this},e(document).on("click.collapse.data-api","[data-toggle=collapse]",function(t){var n=e(this),r,i=n.attr("data-target")||t.preventDefault()||(r=n.attr("href"))&&r.replace(/.*(?=#[^\s]+$)/,""),s=e(i).data("collapse")?"toggle":n.data();n[e(i).hasClass("in")?"addClass":"removeClass"]("collapsed"),e(i).collapse(s)})}(window.jQuery),!function(e){"use strict";function r(){e(".dropdown-backdrop").remove(),e(t).each(function(){i(e(this)).removeClass("open")})}function i(t){var n=t.attr("data-target"),r;n||(n=t.attr("href"),n=n&&/#/.test(n)&&n.replace(/.*(?=#[^\s]*$)/,"")),r=n&&e(n);if(!r||!r.length)r=t.parent();return r}var t="[data-toggle=dropdown]",n=function(t){var n=e(t).on("click.dropdown.data-api",this.toggle);e("html").on("click.dropdown.data-api",function(){n.parent().removeClass("open")})};n.prototype={constructor:n,toggle:function(t){var n=e(this),s,o;if(n.is(".disabled, :disabled"))return;return s=i(n),o=s.hasClass("open"),r(),o||("ontouchstart"in document.documentElement&&e('<div class="dropdown-backdrop"/>').insertBefore(e(this)).on("click",r),s.toggleClass("open")),n.focus(),!1},keydown:function(n){var r,s,o,u,a,f;if(!/(38|40|27)/.test(n.keyCode))return;r=e(this),n.preventDefault(),n.stopPropagation();if(r.is(".disabled, :disabled"))return;u=i(r),a=u.hasClass("open");if(!a||a&&n.keyCode==27)return n.which==27&&u.find(t).focus(),r.click();s=e("[role=menu] li:not(.divider):visible a",u);if(!s.length)return;f=s.index(s.filter(":focus")),n.keyCode==38&&f>0&&f--,n.keyCode==40&&f<s.length-1&&f++,~f||(f=0),s.eq(f).focus()}};var s=e.fn.dropdown;e.fn.dropdown=function(t){return this.each(function(){var r=e(this),i=r.data("dropdown");i||r.data("dropdown",i=new n(this)),typeof t=="string"&&i[t].call(r)})},e.fn.dropdown.Constructor=n,e.fn.dropdown.noConflict=function(){return e.fn.dropdown=s,this},e(document).on("click.dropdown.data-api",r).on("click.dropdown.data-api",".dropdown form",function(e){e.stopPropagation()}).on("click.dropdown.data-api",t,n.prototype.toggle).on("keydown.dropdown.data-api",t+", [role=menu]",n.prototype.keydown)}(window.jQuery),!function(e){"use strict";var t=function(t,n){this.options=n,this.$element=e(t).delegate('[data-dismiss="modal"]',"click.dismiss.modal",e.proxy(this.hide,this)),this.options.remote&&this.$element.find(".modal-body").load(this.options.remote)};t.prototype={constructor:t,toggle:function(){return this[this.isShown?"hide":"show"]()},show:function(){var t=this,n=e.Event("show");this.$element.trigger(n);if(this.isShown||n.isDefaultPrevented())return;this.isShown=!0,this.escape(),this.backdrop(function(){var n=e.support.transition&&t.$element.hasClass("fade");t.$element.parent().length||t.$element.appendTo(document.body),t.$element.show(),n&&t.$element[0].offsetWidth,t.$element.addClass("in").attr("aria-hidden",!1),t.enforceFocus(),n?t.$element.one(e.support.transition.end,function(){t.$element.focus().trigger("shown")}):t.$element.focus().trigger("shown")})},hide:function(t){t&&t.preventDefault();var n=this;t=e.Event("hide"),this.$element.trigger(t);if(!this.isShown||t.isDefaultPrevented())return;this.isShown=!1,this.escape(),e(document).off("focusin.modal"),this.$element.removeClass("in").attr("aria-hidden",!0),e.support.transition&&this.$element.hasClass("fade")?this.hideWithTransition():this.hideModal()},enforceFocus:function(){var t=this;e(document).on("focusin.modal",function(e){t.$element[0]!==e.target&&!t.$element.has(e.target).length&&t.$element.focus()})},escape:function(){var e=this;this.isShown&&this.options.keyboard?this.$element.on("keyup.dismiss.modal",function(t){t.which==27&&e.hide()}):this.isShown||this.$element.off("keyup.dismiss.modal")},hideWithTransition:function(){var t=this,n=setTimeout(function(){t.$element.off(e.support.transition.end),t.hideModal()},500);this.$element.one(e.support.transition.end,function(){clearTimeout(n),t.hideModal()})},hideModal:function(){var e=this;this.$element.hide(),this.backdrop(function(){e.removeBackdrop(),e.$element.trigger("hidden")})},removeBackdrop:function(){this.$backdrop&&this.$backdrop.remove(),this.$backdrop=null},backdrop:function(t){var n=this,r=this.$element.hasClass("fade")?"fade":"";if(this.isShown&&this.options.backdrop){var i=e.support.transition&&r;this.$backdrop=e('<div class="modal-backdrop '+r+'" />').appendTo(document.body),this.$backdrop.click(this.options.backdrop=="static"?e.proxy(this.$element[0].focus,this.$element[0]):e.proxy(this.hide,this)),i&&this.$backdrop[0].offsetWidth,this.$backdrop.addClass("in");if(!t)return;i?this.$backdrop.one(e.support.transition.end,t):t()}else!this.isShown&&this.$backdrop?(this.$backdrop.removeClass("in"),e.support.transition&&this.$element.hasClass("fade")?this.$backdrop.one(e.support.transition.end,t):t()):t&&t()}};var n=e.fn.modal;e.fn.modal=function(n){return this.each(function(){var r=e(this),i=r.data("modal"),s=e.extend({},e.fn.modal.defaults,r.data(),typeof n=="object"&&n);i||r.data("modal",i=new t(this,s)),typeof n=="string"?i[n]():s.show&&i.show()})},e.fn.modal.defaults={backdrop:!0,keyboard:!0,show:!0},e.fn.modal.Constructor=t,e.fn.modal.noConflict=function(){return e.fn.modal=n,this},e(document).on("click.modal.data-api",'[data-toggle="modal"]',function(t){var n=e(this),r=n.attr("href"),i=e(n.attr("data-target")||r&&r.replace(/.*(?=#[^\s]+$)/,"")),s=i.data("modal")?"toggle":e.extend({remote:!/#/.test(r)&&r},i.data(),n.data());t.preventDefault(),i.modal(s).one("hide",function(){n.focus()})})}(window.jQuery),!function(e){"use strict";var t=function(e,t){this.init("tooltip",e,t)};t.prototype={constructor:t,init:function(t,n,r){var i,s,o,u,a;this.type=t,this.$element=e(n),this.options=this.getOptions(r),this.enabled=!0,o=this.options.trigger.split(" ");for(a=o.length;a--;)u=o[a],u=="click"?this.$element.on("click."+this.type,this.options.selector,e.proxy(this.toggle,this)):u!="manual"&&(i=u=="hover"?"mouseenter":"focus",s=u=="hover"?"mouseleave":"blur",this.$element.on(i+"."+this.type,this.options.selector,e.proxy(this.enter,this)),this.$element.on(s+"."+this.type,this.options.selector,e.proxy(this.leave,this)));this.options.selector?this._options=e.extend({},this.options,{trigger:"manual",selector:""}):this.fixTitle()},getOptions:function(t){return t=e.extend({},e.fn[this.type].defaults,this.$element.data(),t),t.delay&&typeof t.delay=="number"&&(t.delay={show:t.delay,hide:t.delay}),t},enter:function(t){var n=e.fn[this.type].defaults,r={},i;this._options&&e.each(this._options,function(e,t){n[e]!=t&&(r[e]=t)},this),i=e(t.currentTarget)[this.type](r).data(this.type);if(!i.options.delay||!i.options.delay.show)return i.show();clearTimeout(this.timeout),i.hoverState="in",this.timeout=setTimeout(function(){i.hoverState=="in"&&i.show()},i.options.delay.show)},leave:function(t){var n=e(t.currentTarget)[this.type](this._options).data(this.type);this.timeout&&clearTimeout(this.timeout);if(!n.options.delay||!n.options.delay.hide)return n.hide();n.hoverState="out",this.timeout=setTimeout(function(){n.hoverState=="out"&&n.hide()},n.options.delay.hide)},show:function(){var t,n,r,i,s,o,u=e.Event("show");if(this.hasContent()&&this.enabled){this.$element.trigger(u);if(u.isDefaultPrevented())return;t=this.tip(),this.setContent(),this.options.animation&&t.addClass("fade"),s=typeof this.options.placement=="function"?this.options.placement.call(this,t[0],this.$element[0]):this.options.placement,t.detach().css({top:0,left:0,display:"block"}),this.options.container?t.appendTo(this.options.container):t.insertAfter(this.$element),n=this.getPosition(),r=t[0].offsetWidth,i=t[0].offsetHeight;switch(s){case"bottom":o={top:n.top+n.height,left:n.left+n.width/2-r/2};break;case"top":o={top:n.top-i,left:n.left+n.width/2-r/2};break;case"left":o={top:n.top+n.height/2-i/2,left:n.left-r};break;case"right":o={top:n.top+n.height/2-i/2,left:n.left+n.width}}this.applyPlacement(o,s),this.$element.trigger("shown")}},applyPlacement:function(e,t){var n=this.tip(),r=n[0].offsetWidth,i=n[0].offsetHeight,s,o,u,a;n.offset(e).addClass(t).addClass("in"),s=n[0].offsetWidth,o=n[0].offsetHeight,t=="top"&&o!=i&&(e.top=e.top+i-o,a=!0),t=="bottom"||t=="top"?(u=0,e.left<0&&(u=e.left*-2,e.left=0,n.offset(e),s=n[0].offsetWidth,o=n[0].offsetHeight),this.replaceArrow(u-r+s,s,"left")):this.replaceArrow(o-i,o,"top"),a&&n.offset(e)},replaceArrow:function(e,t,n){this.arrow().css(n,e?50*(1-e/t)+"%":"")},setContent:function(){var e=this.tip(),t=this.getTitle();e.find(".tooltip-inner")[this.options.html?"html":"text"](t),e.removeClass("fade in top bottom left right")},hide:function(){function i(){var t=setTimeout(function(){n.off(e.support.transition.end).detach()},500);n.one(e.support.transition.end,function(){clearTimeout(t),n.detach()})}var t=this,n=this.tip(),r=e.Event("hide");this.$element.trigger(r);if(r.isDefaultPrevented())return;return n.removeClass("in"),e.support.transition&&this.$tip.hasClass("fade")?i():n.detach(),this.$element.trigger("hidden"),this},fixTitle:function(){var e=this.$element;(e.attr("title")||typeof e.attr("data-original-title")!="string")&&e.attr("data-original-title",e.attr("title")||"").attr("title","")},hasContent:function(){return this.getTitle()},getPosition:function(){var t=this.$element[0];return e.extend({},typeof t.getBoundingClientRect=="function"?t.getBoundingClientRect():{width:t.offsetWidth,height:t.offsetHeight},this.$element.offset())},getTitle:function(){var e,t=this.$element,n=this.options;return e=t.attr("data-original-title")||(typeof n.title=="function"?n.title.call(t[0]):n.title),e},tip:function(){return this.$tip=this.$tip||e(this.options.template)},arrow:function(){return this.$arrow=this.$arrow||this.tip().find(".tooltip-arrow")},validate:function(){this.$element[0].parentNode||(this.hide(),this.$element=null,this.options=null)},enable:function(){this.enabled=!0},disable:function(){this.enabled=!1},toggleEnabled:function(){this.enabled=!this.enabled},toggle:function(t){var n=t?e(t.currentTarget)[this.type](this._options).data(this.type):this;n.tip().hasClass("in")?n.hide():n.show()},destroy:function(){this.hide().$element.off("."+this.type).removeData(this.type)}};var n=e.fn.tooltip;e.fn.tooltip=function(n){return this.each(function(){var r=e(this),i=r.data("tooltip"),s=typeof n=="object"&&n;i||r.data("tooltip",i=new t(this,s)),typeof n=="string"&&i[n]()})},e.fn.tooltip.Constructor=t,e.fn.tooltip.defaults={animation:!0,placement:"top",selector:!1,template:'<div class="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',trigger:"hover focus",title:"",delay:0,html:!1,container:!1},e.fn.tooltip.noConflict=function(){return e.fn.tooltip=n,this}}(window.jQuery),!function(e){"use strict";var t=function(e,t){this.init("popover",e,t)};t.prototype=e.extend({},e.fn.tooltip.Constructor.prototype,{constructor:t,setContent:function(){var e=this.tip(),t=this.getTitle(),n=this.getContent();e.find(".popover-title")[this.options.html?"html":"text"](t),e.find(".popover-content")[this.options.html?"html":"text"](n),e.removeClass("fade top bottom left right in")},hasContent:function(){return this.getTitle()||this.getContent()},getContent:function(){var e,t=this.$element,n=this.options;return e=(typeof n.content=="function"?n.content.call(t[0]):n.content)||t.attr("data-content"),e},tip:function(){return this.$tip||(this.$tip=e(this.options.template)),this.$tip},destroy:function(){this.hide().$element.off("."+this.type).removeData(this.type)}});var n=e.fn.popover;e.fn.popover=function(n){return this.each(function(){var r=e(this),i=r.data("popover"),s=typeof n=="object"&&n;i||r.data("popover",i=new t(this,s)),typeof n=="string"&&i[n]()})},e.fn.popover.Constructor=t,e.fn.popover.defaults=e.extend({},e.fn.tooltip.defaults,{placement:"right",trigger:"click",content:"",template:'<div class="popover"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>'}),e.fn.popover.noConflict=function(){return e.fn.popover=n,this}}(window.jQuery),!function(e){"use strict";function t(t,n){var r=e.proxy(this.process,this),i=e(t).is("body")?e(window):e(t),s;this.options=e.extend({},e.fn.scrollspy.defaults,n),this.$scrollElement=i.on("scroll.scroll-spy.data-api",r),this.selector=(this.options.target||(s=e(t).attr("href"))&&s.replace(/.*(?=#[^\s]+$)/,"")||"")+" .nav li > a",this.$body=e("body"),this.refresh(),this.process()}t.prototype={constructor:t,refresh:function(){var t=this,n;this.offsets=e([]),this.targets=e([]),n=this.$body.find(this.selector).map(function(){var n=e(this),r=n.data("target")||n.attr("href"),i=/^#\w/.test(r)&&e(r);return i&&i.length&&[[i.position().top+(!e.isWindow(t.$scrollElement.get(0))&&t.$scrollElement.scrollTop()),r]]||null}).sort(function(e,t){return e[0]-t[0]}).each(function(){t.offsets.push(this[0]),t.targets.push(this[1])})},process:function(){var e=this.$scrollElement.scrollTop()+this.options.offset,t=this.$scrollElement[0].scrollHeight||this.$body[0].scrollHeight,n=t-this.$scrollElement.height(),r=this.offsets,i=this.targets,s=this.activeTarget,o;if(e>=n)return s!=(o=i.last()[0])&&this.activate(o);for(o=r.length;o--;)s!=i[o]&&e>=r[o]&&(!r[o+1]||e<=r[o+1])&&this.activate(i[o])},activate:function(t){var n,r;this.activeTarget=t,e(this.selector).parent(".active").removeClass("active"),r=this.selector+'[data-target="'+t+'"],'+this.selector+'[href="'+t+'"]',n=e(r).parent("li").addClass("active"),n.parent(".dropdown-menu").length&&(n=n.closest("li.dropdown").addClass("active")),n.trigger("activate")}};var n=e.fn.scrollspy;e.fn.scrollspy=function(n){return this.each(function(){var r=e(this),i=r.data("scrollspy"),s=typeof n=="object"&&n;i||r.data("scrollspy",i=new t(this,s)),typeof n=="string"&&i[n]()})},e.fn.scrollspy.Constructor=t,e.fn.scrollspy.defaults={offset:10},e.fn.scrollspy.noConflict=function(){return e.fn.scrollspy=n,this},e(window).on("load",function(){e('[data-spy="scroll"]').each(function(){var t=e(this);t.scrollspy(t.data())})})}(window.jQuery),!function(e){"use strict";var t=function(t){this.element=e(t)};t.prototype={constructor:t,show:function(){var t=this.element,n=t.closest("ul:not(.dropdown-menu)"),r=t.attr("data-target"),i,s,o;r||(r=t.attr("href"),r=r&&r.replace(/.*(?=#[^\s]*$)/,""));if(t.parent("li").hasClass("active"))return;i=n.find(".active:last a")[0],o=e.Event("show",{relatedTarget:i}),t.trigger(o);if(o.isDefaultPrevented())return;s=e(r),this.activate(t.parent("li"),n),this.activate(s,s.parent(),function(){t.trigger({type:"shown",relatedTarget:i})})},activate:function(t,n,r){function o(){i.removeClass("active").find("> .dropdown-menu > .active").removeClass("active"),t.addClass("active"),s?(t[0].offsetWidth,t.addClass("in")):t.removeClass("fade"),t.parent(".dropdown-menu")&&t.closest("li.dropdown").addClass("active"),r&&r()}var i=n.find("> .active"),s=r&&e.support.transition&&i.hasClass("fade");s?i.one(e.support.transition.end,o):o(),i.removeClass("in")}};var n=e.fn.tab;e.fn.tab=function(n){return this.each(function(){var r=e(this),i=r.data("tab");i||r.data("tab",i=new t(this)),typeof n=="string"&&i[n]()})},e.fn.tab.Constructor=t,e.fn.tab.noConflict=function(){return e.fn.tab=n,this},e(document).on("click.tab.data-api",'[data-toggle="tab"], [data-toggle="pill"]',function(t){t.preventDefault(),e(this).tab("show")})}(window.jQuery),!function(e){"use strict";var t=function(t,n){this.$element=e(t),this.options=e.extend({},e.fn.typeahead.defaults,n),this.matcher=this.options.matcher||this.matcher,this.sorter=this.options.sorter||this.sorter,this.highlighter=this.options.highlighter||this.highlighter,this.updater=this.options.updater||this.updater,this.source=this.options.source,this.$menu=e(this.options.menu),this.shown=!1,this.listen()};t.prototype={constructor:t,select:function(){var e=this.$menu.find(".active").attr("data-value");return this.$element.val(this.updater(e)).change(),this.hide()},updater:function(e){return e},show:function(){var t=e.extend({},this.$element.position(),{height:this.$element[0].offsetHeight});return this.$menu.insertAfter(this.$element).css({top:t.top+t.height,left:t.left}).show(),this.shown=!0,this},hide:function(){return this.$menu.hide(),this.shown=!1,this},lookup:function(t){var n;return this.query=this.$element.val(),!this.query||this.query.length<this.options.minLength?this.shown?this.hide():this:(n=e.isFunction(this.source)?this.source(this.query,e.proxy(this.process,this)):this.source,n?this.process(n):this)},process:function(t){var n=this;return t=e.grep(t,function(e){return n.matcher(e)}),t=this.sorter(t),t.length?this.render(t.slice(0,this.options.items)).show():this.shown?this.hide():this},matcher:function(e){return~e.toLowerCase().indexOf(this.query.toLowerCase())},sorter:function(e){var t=[],n=[],r=[],i;while(i=e.shift())i.toLowerCase().indexOf(this.query.toLowerCase())?~i.indexOf(this.query)?n.push(i):r.push(i):t.push(i);return t.concat(n,r)},highlighter:function(e){var t=this.query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g,"\\$&");return e.replace(new RegExp("("+t+")","ig"),function(e,t){return"<strong>"+t+"</strong>"})},render:function(t){var n=this;return t=e(t).map(function(t,r){return t=e(n.options.item).attr("data-value",r),t.find("a").html(n.highlighter(r)),t[0]}),t.first().addClass("active"),this.$menu.html(t),this},next:function(t){var n=this.$menu.find(".active").removeClass("active"),r=n.next();r.length||(r=e(this.$menu.find("li")[0])),r.addClass("active")},prev:function(e){var t=this.$menu.find(".active").removeClass("active"),n=t.prev();n.length||(n=this.$menu.find("li").last()),n.addClass("active")},listen:function(){this.$element.on("focus",e.proxy(this.focus,this)).on("blur",e.proxy(this.blur,this)).on("keypress",e.proxy(this.keypress,this)).on("keyup",e.proxy(this.keyup,this)),this.eventSupported("keydown")&&this.$element.on("keydown",e.proxy(this.keydown,this)),this.$menu.on("click",e.proxy(this.click,this)).on("mouseenter","li",e.proxy(this.mouseenter,this)).on("mouseleave","li",e.proxy(this.mouseleave,this))},eventSupported:function(e){var t=e in this.$element;return t||(this.$element.setAttribute(e,"return;"),t=typeof this.$element[e]=="function"),t},move:function(e){if(!this.shown)return;switch(e.keyCode){case 9:case 13:case 27:e.preventDefault();break;case 38:e.preventDefault(),this.prev();break;case 40:e.preventDefault(),this.next()}e.stopPropagation()},keydown:function(t){this.suppressKeyPressRepeat=~e.inArray(t.keyCode,[40,38,9,13,27]),this.move(t)},keypress:function(e){if(this.suppressKeyPressRepeat)return;this.move(e)},keyup:function(e){switch(e.keyCode){case 40:case 38:case 16:case 17:case 18:break;case 9:case 13:if(!this.shown)return;this.select();break;case 27:if(!this.shown)return;this.hide();break;default:this.lookup()}e.stopPropagation(),e.preventDefault()},focus:function(e){this.focused=!0},blur:function(e){this.focused=!1,!this.mousedover&&this.shown&&this.hide()},click:function(e){e.stopPropagation(),e.preventDefault(),this.select(),this.$element.focus()},mouseenter:function(t){this.mousedover=!0,this.$menu.find(".active").removeClass("active"),e(t.currentTarget).addClass("active")},mouseleave:function(e){this.mousedover=!1,!this.focused&&this.shown&&this.hide()}};var n=e.fn.typeahead;e.fn.typeahead=function(n){return this.each(function(){var r=e(this),i=r.data("typeahead"),s=typeof n=="object"&&n;i||r.data("typeahead",i=new t(this,s)),typeof n=="string"&&i[n]()})},e.fn.typeahead.defaults={source:[],items:8,menu:'<ul class="typeahead dropdown-menu"></ul>',item:'<li><a href="#"></a></li>',minLength:1},e.fn.typeahead.Constructor=t,e.fn.typeahead.noConflict=function(){return e.fn.typeahead=n,this},e(document).on("focus.typeahead.data-api",'[data-provide="typeahead"]',function(t){var n=e(this);if(n.data("typeahead"))return;n.typeahead(n.data())})}(window.jQuery),!function(e){"use strict";var t=function(t,n){this.options=e.extend({},e.fn.affix.defaults,n),this.$window=e(window).on("scroll.affix.data-api",e.proxy(this.checkPosition,this)).on("click.affix.data-api",e.proxy(function(){setTimeout(e.proxy(this.checkPosition,this),1)},this)),this.$element=e(t),this.checkPosition()};t.prototype.checkPosition=function(){if(!this.$element.is(":visible"))return;var t=e(document).height(),n=this.$window.scrollTop(),r=this.$element.offset(),i=this.options.offset,s=i.bottom,o=i.top,u="affix affix-top affix-bottom",a;typeof i!="object"&&(s=o=i),typeof o=="function"&&(o=i.top()),typeof s=="function"&&(s=i.bottom()),a=this.unpin!=null&&n+this.unpin<=r.top?!1:s!=null&&r.top+this.$element.height()>=t-s?"bottom":o!=null&&n<=o?"top":!1;if(this.affixed===a)return;this.affixed=a,this.unpin=a=="bottom"?r.top-n:null,this.$element.removeClass(u).addClass("affix"+(a?"-"+a:""))};var n=e.fn.affix;e.fn.affix=function(n){return this.each(function(){var r=e(this),i=r.data("affix"),s=typeof n=="object"&&n;i||r.data("affix",i=new t(this,s)),typeof n=="string"&&i[n]()})},e.fn.affix.Constructor=t,e.fn.affix.defaults={offset:0},e.fn.affix.noConflict=function(){return e.fn.affix=n,this},e(window).on("load",function(){e('[data-spy="affix"]').each(function(){var t=e(this),n=t.data();n.offset=n.offset||{},n.offsetBottom&&(n.offset.bottom=n.offsetBottom),n.offsetTop&&(n.offset.top=n.offsetTop),t.affix(n)})})}(window.jQuery);
 </script>
 
-<script>
+  <script>
 /**
  * marked - a markdown parser
  * Copyright (c) 2011-2014, Christopher Jeffrey. (MIT Licensed)
@@ -66,123 +63,120 @@ h={};g()}};typeof define==="function"&&define.amd&&define("google-code-prettify"
  */
 (function(){var block={newline:/^\n+/,code:/^( {4}[^\n]+\n*)+/,fences:noop,hr:/^( *[-*_]){3,} *(?:\n+|$)/,heading:/^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,nptable:noop,lheading:/^([^\n]+)\n *(=|-){2,} *(?:\n+|$)/,blockquote:/^( *>[^\n]+(\n(?!def)[^\n]+)*\n*)+/,list:/^( *)(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,html:/^ *(?:comment *(?:\n|\s*$)|closed *(?:\n{2,}|\s*$)|closing *(?:\n{2,}|\s*$))/,def:/^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +["(]([^\n]+)[")])? *(?:\n+|$)/,table:noop,paragraph:/^((?:[^\n]+\n?(?!hr|heading|lheading|blockquote|tag|def))+)\n*/,text:/^[^\n]+/};block.bullet=/(?:[*+-]|\d+\.)/;block.item=/^( *)(bull) [^\n]*(?:\n(?!\1bull )[^\n]*)*/;block.item=replace(block.item,"gm")(/bull/g,block.bullet)();block.list=replace(block.list)(/bull/g,block.bullet)("hr","\\n+(?=\\1?(?:[-*_] *){3,}(?:\\n+|$))")("def","\\n+(?="+block.def.source+")")();block.blockquote=replace(block.blockquote)("def",block.def)();block._tag="(?!(?:"+"a|em|strong|small|s|cite|q|dfn|abbr|data|time|code"+"|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo"+"|span|br|wbr|ins|del|img)\\b)\\w+(?!:/|[^\\w\\s@]*@)\\b";block.html=replace(block.html)("comment",/<!--[\s\S]*?-->/)("closed",/<(tag)[\s\S]+?<\/\1>/)("closing",/<tag(?:"[^"]*"|'[^']*'|[^'">])*?>/)(/tag/g,block._tag)();block.paragraph=replace(block.paragraph)("hr",block.hr)("heading",block.heading)("lheading",block.lheading)("blockquote",block.blockquote)("tag","<"+block._tag)("def",block.def)();block.normal=merge({},block);block.gfm=merge({},block.normal,{fences:/^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\s*\1 *(?:\n+|$)/,paragraph:/^/,heading:/^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/});block.gfm.paragraph=replace(block.paragraph)("(?!","(?!"+block.gfm.fences.source.replace("\\1","\\2")+"|"+block.list.source.replace("\\1","\\3")+"|")();block.tables=merge({},block.gfm,{nptable:/^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*/,table:/^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/});function Lexer(options){this.tokens=[];this.tokens.links={};this.options=options||marked.defaults;this.rules=block.normal;if(this.options.gfm){if(this.options.tables){this.rules=block.tables}else{this.rules=block.gfm}}}Lexer.rules=block;Lexer.lex=function(src,options){var lexer=new Lexer(options);return lexer.lex(src)};Lexer.prototype.lex=function(src){src=src.replace(/\r\n|\r/g,"\n").replace(/\t/g,"    ").replace(/\u00a0/g," ").replace(/\u2424/g,"\n");return this.token(src,true)};Lexer.prototype.token=function(src,top,bq){var src=src.replace(/^ +$/gm,""),next,loose,cap,bull,b,item,space,i,l;while(src){if(cap=this.rules.newline.exec(src)){src=src.substring(cap[0].length);if(cap[0].length>1){this.tokens.push({type:"space"})}}if(cap=this.rules.code.exec(src)){src=src.substring(cap[0].length);cap=cap[0].replace(/^ {4}/gm,"");this.tokens.push({type:"code",text:!this.options.pedantic?cap.replace(/\n+$/,""):cap});continue}if(cap=this.rules.fences.exec(src)){src=src.substring(cap[0].length);this.tokens.push({type:"code",lang:cap[2],text:cap[3]||""});continue}if(cap=this.rules.heading.exec(src)){src=src.substring(cap[0].length);this.tokens.push({type:"heading",depth:cap[1].length,text:cap[2]});continue}if(top&&(cap=this.rules.nptable.exec(src))){src=src.substring(cap[0].length);item={type:"table",header:cap[1].replace(/^ *| *\| *$/g,"").split(/ *\| */),align:cap[2].replace(/^ *|\| *$/g,"").split(/ *\| */),cells:cap[3].replace(/\n$/,"").split("\n")};for(i=0;i<item.align.length;i++){if(/^ *-+: *$/.test(item.align[i])){item.align[i]="right"}else if(/^ *:-+: *$/.test(item.align[i])){item.align[i]="center"}else if(/^ *:-+ *$/.test(item.align[i])){item.align[i]="left"}else{item.align[i]=null}}for(i=0;i<item.cells.length;i++){item.cells[i]=item.cells[i].split(/ *\| */)}this.tokens.push(item);continue}if(cap=this.rules.lheading.exec(src)){src=src.substring(cap[0].length);this.tokens.push({type:"heading",depth:cap[2]==="="?1:2,text:cap[1]});continue}if(cap=this.rules.hr.exec(src)){src=src.substring(cap[0].length);this.tokens.push({type:"hr"});continue}if(cap=this.rules.blockquote.exec(src)){src=src.substring(cap[0].length);this.tokens.push({type:"blockquote_start"});cap=cap[0].replace(/^ *> ?/gm,"");this.token(cap,top,true);this.tokens.push({type:"blockquote_end"});continue}if(cap=this.rules.list.exec(src)){src=src.substring(cap[0].length);bull=cap[2];this.tokens.push({type:"list_start",ordered:bull.length>1});cap=cap[0].match(this.rules.item);next=false;l=cap.length;i=0;for(;i<l;i++){item=cap[i];space=item.length;item=item.replace(/^ *([*+-]|\d+\.) +/,"");if(~item.indexOf("\n ")){space-=item.length;item=!this.options.pedantic?item.replace(new RegExp("^ {1,"+space+"}","gm"),""):item.replace(/^ {1,4}/gm,"")}if(this.options.smartLists&&i!==l-1){b=block.bullet.exec(cap[i+1])[0];if(bull!==b&&!(bull.length>1&&b.length>1)){src=cap.slice(i+1).join("\n")+src;i=l-1}}loose=next||/\n\n(?!\s*$)/.test(item);if(i!==l-1){next=item.charAt(item.length-1)==="\n";if(!loose)loose=next}this.tokens.push({type:loose?"loose_item_start":"list_item_start"});this.token(item,false,bq);this.tokens.push({type:"list_item_end"})}this.tokens.push({type:"list_end"});continue}if(cap=this.rules.html.exec(src)){src=src.substring(cap[0].length);this.tokens.push({type:this.options.sanitize?"paragraph":"html",pre:!this.options.sanitizer&&(cap[1]==="pre"||cap[1]==="script"||cap[1]==="style"),text:cap[0]});continue}if(!bq&&top&&(cap=this.rules.def.exec(src))){src=src.substring(cap[0].length);this.tokens.links[cap[1].toLowerCase()]={href:cap[2],title:cap[3]};continue}if(top&&(cap=this.rules.table.exec(src))){src=src.substring(cap[0].length);item={type:"table",header:cap[1].replace(/^ *| *\| *$/g,"").split(/ *\| */),align:cap[2].replace(/^ *|\| *$/g,"").split(/ *\| */),cells:cap[3].replace(/(?: *\| *)?\n$/,"").split("\n")};for(i=0;i<item.align.length;i++){if(/^ *-+: *$/.test(item.align[i])){item.align[i]="right"}else if(/^ *:-+: *$/.test(item.align[i])){item.align[i]="center"}else if(/^ *:-+ *$/.test(item.align[i])){item.align[i]="left"}else{item.align[i]=null}}for(i=0;i<item.cells.length;i++){item.cells[i]=item.cells[i].replace(/^ *\| *| *\| *$/g,"").split(/ *\| */)}this.tokens.push(item);continue}if(top&&(cap=this.rules.paragraph.exec(src))){src=src.substring(cap[0].length);this.tokens.push({type:"paragraph",text:cap[1].charAt(cap[1].length-1)==="\n"?cap[1].slice(0,-1):cap[1]});continue}if(cap=this.rules.text.exec(src)){src=src.substring(cap[0].length);this.tokens.push({type:"text",text:cap[0]});continue}if(src){throw new Error("Infinite loop on byte: "+src.charCodeAt(0))}}return this.tokens};var inline={escape:/^\\([\\`*{}\[\]()#+\-.!_>])/,autolink:/^<([^ >]+(@|:\/)[^ >]+)>/,url:noop,tag:/^<!--[\s\S]*?-->|^<\/?\w+(?:"[^"]*"|'[^']*'|[^'">])*?>/,link:/^!?\[(inside)\]\(href\)/,reflink:/^!?\[(inside)\]\s*\[([^\]]*)\]/,nolink:/^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,strong:/^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,em:/^\b_((?:[^_]|__)+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,code:/^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,br:/^ {2,}\n(?!\s*$)/,del:noop,text:/^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/};inline._inside=/(?:\[[^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*/;inline._href=/\s*<?([\s\S]*?)>?(?:\s+['"]([\s\S]*?)['"])?\s*/;inline.link=replace(inline.link)("inside",inline._inside)("href",inline._href)();inline.reflink=replace(inline.reflink)("inside",inline._inside)();inline.normal=merge({},inline);inline.pedantic=merge({},inline.normal,{strong:/^__(?=\S)([\s\S]*?\S)__(?!_)|^\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)/,em:/^_(?=\S)([\s\S]*?\S)_(?!_)|^\*(?=\S)([\s\S]*?\S)\*(?!\*)/});inline.gfm=merge({},inline.normal,{escape:replace(inline.escape)("])","~|])")(),url:/^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/,del:/^~~(?=\S)([\s\S]*?\S)~~/,text:replace(inline.text)("]|","~]|")("|","|https?://|")()});inline.breaks=merge({},inline.gfm,{br:replace(inline.br)("{2,}","*")(),text:replace(inline.gfm.text)("{2,}","*")()});function InlineLexer(links,options){this.options=options||marked.defaults;this.links=links;this.rules=inline.normal;this.renderer=this.options.renderer||new Renderer;this.renderer.options=this.options;if(!this.links){throw new Error("Tokens array requires a `links` property.")}if(this.options.gfm){if(this.options.breaks){this.rules=inline.breaks}else{this.rules=inline.gfm}}else if(this.options.pedantic){this.rules=inline.pedantic}}InlineLexer.rules=inline;InlineLexer.output=function(src,links,options){var inline=new InlineLexer(links,options);return inline.output(src)};InlineLexer.prototype.output=function(src){var out="",link,text,href,cap;while(src){if(cap=this.rules.escape.exec(src)){src=src.substring(cap[0].length);out+=cap[1];continue}if(cap=this.rules.autolink.exec(src)){src=src.substring(cap[0].length);if(cap[2]==="@"){text=cap[1].charAt(6)===":"?this.mangle(cap[1].substring(7)):this.mangle(cap[1]);href=this.mangle("mailto:")+text}else{text=escape(cap[1]);href=text}out+=this.renderer.link(href,null,text);continue}if(!this.inLink&&(cap=this.rules.url.exec(src))){src=src.substring(cap[0].length);text=escape(cap[1]);href=text;out+=this.renderer.link(href,null,text);continue}if(cap=this.rules.tag.exec(src)){if(!this.inLink&&/^<a /i.test(cap[0])){this.inLink=true}else if(this.inLink&&/^<\/a>/i.test(cap[0])){this.inLink=false}src=src.substring(cap[0].length);out+=this.options.sanitize?this.options.sanitizer?this.options.sanitizer(cap[0]):escape(cap[0]):cap[0];continue}if(cap=this.rules.link.exec(src)){src=src.substring(cap[0].length);this.inLink=true;out+=this.outputLink(cap,{href:cap[2],title:cap[3]});this.inLink=false;continue}if((cap=this.rules.reflink.exec(src))||(cap=this.rules.nolink.exec(src))){src=src.substring(cap[0].length);link=(cap[2]||cap[1]).replace(/\s+/g," ");link=this.links[link.toLowerCase()];if(!link||!link.href){out+=cap[0].charAt(0);src=cap[0].substring(1)+src;continue}this.inLink=true;out+=this.outputLink(cap,link);this.inLink=false;continue}if(cap=this.rules.strong.exec(src)){src=src.substring(cap[0].length);out+=this.renderer.strong(this.output(cap[2]||cap[1]));continue}if(cap=this.rules.em.exec(src)){src=src.substring(cap[0].length);out+=this.renderer.em(this.output(cap[2]||cap[1]));continue}if(cap=this.rules.code.exec(src)){src=src.substring(cap[0].length);out+=this.renderer.codespan(escape(cap[2],true));continue}if(cap=this.rules.br.exec(src)){src=src.substring(cap[0].length);out+=this.renderer.br();continue}if(cap=this.rules.del.exec(src)){src=src.substring(cap[0].length);out+=this.renderer.del(this.output(cap[1]));continue}if(cap=this.rules.text.exec(src)){src=src.substring(cap[0].length);out+=this.renderer.text(escape(this.smartypants(cap[0])));continue}if(src){throw new Error("Infinite loop on byte: "+src.charCodeAt(0))}}return out};InlineLexer.prototype.outputLink=function(cap,link){var href=escape(link.href),title=link.title?escape(link.title):null;return cap[0].charAt(0)!=="!"?this.renderer.link(href,title,this.output(cap[1])):this.renderer.image(href,title,escape(cap[1]))};InlineLexer.prototype.smartypants=function(text){if(!this.options.smartypants)return text;return text.replace(/---/g,"—").replace(/--/g,"–").replace(/(^|[-\u2014/(\[{"\s])'/g,"$1‘").replace(/'/g,"’").replace(/(^|[-\u2014/(\[{\u2018\s])"/g,"$1“").replace(/"/g,"”").replace(/\.{3}/g,"…")};InlineLexer.prototype.mangle=function(text){if(!this.options.mangle)return text;var out="",l=text.length,i=0,ch;for(;i<l;i++){ch=text.charCodeAt(i);if(Math.random()>.5){ch="x"+ch.toString(16)}out+="&#"+ch+";"}return out};function Renderer(options){this.options=options||{}}Renderer.prototype.code=function(code,lang,escaped){if(this.options.highlight){var out=this.options.highlight(code,lang);if(out!=null&&out!==code){escaped=true;code=out}}if(!lang){return"<pre><code>"+(escaped?code:escape(code,true))+"\n</code></pre>"}return'<pre><code class="'+this.options.langPrefix+escape(lang,true)+'">'+(escaped?code:escape(code,true))+"\n</code></pre>\n"};Renderer.prototype.blockquote=function(quote){return"<blockquote>\n"+quote+"</blockquote>\n"};Renderer.prototype.html=function(html){return html};Renderer.prototype.heading=function(text,level,raw){return"<h"+level+' id="'+this.options.headerPrefix+raw.toLowerCase().replace(/[^\w]+/g,"-")+'">'+text+"</h"+level+">\n"};Renderer.prototype.hr=function(){return this.options.xhtml?"<hr/>\n":"<hr>\n"};Renderer.prototype.list=function(body,ordered){var type=ordered?"ol":"ul";return"<"+type+">\n"+body+"</"+type+">\n"};Renderer.prototype.listitem=function(text){return"<li>"+text+"</li>\n"};Renderer.prototype.paragraph=function(text){return"<p>"+text+"</p>\n"};Renderer.prototype.table=function(header,body){return"<table>\n"+"<thead>\n"+header+"</thead>\n"+"<tbody>\n"+body+"</tbody>\n"+"</table>\n"};Renderer.prototype.tablerow=function(content){return"<tr>\n"+content+"</tr>\n"};Renderer.prototype.tablecell=function(content,flags){var type=flags.header?"th":"td";var tag=flags.align?"<"+type+' style="text-align:'+flags.align+'">':"<"+type+">";return tag+content+"</"+type+">\n"};Renderer.prototype.strong=function(text){return"<strong>"+text+"</strong>"};Renderer.prototype.em=function(text){return"<em>"+text+"</em>"};Renderer.prototype.codespan=function(text){return"<code>"+text+"</code>"};Renderer.prototype.br=function(){return this.options.xhtml?"<br/>":"<br>"};Renderer.prototype.del=function(text){return"<del>"+text+"</del>"};Renderer.prototype.link=function(href,title,text){if(this.options.sanitize){try{var prot=decodeURIComponent(unescape(href)).replace(/[^\w:]/g,"").toLowerCase()}catch(e){return""}if(prot.indexOf("javascript:")===0||prot.indexOf("vbscript:")===0){return""}}var out='<a href="'+href+'"';if(title){out+=' title="'+title+'"'}out+=">"+text+"</a>";return out};Renderer.prototype.image=function(href,title,text){var out='<img src="'+href+'" alt="'+text+'"';if(title){out+=' title="'+title+'"'}out+=this.options.xhtml?"/>":">";return out};Renderer.prototype.text=function(text){return text};function Parser(options){this.tokens=[];this.token=null;this.options=options||marked.defaults;this.options.renderer=this.options.renderer||new Renderer;this.renderer=this.options.renderer;this.renderer.options=this.options}Parser.parse=function(src,options,renderer){var parser=new Parser(options,renderer);return parser.parse(src)};Parser.prototype.parse=function(src){this.inline=new InlineLexer(src.links,this.options,this.renderer);this.tokens=src.reverse();var out="";while(this.next()){out+=this.tok()}return out};Parser.prototype.next=function(){return this.token=this.tokens.pop()};Parser.prototype.peek=function(){return this.tokens[this.tokens.length-1]||0};Parser.prototype.parseText=function(){var body=this.token.text;while(this.peek().type==="text"){body+="\n"+this.next().text}return this.inline.output(body)};Parser.prototype.tok=function(){switch(this.token.type){case"space":{return""}case"hr":{return this.renderer.hr()}case"heading":{return this.renderer.heading(this.inline.output(this.token.text),this.token.depth,this.token.text)}case"code":{return this.renderer.code(this.token.text,this.token.lang,this.token.escaped)}case"table":{var header="",body="",i,row,cell,flags,j;cell="";for(i=0;i<this.token.header.length;i++){flags={header:true,align:this.token.align[i]};cell+=this.renderer.tablecell(this.inline.output(this.token.header[i]),{header:true,align:this.token.align[i]})}header+=this.renderer.tablerow(cell);for(i=0;i<this.token.cells.length;i++){row=this.token.cells[i];cell="";for(j=0;j<row.length;j++){cell+=this.renderer.tablecell(this.inline.output(row[j]),{header:false,align:this.token.align[j]})}body+=this.renderer.tablerow(cell)}return this.renderer.table(header,body)}case"blockquote_start":{var body="";while(this.next().type!=="blockquote_end"){body+=this.tok()}return this.renderer.blockquote(body)}case"list_start":{var body="",ordered=this.token.ordered;while(this.next().type!=="list_end"){body+=this.tok()}return this.renderer.list(body,ordered)}case"list_item_start":{var body="";while(this.next().type!=="list_item_end"){body+=this.token.type==="text"?this.parseText():this.tok()}return this.renderer.listitem(body)}case"loose_item_start":{var body="";while(this.next().type!=="list_item_end"){body+=this.tok()}return this.renderer.listitem(body)}case"html":{var html=!this.token.pre&&!this.options.pedantic?this.inline.output(this.token.text):this.token.text;return this.renderer.html(html)}case"paragraph":{return this.renderer.paragraph(this.inline.output(this.token.text))}case"text":{return this.renderer.paragraph(this.parseText())}}};function escape(html,encode){return html.replace(!encode?/&(?!#?\w+;)/g:/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#39;")}function unescape(html){return html.replace(/&([#\w]+);/g,function(_,n){n=n.toLowerCase();if(n==="colon")return":";if(n.charAt(0)==="#"){return n.charAt(1)==="x"?String.fromCharCode(parseInt(n.substring(2),16)):String.fromCharCode(+n.substring(1))}return""})}function replace(regex,opt){regex=regex.source;opt=opt||"";return function self(name,val){if(!name)return new RegExp(regex,opt);val=val.source||val;val=val.replace(/(^|[^\[])\^/g,"$1");regex=regex.replace(name,val);return self}}function noop(){}noop.exec=noop;function merge(obj){var i=1,target,key;for(;i<arguments.length;i++){target=arguments[i];for(key in target){if(Object.prototype.hasOwnProperty.call(target,key)){obj[key]=target[key]}}}return obj}function marked(src,opt,callback){if(callback||typeof opt==="function"){if(!callback){callback=opt;opt=null}opt=merge({},marked.defaults,opt||{});var highlight=opt.highlight,tokens,pending,i=0;try{tokens=Lexer.lex(src,opt)}catch(e){return callback(e)}pending=tokens.length;var done=function(err){if(err){opt.highlight=highlight;return callback(err)}var out;try{out=Parser.parse(tokens,opt)}catch(e){err=e}opt.highlight=highlight;return err?callback(err):callback(null,out)};if(!highlight||highlight.length<3){return done()}delete opt.highlight;if(!pending)return done();for(;i<tokens.length;i++){(function(token){if(token.type!=="code"){return--pending||done()}return highlight(token.text,token.lang,function(err,code){if(err)return done(err);if(code==null||code===token.text){return--pending||done()}token.text=code;token.escaped=true;--pending||done()})})(tokens[i])}return}try{if(opt)opt=merge({},marked.defaults,opt);return Parser.parse(Lexer.lex(src,opt),opt)}catch(e){e.message+="\nPlease report this to https://github.com/chjj/marked.";if((opt||marked.defaults).silent){return"<p>An error occured:</p><pre>"+escape(e.message+"",true)+"</pre>"}throw e}}marked.options=marked.setOptions=function(opt){merge(marked.defaults,opt);return marked};marked.defaults={gfm:true,tables:true,breaks:false,pedantic:false,sanitize:false,sanitizer:null,mangle:true,smartLists:false,silent:false,highlight:null,langPrefix:"lang-",smartypants:false,headerPrefix:"",renderer:new Renderer,xhtml:false};marked.Parser=Parser;marked.parser=Parser.parse;marked.Renderer=Renderer;marked.Lexer=Lexer;marked.lexer=Lexer.lex;marked.InlineLexer=InlineLexer;marked.inlineLexer=InlineLexer.output;marked.parse=marked;if(typeof module!=="undefined"&&typeof exports==="object"){module.exports=marked}else if(typeof define==="function"&&define.amd){define(function(){return marked})}else{this.marked=marked}}).call(function(){return this||(typeof window!=="undefined"?window:global)}());
 </script>
+  <script>
+    $( document ).ready(function() {
+      marked.setOptions({
+        renderer: new marked.Renderer(),
+        gfm: true,
+        tables: true,
+        breaks: false,
+        pedantic: false,
+        sanitize: false,
+        smartLists: true,
+        smartypants: false
+      });
 
-<script>
+      var textFile = null;
 
-$( document ).ready(function() {
-  marked.setOptions({
-    renderer: new marked.Renderer(),
-    gfm: true,
-    tables: true,
-    breaks: false,
-    pedantic: false,
-    sanitize: false,
-    smartLists: true,
-    smartypants: false
-  });
+      /// Function to be used to download a text json schema
+      function makeTextFile(text) {
 
-  var textFile = null;
+        var data = new Blob([text], {type: 'text/plain'});
 
-  /// Function to be used to download a text json schema
-  function makeTextFile(text) {
+        // If we are replacing a previously generated file we need to
+        // manually revoke the object URL to avoid memory leaks.
+        if (textFile !== null) {
+          window.URL.revokeObjectURL(textFile);
+        }
 
-    var data = new Blob([text], {type: 'text/plain'});
+        textFile = window.URL.createObjectURL(data);
 
-    // If we are replacing a previously generated file we need to
-    // manually revoke the object URL to avoid memory leaks.
-    if (textFile !== null) {
-      window.URL.revokeObjectURL(textFile);
-    }
+        var a = document.createElement("a");
+        document.body.appendChild(a);
+        a.style = "display: none";
+        a.href = textFile;
+        a.download = 'schema.txt';
+        a.click();
 
-    textFile = window.URL.createObjectURL(data);
+        return textFile;
+      };
 
-    var a = document.createElement("a");
-    document.body.appendChild(a);
-    a.style = "display: none";
-    a.href = textFile;
-    a.download = 'schema.txt';
-    a.click();
+      /// TODO: Implement resizing for expanding within iframe
+      function callResize() {
+        window.parent.postMessage('resize', "*");
+      }
 
-    return textFile;
-  };
-
-  /// TODO: Implement resizing for expanding within iframe
-  function callResize() {
-    window.parent.postMessage('resize', "*");
-  }
-
-  function processMarked() {
-    $(".marked").each(function() {
-      $(this).html(marked($(this).html()));
-    });
-  }
+      function processMarked() {
+        $(".marked").each(function() {
+          $(this).html(marked($(this).html()));
+        });
+      }
 
 
-  // load google web fonts
-  loadGoogleFontCss();
+      // load google web fonts
+      loadGoogleFontCss();
 
 
-  // Bootstrap Scrollspy
-  $(this).scrollspy({ target: '#scrollingNav', offset: 18 });
+      // Bootstrap Scrollspy
+      $(this).scrollspy({ target: '#scrollingNav', offset: 18 });
 
-  // Content-Scroll on Navigation click.
-  $('.sidenav').find('a').on('click', function(e) {
-      e.preventDefault();
-      var id = $(this).attr('href');
-      if ($(id).length > 0)
-          $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 400);
-      window.location.hash = $(this).attr('href');
-  });
+      // Content-Scroll on Navigation click.
+      $('.sidenav').find('a').on('click', function(e) {
+          e.preventDefault();
+          var id = $(this).attr('href');
+          if ($(id).length > 0)
+              $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 400);
+          window.location.hash = $(this).attr('href');
+      });
 
-  // Quickjump on Pageload to hash position.
-  if(window.location.hash) {
-      var id = window.location.hash;
-      if ($(id).length > 0)
-          $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 0);
-  }
-
-
-  function initDynamic() {
-    // tabs
-    $('.nav-tabs-examples a').click(function (e) {
-        e.preventDefault();
-        $(this).tab('show');
-    });
+      // Quickjump on Pageload to hash position.
+      if(window.location.hash) {
+          var id = window.location.hash;
+          if ($(id).length > 0)
+              $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 0);
+      }
 
 
-    $('.nav-tabs-examples').find('a:first').tab('show');
+      function initDynamic() {
+        // tabs
+        $('.nav-tabs-examples a').click(function (e) {
+            e.preventDefault();
+            $(this).tab('show');
+        });
 
-    // call scrollspy refresh method
-    $(window).scrollspy('refresh');
-  }
 
-  initDynamic();
+        $('.nav-tabs-examples').find('a:first').tab('show');
 
-  // Pre- / Code-Format
-  prettyPrint();
+        // call scrollspy refresh method
+        $(window).scrollspy('refresh');
+      }
 
-  //Convert elements with "marked" class to markdown
-  processMarked();
+      initDynamic();
 
-  /**
-   * Load google fonts.
-   */
-  function loadGoogleFontCss() {
-    WebFont.load({
-      active: function() {
-        // Update scrollspy
-        $(window).scrollspy('refresh')
-      },
-      google: {
-        families: ['Source Code Pro', 'Source Sans Pro:n4,n6,n7']
+      // Pre- / Code-Format
+      prettyPrint();
+
+      //Convert elements with "marked" class to markdown
+      processMarked();
+
+      /**
+       * Load google fonts.
+       */
+      function loadGoogleFontCss() {
+        WebFont.load({
+          active: function() {
+            // Update scrollspy
+            $(window).scrollspy('refresh')
+          },
+          google: {
+            families: ['Source Code Pro', 'Source Sans Pro:n4,n6,n7']
+          }
+        });
       }
     });
-  }
-});
-</script>
-
-<style type="text/css">
-
+  </script>
+  <style type="text/css">
+  
 /*!
  * Bootstrap v2.3.2
  *
@@ -193,7 +187,7 @@ $( document ).ready(function() {
  * Designed and built with all the love in the world by @mdo and @fat.
  */.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;line-height:0;content:""}.clearfix:after{clear:both}.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block}audio,canvas,video{display:inline-block;*display:inline;*zoom:1}audio:not([controls]){display:none}html{font-size:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}a:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}a:hover,a:active{outline:0}sub,sup{position:relative;font-size:75%;line-height:0;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{width:auto\9;height:auto;max-width:100%;vertical-align:middle;border:0;-ms-interpolation-mode:bicubic}#map_canvas img,.google-maps img{max-width:none}button,input,select,textarea{margin:0;font-size:100%;vertical-align:middle}button,input{*overflow:visible;line-height:normal}button::-moz-focus-inner,input::-moz-focus-inner{padding:0;border:0}button,html input[type="button"],input[type="reset"],input[type="submit"]{cursor:pointer;-webkit-appearance:button}label,select,button,input[type="button"],input[type="reset"],input[type="submit"],input[type="radio"],input[type="checkbox"]{cursor:pointer}input[type="search"]{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;-webkit-appearance:textfield}input[type="search"]::-webkit-search-decoration,input[type="search"]::-webkit-search-cancel-button{-webkit-appearance:none}textarea{overflow:auto;vertical-align:top}@media print{*{color:#000!important;text-shadow:none!important;background:transparent!important;box-shadow:none!important}a,a:visited{text-decoration:underline}a[href]:after{content:" (" attr(href) ")"}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100%!important}@page{margin:.5cm}p,h2,h3{orphans:3;widows:3}h2,h3{page-break-after:avoid}}body{margin:0;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line-height:20px;color:#333;background-color:#fff}a{color:#08c;text-decoration:none}a:hover,a:focus{color:#005580;text-decoration:underline}.img-rounded{-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}.img-polaroid{padding:4px;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.2);-webkit-box-shadow:0 1px 3px rgba(0,0,0,0.1);-moz-box-shadow:0 1px 3px rgba(0,0,0,0.1);box-shadow:0 1px 3px rgba(0,0,0,0.1)}.img-circle{-webkit-border-radius:500px;-moz-border-radius:500px;border-radius:500px}.row{margin-left:-20px;*zoom:1}.row:before,.row:after{display:table;line-height:0;content:""}.row:after{clear:both}[class*="span"]{float:left;min-height:1px;margin-left:20px}.container,.navbar-static-top .container,.navbar-fixed-top .container,.navbar-fixed-bottom .container{width:940px}.span12{width:940px}.span11{width:860px}.span10{width:780px}.span9{width:700px}.span8{width:620px}.span7{width:540px}.span6{width:460px}.span5{width:380px}.span4{width:300px}.span3{width:220px}.span2{width:140px}.span1{width:60px}.offset12{margin-left:980px}.offset11{margin-left:900px}.offset10{margin-left:820px}.offset9{margin-left:740px}.offset8{margin-left:660px}.offset7{margin-left:580px}.offset6{margin-left:500px}.offset5{margin-left:420px}.offset4{margin-left:340px}.offset3{margin-left:260px}.offset2{margin-left:180px}.offset1{margin-left:100px}.row-fluid{width:100%;*zoom:1}.row-fluid:before,.row-fluid:after{display:table;line-height:0;content:""}.row-fluid:after{clear:both}.row-fluid [class*="span"]{display:block;float:left;width:100%;min-height:30px;margin-left:2.127659574468085%;*margin-left:2.074468085106383%;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.row-fluid [class*="span"]:first-child{margin-left:0}.row-fluid .controls-row [class*="span"]+[class*="span"]{margin-left:2.127659574468085%}.row-fluid .span12{width:100%;*width:99.94680851063829%}.row-fluid .span11{width:91.48936170212765%;*width:91.43617021276594%}.row-fluid .span10{width:82.97872340425532%;*width:82.92553191489361%}.row-fluid .span9{width:74.46808510638297%;*width:74.41489361702126%}.row-fluid .span8{width:65.95744680851064%;*width:65.90425531914893%}.row-fluid .span7{width:57.44680851063829%;*width:57.39361702127659%}.row-fluid .span6{width:48.93617021276595%;*width:48.88297872340425%}.row-fluid .span5{width:40.42553191489362%;*width:40.37234042553192%}.row-fluid .span4{width:31.914893617021278%;*width:31.861702127659576%}.row-fluid .span3{width:23.404255319148934%;*width:23.351063829787233%}.row-fluid .span2{width:14.893617021276595%;*width:14.840425531914894%}.row-fluid .span1{width:6.382978723404255%;*width:6.329787234042553%}.row-fluid .offset12{margin-left:104.25531914893617%;*margin-left:104.14893617021275%}.row-fluid .offset12:first-child{margin-left:102.12765957446808%;*margin-left:102.02127659574467%}.row-fluid .offset11{margin-left:95.74468085106382%;*margin-left:95.6382978723404%}.row-fluid .offset11:first-child{margin-left:93.61702127659574%;*margin-left:93.51063829787232%}.row-fluid .offset10{margin-left:87.23404255319149%;*margin-left:87.12765957446807%}.row-fluid .offset10:first-child{margin-left:85.1063829787234%;*margin-left:84.99999999999999%}.row-fluid .offset9{margin-left:78.72340425531914%;*margin-left:78.61702127659572%}.row-fluid .offset9:first-child{margin-left:76.59574468085106%;*margin-left:76.48936170212764%}.row-fluid .offset8{margin-left:70.2127659574468%;*margin-left:70.10638297872339%}.row-fluid .offset8:first-child{margin-left:68.08510638297872%;*margin-left:67.9787234042553%}.row-fluid .offset7{margin-left:61.70212765957446%;*margin-left:61.59574468085106%}.row-fluid .offset7:first-child{margin-left:59.574468085106375%;*margin-left:59.46808510638297%}.row-fluid .offset6{margin-left:53.191489361702125%;*margin-left:53.085106382978715%}.row-fluid .offset6:first-child{margin-left:51.063829787234035%;*margin-left:50.95744680851063%}.row-fluid .offset5{margin-left:44.68085106382979%;*margin-left:44.57446808510638%}.row-fluid .offset5:first-child{margin-left:42.5531914893617%;*margin-left:42.4468085106383%}.row-fluid .offset4{margin-left:36.170212765957444%;*margin-left:36.06382978723405%}.row-fluid .offset4:first-child{margin-left:34.04255319148936%;*margin-left:33.93617021276596%}.row-fluid .offset3{margin-left:27.659574468085104%;*margin-left:27.5531914893617%}.row-fluid .offset3:first-child{margin-left:25.53191489361702%;*margin-left:25.425531914893618%}.row-fluid .offset2{margin-left:19.148936170212764%;*margin-left:19.04255319148936%}.row-fluid .offset2:first-child{margin-left:17.02127659574468%;*margin-left:16.914893617021278%}.row-fluid .offset1{margin-left:10.638297872340425%;*margin-left:10.53191489361702%}.row-fluid .offset1:first-child{margin-left:8.51063829787234%;*margin-left:8.404255319148938%}[class*="span"].hide,.row-fluid [class*="span"].hide{display:none}[class*="span"].pull-right,.row-fluid [class*="span"].pull-right{float:right}.container{margin-right:auto;margin-left:auto;*zoom:1}.container:before,.container:after{display:table;line-height:0;content:""}.container:after{clear:both}.container-fluid{padding-right:20px;padding-left:20px;*zoom:1}.container-fluid:before,.container-fluid:after{display:table;line-height:0;content:""}.container-fluid:after{clear:both}p{margin:0 0 10px}.lead{margin-bottom:20px;font-size:21px;font-weight:200;line-height:30px}small{font-size:85%}strong{font-weight:bold}em{font-style:italic}cite{font-style:normal}.muted{color:#999}a.muted:hover,a.muted:focus{color:#808080}.text-warning{color:#c09853}a.text-warning:hover,a.text-warning:focus{color:#a47e3c}.text-error{color:#b94a48}a.text-error:hover,a.text-error:focus{color:#953b39}.text-info{color:#3a87ad}a.text-info:hover,a.text-info:focus{color:#2d6987}.text-success{color:#468847}a.text-success:hover,a.text-success:focus{color:#356635}.text-left{text-align:left}.text-right{text-align:right}.text-center{text-align:center}h1,h2,h3,h4,h5,h6{margin:10px 0;font-family:inherit;font-weight:bold;line-height:20px;color:inherit;text-rendering:optimizelegibility}h1 small,h2 small,h3 small,h4 small,h5 small,h6 small{font-weight:normal;line-height:1;color:#999}h1,h2,h3{line-height:40px}h1{font-size:38.5px}h2{font-size:31.5px}h3{font-size:24.5px}h4{font-size:17.5px}h5{font-size:14px}h6{font-size:11.9px}h1 small{font-size:24.5px}h2 small{font-size:17.5px}h3 small{font-size:14px}h4 small{font-size:14px}.page-header{padding-bottom:9px;margin:20px 0 30px;border-bottom:1px solid #eee}ul,ol{padding:0;margin:0 0 10px 25px}ul ul,ul ol,ol ol,ol ul{margin-bottom:0}li{line-height:20px}ul.unstyled,ol.unstyled{margin-left:0;list-style:none}ul.inline,ol.inline{margin-left:0;list-style:none}ul.inline>li,ol.inline>li{display:inline-block;*display:inline;padding-right:5px;padding-left:5px;*zoom:1}dl{margin-bottom:20px}dt,dd{line-height:20px}dt{font-weight:bold}dd{margin-left:10px}.dl-horizontal{*zoom:1}.dl-horizontal:before,.dl-horizontal:after{display:table;line-height:0;content:""}.dl-horizontal:after{clear:both}.dl-horizontal dt{float:left;width:160px;overflow:hidden;clear:left;text-align:right;text-overflow:ellipsis;white-space:nowrap}.dl-horizontal dd{margin-left:180px}hr{margin:20px 0;border:0;border-top:1px solid #eee;border-bottom:1px solid #fff}abbr[title],abbr[data-original-title]{cursor:help;border-bottom:1px dotted #999}abbr.initialism{font-size:90%;text-transform:uppercase}blockquote{padding:0 0 0 15px;margin:0 0 20px;border-left:5px solid #eee}blockquote p{margin-bottom:0;font-size:17.5px;font-weight:300;line-height:1.25}blockquote small{display:block;line-height:20px;color:#999}blockquote small:before{content:'\2014 \00A0'}blockquote.pull-right{float:right;padding-right:15px;padding-left:0;border-right:5px solid #eee;border-left:0}blockquote.pull-right p,blockquote.pull-right small{text-align:right}blockquote.pull-right small:before{content:''}blockquote.pull-right small:after{content:'\00A0 \2014'}q:before,q:after,blockquote:before,blockquote:after{content:""}address{display:block;margin-bottom:20px;font-style:normal;line-height:20px}code,pre{padding:0 3px 2px;font-family:Monaco,Menlo,Consolas,"Courier New",monospace;font-size:12px;color:#333;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}code{padding:2px 4px;color:#d14;white-space:nowrap;background-color:#f7f7f9;border:1px solid #e1e1e8}pre{display:block;padding:9.5px;margin:0 0 10px;font-size:13px;line-height:20px;word-break:break-all;word-wrap:break-word;white-space:pre;white-space:pre-wrap;background-color:#f5f5f5;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.15);-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}pre.prettyprint{margin-bottom:20px}pre code{padding:0;color:inherit;white-space:pre;white-space:pre-wrap;background-color:transparent;border:0}.pre-scrollable{max-height:340px;overflow-y:scroll}form{margin:0 0 20px}fieldset{padding:0;margin:0;border:0}legend{display:block;width:100%;padding:0;margin-bottom:20px;font-size:21px;line-height:40px;color:#333;border:0;border-bottom:1px solid #e5e5e5}legend small{font-size:15px;color:#999}label,input,button,select,textarea{font-size:14px;font-weight:normal;line-height:20px}input,button,select,textarea{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif}label{display:block;margin-bottom:5px}select,textarea,input[type="text"],input[type="password"],input[type="datetime"],input[type="datetime-local"],input[type="date"],input[type="month"],input[type="time"],input[type="week"],input[type="number"],input[type="email"],input[type="url"],input[type="search"],input[type="tel"],input[type="color"],.uneditable-input{display:inline-block;height:20px;padding:4px 6px;margin-bottom:10px;font-size:14px;line-height:20px;color:#555;vertical-align:middle;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}input,textarea,.uneditable-input{width:206px}textarea{height:auto}textarea,input[type="text"],input[type="password"],input[type="datetime"],input[type="datetime-local"],input[type="date"],input[type="month"],input[type="time"],input[type="week"],input[type="number"],input[type="email"],input[type="url"],input[type="search"],input[type="tel"],input[type="color"],.uneditable-input{background-color:#fff;border:1px solid #ccc;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-webkit-transition:border linear .2s,box-shadow linear .2s;-moz-transition:border linear .2s,box-shadow linear .2s;-o-transition:border linear .2s,box-shadow linear .2s;transition:border linear .2s,box-shadow linear .2s}textarea:focus,input[type="text"]:focus,input[type="password"]:focus,input[type="datetime"]:focus,input[type="datetime-local"]:focus,input[type="date"]:focus,input[type="month"]:focus,input[type="time"]:focus,input[type="week"]:focus,input[type="number"]:focus,input[type="email"]:focus,input[type="url"]:focus,input[type="search"]:focus,input[type="tel"]:focus,input[type="color"]:focus,.uneditable-input:focus{border-color:rgba(82,168,236,0.8);outline:0;outline:thin dotted \9;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(82,168,236,0.6);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(82,168,236,0.6);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(82,168,236,0.6)}input[type="radio"],input[type="checkbox"]{margin:4px 0 0;margin-top:1px \9;*margin-top:0;line-height:normal}input[type="file"],input[type="image"],input[type="submit"],input[type="reset"],input[type="button"],input[type="radio"],input[type="checkbox"]{width:auto}select,input[type="file"]{height:30px;*margin-top:4px;line-height:30px}select{width:220px;background-color:#fff;border:1px solid #ccc}select[multiple],select[size]{height:auto}select:focus,input[type="file"]:focus,input[type="radio"]:focus,input[type="checkbox"]:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}.uneditable-input,.uneditable-textarea{color:#999;cursor:not-allowed;background-color:#fcfcfc;border-color:#ccc;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.025);-moz-box-shadow:inset 0 1px 2px rgba(0,0,0,0.025);box-shadow:inset 0 1px 2px rgba(0,0,0,0.025)}.uneditable-input{overflow:hidden;white-space:nowrap}.uneditable-textarea{width:auto;height:auto}input:-moz-placeholder,textarea:-moz-placeholder{color:#999}input:-ms-input-placeholder,textarea:-ms-input-placeholder{color:#999}input::-webkit-input-placeholder,textarea::-webkit-input-placeholder{color:#999}.radio,.checkbox{min-height:20px;padding-left:20px}.radio input[type="radio"],.checkbox input[type="checkbox"]{float:left;margin-left:-20px}.controls>.radio:first-child,.controls>.checkbox:first-child{padding-top:5px}.radio.inline,.checkbox.inline{display:inline-block;padding-top:5px;margin-bottom:0;vertical-align:middle}.radio.inline+.radio.inline,.checkbox.inline+.checkbox.inline{margin-left:10px}.input-mini{width:60px}.input-small{width:90px}.input-medium{width:150px}.input-large{width:210px}.input-xlarge{width:270px}.input-xxlarge{width:530px}input[class*="span"],select[class*="span"],textarea[class*="span"],.uneditable-input[class*="span"],.row-fluid input[class*="span"],.row-fluid select[class*="span"],.row-fluid textarea[class*="span"],.row-fluid .uneditable-input[class*="span"]{float:none;margin-left:0}.input-append input[class*="span"],.input-append .uneditable-input[class*="span"],.input-prepend input[class*="span"],.input-prepend .uneditable-input[class*="span"],.row-fluid input[class*="span"],.row-fluid select[class*="span"],.row-fluid textarea[class*="span"],.row-fluid .uneditable-input[class*="span"],.row-fluid .input-prepend [class*="span"],.row-fluid .input-append [class*="span"]{display:inline-block}input,textarea,.uneditable-input{margin-left:0}.controls-row [class*="span"]+[class*="span"]{margin-left:20px}input.span12,textarea.span12,.uneditable-input.span12{width:926px}input.span11,textarea.span11,.uneditable-input.span11{width:846px}input.span10,textarea.span10,.uneditable-input.span10{width:766px}input.span9,textarea.span9,.uneditable-input.span9{width:686px}input.span8,textarea.span8,.uneditable-input.span8{width:606px}input.span7,textarea.span7,.uneditable-input.span7{width:526px}input.span6,textarea.span6,.uneditable-input.span6{width:446px}input.span5,textarea.span5,.uneditable-input.span5{width:366px}input.span4,textarea.span4,.uneditable-input.span4{width:286px}input.span3,textarea.span3,.uneditable-input.span3{width:206px}input.span2,textarea.span2,.uneditable-input.span2{width:126px}input.span1,textarea.span1,.uneditable-input.span1{width:46px}.controls-row{*zoom:1}.controls-row:before,.controls-row:after{display:table;line-height:0;content:""}.controls-row:after{clear:both}.controls-row [class*="span"],.row-fluid .controls-row [class*="span"]{float:left}.controls-row .checkbox[class*="span"],.controls-row .radio[class*="span"]{padding-top:5px}input[disabled],select[disabled],textarea[disabled],input[readonly],select[readonly],textarea[readonly]{cursor:not-allowed;background-color:#eee}input[type="radio"][disabled],input[type="checkbox"][disabled],input[type="radio"][readonly],input[type="checkbox"][readonly]{background-color:transparent}.control-group.warning .control-label,.control-group.warning .help-block,.control-group.warning .help-inline{color:#c09853}.control-group.warning .checkbox,.control-group.warning .radio,.control-group.warning input,.control-group.warning select,.control-group.warning textarea{color:#c09853}.control-group.warning input,.control-group.warning select,.control-group.warning textarea{border-color:#c09853;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.control-group.warning input:focus,.control-group.warning select:focus,.control-group.warning textarea:focus{border-color:#a47e3c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #dbc59e;-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #dbc59e;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #dbc59e}.control-group.warning .input-prepend .add-on,.control-group.warning .input-append .add-on{color:#c09853;background-color:#fcf8e3;border-color:#c09853}.control-group.error .control-label,.control-group.error .help-block,.control-group.error .help-inline{color:#b94a48}.control-group.error .checkbox,.control-group.error .radio,.control-group.error input,.control-group.error select,.control-group.error textarea{color:#b94a48}.control-group.error input,.control-group.error select,.control-group.error textarea{border-color:#b94a48;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.control-group.error input:focus,.control-group.error select:focus,.control-group.error textarea:focus{border-color:#953b39;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d59392;-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d59392;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d59392}.control-group.error .input-prepend .add-on,.control-group.error .input-append .add-on{color:#b94a48;background-color:#f2dede;border-color:#b94a48}.control-group.success .control-label,.control-group.success .help-block,.control-group.success .help-inline{color:#468847}.control-group.success .checkbox,.control-group.success .radio,.control-group.success input,.control-group.success select,.control-group.success textarea{color:#468847}.control-group.success input,.control-group.success select,.control-group.success textarea{border-color:#468847;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.control-group.success input:focus,.control-group.success select:focus,.control-group.success textarea:focus{border-color:#356635;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7aba7b;-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7aba7b;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7aba7b}.control-group.success .input-prepend .add-on,.control-group.success .input-append .add-on{color:#468847;background-color:#dff0d8;border-color:#468847}.control-group.info .control-label,.control-group.info .help-block,.control-group.info .help-inline{color:#3a87ad}.control-group.info .checkbox,.control-group.info .radio,.control-group.info input,.control-group.info select,.control-group.info textarea{color:#3a87ad}.control-group.info input,.control-group.info select,.control-group.info textarea{border-color:#3a87ad;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.control-group.info input:focus,.control-group.info select:focus,.control-group.info textarea:focus{border-color:#2d6987;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7ab5d3;-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7ab5d3;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7ab5d3}.control-group.info .input-prepend .add-on,.control-group.info .input-append .add-on{color:#3a87ad;background-color:#d9edf7;border-color:#3a87ad}input:focus:invalid,textarea:focus:invalid,select:focus:invalid{color:#b94a48;border-color:#ee5f5b}input:focus:invalid:focus,textarea:focus:invalid:focus,select:focus:invalid:focus{border-color:#e9322d;-webkit-box-shadow:0 0 6px #f8b9b7;-moz-box-shadow:0 0 6px #f8b9b7;box-shadow:0 0 6px #f8b9b7}.form-actions{padding:19px 20px 20px;margin-top:20px;margin-bottom:20px;background-color:#f5f5f5;border-top:1px solid #e5e5e5;*zoom:1}.form-actions:before,.form-actions:after{display:table;line-height:0;content:""}.form-actions:after{clear:both}.help-block,.help-inline{color:#595959}.help-block{display:block;margin-bottom:10px}.help-inline{display:inline-block;*display:inline;padding-left:5px;vertical-align:middle;*zoom:1}.input-append,.input-prepend{display:inline-block;margin-bottom:10px;font-size:0;white-space:nowrap;vertical-align:middle}.input-append input,.input-prepend input,.input-append select,.input-prepend select,.input-append .uneditable-input,.input-prepend .uneditable-input,.input-append .dropdown-menu,.input-prepend .dropdown-menu,.input-append .popover,.input-prepend .popover{font-size:14px}.input-append input,.input-prepend input,.input-append select,.input-prepend select,.input-append .uneditable-input,.input-prepend .uneditable-input{position:relative;margin-bottom:0;*margin-left:0;vertical-align:top;-webkit-border-radius:0 4px 4px 0;-moz-border-radius:0 4px 4px 0;border-radius:0 4px 4px 0}.input-append input:focus,.input-prepend input:focus,.input-append select:focus,.input-prepend select:focus,.input-append .uneditable-input:focus,.input-prepend .uneditable-input:focus{z-index:2}.input-append .add-on,.input-prepend .add-on{display:inline-block;width:auto;height:20px;min-width:16px;padding:4px 5px;font-size:14px;font-weight:normal;line-height:20px;text-align:center;text-shadow:0 1px 0 #fff;background-color:#eee;border:1px solid #ccc}.input-append .add-on,.input-prepend .add-on,.input-append .btn,.input-prepend .btn,.input-append .btn-group>.dropdown-toggle,.input-prepend .btn-group>.dropdown-toggle{vertical-align:top;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.input-append .active,.input-prepend .active{background-color:#a9dba9;border-color:#46a546}.input-prepend .add-on,.input-prepend .btn{margin-right:-1px}.input-prepend .add-on:first-child,.input-prepend .btn:first-child{-webkit-border-radius:4px 0 0 4px;-moz-border-radius:4px 0 0 4px;border-radius:4px 0 0 4px}.input-append input,.input-append select,.input-append .uneditable-input{-webkit-border-radius:4px 0 0 4px;-moz-border-radius:4px 0 0 4px;border-radius:4px 0 0 4px}.input-append input+.btn-group .btn:last-child,.input-append select+.btn-group .btn:last-child,.input-append .uneditable-input+.btn-group .btn:last-child{-webkit-border-radius:0 4px 4px 0;-moz-border-radius:0 4px 4px 0;border-radius:0 4px 4px 0}.input-append .add-on,.input-append .btn,.input-append .btn-group{margin-left:-1px}.input-append .add-on:last-child,.input-append .btn:last-child,.input-append .btn-group:last-child>.dropdown-toggle{-webkit-border-radius:0 4px 4px 0;-moz-border-radius:0 4px 4px 0;border-radius:0 4px 4px 0}.input-prepend.input-append input,.input-prepend.input-append select,.input-prepend.input-append .uneditable-input{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.input-prepend.input-append input+.btn-group .btn,.input-prepend.input-append select+.btn-group .btn,.input-prepend.input-append .uneditable-input+.btn-group .btn{-webkit-border-radius:0 4px 4px 0;-moz-border-radius:0 4px 4px 0;border-radius:0 4px 4px 0}.input-prepend.input-append .add-on:first-child,.input-prepend.input-append .btn:first-child{margin-right:-1px;-webkit-border-radius:4px 0 0 4px;-moz-border-radius:4px 0 0 4px;border-radius:4px 0 0 4px}.input-prepend.input-append .add-on:last-child,.input-prepend.input-append .btn:last-child{margin-left:-1px;-webkit-border-radius:0 4px 4px 0;-moz-border-radius:0 4px 4px 0;border-radius:0 4px 4px 0}.input-prepend.input-append .btn-group:first-child{margin-left:0}input.search-query{padding-right:14px;padding-right:4px \9;padding-left:14px;padding-left:4px \9;margin-bottom:0;-webkit-border-radius:15px;-moz-border-radius:15px;border-radius:15px}.form-search .input-append .search-query,.form-search .input-prepend .search-query{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.form-search .input-append .search-query{-webkit-border-radius:14px 0 0 14px;-moz-border-radius:14px 0 0 14px;border-radius:14px 0 0 14px}.form-search .input-append .btn{-webkit-border-radius:0 14px 14px 0;-moz-border-radius:0 14px 14px 0;border-radius:0 14px 14px 0}.form-search .input-prepend .search-query{-webkit-border-radius:0 14px 14px 0;-moz-border-radius:0 14px 14px 0;border-radius:0 14px 14px 0}.form-search .input-prepend .btn{-webkit-border-radius:14px 0 0 14px;-moz-border-radius:14px 0 0 14px;border-radius:14px 0 0 14px}.form-search input,.form-inline input,.form-horizontal input,.form-search textarea,.form-inline textarea,.form-horizontal textarea,.form-search select,.form-inline select,.form-horizontal select,.form-search .help-inline,.form-inline .help-inline,.form-horizontal .help-inline,.form-search .uneditable-input,.form-inline .uneditable-input,.form-horizontal .uneditable-input,.form-search .input-prepend,.form-inline .input-prepend,.form-horizontal .input-prepend,.form-search .input-append,.form-inline .input-append,.form-horizontal .input-append{display:inline-block;*display:inline;margin-bottom:0;vertical-align:middle;*zoom:1}.form-search .hide,.form-inline .hide,.form-horizontal .hide{display:none}.form-search label,.form-inline label,.form-search .btn-group,.form-inline .btn-group{display:inline-block}.form-search .input-append,.form-inline .input-append,.form-search .input-prepend,.form-inline .input-prepend{margin-bottom:0}.form-search .radio,.form-search .checkbox,.form-inline .radio,.form-inline .checkbox{padding-left:0;margin-bottom:0;vertical-align:middle}.form-search .radio input[type="radio"],.form-search .checkbox input[type="checkbox"],.form-inline .radio input[type="radio"],.form-inline .checkbox input[type="checkbox"]{float:left;margin-right:3px;margin-left:0}.control-group{margin-bottom:10px}legend+.control-group{margin-top:20px;-webkit-margin-top-collapse:separate}.form-horizontal .control-group{margin-bottom:20px;*zoom:1}.form-horizontal .control-group:before,.form-horizontal .control-group:after{display:table;line-height:0;content:""}.form-horizontal .control-group:after{clear:both}.form-horizontal .control-label{float:left;width:160px;padding-top:5px;text-align:right}.form-horizontal .controls{*display:inline-block;*padding-left:20px;margin-left:180px;*margin-left:0}.form-horizontal .controls:first-child{*padding-left:180px}.form-horizontal .help-block{margin-bottom:0}.form-horizontal input+.help-block,.form-horizontal select+.help-block,.form-horizontal textarea+.help-block,.form-horizontal .uneditable-input+.help-block,.form-horizontal .input-prepend+.help-block,.form-horizontal .input-append+.help-block{margin-top:10px}.form-horizontal .form-actions{padding-left:180px}table{max-width:100%;background-color:transparent;border-collapse:collapse;border-spacing:0}.table{width:100%;margin-bottom:20px}.table th,.table td{padding:8px;line-height:20px;text-align:left;vertical-align:top;border-top:1px solid #ddd}.table th{font-weight:bold}.table thead th{vertical-align:bottom}.table caption+thead tr:first-child th,.table caption+thead tr:first-child td,.table colgroup+thead tr:first-child th,.table colgroup+thead tr:first-child td,.table thead:first-child tr:first-child th,.table thead:first-child tr:first-child td{border-top:0}.table tbody+tbody{border-top:2px solid #ddd}.table .table{background-color:#fff}.table-condensed th,.table-condensed td{padding:4px 5px}.table-bordered{border:1px solid #ddd;border-collapse:separate;*border-collapse:collapse;border-left:0;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}.table-bordered th,.table-bordered td{border-left:1px solid #ddd}.table-bordered caption+thead tr:first-child th,.table-bordered caption+tbody tr:first-child th,.table-bordered caption+tbody tr:first-child td,.table-bordered colgroup+thead tr:first-child th,.table-bordered colgroup+tbody tr:first-child th,.table-bordered colgroup+tbody tr:first-child td,.table-bordered thead:first-child tr:first-child th,.table-bordered tbody:first-child tr:first-child th,.table-bordered tbody:first-child tr:first-child td{border-top:0}.table-bordered thead:first-child tr:first-child>th:first-child,.table-bordered tbody:first-child tr:first-child>td:first-child,.table-bordered tbody:first-child tr:first-child>th:first-child{-webkit-border-top-left-radius:4px;border-top-left-radius:4px;-moz-border-radius-topleft:4px}.table-bordered thead:first-child tr:first-child>th:last-child,.table-bordered tbody:first-child tr:first-child>td:last-child,.table-bordered tbody:first-child tr:first-child>th:last-child{-webkit-border-top-right-radius:4px;border-top-right-radius:4px;-moz-border-radius-topright:4px}.table-bordered thead:last-child tr:last-child>th:first-child,.table-bordered tbody:last-child tr:last-child>td:first-child,.table-bordered tbody:last-child tr:last-child>th:first-child,.table-bordered tfoot:last-child tr:last-child>td:first-child,.table-bordered tfoot:last-child tr:last-child>th:first-child{-webkit-border-bottom-left-radius:4px;border-bottom-left-radius:4px;-moz-border-radius-bottomleft:4px}.table-bordered thead:last-child tr:last-child>th:last-child,.table-bordered tbody:last-child tr:last-child>td:last-child,.table-bordered tbody:last-child tr:last-child>th:last-child,.table-bordered tfoot:last-child tr:last-child>td:last-child,.table-bordered tfoot:last-child tr:last-child>th:last-child{-webkit-border-bottom-right-radius:4px;border-bottom-right-radius:4px;-moz-border-radius-bottomright:4px}.table-bordered tfoot+tbody:last-child tr:last-child td:first-child{-webkit-border-bottom-left-radius:0;border-bottom-left-radius:0;-moz-border-radius-bottomleft:0}.table-bordered tfoot+tbody:last-child tr:last-child td:last-child{-webkit-border-bottom-right-radius:0;border-bottom-right-radius:0;-moz-border-radius-bottomright:0}.table-bordered caption+thead tr:first-child th:first-child,.table-bordered caption+tbody tr:first-child td:first-child,.table-bordered colgroup+thead tr:first-child th:first-child,.table-bordered colgroup+tbody tr:first-child td:first-child{-webkit-border-top-left-radius:4px;border-top-left-radius:4px;-moz-border-radius-topleft:4px}.table-bordered caption+thead tr:first-child th:last-child,.table-bordered caption+tbody tr:first-child td:last-child,.table-bordered colgroup+thead tr:first-child th:last-child,.table-bordered colgroup+tbody tr:first-child td:last-child{-webkit-border-top-right-radius:4px;border-top-right-radius:4px;-moz-border-radius-topright:4px}.table-striped tbody>tr:nth-child(odd)>td,.table-striped tbody>tr:nth-child(odd)>th{background-color:#f9f9f9}.table-hover tbody tr:hover>td,.table-hover tbody tr:hover>th{background-color:#f5f5f5}table td[class*="span"],table th[class*="span"],.row-fluid table td[class*="span"],.row-fluid table th[class*="span"]{display:table-cell;float:none;margin-left:0}.table td.span1,.table th.span1{float:none;width:44px;margin-left:0}.table td.span2,.table th.span2{float:none;width:124px;margin-left:0}.table td.span3,.table th.span3{float:none;width:204px;margin-left:0}.table td.span4,.table th.span4{float:none;width:284px;margin-left:0}.table td.span5,.table th.span5{float:none;width:364px;margin-left:0}.table td.span6,.table th.span6{float:none;width:444px;margin-left:0}.table td.span7,.table th.span7{float:none;width:524px;margin-left:0}.table td.span8,.table th.span8{float:none;width:604px;margin-left:0}.table td.span9,.table th.span9{float:none;width:684px;margin-left:0}.table td.span10,.table th.span10{float:none;width:764px;margin-left:0}.table td.span11,.table th.span11{float:none;width:844px;margin-left:0}.table td.span12,.table th.span12{float:none;width:924px;margin-left:0}.table tbody tr.success>td{background-color:#dff0d8}.table tbody tr.error>td{background-color:#f2dede}.table tbody tr.warning>td{background-color:#fcf8e3}.table tbody tr.info>td{background-color:#d9edf7}.table-hover tbody tr.success:hover>td{background-color:#d0e9c6}.table-hover tbody tr.error:hover>td{background-color:#ebcccc}.table-hover tbody tr.warning:hover>td{background-color:#faf2cc}.table-hover tbody tr.info:hover>td{background-color:#c4e3f3}[class^="icon-"],[class*=" icon-"]{display:inline-block;width:14px;height:14px;margin-top:1px;*margin-right:.3em;line-height:14px;vertical-align:text-top;background-image:url("../img/glyphicons-halflings.png");background-position:14px 14px;background-repeat:no-repeat}.icon-white,.nav-pills>.active>a>[class^="icon-"],.nav-pills>.active>a>[class*=" icon-"],.nav-list>.active>a>[class^="icon-"],.nav-list>.active>a>[class*=" icon-"],.navbar-inverse .nav>.active>a>[class^="icon-"],.navbar-inverse .nav>.active>a>[class*=" icon-"],.dropdown-menu>li>a:hover>[class^="icon-"],.dropdown-menu>li>a:focus>[class^="icon-"],.dropdown-menu>li>a:hover>[class*=" icon-"],.dropdown-menu>li>a:focus>[class*=" icon-"],.dropdown-menu>.active>a>[class^="icon-"],.dropdown-menu>.active>a>[class*=" icon-"],.dropdown-submenu:hover>a>[class^="icon-"],.dropdown-submenu:focus>a>[class^="icon-"],.dropdown-submenu:hover>a>[class*=" icon-"],.dropdown-submenu:focus>a>[class*=" icon-"]{background-image:url("../img/glyphicons-halflings-white.png")}.icon-glass{background-position:0 0}.icon-music{background-position:-24px 0}.icon-search{background-position:-48px 0}.icon-envelope{background-position:-72px 0}.icon-heart{background-position:-96px 0}.icon-star{background-position:-120px 0}.icon-star-empty{background-position:-144px 0}.icon-user{background-position:-168px 0}.icon-film{background-position:-192px 0}.icon-th-large{background-position:-216px 0}.icon-th{background-position:-240px 0}.icon-th-list{background-position:-264px 0}.icon-ok{background-position:-288px 0}.icon-remove{background-position:-312px 0}.icon-zoom-in{background-position:-336px 0}.icon-zoom-out{background-position:-360px 0}.icon-off{background-position:-384px 0}.icon-signal{background-position:-408px 0}.icon-cog{background-position:-432px 0}.icon-trash{background-position:-456px 0}.icon-home{background-position:0 -24px}.icon-file{background-position:-24px -24px}.icon-time{background-position:-48px -24px}.icon-road{background-position:-72px -24px}.icon-download-alt{background-position:-96px -24px}.icon-download{background-position:-120px -24px}.icon-upload{background-position:-144px -24px}.icon-inbox{background-position:-168px -24px}.icon-play-circle{background-position:-192px -24px}.icon-repeat{background-position:-216px -24px}.icon-refresh{background-position:-240px -24px}.icon-list-alt{background-position:-264px -24px}.icon-lock{background-position:-287px -24px}.icon-flag{background-position:-312px -24px}.icon-headphones{background-position:-336px -24px}.icon-volume-off{background-position:-360px -24px}.icon-volume-down{background-position:-384px -24px}.icon-volume-up{background-position:-408px -24px}.icon-qrcode{background-position:-432px -24px}.icon-barcode{background-position:-456px -24px}.icon-tag{background-position:0 -48px}.icon-tags{background-position:-25px -48px}.icon-book{background-position:-48px -48px}.icon-bookmark{background-position:-72px -48px}.icon-print{background-position:-96px -48px}.icon-camera{background-position:-120px -48px}.icon-font{background-position:-144px -48px}.icon-bold{background-position:-167px -48px}.icon-italic{background-position:-192px -48px}.icon-text-height{background-position:-216px -48px}.icon-text-width{background-position:-240px -48px}.icon-align-left{background-position:-264px -48px}.icon-align-center{background-position:-288px -48px}.icon-align-right{background-position:-312px -48px}.icon-align-justify{background-position:-336px -48px}.icon-list{background-position:-360px -48px}.icon-indent-left{background-position:-384px -48px}.icon-indent-right{background-position:-408px -48px}.icon-facetime-video{background-position:-432px -48px}.icon-picture{background-position:-456px -48px}.icon-pencil{background-position:0 -72px}.icon-map-marker{background-position:-24px -72px}.icon-adjust{background-position:-48px -72px}.icon-tint{background-position:-72px -72px}.icon-edit{background-position:-96px -72px}.icon-share{background-position:-120px -72px}.icon-check{background-position:-144px -72px}.icon-move{background-position:-168px -72px}.icon-step-backward{background-position:-192px -72px}.icon-fast-backward{background-position:-216px -72px}.icon-backward{background-position:-240px -72px}.icon-play{background-position:-264px -72px}.icon-pause{background-position:-288px -72px}.icon-stop{background-position:-312px -72px}.icon-forward{background-position:-336px -72px}.icon-fast-forward{background-position:-360px -72px}.icon-step-forward{background-position:-384px -72px}.icon-eject{background-position:-408px -72px}.icon-chevron-left{background-position:-432px -72px}.icon-chevron-right{background-position:-456px -72px}.icon-plus-sign{background-position:0 -96px}.icon-minus-sign{background-position:-24px -96px}.icon-remove-sign{background-position:-48px -96px}.icon-ok-sign{background-position:-72px -96px}.icon-question-sign{background-position:-96px -96px}.icon-info-sign{background-position:-120px -96px}.icon-screenshot{background-position:-144px -96px}.icon-remove-circle{background-position:-168px -96px}.icon-ok-circle{background-position:-192px -96px}.icon-ban-circle{background-position:-216px -96px}.icon-arrow-left{background-position:-240px -96px}.icon-arrow-right{background-position:-264px -96px}.icon-arrow-up{background-position:-289px -96px}.icon-arrow-down{background-position:-312px -96px}.icon-share-alt{background-position:-336px -96px}.icon-resize-full{background-position:-360px -96px}.icon-resize-small{background-position:-384px -96px}.icon-plus{background-position:-408px -96px}.icon-minus{background-position:-433px -96px}.icon-asterisk{background-position:-456px -96px}.icon-exclamation-sign{background-position:0 -120px}.icon-gift{background-position:-24px -120px}.icon-leaf{background-position:-48px -120px}.icon-fire{background-position:-72px -120px}.icon-eye-open{background-position:-96px -120px}.icon-eye-close{background-position:-120px -120px}.icon-warning-sign{background-position:-144px -120px}.icon-plane{background-position:-168px -120px}.icon-calendar{background-position:-192px -120px}.icon-random{width:16px;background-position:-216px -120px}.icon-comment{background-position:-240px -120px}.icon-magnet{background-position:-264px -120px}.icon-chevron-up{background-position:-288px -120px}.icon-chevron-down{background-position:-313px -119px}.icon-retweet{background-position:-336px -120px}.icon-shopping-cart{background-position:-360px -120px}.icon-folder-close{width:16px;background-position:-384px -120px}.icon-folder-open{width:16px;background-position:-408px -120px}.icon-resize-vertical{background-position:-432px -119px}.icon-resize-horizontal{background-position:-456px -118px}.icon-hdd{background-position:0 -144px}.icon-bullhorn{background-position:-24px -144px}.icon-bell{background-position:-48px -144px}.icon-certificate{background-position:-72px -144px}.icon-thumbs-up{background-position:-96px -144px}.icon-thumbs-down{background-position:-120px -144px}.icon-hand-right{background-position:-144px -144px}.icon-hand-left{background-position:-168px -144px}.icon-hand-up{background-position:-192px -144px}.icon-hand-down{background-position:-216px -144px}.icon-circle-arrow-right{background-position:-240px -144px}.icon-circle-arrow-left{background-position:-264px -144px}.icon-circle-arrow-up{background-position:-288px -144px}.icon-circle-arrow-down{background-position:-312px -144px}.icon-globe{background-position:-336px -144px}.icon-wrench{background-position:-360px -144px}.icon-tasks{background-position:-384px -144px}.icon-filter{background-position:-408px -144px}.icon-briefcase{background-position:-432px -144px}.icon-fullscreen{background-position:-456px -144px}.dropup,.dropdown{position:relative}.dropdown-toggle{*margin-bottom:-3px}.dropdown-toggle:active,.open .dropdown-toggle{outline:0}.caret{display:inline-block;width:0;height:0;vertical-align:top;border-top:4px solid #000;border-right:4px solid transparent;border-left:4px solid transparent;content:""}.dropdown .caret{margin-top:8px;margin-left:2px}.dropdown-menu{position:absolute;top:100%;left:0;z-index:1000;display:none;float:left;min-width:160px;padding:5px 0;margin:2px 0 0;list-style:none;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.2);*border-right-width:2px;*border-bottom-width:2px;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;-webkit-box-shadow:0 5px 10px rgba(0,0,0,0.2);-moz-box-shadow:0 5px 10px rgba(0,0,0,0.2);box-shadow:0 5px 10px rgba(0,0,0,0.2);-webkit-background-clip:padding-box;-moz-background-clip:padding;background-clip:padding-box}.dropdown-menu.pull-right{right:0;left:auto}.dropdown-menu .divider{*width:100%;height:1px;margin:9px 1px;*margin:-5px 0 5px;overflow:hidden;background-color:#e5e5e5;border-bottom:1px solid #fff}.dropdown-menu>li>a{display:block;padding:3px 20px;clear:both;font-weight:normal;line-height:20px;color:#333;white-space:nowrap}.dropdown-menu>li>a:hover,.dropdown-menu>li>a:focus,.dropdown-submenu:hover>a,.dropdown-submenu:focus>a{color:#fff;text-decoration:none;background-color:#0081c2;background-image:-moz-linear-gradient(top,#08c,#0077b3);background-image:-webkit-gradient(linear,0 0,0 100%,from(#08c),to(#0077b3));background-image:-webkit-linear-gradient(top,#08c,#0077b3);background-image:-o-linear-gradient(top,#08c,#0077b3);background-image:linear-gradient(to bottom,#08c,#0077b3);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc',endColorstr='#ff0077b3',GradientType=0)}.dropdown-menu>.active>a,.dropdown-menu>.active>a:hover,.dropdown-menu>.active>a:focus{color:#fff;text-decoration:none;background-color:#0081c2;background-image:-moz-linear-gradient(top,#08c,#0077b3);background-image:-webkit-gradient(linear,0 0,0 100%,from(#08c),to(#0077b3));background-image:-webkit-linear-gradient(top,#08c,#0077b3);background-image:-o-linear-gradient(top,#08c,#0077b3);background-image:linear-gradient(to bottom,#08c,#0077b3);background-repeat:repeat-x;outline:0;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc',endColorstr='#ff0077b3',GradientType=0)}.dropdown-menu>.disabled>a,.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{color:#999}.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{text-decoration:none;cursor:default;background-color:transparent;background-image:none;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.open{*z-index:1000}.open>.dropdown-menu{display:block}.dropdown-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:990}.pull-right>.dropdown-menu{right:0;left:auto}.dropup .caret,.navbar-fixed-bottom .dropdown .caret{border-top:0;border-bottom:4px solid #000;content:""}.dropup .dropdown-menu,.navbar-fixed-bottom .dropdown .dropdown-menu{top:auto;bottom:100%;margin-bottom:1px}.dropdown-submenu{position:relative}.dropdown-submenu>.dropdown-menu{top:0;left:100%;margin-top:-6px;margin-left:-1px;-webkit-border-radius:0 6px 6px 6px;-moz-border-radius:0 6px 6px 6px;border-radius:0 6px 6px 6px}.dropdown-submenu:hover>.dropdown-menu{display:block}.dropup .dropdown-submenu>.dropdown-menu{top:auto;bottom:0;margin-top:0;margin-bottom:-2px;-webkit-border-radius:5px 5px 5px 0;-moz-border-radius:5px 5px 5px 0;border-radius:5px 5px 5px 0}.dropdown-submenu>a:after{display:block;float:right;width:0;height:0;margin-top:5px;margin-right:-10px;border-color:transparent;border-left-color:#ccc;border-style:solid;border-width:5px 0 5px 5px;content:" "}.dropdown-submenu:hover>a:after{border-left-color:#fff}.dropdown-submenu.pull-left{float:none}.dropdown-submenu.pull-left>.dropdown-menu{left:-100%;margin-left:10px;-webkit-border-radius:6px 0 6px 6px;-moz-border-radius:6px 0 6px 6px;border-radius:6px 0 6px 6px}.dropdown .dropdown-menu .nav-header{padding-right:20px;padding-left:20px}.typeahead{z-index:1051;margin-top:2px;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}.well{min-height:20px;padding:19px;margin-bottom:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.05);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,0.05);box-shadow:inset 0 1px 1px rgba(0,0,0,0.05)}.well blockquote{border-color:#ddd;border-color:rgba(0,0,0,0.15)}.well-large{padding:24px;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}.well-small{padding:9px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}.fade{opacity:0;-webkit-transition:opacity .15s linear;-moz-transition:opacity .15s linear;-o-transition:opacity .15s linear;transition:opacity .15s linear}.fade.in{opacity:1}.collapse{position:relative;height:0;overflow:hidden;-webkit-transition:height .35s ease;-moz-transition:height .35s ease;-o-transition:height .35s ease;transition:height .35s ease}.collapse.in{height:auto}.close{float:right;font-size:20px;font-weight:bold;line-height:20px;color:#000;text-shadow:0 1px 0 #fff;opacity:.2;filter:alpha(opacity=20)}.close:hover,.close:focus{color:#000;text-decoration:none;cursor:pointer;opacity:.4;filter:alpha(opacity=40)}button.close{padding:0;cursor:pointer;background:transparent;border:0;-webkit-appearance:none}.btn{display:inline-block;*display:inline;padding:4px 12px;margin-bottom:0;*margin-left:.3em;font-size:14px;line-height:20px;color:#333;text-align:center;text-shadow:0 1px 1px rgba(255,255,255,0.75);vertical-align:middle;cursor:pointer;background-color:#f5f5f5;*background-color:#e6e6e6;background-image:-moz-linear-gradient(top,#fff,#e6e6e6);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#e6e6e6));background-image:-webkit-linear-gradient(top,#fff,#e6e6e6);background-image:-o-linear-gradient(top,#fff,#e6e6e6);background-image:linear-gradient(to bottom,#fff,#e6e6e6);background-repeat:repeat-x;border:1px solid #ccc;*border:0;border-color:#e6e6e6 #e6e6e6 #bfbfbf;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);border-bottom-color:#b3b3b3;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff',endColorstr='#ffe6e6e6',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false);*zoom:1;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);box-shadow:inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05)}.btn:hover,.btn:focus,.btn:active,.btn.active,.btn.disabled,.btn[disabled]{color:#333;background-color:#e6e6e6;*background-color:#d9d9d9}.btn:active,.btn.active{background-color:#ccc \9}.btn:first-child{*margin-left:0}.btn:hover,.btn:focus{color:#333;text-decoration:none;background-position:0 -15px;-webkit-transition:background-position .1s linear;-moz-transition:background-position .1s linear;-o-transition:background-position .1s linear;transition:background-position .1s linear}.btn:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}.btn.active,.btn:active{background-image:none;outline:0;-webkit-box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05)}.btn.disabled,.btn[disabled]{cursor:default;background-image:none;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.btn-large{padding:11px 19px;font-size:17.5px;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}.btn-large [class^="icon-"],.btn-large [class*=" icon-"]{margin-top:4px}.btn-small{padding:2px 10px;font-size:11.9px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}.btn-small [class^="icon-"],.btn-small [class*=" icon-"]{margin-top:0}.btn-mini [class^="icon-"],.btn-mini [class*=" icon-"]{margin-top:-1px}.btn-mini{padding:0 6px;font-size:10.5px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}.btn-block{display:block;width:100%;padding-right:0;padding-left:0;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.btn-block+.btn-block{margin-top:5px}input[type="submit"].btn-block,input[type="reset"].btn-block,input[type="button"].btn-block{width:100%}.btn-primary.active,.btn-warning.active,.btn-danger.active,.btn-success.active,.btn-info.active,.btn-inverse.active{color:rgba(255,255,255,0.75)}.btn-primary{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#006dcc;*background-color:#04c;background-image:-moz-linear-gradient(top,#08c,#04c);background-image:-webkit-gradient(linear,0 0,0 100%,from(#08c),to(#04c));background-image:-webkit-linear-gradient(top,#08c,#04c);background-image:-o-linear-gradient(top,#08c,#04c);background-image:linear-gradient(to bottom,#08c,#04c);background-repeat:repeat-x;border-color:#04c #04c #002a80;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc',endColorstr='#ff0044cc',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-primary:hover,.btn-primary:focus,.btn-primary:active,.btn-primary.active,.btn-primary.disabled,.btn-primary[disabled]{color:#fff;background-color:#04c;*background-color:#003bb3}.btn-primary:active,.btn-primary.active{background-color:#039 \9}.btn-warning{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#faa732;*background-color:#f89406;background-image:-moz-linear-gradient(top,#fbb450,#f89406);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fbb450),to(#f89406));background-image:-webkit-linear-gradient(top,#fbb450,#f89406);background-image:-o-linear-gradient(top,#fbb450,#f89406);background-image:linear-gradient(to bottom,#fbb450,#f89406);background-repeat:repeat-x;border-color:#f89406 #f89406 #ad6704;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffbb450',endColorstr='#fff89406',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-warning:hover,.btn-warning:focus,.btn-warning:active,.btn-warning.active,.btn-warning.disabled,.btn-warning[disabled]{color:#fff;background-color:#f89406;*background-color:#df8505}.btn-warning:active,.btn-warning.active{background-color:#c67605 \9}.btn-danger{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#da4f49;*background-color:#bd362f;background-image:-moz-linear-gradient(top,#ee5f5b,#bd362f);background-image:-webkit-gradient(linear,0 0,0 100%,from(#ee5f5b),to(#bd362f));background-image:-webkit-linear-gradient(top,#ee5f5b,#bd362f);background-image:-o-linear-gradient(top,#ee5f5b,#bd362f);background-image:linear-gradient(to bottom,#ee5f5b,#bd362f);background-repeat:repeat-x;border-color:#bd362f #bd362f #802420;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffee5f5b',endColorstr='#ffbd362f',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-danger:hover,.btn-danger:focus,.btn-danger:active,.btn-danger.active,.btn-danger.disabled,.btn-danger[disabled]{color:#fff;background-color:#bd362f;*background-color:#a9302a}.btn-danger:active,.btn-danger.active{background-color:#942a25 \9}.btn-success{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#5bb75b;*background-color:#51a351;background-image:-moz-linear-gradient(top,#62c462,#51a351);background-image:-webkit-gradient(linear,0 0,0 100%,from(#62c462),to(#51a351));background-image:-webkit-linear-gradient(top,#62c462,#51a351);background-image:-o-linear-gradient(top,#62c462,#51a351);background-image:linear-gradient(to bottom,#62c462,#51a351);background-repeat:repeat-x;border-color:#51a351 #51a351 #387038;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff62c462',endColorstr='#ff51a351',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-success:hover,.btn-success:focus,.btn-success:active,.btn-success.active,.btn-success.disabled,.btn-success[disabled]{color:#fff;background-color:#51a351;*background-color:#499249}.btn-success:active,.btn-success.active{background-color:#408140 \9}.btn-info{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#49afcd;*background-color:#2f96b4;background-image:-moz-linear-gradient(top,#5bc0de,#2f96b4);background-image:-webkit-gradient(linear,0 0,0 100%,from(#5bc0de),to(#2f96b4));background-image:-webkit-linear-gradient(top,#5bc0de,#2f96b4);background-image:-o-linear-gradient(top,#5bc0de,#2f96b4);background-image:linear-gradient(to bottom,#5bc0de,#2f96b4);background-repeat:repeat-x;border-color:#2f96b4 #2f96b4 #1f6377;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5bc0de',endColorstr='#ff2f96b4',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-info:hover,.btn-info:focus,.btn-info:active,.btn-info.active,.btn-info.disabled,.btn-info[disabled]{color:#fff;background-color:#2f96b4;*background-color:#2a85a0}.btn-info:active,.btn-info.active{background-color:#24748c \9}.btn-inverse{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#363636;*background-color:#222;background-image:-moz-linear-gradient(top,#444,#222);background-image:-webkit-gradient(linear,0 0,0 100%,from(#444),to(#222));background-image:-webkit-linear-gradient(top,#444,#222);background-image:-o-linear-gradient(top,#444,#222);background-image:linear-gradient(to bottom,#444,#222);background-repeat:repeat-x;border-color:#222 #222 #000;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff444444',endColorstr='#ff222222',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-inverse:hover,.btn-inverse:focus,.btn-inverse:active,.btn-inverse.active,.btn-inverse.disabled,.btn-inverse[disabled]{color:#fff;background-color:#222;*background-color:#151515}.btn-inverse:active,.btn-inverse.active{background-color:#080808 \9}button.btn,input[type="submit"].btn{*padding-top:3px;*padding-bottom:3px}button.btn::-moz-focus-inner,input[type="submit"].btn::-moz-focus-inner{padding:0;border:0}button.btn.btn-large,input[type="submit"].btn.btn-large{*padding-top:7px;*padding-bottom:7px}button.btn.btn-small,input[type="submit"].btn.btn-small{*padding-top:3px;*padding-bottom:3px}button.btn.btn-mini,input[type="submit"].btn.btn-mini{*padding-top:1px;*padding-bottom:1px}.btn-link,.btn-link:active,.btn-link[disabled]{background-color:transparent;background-image:none;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.btn-link{color:#08c;cursor:pointer;border-color:transparent;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.btn-link:hover,.btn-link:focus{color:#005580;text-decoration:underline;background-color:transparent}.btn-link[disabled]:hover,.btn-link[disabled]:focus{color:#333;text-decoration:none}.btn-group{position:relative;display:inline-block;*display:inline;*margin-left:.3em;font-size:0;white-space:nowrap;vertical-align:middle;*zoom:1}.btn-group:first-child{*margin-left:0}.btn-group+.btn-group{margin-left:5px}.btn-toolbar{margin-top:10px;margin-bottom:10px;font-size:0}.btn-toolbar>.btn+.btn,.btn-toolbar>.btn-group+.btn,.btn-toolbar>.btn+.btn-group{margin-left:5px}.btn-group>.btn{position:relative;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.btn-group>.btn+.btn{margin-left:-1px}.btn-group>.btn,.btn-group>.dropdown-menu,.btn-group>.popover{font-size:14px}.btn-group>.btn-mini{font-size:10.5px}.btn-group>.btn-small{font-size:11.9px}.btn-group>.btn-large{font-size:17.5px}.btn-group>.btn:first-child{margin-left:0;-webkit-border-bottom-left-radius:4px;border-bottom-left-radius:4px;-webkit-border-top-left-radius:4px;border-top-left-radius:4px;-moz-border-radius-bottomleft:4px;-moz-border-radius-topleft:4px}.btn-group>.btn:last-child,.btn-group>.dropdown-toggle{-webkit-border-top-right-radius:4px;border-top-right-radius:4px;-webkit-border-bottom-right-radius:4px;border-bottom-right-radius:4px;-moz-border-radius-topright:4px;-moz-border-radius-bottomright:4px}.btn-group>.btn.large:first-child{margin-left:0;-webkit-border-bottom-left-radius:6px;border-bottom-left-radius:6px;-webkit-border-top-left-radius:6px;border-top-left-radius:6px;-moz-border-radius-bottomleft:6px;-moz-border-radius-topleft:6px}.btn-group>.btn.large:last-child,.btn-group>.large.dropdown-toggle{-webkit-border-top-right-radius:6px;border-top-right-radius:6px;-webkit-border-bottom-right-radius:6px;border-bottom-right-radius:6px;-moz-border-radius-topright:6px;-moz-border-radius-bottomright:6px}.btn-group>.btn:hover,.btn-group>.btn:focus,.btn-group>.btn:active,.btn-group>.btn.active{z-index:2}.btn-group .dropdown-toggle:active,.btn-group.open .dropdown-toggle{outline:0}.btn-group>.btn+.dropdown-toggle{*padding-top:5px;padding-right:8px;*padding-bottom:5px;padding-left:8px;-webkit-box-shadow:inset 1px 0 0 rgba(255,255,255,0.125),inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:inset 1px 0 0 rgba(255,255,255,0.125),inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);box-shadow:inset 1px 0 0 rgba(255,255,255,0.125),inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05)}.btn-group>.btn-mini+.dropdown-toggle{*padding-top:2px;padding-right:5px;*padding-bottom:2px;padding-left:5px}.btn-group>.btn-small+.dropdown-toggle{*padding-top:5px;*padding-bottom:4px}.btn-group>.btn-large+.dropdown-toggle{*padding-top:7px;padding-right:12px;*padding-bottom:7px;padding-left:12px}.btn-group.open .dropdown-toggle{background-image:none;-webkit-box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05);box-shadow:inset 0 2px 4px rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.05)}.btn-group.open .btn.dropdown-toggle{background-color:#e6e6e6}.btn-group.open .btn-primary.dropdown-toggle{background-color:#04c}.btn-group.open .btn-warning.dropdown-toggle{background-color:#f89406}.btn-group.open .btn-danger.dropdown-toggle{background-color:#bd362f}.btn-group.open .btn-success.dropdown-toggle{background-color:#51a351}.btn-group.open .btn-info.dropdown-toggle{background-color:#2f96b4}.btn-group.open .btn-inverse.dropdown-toggle{background-color:#222}.btn .caret{margin-top:8px;margin-left:0}.btn-large .caret{margin-top:6px}.btn-large .caret{border-top-width:5px;border-right-width:5px;border-left-width:5px}.btn-mini .caret,.btn-small .caret{margin-top:8px}.dropup .btn-large .caret{border-bottom-width:5px}.btn-primary .caret,.btn-warning .caret,.btn-danger .caret,.btn-info .caret,.btn-success .caret,.btn-inverse .caret{border-top-color:#fff;border-bottom-color:#fff}.btn-group-vertical{display:inline-block;*display:inline;*zoom:1}.btn-group-vertical>.btn{display:block;float:none;max-width:100%;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.btn-group-vertical>.btn+.btn{margin-top:-1px;margin-left:0}.btn-group-vertical>.btn:first-child{-webkit-border-radius:4px 4px 0 0;-moz-border-radius:4px 4px 0 0;border-radius:4px 4px 0 0}.btn-group-vertical>.btn:last-child{-webkit-border-radius:0 0 4px 4px;-moz-border-radius:0 0 4px 4px;border-radius:0 0 4px 4px}.btn-group-vertical>.btn-large:first-child{-webkit-border-radius:6px 6px 0 0;-moz-border-radius:6px 6px 0 0;border-radius:6px 6px 0 0}.btn-group-vertical>.btn-large:last-child{-webkit-border-radius:0 0 6px 6px;-moz-border-radius:0 0 6px 6px;border-radius:0 0 6px 6px}.alert{padding:8px 35px 8px 14px;margin-bottom:20px;text-shadow:0 1px 0 rgba(255,255,255,0.5);background-color:#fcf8e3;border:1px solid #fbeed5;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}.alert,.alert h4{color:#c09853}.alert h4{margin:0}.alert .close{position:relative;top:-2px;right:-21px;line-height:20px}.alert-success{color:#468847;background-color:#dff0d8;border-color:#d6e9c6}.alert-success h4{color:#468847}.alert-danger,.alert-error{color:#b94a48;background-color:#f2dede;border-color:#eed3d7}.alert-danger h4,.alert-error h4{color:#b94a48}.alert-info{color:#3a87ad;background-color:#d9edf7;border-color:#bce8f1}.alert-info h4{color:#3a87ad}.alert-block{padding-top:14px;padding-bottom:14px}.alert-block>p,.alert-block>ul{margin-bottom:0}.alert-block p+p{margin-top:5px}.nav{margin-bottom:20px;margin-left:0;list-style:none}.nav>li>a{display:block}.nav>li>a:hover,.nav>li>a:focus{text-decoration:none;background-color:#eee}.nav>li>a>img{max-width:none}.nav>.pull-right{float:right}.nav-header{display:block;padding:3px 15px;font-size:11px;font-weight:bold;line-height:20px;color:#999;text-shadow:0 1px 0 rgba(255,255,255,0.5);text-transform:uppercase}.nav li+.nav-header{margin-top:9px}.nav-list{padding-right:15px;padding-left:15px;margin-bottom:0}.nav-list>li>a,.nav-list .nav-header{margin-right:-15px;margin-left:-15px;text-shadow:0 1px 0 rgba(255,255,255,0.5)}.nav-list>li>a{padding:3px 15px}.nav-list>.active>a,.nav-list>.active>a:hover,.nav-list>.active>a:focus{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.2);background-color:#08c}.nav-list [class^="icon-"],.nav-list [class*=" icon-"]{margin-right:2px}.nav-list .divider{*width:100%;height:1px;margin:9px 1px;*margin:-5px 0 5px;overflow:hidden;background-color:#e5e5e5;border-bottom:1px solid #fff}.nav-tabs,.nav-pills{*zoom:1}.nav-tabs:before,.nav-pills:before,.nav-tabs:after,.nav-pills:after{display:table;line-height:0;content:""}.nav-tabs:after,.nav-pills:after{clear:both}.nav-tabs>li,.nav-pills>li{float:left}.nav-tabs>li>a,.nav-pills>li>a{padding-right:12px;padding-left:12px;margin-right:2px;line-height:14px}.nav-tabs{border-bottom:1px solid #ddd}.nav-tabs>li{margin-bottom:-1px}.nav-tabs>li>a{padding-top:8px;padding-bottom:8px;line-height:20px;border:1px solid transparent;-webkit-border-radius:4px 4px 0 0;-moz-border-radius:4px 4px 0 0;border-radius:4px 4px 0 0}.nav-tabs>li>a:hover,.nav-tabs>li>a:focus{border-color:#eee #eee #ddd}.nav-tabs>.active>a,.nav-tabs>.active>a:hover,.nav-tabs>.active>a:focus{color:#555;cursor:default;background-color:#fff;border:1px solid #ddd;border-bottom-color:transparent}.nav-pills>li>a{padding-top:8px;padding-bottom:8px;margin-top:2px;margin-bottom:2px;-webkit-border-radius:5px;-moz-border-radius:5px;border-radius:5px}.nav-pills>.active>a,.nav-pills>.active>a:hover,.nav-pills>.active>a:focus{color:#fff;background-color:#08c}.nav-stacked>li{float:none}.nav-stacked>li>a{margin-right:0}.nav-tabs.nav-stacked{border-bottom:0}.nav-tabs.nav-stacked>li>a{border:1px solid #ddd;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.nav-tabs.nav-stacked>li:first-child>a{-webkit-border-top-right-radius:4px;border-top-right-radius:4px;-webkit-border-top-left-radius:4px;border-top-left-radius:4px;-moz-border-radius-topright:4px;-moz-border-radius-topleft:4px}.nav-tabs.nav-stacked>li:last-child>a{-webkit-border-bottom-right-radius:4px;border-bottom-right-radius:4px;-webkit-border-bottom-left-radius:4px;border-bottom-left-radius:4px;-moz-border-radius-bottomright:4px;-moz-border-radius-bottomleft:4px}.nav-tabs.nav-stacked>li>a:hover,.nav-tabs.nav-stacked>li>a:focus{z-index:2;border-color:#ddd}.nav-pills.nav-stacked>li>a{margin-bottom:3px}.nav-pills.nav-stacked>li:last-child>a{margin-bottom:1px}.nav-tabs .dropdown-menu{-webkit-border-radius:0 0 6px 6px;-moz-border-radius:0 0 6px 6px;border-radius:0 0 6px 6px}.nav-pills .dropdown-menu{-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}.nav .dropdown-toggle .caret{margin-top:6px;border-top-color:#08c;border-bottom-color:#08c}.nav .dropdown-toggle:hover .caret,.nav .dropdown-toggle:focus .caret{border-top-color:#005580;border-bottom-color:#005580}.nav-tabs .dropdown-toggle .caret{margin-top:8px}.nav .active .dropdown-toggle .caret{border-top-color:#fff;border-bottom-color:#fff}.nav-tabs .active .dropdown-toggle .caret{border-top-color:#555;border-bottom-color:#555}.nav>.dropdown.active>a:hover,.nav>.dropdown.active>a:focus{cursor:pointer}.nav-tabs .open .dropdown-toggle,.nav-pills .open .dropdown-toggle,.nav>li.dropdown.open.active>a:hover,.nav>li.dropdown.open.active>a:focus{color:#fff;background-color:#999;border-color:#999}.nav li.dropdown.open .caret,.nav li.dropdown.open.active .caret,.nav li.dropdown.open a:hover .caret,.nav li.dropdown.open a:focus .caret{border-top-color:#fff;border-bottom-color:#fff;opacity:1;filter:alpha(opacity=100)}.tabs-stacked .open>a:hover,.tabs-stacked .open>a:focus{border-color:#999}.tabbable{*zoom:1}.tabbable:before,.tabbable:after{display:table;line-height:0;content:""}.tabbable:after{clear:both}.tab-content{overflow:auto}.tabs-below>.nav-tabs,.tabs-right>.nav-tabs,.tabs-left>.nav-tabs{border-bottom:0}.tab-content>.tab-pane,.pill-content>.pill-pane{display:none}.tab-content>.active,.pill-content>.active{display:block}.tabs-below>.nav-tabs{border-top:1px solid #ddd}.tabs-below>.nav-tabs>li{margin-top:-1px;margin-bottom:0}.tabs-below>.nav-tabs>li>a{-webkit-border-radius:0 0 4px 4px;-moz-border-radius:0 0 4px 4px;border-radius:0 0 4px 4px}.tabs-below>.nav-tabs>li>a:hover,.tabs-below>.nav-tabs>li>a:focus{border-top-color:#ddd;border-bottom-color:transparent}.tabs-below>.nav-tabs>.active>a,.tabs-below>.nav-tabs>.active>a:hover,.tabs-below>.nav-tabs>.active>a:focus{border-color:transparent #ddd #ddd #ddd}.tabs-left>.nav-tabs>li,.tabs-right>.nav-tabs>li{float:none}.tabs-left>.nav-tabs>li>a,.tabs-right>.nav-tabs>li>a{min-width:74px;margin-right:0;margin-bottom:3px}.tabs-left>.nav-tabs{float:left;margin-right:19px;border-right:1px solid #ddd}.tabs-left>.nav-tabs>li>a{margin-right:-1px;-webkit-border-radius:4px 0 0 4px;-moz-border-radius:4px 0 0 4px;border-radius:4px 0 0 4px}.tabs-left>.nav-tabs>li>a:hover,.tabs-left>.nav-tabs>li>a:focus{border-color:#eee #ddd #eee #eee}.tabs-left>.nav-tabs .active>a,.tabs-left>.nav-tabs .active>a:hover,.tabs-left>.nav-tabs .active>a:focus{border-color:#ddd transparent #ddd #ddd;*border-right-color:#fff}.tabs-right>.nav-tabs{float:right;margin-left:19px;border-left:1px solid #ddd}.tabs-right>.nav-tabs>li>a{margin-left:-1px;-webkit-border-radius:0 4px 4px 0;-moz-border-radius:0 4px 4px 0;border-radius:0 4px 4px 0}.tabs-right>.nav-tabs>li>a:hover,.tabs-right>.nav-tabs>li>a:focus{border-color:#eee #eee #eee #ddd}.tabs-right>.nav-tabs .active>a,.tabs-right>.nav-tabs .active>a:hover,.tabs-right>.nav-tabs .active>a:focus{border-color:#ddd #ddd #ddd transparent;*border-left-color:#fff}.nav>.disabled>a{color:#999}.nav>.disabled>a:hover,.nav>.disabled>a:focus{text-decoration:none;cursor:default;background-color:transparent}.navbar{*position:relative;*z-index:2;margin-bottom:20px;overflow:visible}.navbar-inner{min-height:40px;padding-right:20px;padding-left:20px;background-color:#fafafa;background-image:-moz-linear-gradient(top,#fff,#f2f2f2);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#f2f2f2));background-image:-webkit-linear-gradient(top,#fff,#f2f2f2);background-image:-o-linear-gradient(top,#fff,#f2f2f2);background-image:linear-gradient(to bottom,#fff,#f2f2f2);background-repeat:repeat-x;border:1px solid #d4d4d4;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff',endColorstr='#fff2f2f2',GradientType=0);*zoom:1;-webkit-box-shadow:0 1px 4px rgba(0,0,0,0.065);-moz-box-shadow:0 1px 4px rgba(0,0,0,0.065);box-shadow:0 1px 4px rgba(0,0,0,0.065)}.navbar-inner:before,.navbar-inner:after{display:table;line-height:0;content:""}.navbar-inner:after{clear:both}.navbar .container{width:auto}.nav-collapse.collapse{height:auto;overflow:visible}.navbar .brand{display:block;float:left;padding:10px 20px 10px;margin-left:-20px;font-size:20px;font-weight:200;color:#777;text-shadow:0 1px 0 #fff}.navbar .brand:hover,.navbar .brand:focus{text-decoration:none}.navbar-text{margin-bottom:0;line-height:40px;color:#777}.navbar-link{color:#777}.navbar-link:hover,.navbar-link:focus{color:#333}.navbar .divider-vertical{height:40px;margin:0 9px;border-right:1px solid #fff;border-left:1px solid #f2f2f2}.navbar .btn,.navbar .btn-group{margin-top:5px}.navbar .btn-group .btn,.navbar .input-prepend .btn,.navbar .input-append .btn,.navbar .input-prepend .btn-group,.navbar .input-append .btn-group{margin-top:0}.navbar-form{margin-bottom:0;*zoom:1}.navbar-form:before,.navbar-form:after{display:table;line-height:0;content:""}.navbar-form:after{clear:both}.navbar-form input,.navbar-form select,.navbar-form .radio,.navbar-form .checkbox{margin-top:5px}.navbar-form input,.navbar-form select,.navbar-form .btn{display:inline-block;margin-bottom:0}.navbar-form input[type="image"],.navbar-form input[type="checkbox"],.navbar-form input[type="radio"]{margin-top:3px}.navbar-form .input-append,.navbar-form .input-prepend{margin-top:5px;white-space:nowrap}.navbar-form .input-append input,.navbar-form .input-prepend input{margin-top:0}.navbar-search{position:relative;float:left;margin-top:5px;margin-bottom:0}.navbar-search .search-query{padding:4px 14px;margin-bottom:0;font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:13px;font-weight:normal;line-height:1;-webkit-border-radius:15px;-moz-border-radius:15px;border-radius:15px}.navbar-static-top{position:static;margin-bottom:0}.navbar-static-top .navbar-inner{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.navbar-fixed-top,.navbar-fixed-bottom{position:fixed;right:0;left:0;z-index:1030;margin-bottom:0}.navbar-fixed-top .navbar-inner,.navbar-static-top .navbar-inner{border-width:0 0 1px}.navbar-fixed-bottom .navbar-inner{border-width:1px 0 0}.navbar-fixed-top .navbar-inner,.navbar-fixed-bottom .navbar-inner{padding-right:0;padding-left:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.navbar-static-top .container,.navbar-fixed-top .container,.navbar-fixed-bottom .container{width:940px}.navbar-fixed-top{top:0}.navbar-fixed-top .navbar-inner,.navbar-static-top .navbar-inner{-webkit-box-shadow:0 1px 10px rgba(0,0,0,0.1);-moz-box-shadow:0 1px 10px rgba(0,0,0,0.1);box-shadow:0 1px 10px rgba(0,0,0,0.1)}.navbar-fixed-bottom{bottom:0}.navbar-fixed-bottom .navbar-inner{-webkit-box-shadow:0 -1px 10px rgba(0,0,0,0.1);-moz-box-shadow:0 -1px 10px rgba(0,0,0,0.1);box-shadow:0 -1px 10px rgba(0,0,0,0.1)}.navbar .nav{position:relative;left:0;display:block;float:left;margin:0 10px 0 0}.navbar .nav.pull-right{float:right;margin-right:0}.navbar .nav>li{float:left}.navbar .nav>li>a{float:none;padding:10px 15px 10px;color:#777;text-decoration:none;text-shadow:0 1px 0 #fff}.navbar .nav .dropdown-toggle .caret{margin-top:8px}.navbar .nav>li>a:focus,.navbar .nav>li>a:hover{color:#333;text-decoration:none;background-color:transparent}.navbar .nav>.active>a,.navbar .nav>.active>a:hover,.navbar .nav>.active>a:focus{color:#555;text-decoration:none;background-color:#e5e5e5;-webkit-box-shadow:inset 0 3px 8px rgba(0,0,0,0.125);-moz-box-shadow:inset 0 3px 8px rgba(0,0,0,0.125);box-shadow:inset 0 3px 8px rgba(0,0,0,0.125)}.navbar .btn-navbar{display:none;float:right;padding:7px 10px;margin-right:5px;margin-left:5px;color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#ededed;*background-color:#e5e5e5;background-image:-moz-linear-gradient(top,#f2f2f2,#e5e5e5);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f2f2f2),to(#e5e5e5));background-image:-webkit-linear-gradient(top,#f2f2f2,#e5e5e5);background-image:-o-linear-gradient(top,#f2f2f2,#e5e5e5);background-image:linear-gradient(to bottom,#f2f2f2,#e5e5e5);background-repeat:repeat-x;border-color:#e5e5e5 #e5e5e5 #bfbfbf;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff2f2f2',endColorstr='#ffe5e5e5',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false);-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.075);-moz-box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.075);box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.075)}.navbar .btn-navbar:hover,.navbar .btn-navbar:focus,.navbar .btn-navbar:active,.navbar .btn-navbar.active,.navbar .btn-navbar.disabled,.navbar .btn-navbar[disabled]{color:#fff;background-color:#e5e5e5;*background-color:#d9d9d9}.navbar .btn-navbar:active,.navbar .btn-navbar.active{background-color:#ccc \9}.navbar .btn-navbar .icon-bar{display:block;width:18px;height:2px;background-color:#f5f5f5;-webkit-border-radius:1px;-moz-border-radius:1px;border-radius:1px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,0.25);-moz-box-shadow:0 1px 0 rgba(0,0,0,0.25);box-shadow:0 1px 0 rgba(0,0,0,0.25)}.btn-navbar .icon-bar+.icon-bar{margin-top:3px}.navbar .nav>li>.dropdown-menu:before{position:absolute;top:-7px;left:9px;display:inline-block;border-right:7px solid transparent;border-bottom:7px solid #ccc;border-left:7px solid transparent;border-bottom-color:rgba(0,0,0,0.2);content:''}.navbar .nav>li>.dropdown-menu:after{position:absolute;top:-6px;left:10px;display:inline-block;border-right:6px solid transparent;border-bottom:6px solid #fff;border-left:6px solid transparent;content:''}.navbar-fixed-bottom .nav>li>.dropdown-menu:before{top:auto;bottom:-7px;border-top:7px solid #ccc;border-bottom:0;border-top-color:rgba(0,0,0,0.2)}.navbar-fixed-bottom .nav>li>.dropdown-menu:after{top:auto;bottom:-6px;border-top:6px solid #fff;border-bottom:0}.navbar .nav li.dropdown>a:hover .caret,.navbar .nav li.dropdown>a:focus .caret{border-top-color:#333;border-bottom-color:#333}.navbar .nav li.dropdown.open>.dropdown-toggle,.navbar .nav li.dropdown.active>.dropdown-toggle,.navbar .nav li.dropdown.open.active>.dropdown-toggle{color:#555;background-color:#e5e5e5}.navbar .nav li.dropdown>.dropdown-toggle .caret{border-top-color:#777;border-bottom-color:#777}.navbar .nav li.dropdown.open>.dropdown-toggle .caret,.navbar .nav li.dropdown.active>.dropdown-toggle .caret,.navbar .nav li.dropdown.open.active>.dropdown-toggle .caret{border-top-color:#555;border-bottom-color:#555}.navbar .pull-right>li>.dropdown-menu,.navbar .nav>li>.dropdown-menu.pull-right{right:0;left:auto}.navbar .pull-right>li>.dropdown-menu:before,.navbar .nav>li>.dropdown-menu.pull-right:before{right:12px;left:auto}.navbar .pull-right>li>.dropdown-menu:after,.navbar .nav>li>.dropdown-menu.pull-right:after{right:13px;left:auto}.navbar .pull-right>li>.dropdown-menu .dropdown-menu,.navbar .nav>li>.dropdown-menu.pull-right .dropdown-menu{right:100%;left:auto;margin-right:-1px;margin-left:0;-webkit-border-radius:6px 0 6px 6px;-moz-border-radius:6px 0 6px 6px;border-radius:6px 0 6px 6px}.navbar-inverse .navbar-inner{background-color:#1b1b1b;background-image:-moz-linear-gradient(top,#222,#111);background-image:-webkit-gradient(linear,0 0,0 100%,from(#222),to(#111));background-image:-webkit-linear-gradient(top,#222,#111);background-image:-o-linear-gradient(top,#222,#111);background-image:linear-gradient(to bottom,#222,#111);background-repeat:repeat-x;border-color:#252525;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff222222',endColorstr='#ff111111',GradientType=0)}.navbar-inverse .brand,.navbar-inverse .nav>li>a{color:#999;text-shadow:0 -1px 0 rgba(0,0,0,0.25)}.navbar-inverse .brand:hover,.navbar-inverse .nav>li>a:hover,.navbar-inverse .brand:focus,.navbar-inverse .nav>li>a:focus{color:#fff}.navbar-inverse .brand{color:#999}.navbar-inverse .navbar-text{color:#999}.navbar-inverse .nav>li>a:focus,.navbar-inverse .nav>li>a:hover{color:#fff;background-color:transparent}.navbar-inverse .nav .active>a,.navbar-inverse .nav .active>a:hover,.navbar-inverse .nav .active>a:focus{color:#fff;background-color:#111}.navbar-inverse .navbar-link{color:#999}.navbar-inverse .navbar-link:hover,.navbar-inverse .navbar-link:focus{color:#fff}.navbar-inverse .divider-vertical{border-right-color:#222;border-left-color:#111}.navbar-inverse .nav li.dropdown.open>.dropdown-toggle,.navbar-inverse .nav li.dropdown.active>.dropdown-toggle,.navbar-inverse .nav li.dropdown.open.active>.dropdown-toggle{color:#fff;background-color:#111}.navbar-inverse .nav li.dropdown>a:hover .caret,.navbar-inverse .nav li.dropdown>a:focus .caret{border-top-color:#fff;border-bottom-color:#fff}.navbar-inverse .nav li.dropdown>.dropdown-toggle .caret{border-top-color:#999;border-bottom-color:#999}.navbar-inverse .nav li.dropdown.open>.dropdown-toggle .caret,.navbar-inverse .nav li.dropdown.active>.dropdown-toggle .caret,.navbar-inverse .nav li.dropdown.open.active>.dropdown-toggle .caret{border-top-color:#fff;border-bottom-color:#fff}.navbar-inverse .navbar-search .search-query{color:#fff;background-color:#515151;border-color:#111;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1),0 1px 0 rgba(255,255,255,0.15);-moz-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1),0 1px 0 rgba(255,255,255,0.15);box-shadow:inset 0 1px 2px rgba(0,0,0,0.1),0 1px 0 rgba(255,255,255,0.15);-webkit-transition:none;-moz-transition:none;-o-transition:none;transition:none}.navbar-inverse .navbar-search .search-query:-moz-placeholder{color:#ccc}.navbar-inverse .navbar-search .search-query:-ms-input-placeholder{color:#ccc}.navbar-inverse .navbar-search .search-query::-webkit-input-placeholder{color:#ccc}.navbar-inverse .navbar-search .search-query:focus,.navbar-inverse .navbar-search .search-query.focused{padding:5px 15px;color:#333;text-shadow:0 1px 0 #fff;background-color:#fff;border:0;outline:0;-webkit-box-shadow:0 0 3px rgba(0,0,0,0.15);-moz-box-shadow:0 0 3px rgba(0,0,0,0.15);box-shadow:0 0 3px rgba(0,0,0,0.15)}.navbar-inverse .btn-navbar{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#0e0e0e;*background-color:#040404;background-image:-moz-linear-gradient(top,#151515,#040404);background-image:-webkit-gradient(linear,0 0,0 100%,from(#151515),to(#040404));background-image:-webkit-linear-gradient(top,#151515,#040404);background-image:-o-linear-gradient(top,#151515,#040404);background-image:linear-gradient(to bottom,#151515,#040404);background-repeat:repeat-x;border-color:#040404 #040404 #000;border-color:rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff151515',endColorstr='#ff040404',GradientType=0);filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.navbar-inverse .btn-navbar:hover,.navbar-inverse .btn-navbar:focus,.navbar-inverse .btn-navbar:active,.navbar-inverse .btn-navbar.active,.navbar-inverse .btn-navbar.disabled,.navbar-inverse .btn-navbar[disabled]{color:#fff;background-color:#040404;*background-color:#000}.navbar-inverse .btn-navbar:active,.navbar-inverse .btn-navbar.active{background-color:#000 \9}.breadcrumb{padding:8px 15px;margin:0 0 20px;list-style:none;background-color:#f5f5f5;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}.breadcrumb>li{display:inline-block;*display:inline;text-shadow:0 1px 0 #fff;*zoom:1}.breadcrumb>li>.divider{padding:0 5px;color:#ccc}.breadcrumb>.active{color:#999}.pagination{margin:20px 0}.pagination ul{display:inline-block;*display:inline;margin-bottom:0;margin-left:0;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;*zoom:1;-webkit-box-shadow:0 1px 2px rgba(0,0,0,0.05);-moz-box-shadow:0 1px 2px rgba(0,0,0,0.05);box-shadow:0 1px 2px rgba(0,0,0,0.05)}.pagination ul>li{display:inline}.pagination ul>li>a,.pagination ul>li>span{float:left;padding:4px 12px;line-height:20px;text-decoration:none;background-color:#fff;border:1px solid #ddd;border-left-width:0}.pagination ul>li>a:hover,.pagination ul>li>a:focus,.pagination ul>.active>a,.pagination ul>.active>span{background-color:#f5f5f5}.pagination ul>.active>a,.pagination ul>.active>span{color:#999;cursor:default}.pagination ul>.disabled>span,.pagination ul>.disabled>a,.pagination ul>.disabled>a:hover,.pagination ul>.disabled>a:focus{color:#999;cursor:default;background-color:transparent}.pagination ul>li:first-child>a,.pagination ul>li:first-child>span{border-left-width:1px;-webkit-border-bottom-left-radius:4px;border-bottom-left-radius:4px;-webkit-border-top-left-radius:4px;border-top-left-radius:4px;-moz-border-radius-bottomleft:4px;-moz-border-radius-topleft:4px}.pagination ul>li:last-child>a,.pagination ul>li:last-child>span{-webkit-border-top-right-radius:4px;border-top-right-radius:4px;-webkit-border-bottom-right-radius:4px;border-bottom-right-radius:4px;-moz-border-radius-topright:4px;-moz-border-radius-bottomright:4px}.pagination-centered{text-align:center}.pagination-right{text-align:right}.pagination-large ul>li>a,.pagination-large ul>li>span{padding:11px 19px;font-size:17.5px}.pagination-large ul>li:first-child>a,.pagination-large ul>li:first-child>span{-webkit-border-bottom-left-radius:6px;border-bottom-left-radius:6px;-webkit-border-top-left-radius:6px;border-top-left-radius:6px;-moz-border-radius-bottomleft:6px;-moz-border-radius-topleft:6px}.pagination-large ul>li:last-child>a,.pagination-large ul>li:last-child>span{-webkit-border-top-right-radius:6px;border-top-right-radius:6px;-webkit-border-bottom-right-radius:6px;border-bottom-right-radius:6px;-moz-border-radius-topright:6px;-moz-border-radius-bottomright:6px}.pagination-mini ul>li:first-child>a,.pagination-small ul>li:first-child>a,.pagination-mini ul>li:first-child>span,.pagination-small ul>li:first-child>span{-webkit-border-bottom-left-radius:3px;border-bottom-left-radius:3px;-webkit-border-top-left-radius:3px;border-top-left-radius:3px;-moz-border-radius-bottomleft:3px;-moz-border-radius-topleft:3px}.pagination-mini ul>li:last-child>a,.pagination-small ul>li:last-child>a,.pagination-mini ul>li:last-child>span,.pagination-small ul>li:last-child>span{-webkit-border-top-right-radius:3px;border-top-right-radius:3px;-webkit-border-bottom-right-radius:3px;border-bottom-right-radius:3px;-moz-border-radius-topright:3px;-moz-border-radius-bottomright:3px}.pagination-small ul>li>a,.pagination-small ul>li>span{padding:2px 10px;font-size:11.9px}.pagination-mini ul>li>a,.pagination-mini ul>li>span{padding:0 6px;font-size:10.5px}.pager{margin:20px 0;text-align:center;list-style:none;*zoom:1}.pager:before,.pager:after{display:table;line-height:0;content:""}.pager:after{clear:both}.pager li{display:inline}.pager li>a,.pager li>span{display:inline-block;padding:5px 14px;background-color:#fff;border:1px solid #ddd;-webkit-border-radius:15px;-moz-border-radius:15px;border-radius:15px}.pager li>a:hover,.pager li>a:focus{text-decoration:none;background-color:#f5f5f5}.pager .next>a,.pager .next>span{float:right}.pager .previous>a,.pager .previous>span{float:left}.pager .disabled>a,.pager .disabled>a:hover,.pager .disabled>a:focus,.pager .disabled>span{color:#999;cursor:default;background-color:#fff}.modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1040;background-color:#000}.modal-backdrop.fade{opacity:0}.modal-backdrop,.modal-backdrop.fade.in{opacity:.8;filter:alpha(opacity=80)}.modal{position:fixed;top:10%;left:50%;z-index:1050;width:560px;margin-left:-280px;background-color:#fff;border:1px solid #999;border:1px solid rgba(0,0,0,0.3);*border:1px solid #999;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;outline:0;-webkit-box-shadow:0 3px 7px rgba(0,0,0,0.3);-moz-box-shadow:0 3px 7px rgba(0,0,0,0.3);box-shadow:0 3px 7px rgba(0,0,0,0.3);-webkit-background-clip:padding-box;-moz-background-clip:padding-box;background-clip:padding-box}.modal.fade{top:-25%;-webkit-transition:opacity .3s linear,top .3s ease-out;-moz-transition:opacity .3s linear,top .3s ease-out;-o-transition:opacity .3s linear,top .3s ease-out;transition:opacity .3s linear,top .3s ease-out}.modal.fade.in{top:10%}.modal-header{padding:9px 15px;border-bottom:1px solid #eee}.modal-header .close{margin-top:2px}.modal-header h3{margin:0;line-height:30px}.modal-body{position:relative;max-height:400px;padding:15px;overflow-y:auto}.modal-form{margin-bottom:0}.modal-footer{padding:14px 15px 15px;margin-bottom:0;text-align:right;background-color:#f5f5f5;border-top:1px solid #ddd;-webkit-border-radius:0 0 6px 6px;-moz-border-radius:0 0 6px 6px;border-radius:0 0 6px 6px;*zoom:1;-webkit-box-shadow:inset 0 1px 0 #fff;-moz-box-shadow:inset 0 1px 0 #fff;box-shadow:inset 0 1px 0 #fff}.modal-footer:before,.modal-footer:after{display:table;line-height:0;content:""}.modal-footer:after{clear:both}.modal-footer .btn+.btn{margin-bottom:0;margin-left:5px}.modal-footer .btn-group .btn+.btn{margin-left:-1px}.modal-footer .btn-block+.btn-block{margin-left:0}.tooltip{position:absolute;z-index:1030;display:block;font-size:11px;line-height:1.4;opacity:0;filter:alpha(opacity=0);visibility:visible}.tooltip.in{opacity:.8;filter:alpha(opacity=80)}.tooltip.top{padding:5px 0;margin-top:-3px}.tooltip.right{padding:0 5px;margin-left:3px}.tooltip.bottom{padding:5px 0;margin-top:3px}.tooltip.left{padding:0 5px;margin-left:-3px}.tooltip-inner{max-width:200px;padding:8px;color:#fff;text-align:center;text-decoration:none;background-color:#000;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}.tooltip-arrow{position:absolute;width:0;height:0;border-color:transparent;border-style:solid}.tooltip.top .tooltip-arrow{bottom:0;left:50%;margin-left:-5px;border-top-color:#000;border-width:5px 5px 0}.tooltip.right .tooltip-arrow{top:50%;left:0;margin-top:-5px;border-right-color:#000;border-width:5px 5px 5px 0}.tooltip.left .tooltip-arrow{top:50%;right:0;margin-top:-5px;border-left-color:#000;border-width:5px 0 5px 5px}.tooltip.bottom .tooltip-arrow{top:0;left:50%;margin-left:-5px;border-bottom-color:#000;border-width:0 5px 5px}.popover{position:absolute;top:0;left:0;z-index:1010;display:none;max-width:276px;padding:1px;text-align:left;white-space:normal;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.2);-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px;-webkit-box-shadow:0 5px 10px rgba(0,0,0,0.2);-moz-box-shadow:0 5px 10px rgba(0,0,0,0.2);box-shadow:0 5px 10px rgba(0,0,0,0.2);-webkit-background-clip:padding-box;-moz-background-clip:padding;background-clip:padding-box}.popover.top{margin-top:-10px}.popover.right{margin-left:10px}.popover.bottom{margin-top:10px}.popover.left{margin-left:-10px}.popover-title{padding:8px 14px;margin:0;font-size:14px;font-weight:normal;line-height:18px;background-color:#f7f7f7;border-bottom:1px solid #ebebeb;-webkit-border-radius:5px 5px 0 0;-moz-border-radius:5px 5px 0 0;border-radius:5px 5px 0 0}.popover-title:empty{display:none}.popover-content{padding:9px 14px}.popover .arrow,.popover .arrow:after{position:absolute;display:block;width:0;height:0;border-color:transparent;border-style:solid}.popover .arrow{border-width:11px}.popover .arrow:after{border-width:10px;content:""}.popover.top .arrow{bottom:-11px;left:50%;margin-left:-11px;border-top-color:#999;border-top-color:rgba(0,0,0,0.25);border-bottom-width:0}.popover.top .arrow:after{bottom:1px;margin-left:-10px;border-top-color:#fff;border-bottom-width:0}.popover.right .arrow{top:50%;left:-11px;margin-top:-11px;border-right-color:#999;border-right-color:rgba(0,0,0,0.25);border-left-width:0}.popover.right .arrow:after{bottom:-10px;left:1px;border-right-color:#fff;border-left-width:0}.popover.bottom .arrow{top:-11px;left:50%;margin-left:-11px;border-bottom-color:#999;border-bottom-color:rgba(0,0,0,0.25);border-top-width:0}.popover.bottom .arrow:after{top:1px;margin-left:-10px;border-bottom-color:#fff;border-top-width:0}.popover.left .arrow{top:50%;right:-11px;margin-top:-11px;border-left-color:#999;border-left-color:rgba(0,0,0,0.25);border-right-width:0}.popover.left .arrow:after{right:1px;bottom:-10px;border-left-color:#fff;border-right-width:0}.thumbnails{margin-left:-20px;list-style:none;*zoom:1}.thumbnails:before,.thumbnails:after{display:table;line-height:0;content:""}.thumbnails:after{clear:both}.row-fluid .thumbnails{margin-left:0}.thumbnails>li{float:left;margin-bottom:20px;margin-left:20px}.thumbnail{display:block;padding:4px;line-height:20px;border:1px solid #ddd;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:0 1px 3px rgba(0,0,0,0.055);-moz-box-shadow:0 1px 3px rgba(0,0,0,0.055);box-shadow:0 1px 3px rgba(0,0,0,0.055);-webkit-transition:all .2s ease-in-out;-moz-transition:all .2s ease-in-out;-o-transition:all .2s ease-in-out;transition:all .2s ease-in-out}a.thumbnail:hover,a.thumbnail:focus{border-color:#08c;-webkit-box-shadow:0 1px 4px rgba(0,105,214,0.25);-moz-box-shadow:0 1px 4px rgba(0,105,214,0.25);box-shadow:0 1px 4px rgba(0,105,214,0.25)}.thumbnail>img{display:block;max-width:100%;margin-right:auto;margin-left:auto}.thumbnail .caption{padding:9px;color:#555}.media,.media-body{overflow:hidden;*overflow:visible;zoom:1}.media,.media .media{margin-top:15px}.media:first-child{margin-top:0}.media-object{display:block}.media-heading{margin:0 0 5px}.media>.pull-left{margin-right:10px}.media>.pull-right{margin-left:10px}.media-list{margin-left:0;list-style:none}.label,.badge{display:inline-block;padding:2px 4px;font-size:11.844px;font-weight:bold;line-height:14px;color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,0.25);white-space:nowrap;vertical-align:baseline;background-color:#999}.label{-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}.badge{padding-right:9px;padding-left:9px;-webkit-border-radius:9px;-moz-border-radius:9px;border-radius:9px}.label:empty,.badge:empty{display:none}a.label:hover,a.label:focus,a.badge:hover,a.badge:focus{color:#fff;text-decoration:none;cursor:pointer}.label-important,.badge-important{background-color:#b94a48}.label-important[href],.badge-important[href]{background-color:#953b39}.label-warning,.badge-warning{background-color:#f89406}.label-warning[href],.badge-warning[href]{background-color:#c67605}.label-success,.badge-success{background-color:#468847}.label-success[href],.badge-success[href]{background-color:#356635}.label-info,.badge-info{background-color:#3a87ad}.label-info[href],.badge-info[href]{background-color:#2d6987}.label-inverse,.badge-inverse{background-color:#333}.label-inverse[href],.badge-inverse[href]{background-color:#1a1a1a}.btn .label,.btn .badge{position:relative;top:-1px}.btn-mini .label,.btn-mini .badge{top:0}@-webkit-keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}@-moz-keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}@-ms-keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}@-o-keyframes progress-bar-stripes{from{background-position:0 0}to{background-position:40px 0}}@keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}.progress{height:20px;margin-bottom:20px;overflow:hidden;background-color:#f7f7f7;background-image:-moz-linear-gradient(top,#f5f5f5,#f9f9f9);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f5f5f5),to(#f9f9f9));background-image:-webkit-linear-gradient(top,#f5f5f5,#f9f9f9);background-image:-o-linear-gradient(top,#f5f5f5,#f9f9f9);background-image:linear-gradient(to bottom,#f5f5f5,#f9f9f9);background-repeat:repeat-x;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff5f5f5',endColorstr='#fff9f9f9',GradientType=0);-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1);-moz-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1);box-shadow:inset 0 1px 2px rgba(0,0,0,0.1)}.progress .bar{float:left;width:0;height:100%;font-size:12px;color:#fff;text-align:center;text-shadow:0 -1px 0 rgba(0,0,0,0.25);background-color:#0e90d2;background-image:-moz-linear-gradient(top,#149bdf,#0480be);background-image:-webkit-gradient(linear,0 0,0 100%,from(#149bdf),to(#0480be));background-image:-webkit-linear-gradient(top,#149bdf,#0480be);background-image:-o-linear-gradient(top,#149bdf,#0480be);background-image:linear-gradient(to bottom,#149bdf,#0480be);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff149bdf',endColorstr='#ff0480be',GradientType=0);-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);-moz-box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;-webkit-transition:width .6s ease;-moz-transition:width .6s ease;-o-transition:width .6s ease;transition:width .6s ease}.progress .bar+.bar{-webkit-box-shadow:inset 1px 0 0 rgba(0,0,0,0.15),inset 0 -1px 0 rgba(0,0,0,0.15);-moz-box-shadow:inset 1px 0 0 rgba(0,0,0,0.15),inset 0 -1px 0 rgba(0,0,0,0.15);box-shadow:inset 1px 0 0 rgba(0,0,0,0.15),inset 0 -1px 0 rgba(0,0,0,0.15)}.progress-striped .bar{background-color:#149bdf;background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-o-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);-webkit-background-size:40px 40px;-moz-background-size:40px 40px;-o-background-size:40px 40px;background-size:40px 40px}.progress.active .bar{-webkit-animation:progress-bar-stripes 2s linear infinite;-moz-animation:progress-bar-stripes 2s linear infinite;-ms-animation:progress-bar-stripes 2s linear infinite;-o-animation:progress-bar-stripes 2s linear infinite;animation:progress-bar-stripes 2s linear infinite}.progress-danger .bar,.progress .bar-danger{background-color:#dd514c;background-image:-moz-linear-gradient(top,#ee5f5b,#c43c35);background-image:-webkit-gradient(linear,0 0,0 100%,from(#ee5f5b),to(#c43c35));background-image:-webkit-linear-gradient(top,#ee5f5b,#c43c35);background-image:-o-linear-gradient(top,#ee5f5b,#c43c35);background-image:linear-gradient(to bottom,#ee5f5b,#c43c35);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffee5f5b',endColorstr='#ffc43c35',GradientType=0)}.progress-danger.progress-striped .bar,.progress-striped .bar-danger{background-color:#ee5f5b;background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-o-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-success .bar,.progress .bar-success{background-color:#5eb95e;background-image:-moz-linear-gradient(top,#62c462,#57a957);background-image:-webkit-gradient(linear,0 0,0 100%,from(#62c462),to(#57a957));background-image:-webkit-linear-gradient(top,#62c462,#57a957);background-image:-o-linear-gradient(top,#62c462,#57a957);background-image:linear-gradient(to bottom,#62c462,#57a957);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff62c462',endColorstr='#ff57a957',GradientType=0)}.progress-success.progress-striped .bar,.progress-striped .bar-success{background-color:#62c462;background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-o-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-info .bar,.progress .bar-info{background-color:#4bb1cf;background-image:-moz-linear-gradient(top,#5bc0de,#339bb9);background-image:-webkit-gradient(linear,0 0,0 100%,from(#5bc0de),to(#339bb9));background-image:-webkit-linear-gradient(top,#5bc0de,#339bb9);background-image:-o-linear-gradient(top,#5bc0de,#339bb9);background-image:linear-gradient(to bottom,#5bc0de,#339bb9);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5bc0de',endColorstr='#ff339bb9',GradientType=0)}.progress-info.progress-striped .bar,.progress-striped .bar-info{background-color:#5bc0de;background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-o-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-warning .bar,.progress .bar-warning{background-color:#faa732;background-image:-moz-linear-gradient(top,#fbb450,#f89406);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fbb450),to(#f89406));background-image:-webkit-linear-gradient(top,#fbb450,#f89406);background-image:-o-linear-gradient(top,#fbb450,#f89406);background-image:linear-gradient(to bottom,#fbb450,#f89406);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffbb450',endColorstr='#fff89406',GradientType=0)}.progress-warning.progress-striped .bar,.progress-striped .bar-warning{background-color:#fbb450;background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-o-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.accordion{margin-bottom:20px}.accordion-group{margin-bottom:2px;border:1px solid #e5e5e5;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px}.accordion-heading{border-bottom:0}.accordion-heading .accordion-toggle{display:block;padding:8px 15px}.accordion-toggle{cursor:pointer}.accordion-inner{padding:9px 15px;border-top:1px solid #e5e5e5}.carousel{position:relative;margin-bottom:20px;line-height:1}.carousel-inner{position:relative;width:100%;overflow:hidden}.carousel-inner>.item{position:relative;display:none;-webkit-transition:.6s ease-in-out left;-moz-transition:.6s ease-in-out left;-o-transition:.6s ease-in-out left;transition:.6s ease-in-out left}.carousel-inner>.item>img,.carousel-inner>.item>a>img{display:block;line-height:1}.carousel-inner>.active,.carousel-inner>.next,.carousel-inner>.prev{display:block}.carousel-inner>.active{left:0}.carousel-inner>.next,.carousel-inner>.prev{position:absolute;top:0;width:100%}.carousel-inner>.next{left:100%}.carousel-inner>.prev{left:-100%}.carousel-inner>.next.left,.carousel-inner>.prev.right{left:0}.carousel-inner>.active.left{left:-100%}.carousel-inner>.active.right{left:100%}.carousel-control{position:absolute;top:40%;left:15px;width:40px;height:40px;margin-top:-20px;font-size:60px;font-weight:100;line-height:30px;color:#fff;text-align:center;background:#222;border:3px solid #fff;-webkit-border-radius:23px;-moz-border-radius:23px;border-radius:23px;opacity:.5;filter:alpha(opacity=50)}.carousel-control.right{right:15px;left:auto}.carousel-control:hover,.carousel-control:focus{color:#fff;text-decoration:none;opacity:.9;filter:alpha(opacity=90)}.carousel-indicators{position:absolute;top:15px;right:15px;z-index:5;margin:0;list-style:none}.carousel-indicators li{display:block;float:left;width:10px;height:10px;margin-left:5px;text-indent:-999px;background-color:#ccc;background-color:rgba(255,255,255,0.25);border-radius:5px}.carousel-indicators .active{background-color:#fff}.carousel-caption{position:absolute;right:0;bottom:0;left:0;padding:15px;background:#333;background:rgba(0,0,0,0.75)}.carousel-caption h4,.carousel-caption p{line-height:20px;color:#fff}.carousel-caption h4{margin:0 0 5px}.carousel-caption p{margin-bottom:0}.hero-unit{padding:60px;margin-bottom:30px;font-size:18px;font-weight:200;line-height:30px;color:inherit;background-color:#eee;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}.hero-unit h1{margin-bottom:0;font-size:60px;line-height:1;letter-spacing:-1px;color:inherit}.hero-unit li{line-height:30px}.pull-right{float:right}.pull-left{float:left}.hide{display:none}.show{display:block}.invisible{visibility:hidden}.affix{position:fixed}
 
-/* Pretty printing styles. Used with prettify.js. */
+  /* Pretty printing styles. Used with prettify.js. */
 /* Vim sunburst theme by David Leibovic */
 pre .str {
   color: #65B042;
@@ -294,8 +288,7 @@ li.L8 {
     color: #060;
   }
 }
-
-/* ------------------------------------------------------------------------------------------
+  /* ------------------------------------------------------------------------------------------
  * Content
  * ------------------------------------------------------------------------------------------ */
 body {
@@ -711,19 +704,13 @@ margin-bottom: 20px;
   }
   .json-schema-view .title,.json-schema-view .title:hover,json-schema-view .title,json-schema-view .title:hover{text-decoration:none;color:#333}.json-schema-view .brace,.json-schema-view .bracket,.json-schema-view .title,json-schema-view .brace,json-schema-view .bracket,json-schema-view .title{color:#333}.json-schema-view .property,json-schema-view .property{font-size:0;display:table-row}.json-schema-view .property>*,json-schema-view .property>*{font-size:14px;padding:.2em}.json-schema-view .name,json-schema-view .name{color:#00f;display:table-cell;vertical-align:top}.json-schema-view .type,json-schema-view .type{color:green}.json-schema-view .type-any,json-schema-view .type-any{color:#33f}.json-schema-view .required,json-schema-view .required{color:red}.json-schema-view .inner,json-schema-view .inner{padding-left:18px}.json-schema-view.collapsed .description,.json-schema-view.collapsed .property,json-schema-view.collapsed .description,json-schema-view.collapsed .property{display:none}.json-schema-view.collapsed .closeing.brace,json-schema-view.collapsed .closeing.brace{display:inline-block}.json-schema-view.collapsed .toggle-handle,json-schema-view.collapsed .toggle-handle{transform:rotate(-90deg)}.json-schema-view.json-schema-view-dark,json-schema-view[json-schema-view-dark]{font-family:monospace;font-size:0;display:table-cell}.json-schema-view.json-schema-view-dark>*,json-schema-view[json-schema-view-dark]>*{font-size:14px}.json-schema-view.json-schema-view-dark .toggle-handle,json-schema-view[json-schema-view-dark] .toggle-handle{cursor:pointer;margin:auto .3em;font-size:10px;display:inline-block;transform-origin:50% 40%;transition:transform 150ms ease-in}.json-schema-view.json-schema-view-dark .toggle-handle,.json-schema-view.json-schema-view-dark .toggle-handle:hover,json-schema-view[json-schema-view-dark] .toggle-handle,json-schema-view[json-schema-view-dark] .toggle-handle:hover{text-decoration:none;color:#eee}.json-schema-view.json-schema-view-dark .description,json-schema-view[json-schema-view-dark] .description{color:gray;font-style:italic}.json-schema-view.json-schema-view-dark .title,.json-schema-view.json-schema-view-dark .title:hover,json-schema-view[json-schema-view-dark] .title,json-schema-view[json-schema-view-dark] .title:hover{text-decoration:none;color:#eee}.json-schema-view.json-schema-view-dark .brace,.json-schema-view.json-schema-view-dark .bracket,.json-schema-view.json-schema-view-dark .title,json-schema-view[json-schema-view-dark] .brace,json-schema-view[json-schema-view-dark] .bracket,json-schema-view[json-schema-view-dark] .title{color:#eee}.json-schema-view.json-schema-view-dark .property,json-schema-view[json-schema-view-dark] .property{font-size:0;display:table-row}.json-schema-view.json-schema-view-dark .property>*,json-schema-view[json-schema-view-dark] .property>*{font-size:14px;padding:.2em}.json-schema-view.json-schema-view-dark .name,json-schema-view[json-schema-view-dark] .name{color:#add8e6;display:table-cell;vertical-align:top}.json-schema-view.json-schema-view-dark .type,json-schema-view[json-schema-view-dark] .type{color:#90ee90}.json-schema-view.json-schema-view-dark .type-any,json-schema-view[json-schema-view-dark] .type-any{color:#d4ebf2}.json-schema-view.json-schema-view-dark .required,json-schema-view[json-schema-view-dark] .required{color:#fe0000}.json-schema-view.json-schema-view-dark .inner,json-schema-view[json-schema-view-dark] .inner{padding-left:18px}.json-schema-view.json-schema-view-dark.collapsed .description,.json-schema-view.json-schema-view-dark.collapsed .property,json-schema-view[json-schema-view-dark].collapsed .description,json-schema-view[json-schema-view-dark].collapsed .property{display:none}.json-schema-view.json-schema-view-dark.collapsed .closeing.brace,json-schema-view[json-schema-view-dark].collapsed .closeing.brace{display:inline-block}.json-schema-view.json-schema-view-dark.collapsed .toggle-handle,json-schema-view[json-schema-view-dark].collapsed .toggle-handle{transform:rotate(-90deg)}
 
-
-</style>
-
-
+  </style>
 </head>
 <body>
   <script>
-
-  // Script section to load models into a JS Var
-
-  var defs = {}
-
-  defs.ApiResponse = {
+    // Script section to load models into a JS Var
+    var defs = {}
+    defs.ApiResponse = {
   "type" : "object",
   "properties" : {
     "code" : {
@@ -740,7 +727,7 @@ margin-bottom: 20px;
   "title" : "An uploaded response",
   "description" : "Describes the result of uploading an image resource"
 };
-  defs.Category = {
+    defs.Category = {
   "type" : "object",
   "properties" : {
     "id" : {
@@ -757,7 +744,7 @@ margin-bottom: 20px;
     "name" : "Category"
   }
 };
-  defs.Order = {
+    defs.Order = {
   "type" : "object",
   "properties" : {
     "id" : {
@@ -792,7 +779,7 @@ margin-bottom: 20px;
     "name" : "Order"
   }
 };
-  defs.Pet = {
+    defs.Pet = {
   "type" : "object",
   "required" : [ "name", "photoUrls" ],
   "properties" : {
@@ -839,7 +826,7 @@ margin-bottom: 20px;
     "name" : "Pet"
   }
 };
-  defs.Tag = {
+    defs.Tag = {
   "type" : "object",
   "properties" : {
     "id" : {
@@ -856,7 +843,7 @@ margin-bottom: 20px;
     "name" : "Tag"
   }
 };
-  defs.User = {
+    defs.User = {
   "type" : "object",
   "properties" : {
     "id" : {
@@ -895,189 +882,141 @@ margin-bottom: 20px;
 };
   </script>
 
-<div class="container-fluid">
+  <div class="container-fluid">
     <div class="row-fluid">
-        <div id="sidenav" class="span2">
-            <nav id="scrollingNav">
-                <ul class="sidenav nav nav-list">
+      <div id="sidenav" class="span2">
+        <nav id="scrollingNav">
+          <ul class="sidenav nav nav-list">
+            <!-- Logo Area -->
+              <!--<div style="width: 80%; background-color: #4c8eca; color: white; padding: 20px; text-align: center; margin-bottom: 20px; ">
 
+              API Docs 2
 
-                    <!-- Logo Area -->
-                    <!--<div style="width: 80%; background-color: #4c8eca; color: white; padding: 20px; text-align: center; margin-bottom: 20px; ">
+              </div>
+            -->
+            <li class="nav-fixed nav-header active" data-group="_"><a href="#api-_">API Summary</a></li>
 
-                    API Docs 2
-
-                    </div>
-                    -->
-                    <li class="nav-fixed nav-header active" data-group="_"><a href="#api-_">API Summary</a></li>
-
-
-                                <li class="nav-header" data-group="Pet"><a href="#api-Pet">API Methods - Pet</a></li>
-                                    <li data-group="Pet" data-name="addPet" class="">
-                                        <a href="#api-Pet-addPet">addPet</a>
-                                    </li>
-                                    <li data-group="Pet" data-name="deletePet" class="">
-                                        <a href="#api-Pet-deletePet">deletePet</a>
-                                    </li>
-                                    <li data-group="Pet" data-name="findPetsByStatus" class="">
-                                        <a href="#api-Pet-findPetsByStatus">findPetsByStatus</a>
-                                    </li>
-                                    <li data-group="Pet" data-name="findPetsByTags" class="">
-                                        <a href="#api-Pet-findPetsByTags">findPetsByTags</a>
-                                    </li>
-                                    <li data-group="Pet" data-name="getPetById" class="">
-                                        <a href="#api-Pet-getPetById">getPetById</a>
-                                    </li>
-                                    <li data-group="Pet" data-name="updatePet" class="">
-                                        <a href="#api-Pet-updatePet">updatePet</a>
-                                    </li>
-                                    <li data-group="Pet" data-name="updatePetWithForm" class="">
-                                        <a href="#api-Pet-updatePetWithForm">updatePetWithForm</a>
-                                    </li>
-                                    <li data-group="Pet" data-name="uploadFile" class="">
-                                        <a href="#api-Pet-uploadFile">uploadFile</a>
-                                    </li>
-                                <li class="nav-header" data-group="Store"><a href="#api-Store">API Methods - Store</a></li>
-                                    <li data-group="Store" data-name="deleteOrder" class="">
-                                        <a href="#api-Store-deleteOrder">deleteOrder</a>
-                                    </li>
-                                    <li data-group="Store" data-name="getInventory" class="">
-                                        <a href="#api-Store-getInventory">getInventory</a>
-                                    </li>
-                                    <li data-group="Store" data-name="getOrderById" class="">
-                                        <a href="#api-Store-getOrderById">getOrderById</a>
-                                    </li>
-                                    <li data-group="Store" data-name="placeOrder" class="">
-                                        <a href="#api-Store-placeOrder">placeOrder</a>
-                                    </li>
-                                <li class="nav-header" data-group="User"><a href="#api-User">API Methods - User</a></li>
-                                    <li data-group="User" data-name="createUser" class="">
-                                        <a href="#api-User-createUser">createUser</a>
-                                    </li>
-                                    <li data-group="User" data-name="createUsersWithArrayInput" class="">
-                                        <a href="#api-User-createUsersWithArrayInput">createUsersWithArrayInput</a>
-                                    </li>
-                                    <li data-group="User" data-name="createUsersWithListInput" class="">
-                                        <a href="#api-User-createUsersWithListInput">createUsersWithListInput</a>
-                                    </li>
-                                    <li data-group="User" data-name="deleteUser" class="">
-                                        <a href="#api-User-deleteUser">deleteUser</a>
-                                    </li>
-                                    <li data-group="User" data-name="getUserByName" class="">
-                                        <a href="#api-User-getUserByName">getUserByName</a>
-                                    </li>
-                                    <li data-group="User" data-name="loginUser" class="">
-                                        <a href="#api-User-loginUser">loginUser</a>
-                                    </li>
-                                    <li data-group="User" data-name="logoutUser" class="">
-                                        <a href="#api-User-logoutUser">logoutUser</a>
-                                    </li>
-                                    <li data-group="User" data-name="updateUser" class="">
-                                        <a href="#api-User-updateUser">updateUser</a>
-                                    </li>
-
-
-
-
-                </ul>
-            </nav>
+                  <li class="nav-header" data-group="Pet"><a href="#api-Pet">API Methods - Pet</a></li>
+                    <li data-group="Pet" data-name="addPet" class="">
+                      <a href="#api-Pet-addPet">addPet</a>
+                    </li>
+                    <li data-group="Pet" data-name="deletePet" class="">
+                      <a href="#api-Pet-deletePet">deletePet</a>
+                    </li>
+                    <li data-group="Pet" data-name="findPetsByStatus" class="">
+                      <a href="#api-Pet-findPetsByStatus">findPetsByStatus</a>
+                    </li>
+                    <li data-group="Pet" data-name="findPetsByTags" class="">
+                      <a href="#api-Pet-findPetsByTags">findPetsByTags</a>
+                    </li>
+                    <li data-group="Pet" data-name="getPetById" class="">
+                      <a href="#api-Pet-getPetById">getPetById</a>
+                    </li>
+                    <li data-group="Pet" data-name="updatePet" class="">
+                      <a href="#api-Pet-updatePet">updatePet</a>
+                    </li>
+                    <li data-group="Pet" data-name="updatePetWithForm" class="">
+                      <a href="#api-Pet-updatePetWithForm">updatePetWithForm</a>
+                    </li>
+                    <li data-group="Pet" data-name="uploadFile" class="">
+                      <a href="#api-Pet-uploadFile">uploadFile</a>
+                    </li>
+                  <li class="nav-header" data-group="Store"><a href="#api-Store">API Methods - Store</a></li>
+                    <li data-group="Store" data-name="deleteOrder" class="">
+                      <a href="#api-Store-deleteOrder">deleteOrder</a>
+                    </li>
+                    <li data-group="Store" data-name="getInventory" class="">
+                      <a href="#api-Store-getInventory">getInventory</a>
+                    </li>
+                    <li data-group="Store" data-name="getOrderById" class="">
+                      <a href="#api-Store-getOrderById">getOrderById</a>
+                    </li>
+                    <li data-group="Store" data-name="placeOrder" class="">
+                      <a href="#api-Store-placeOrder">placeOrder</a>
+                    </li>
+                  <li class="nav-header" data-group="User"><a href="#api-User">API Methods - User</a></li>
+                    <li data-group="User" data-name="createUser" class="">
+                      <a href="#api-User-createUser">createUser</a>
+                    </li>
+                    <li data-group="User" data-name="createUsersWithArrayInput" class="">
+                      <a href="#api-User-createUsersWithArrayInput">createUsersWithArrayInput</a>
+                    </li>
+                    <li data-group="User" data-name="createUsersWithListInput" class="">
+                      <a href="#api-User-createUsersWithListInput">createUsersWithListInput</a>
+                    </li>
+                    <li data-group="User" data-name="deleteUser" class="">
+                      <a href="#api-User-deleteUser">deleteUser</a>
+                    </li>
+                    <li data-group="User" data-name="getUserByName" class="">
+                      <a href="#api-User-getUserByName">getUserByName</a>
+                    </li>
+                    <li data-group="User" data-name="loginUser" class="">
+                      <a href="#api-User-loginUser">loginUser</a>
+                    </li>
+                    <li data-group="User" data-name="logoutUser" class="">
+                      <a href="#api-User-logoutUser">logoutUser</a>
+                    </li>
+                    <li data-group="User" data-name="updateUser" class="">
+                      <a href="#api-User-updateUser">updateUser</a>
+                    </li>
+          </ul>
+        </nav>
+      </div>
+      <div id="content">
+        <div id="project">
+          <div class="pull-left">
+            <h1>Swagger Petstore</h1>
+          </div>
+          <div class="clearfix"></div>
         </div>
-        <div id="content">
-            <div id="project">
-                <div class="pull-left">
-                    <h1>Swagger Petstore</h1>
-                </div>
-                <div class="clearfix"></div>
-            </div>
-            <div id="header">
-                <div id="api-_">
-                    <h2 id="welcome-to-apidoc">API and SDK Documentation</h2>
+        <div id="header">
+          <div id="api-_">
+            <h2 id="welcome-to-apidoc">API and SDK Documentation</h2>
+              <div class="app-desc">Version: 1.0.0</div>
+            <hr>
+            <p class="marked">This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.</p>
+          </div>
+        </div>
+        <div id="sections">
+                <section id="api-Pet">
+                  <h1>Pet</h1>
+                    <div id="api-Pet-addPet">
+                      <article id="api-Pet-addPet-0" data-group="User" data-name="addPet" data-version="0">
+                        <div class="pull-left">
+                          <h1>addPet</h1>
+                          <p>Add a new pet to the store</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/pet</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Pet-addPet-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Pet-addPet-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-addPet-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Pet-addPet-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Pet-addPet-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Pet-addPet-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Pet-addPet-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Pet-addPet-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Pet-addPet-0-php">PHP</a></li>
+                        </ul>
 
-                        <div class="app-desc">Version: 1.0.0</div>
-
-
-                    <hr>
-
-                    <p class="marked">This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key &#x60;special-key&#x60; to test the authorization filters.</p>
-                </div>
-            </div>
-            <div id="sections">
-
-
-                            <section id="api-Pet">
-                                <h1>Pet</h1>
-
-
-
-
-
-
-
-                                    <div id="api-Pet-addPet">
-
-                                        <article id="api-Pet-addPet-0" data-group="User" data-name="addPet" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>addPet</h1>
-                                                <p>Add a new pet to the store</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/pet</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Pet-addPet-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-addPet-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Pet-addPet-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Pet-addPet-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-addPet-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Pet-addPet-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Pet-addPet-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-addPet-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-addPet-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Pet-addPet-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/pet"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Pet-addPet-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Pet-addPet-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/pet"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Pet-addPet-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .PetApi;
@@ -1105,13 +1044,12 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-addPet-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .PetApi;
+                          <div class="tab-pane" id="examples-Pet-addPet-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .PetApi;
 
 public class PetApiExample {
 
@@ -1127,18 +1065,15 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Pet-addPet-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Pet-addPet-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Pet-addPet-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Pet-addPet-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure OAuth2 access token for authorization: (authentication scheme: petstore_auth)
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];
@@ -1156,11 +1091,12 @@ PetApi *apiInstance = [[PetApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Pet-addPet-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Pet-addPet-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -1181,16 +1117,15 @@ var callback = function(error, data, response) {
 };
 api.addPet(body, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Pet-addPet-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Pet-addPet-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Pet-addPet-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Pet-addPet-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -1222,13 +1157,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-addPet-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Pet-addPet-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -1243,30 +1177,21 @@ try {
     echo 'Exception when calling PetApi->addPet: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Body parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
 <td>
 
 
@@ -1310,172 +1235,53 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 405 - Invalid input </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-addPet-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-addPet-schema">
-
-
-
-
-                                                        <div id='examples-Pet-addPet-schema-405' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid input"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-addPet-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-addPet-schema-405');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-addPet-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Pet-deletePet">
-
-                                        <article id="api-Pet-deletePet-0" data-group="User" data-name="deletePet" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>deletePet</h1>
-                                                <p>Deletes a pet</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/pet/{petId}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Pet-deletePet-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-deletePet-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Pet-deletePet-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Pet-deletePet-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-deletePet-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Pet-deletePet-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Pet-deletePet-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-deletePet-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-deletePet-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Pet-deletePet-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">delete</span> "http://petstore.swagger.io/v2/pet/{petId}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Pet-deletePet-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 405 - Invalid input </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Pet-deletePet">
+                      <article id="api-Pet-deletePet-0" data-group="User" data-name="deletePet" data-version="0">
+                        <div class="pull-left">
+                          <h1>deletePet</h1>
+                          <p>Deletes a pet</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/pet/{petId}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Pet-deletePet-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Pet-deletePet-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-deletePet-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Pet-deletePet-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Pet-deletePet-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Pet-deletePet-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Pet-deletePet-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Pet-deletePet-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Pet-deletePet-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Pet-deletePet-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">delete</span> "http://petstore.swagger.io/v2/pet/{petId}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Pet-deletePet-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .PetApi;
@@ -1504,13 +1310,12 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-deletePet-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .PetApi;
+                          <div class="tab-pane" id="examples-Pet-deletePet-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .PetApi;
 
 public class PetApiExample {
 
@@ -1527,18 +1332,15 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Pet-deletePet-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Pet-deletePet-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Pet-deletePet-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Pet-deletePet-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure OAuth2 access token for authorization: (authentication scheme: petstore_auth)
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];
@@ -1558,11 +1360,12 @@ PetApi *apiInstance = [[PetApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Pet-deletePet-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Pet-deletePet-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -1586,16 +1389,15 @@ var callback = function(error, data, response) {
 };
 api.deletePet(petId, opts, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Pet-deletePet-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Pet-deletePet-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Pet-deletePet-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Pet-deletePet-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -1628,13 +1430,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-deletePet-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Pet-deletePet-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -1650,27 +1451,19 @@ try {
     echo 'Exception when calling PetApi->deletePet: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">petId*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">petId*</td>
 <td>
 
 
@@ -1704,16 +1497,15 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
-                                                <div class="methodsubtabletitle">Header parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">apiKey</td>
+                            <div class="methodsubtabletitle">Header parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                  <tr><td style="width:150px;">apiKey</td>
 <td>
 
 
@@ -1745,174 +1537,54 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 400 - Invalid pet value </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-deletePet-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-deletePet-schema">
-
-
-
-
-                                                        <div id='examples-Pet-deletePet-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid pet value"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-deletePet-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-deletePet-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-deletePet-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Pet-findPetsByStatus">
-
-                                        <article id="api-Pet-findPetsByStatus-0" data-group="User" data-name="findPetsByStatus" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>findPetsByStatus</h1>
-                                                <p>Finds Pets by status</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">Multiple status values can be provided with comma separated strings</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/pet/findByStatus</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Pet-findPetsByStatus-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-findPetsByStatus-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Pet-findPetsByStatus-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Pet-findPetsByStatus-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-findPetsByStatus-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Pet-findPetsByStatus-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Pet-findPetsByStatus-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-findPetsByStatus-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-findPetsByStatus-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Pet-findPetsByStatus-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/pet/findByStatus?status="
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 400 - Invalid pet value </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Pet-findPetsByStatus">
+                      <article id="api-Pet-findPetsByStatus-0" data-group="User" data-name="findPetsByStatus" data-version="0">
+                        <div class="pull-left">
+                          <h1>findPetsByStatus</h1>
+                          <p>Finds Pets by status</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Multiple status values can be provided with comma separated strings</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/pet/findByStatus</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Pet-findPetsByStatus-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByStatus-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByStatus-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Pet-findPetsByStatus-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Pet-findPetsByStatus-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByStatus-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Pet-findPetsByStatus-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Pet-findPetsByStatus-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByStatus-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Pet-findPetsByStatus-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/pet/findByStatus?status="
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .PetApi;
@@ -1941,13 +1613,12 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .PetApi;
+                          <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .PetApi;
 
 public class PetApiExample {
 
@@ -1964,18 +1635,15 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure OAuth2 access token for authorization: (authentication scheme: petstore_auth)
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];
@@ -1996,11 +1664,12 @@ PetApi *apiInstance = [[PetApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -2021,16 +1690,15 @@ var callback = function(error, data, response) {
 };
 api.findPetsByStatus(status, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Pet-findPetsByStatus-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Pet-findPetsByStatus-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -2063,13 +1731,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -2085,32 +1752,23 @@ try {
     echo 'Exception when calling PetApi->findPetsByStatus: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Query parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">status*</td>
+                            <div class="methodsubtabletitle">Query parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">status*</td>
 <td>
 
 
@@ -2149,41 +1807,25 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
-                                            <h2>Responses</h2>
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
-                                                <h3> Status: 200 - successful operation </h3>
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-Pet-findPetsByStatus-schema">Schema</a>
+                                </li>
 
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
+                              </ul>
 
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-findPetsByStatus-schema">Schema</a>
-                                                    </li>
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-Pet-findPetsByStatus-schema">
+                                  <div id='examples-Pet-findPetsByStatus-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-findPetsByStatus-schema">
-
-
-
-
-                                                        <div id='examples-Pet-findPetsByStatus-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "type" : "array",
@@ -2192,208 +1834,69 @@ try {
     }
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-findPetsByStatus-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-findPetsByStatus-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-findPetsByStatus-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 400 - Invalid status value </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-findPetsByStatus-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-findPetsByStatus-schema">
-
-
-
-
-                                                        <div id='examples-Pet-findPetsByStatus-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid status value"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-findPetsByStatus-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-findPetsByStatus-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-findPetsByStatus-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Pet-findPetsByTags">
-
-                                        <article id="api-Pet-findPetsByTags-0" data-group="User" data-name="findPetsByTags" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>findPetsByTags</h1>
-                                                <p>Finds Pets by tags</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/pet/findByTags</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Pet-findPetsByTags-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-findPetsByTags-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Pet-findPetsByTags-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Pet-findPetsByTags-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-findPetsByTags-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Pet-findPetsByTags-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Pet-findPetsByTags-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-findPetsByTags-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-findPetsByTags-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Pet-findPetsByTags-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/pet/findByTags?tags="
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByTags-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-Pet-findPetsByStatus-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-Pet-findPetsByStatus-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-Pet-findPetsByStatus-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                            <h3> Status: 400 - Invalid status value </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Pet-findPetsByTags">
+                      <article id="api-Pet-findPetsByTags-0" data-group="User" data-name="findPetsByTags" data-version="0">
+                        <div class="pull-left">
+                          <h1>findPetsByTags</h1>
+                          <p>Finds Pets by tags</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/pet/findByTags</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Pet-findPetsByTags-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByTags-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByTags-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Pet-findPetsByTags-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Pet-findPetsByTags-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByTags-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Pet-findPetsByTags-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Pet-findPetsByTags-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByTags-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Pet-findPetsByTags-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/pet/findByTags?tags="
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Pet-findPetsByTags-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .PetApi;
@@ -2422,13 +1925,12 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByTags-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .PetApi;
+                          <div class="tab-pane" id="examples-Pet-findPetsByTags-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .PetApi;
 
 public class PetApiExample {
 
@@ -2445,18 +1947,15 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Pet-findPetsByTags-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByTags-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Pet-findPetsByTags-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Pet-findPetsByTags-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure OAuth2 access token for authorization: (authentication scheme: petstore_auth)
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];
@@ -2477,11 +1976,12 @@ PetApi *apiInstance = [[PetApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Pet-findPetsByTags-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Pet-findPetsByTags-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -2502,16 +2002,15 @@ var callback = function(error, data, response) {
 };
 api.findPetsByTags(tags, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Pet-findPetsByTags-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByTags-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Pet-findPetsByTags-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Pet-findPetsByTags-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -2544,13 +2043,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-findPetsByTags-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Pet-findPetsByTags-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -2566,32 +2064,23 @@ try {
     echo 'Exception when calling PetApi->findPetsByTags: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Query parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">tags*</td>
+                            <div class="methodsubtabletitle">Query parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">tags*</td>
 <td>
 
 
@@ -2628,41 +2117,25 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
-                                            <h2>Responses</h2>
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
-                                                <h3> Status: 200 - successful operation </h3>
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-Pet-findPetsByTags-schema">Schema</a>
+                                </li>
 
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
+                              </ul>
 
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-findPetsByTags-schema">Schema</a>
-                                                    </li>
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-Pet-findPetsByTags-schema">
+                                  <div id='examples-Pet-findPetsByTags-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-findPetsByTags-schema">
-
-
-
-
-                                                        <div id='examples-Pet-findPetsByTags-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "type" : "array",
@@ -2671,208 +2144,69 @@ try {
     }
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-findPetsByTags-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-findPetsByTags-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-findPetsByTags-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 400 - Invalid tag value </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-findPetsByTags-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-findPetsByTags-schema">
-
-
-
-
-                                                        <div id='examples-Pet-findPetsByTags-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid tag value"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-findPetsByTags-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-findPetsByTags-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-findPetsByTags-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Pet-getPetById">
-
-                                        <article id="api-Pet-getPetById-0" data-group="User" data-name="getPetById" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>getPetById</h1>
-                                                <p>Find pet by ID</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">Returns a single pet</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/pet/{petId}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Pet-getPetById-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-getPetById-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Pet-getPetById-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Pet-getPetById-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-getPetById-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Pet-getPetById-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Pet-getPetById-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-getPetById-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-getPetById-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Pet-getPetById-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> -H "api_key: [[apiKey]]"  "http://petstore.swagger.io/v2/pet/{petId}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Pet-getPetById-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-Pet-findPetsByTags-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-Pet-findPetsByTags-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-Pet-findPetsByTags-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                            <h3> Status: 400 - Invalid tag value </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Pet-getPetById">
+                      <article id="api-Pet-getPetById-0" data-group="User" data-name="getPetById" data-version="0">
+                        <div class="pull-left">
+                          <h1>getPetById</h1>
+                          <p>Find pet by ID</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns a single pet</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/pet/{petId}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Pet-getPetById-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Pet-getPetById-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-getPetById-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Pet-getPetById-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Pet-getPetById-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Pet-getPetById-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Pet-getPetById-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Pet-getPetById-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Pet-getPetById-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Pet-getPetById-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">get</span> -H "api_key: [[apiKey]]"  "http://petstore.swagger.io/v2/pet/{petId}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Pet-getPetById-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .PetApi;
@@ -2903,13 +2237,12 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-getPetById-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .PetApi;
+                          <div class="tab-pane" id="examples-Pet-getPetById-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .PetApi;
 
 public class PetApiExample {
 
@@ -2926,18 +2259,15 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Pet-getPetById-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Pet-getPetById-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Pet-getPetById-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Pet-getPetById-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure API key authorization: (authentication scheme: api_key)
 [apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"api_key"];
@@ -2960,11 +2290,12 @@ PetApi *apiInstance = [[PetApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Pet-getPetById-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Pet-getPetById-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure API key authorization: api_key
@@ -2987,16 +2318,15 @@ var callback = function(error, data, response) {
 };
 api.getPetById(petId, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Pet-getPetById-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Pet-getPetById-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Pet-getPetById-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Pet-getPetById-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -3031,13 +2361,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-getPetById-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Pet-getPetById-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure API key authorization: api_key
@@ -3055,27 +2384,19 @@ try {
     echo 'Exception when calling PetApi->getPetById: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">petId*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">petId*</td>
 <td>
 
 
@@ -3109,329 +2430,99 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
 
 
 
 
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
-                                            <h2>Responses</h2>
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-Pet-getPetById-schema">Schema</a>
+                                </li>
 
-                                                <h3> Status: 200 - successful operation </h3>
+                              </ul>
 
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-Pet-getPetById-schema">
+                                  <div id='examples-Pet-getPetById-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-getPetById-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-getPetById-schema">
-
-
-
-
-                                                        <div id='examples-Pet-getPetById-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "$ref" : "#/definitions/Pet"
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-getPetById-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-getPetById-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-getPetById-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 400 - Invalid ID supplied </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-getPetById-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-getPetById-schema">
-
-
-
-
-                                                        <div id='examples-Pet-getPetById-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid ID supplied"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-getPetById-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-getPetById-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-getPetById-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 404 - Pet not found </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-getPetById-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-getPetById-schema">
-
-
-
-
-                                                        <div id='examples-Pet-getPetById-schema-404' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Pet not found"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-getPetById-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-getPetById-schema-404');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-getPetById-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Pet-updatePet">
-
-                                        <article id="api-Pet-updatePet-0" data-group="User" data-name="updatePet" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>updatePet</h1>
-                                                <p>Update an existing pet</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/pet</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Pet-updatePet-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-updatePet-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Pet-updatePet-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Pet-updatePet-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-updatePet-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Pet-updatePet-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Pet-updatePet-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-updatePet-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-updatePet-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Pet-updatePet-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">put</span> "http://petstore.swagger.io/v2/pet"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Pet-updatePet-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-Pet-getPetById-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-Pet-getPetById-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-Pet-getPetById-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                            <h3> Status: 400 - Invalid ID supplied </h3>
+
+                            <h3> Status: 404 - Pet not found </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Pet-updatePet">
+                      <article id="api-Pet-updatePet-0" data-group="User" data-name="updatePet" data-version="0">
+                        <div class="pull-left">
+                          <h1>updatePet</h1>
+                          <p>Update an existing pet</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/pet</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Pet-updatePet-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Pet-updatePet-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-updatePet-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Pet-updatePet-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Pet-updatePet-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Pet-updatePet-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Pet-updatePet-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Pet-updatePet-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Pet-updatePet-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Pet-updatePet-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">put</span> "http://petstore.swagger.io/v2/pet"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Pet-updatePet-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .PetApi;
@@ -3459,13 +2550,12 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-updatePet-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .PetApi;
+                          <div class="tab-pane" id="examples-Pet-updatePet-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .PetApi;
 
 public class PetApiExample {
 
@@ -3481,18 +2571,15 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Pet-updatePet-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Pet-updatePet-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Pet-updatePet-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Pet-updatePet-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure OAuth2 access token for authorization: (authentication scheme: petstore_auth)
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];
@@ -3510,11 +2597,12 @@ PetApi *apiInstance = [[PetApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Pet-updatePet-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Pet-updatePet-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -3535,16 +2623,15 @@ var callback = function(error, data, response) {
 };
 api.updatePet(body, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Pet-updatePet-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Pet-updatePet-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Pet-updatePet-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Pet-updatePet-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -3576,13 +2663,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-updatePet-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Pet-updatePet-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -3597,30 +2683,21 @@ try {
     echo 'Exception when calling PetApi->updatePet: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Body parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
 <td>
 
 
@@ -3664,324 +2741,57 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 400 - Invalid ID supplied </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-updatePet-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-updatePet-schema">
-
-
-
-
-                                                        <div id='examples-Pet-updatePet-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid ID supplied"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-updatePet-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-updatePet-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-updatePet-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 404 - Pet not found </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-updatePet-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-updatePet-schema">
-
-
-
-
-                                                        <div id='examples-Pet-updatePet-schema-404' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Pet not found"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-updatePet-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-updatePet-schema-404');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-updatePet-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 405 - Validation exception </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-updatePet-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-updatePet-schema">
-
-
-
-
-                                                        <div id='examples-Pet-updatePet-schema-405' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Validation exception"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-updatePet-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-updatePet-schema-405');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-updatePet-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Pet-updatePetWithForm">
-
-                                        <article id="api-Pet-updatePetWithForm-0" data-group="User" data-name="updatePetWithForm" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>updatePetWithForm</h1>
-                                                <p>Updates a pet in the store with form data</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/pet/{petId}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Pet-updatePetWithForm-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-updatePetWithForm-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Pet-updatePetWithForm-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Pet-updatePetWithForm-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-updatePetWithForm-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Pet-updatePetWithForm-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Pet-updatePetWithForm-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-updatePetWithForm-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-updatePetWithForm-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Pet-updatePetWithForm-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/pet/{petId}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 400 - Invalid ID supplied </h3>
+
+                            <h3> Status: 404 - Pet not found </h3>
+
+                            <h3> Status: 405 - Validation exception </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Pet-updatePetWithForm">
+                      <article id="api-Pet-updatePetWithForm-0" data-group="User" data-name="updatePetWithForm" data-version="0">
+                        <div class="pull-left">
+                          <h1>updatePetWithForm</h1>
+                          <p>Updates a pet in the store with form data</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/pet/{petId}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Pet-updatePetWithForm-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Pet-updatePetWithForm-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-updatePetWithForm-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Pet-updatePetWithForm-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Pet-updatePetWithForm-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Pet-updatePetWithForm-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Pet-updatePetWithForm-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Pet-updatePetWithForm-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Pet-updatePetWithForm-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Pet-updatePetWithForm-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/pet/{petId}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .PetApi;
@@ -4011,13 +2821,12 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .PetApi;
+                          <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .PetApi;
 
 public class PetApiExample {
 
@@ -4035,18 +2844,15 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure OAuth2 access token for authorization: (authentication scheme: petstore_auth)
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];
@@ -4068,11 +2874,12 @@ PetApi *apiInstance = [[PetApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -4097,16 +2904,15 @@ var callback = function(error, data, response) {
 };
 api.updatePetWithForm(petId, opts, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Pet-updatePetWithForm-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Pet-updatePetWithForm-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -4140,13 +2946,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -4163,27 +2968,19 @@ try {
     echo 'Exception when calling PetApi->updatePetWithForm: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">petId*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">petId*</td>
 <td>
 
 
@@ -4217,19 +3014,17 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
 
 
-
-                                                <div class="methodsubtabletitle">Form parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">name</td>
+                            <div class="methodsubtabletitle">Form parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                  <tr><td style="width:150px;">name</td>
 <td>
 
 
@@ -4262,7 +3057,7 @@ try {
 </td>
 </tr>
 
-                                                        <tr><td style="width:150px;">status</td>
+                                  <tr><td style="width:150px;">status</td>
 <td>
 
 
@@ -4295,171 +3090,52 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 405 - Invalid input </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-updatePetWithForm-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-updatePetWithForm-schema">
-
-
-
-
-                                                        <div id='examples-Pet-updatePetWithForm-schema-405' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid input"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-updatePetWithForm-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-updatePetWithForm-schema-405');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-updatePetWithForm-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Pet-uploadFile">
-
-                                        <article id="api-Pet-uploadFile-0" data-group="User" data-name="uploadFile" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>uploadFile</h1>
-                                                <p>uploads an image</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/pet/{petId}/uploadImage</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Pet-uploadFile-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-uploadFile-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Pet-uploadFile-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Pet-uploadFile-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-uploadFile-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Pet-uploadFile-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Pet-uploadFile-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Pet-uploadFile-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Pet-uploadFile-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Pet-uploadFile-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/pet/{petId}/uploadImage"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Pet-uploadFile-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 405 - Invalid input </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Pet-uploadFile">
+                      <article id="api-Pet-uploadFile-0" data-group="User" data-name="uploadFile" data-version="0">
+                        <div class="pull-left">
+                          <h1>uploadFile</h1>
+                          <p>uploads an image</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/pet/{petId}/uploadImage</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Pet-uploadFile-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Pet-uploadFile-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-uploadFile-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Pet-uploadFile-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Pet-uploadFile-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Pet-uploadFile-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Pet-uploadFile-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Pet-uploadFile-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Pet-uploadFile-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Pet-uploadFile-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/pet/{petId}/uploadImage"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Pet-uploadFile-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .PetApi;
@@ -4490,13 +3166,12 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-uploadFile-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .PetApi;
+                          <div class="tab-pane" id="examples-Pet-uploadFile-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .PetApi;
 
 public class PetApiExample {
 
@@ -4515,18 +3190,15 @@ public class PetApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Pet-uploadFile-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Pet-uploadFile-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Pet-uploadFile-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Pet-uploadFile-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure OAuth2 access token for authorization: (authentication scheme: petstore_auth)
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];
@@ -4551,11 +3223,12 @@ PetApi *apiInstance = [[PetApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Pet-uploadFile-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Pet-uploadFile-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -4580,16 +3253,15 @@ var callback = function(error, data, response) {
 };
 api.uploadFile(petId, opts, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Pet-uploadFile-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Pet-uploadFile-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Pet-uploadFile-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Pet-uploadFile-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -4624,13 +3296,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Pet-uploadFile-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Pet-uploadFile-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure OAuth2 access token for authorization: petstore_auth
@@ -4648,27 +3319,19 @@ try {
     echo 'Exception when calling PetApi->uploadFile: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">petId*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">petId*</td>
 <td>
 
 
@@ -4702,19 +3365,17 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
 
 
-
-                                                <div class="methodsubtabletitle">Form parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">additionalMetadata</td>
+                            <div class="methodsubtabletitle">Form parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                  <tr><td style="width:150px;">additionalMetadata</td>
 <td>
 
 
@@ -4747,7 +3408,7 @@ try {
 </td>
 </tr>
 
-                                                        <tr><td style="width:150px;">file</td>
+                                  <tr><td style="width:150px;">file</td>
 <td>
 
 
@@ -4780,178 +3441,95 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 200 - successful operation </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Pet-uploadFile-schema">Schema</a>
-                                                    </li>
+                            </table>
 
 
-                                                </ul>
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-Pet-uploadFile-schema">Schema</a>
+                                </li>
 
+                              </ul>
 
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-Pet-uploadFile-schema">
+                                  <div id='examples-Pet-uploadFile-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Pet-uploadFile-schema">
-
-
-
-
-                                                        <div id='examples-Pet-uploadFile-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "$ref" : "#/definitions/ApiResponse"
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-Pet-uploadFile-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-Pet-uploadFile-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-Pet-uploadFile-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                        </article>
+                      </div>
+                      <hr>
+                  </section>
+                <section id="api-Store">
+                  <h1>Store</h1>
+                    <div id="api-Store-deleteOrder">
+                      <article id="api-Store-deleteOrder-0" data-group="User" data-name="deleteOrder" data-version="0">
+                        <div class="pull-left">
+                          <h1>deleteOrder</h1>
+                          <p>Delete purchase order by ID</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/store/order/{orderId}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Store-deleteOrder-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Store-deleteOrder-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Store-deleteOrder-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Store-deleteOrder-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Store-deleteOrder-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Store-deleteOrder-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Store-deleteOrder-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Store-deleteOrder-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Store-deleteOrder-0-php">PHP</a></li>
+                        </ul>
 
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Pet-uploadFile-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Pet-uploadFile-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Pet-uploadFile-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-                            </section>
-
-                            <section id="api-Store">
-                                <h1>Store</h1>
-
-
-
-
-
-
-
-                                    <div id="api-Store-deleteOrder">
-
-                                        <article id="api-Store-deleteOrder-0" data-group="User" data-name="deleteOrder" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>deleteOrder</h1>
-                                                <p>Delete purchase order by ID</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/store/order/{orderId}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Store-deleteOrder-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Store-deleteOrder-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Store-deleteOrder-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Store-deleteOrder-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Store-deleteOrder-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Store-deleteOrder-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Store-deleteOrder-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Store-deleteOrder-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Store-deleteOrder-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Store-deleteOrder-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">delete</span> "http://petstore.swagger.io/v2/store/order/{orderId}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Store-deleteOrder-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Store-deleteOrder-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">delete</span> "http://petstore.swagger.io/v2/store/order/{orderId}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Store-deleteOrder-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .StoreApi;
@@ -4974,13 +3552,12 @@ public class StoreApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Store-deleteOrder-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .StoreApi;
+                          <div class="tab-pane" id="examples-Store-deleteOrder-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .StoreApi;
 
 public class StoreApiExample {
 
@@ -4996,18 +3573,15 @@ public class StoreApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Store-deleteOrder-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Store-deleteOrder-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Store-deleteOrder-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Store-deleteOrder-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 String *orderId = orderId_example; // ID of the order that needs to be deleted
 
 StoreApi *apiInstance = [[StoreApi alloc] init];
@@ -5020,11 +3594,12 @@ StoreApi *apiInstance = [[StoreApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Store-deleteOrder-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Store-deleteOrder-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .StoreApi()
 
@@ -5040,16 +3615,15 @@ var callback = function(error, data, response) {
 };
 api.deleteOrder(orderId, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Store-deleteOrder-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Store-deleteOrder-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Store-deleteOrder-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Store-deleteOrder-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -5078,13 +3652,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Store-deleteOrder-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Store-deleteOrder-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\StoreApi();
@@ -5096,27 +3669,19 @@ try {
     echo 'Exception when calling StoreApi->deleteOrder: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">orderId*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">orderId*</td>
 <td>
 
 
@@ -5150,250 +3715,57 @@ try {
 </td>
 </tr>
 
-                                                </table>
-
-
-
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 400 - Invalid ID supplied </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Store-deleteOrder-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Store-deleteOrder-schema">
-
-
-
-
-                                                        <div id='examples-Store-deleteOrder-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid ID supplied"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Store-deleteOrder-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Store-deleteOrder-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Store-deleteOrder-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 404 - Order not found </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Store-deleteOrder-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Store-deleteOrder-schema">
-
-
-
-
-                                                        <div id='examples-Store-deleteOrder-schema-404' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Order not found"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Store-deleteOrder-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Store-deleteOrder-schema-404');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Store-deleteOrder-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Store-getInventory">
-
-                                        <article id="api-Store-getInventory-0" data-group="User" data-name="getInventory" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>getInventory</h1>
-                                                <p>Returns pet inventories by status</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">Returns a map of status codes to quantities</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/store/inventory</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Store-getInventory-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Store-getInventory-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Store-getInventory-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Store-getInventory-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Store-getInventory-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Store-getInventory-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Store-getInventory-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Store-getInventory-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Store-getInventory-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Store-getInventory-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> -H "api_key: [[apiKey]]"  "http://petstore.swagger.io/v2/store/inventory"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Store-getInventory-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 400 - Invalid ID supplied </h3>
+
+                            <h3> Status: 404 - Order not found </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Store-getInventory">
+                      <article id="api-Store-getInventory-0" data-group="User" data-name="getInventory" data-version="0">
+                        <div class="pull-left">
+                          <h1>getInventory</h1>
+                          <p>Returns pet inventories by status</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns a map of status codes to quantities</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/store/inventory</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Store-getInventory-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Store-getInventory-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Store-getInventory-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Store-getInventory-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Store-getInventory-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Store-getInventory-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Store-getInventory-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Store-getInventory-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Store-getInventory-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Store-getInventory-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">get</span> -H "api_key: [[apiKey]]"  "http://petstore.swagger.io/v2/store/inventory"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Store-getInventory-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .StoreApi;
@@ -5423,13 +3795,12 @@ public class StoreApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Store-getInventory-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .StoreApi;
+                          <div class="tab-pane" id="examples-Store-getInventory-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .StoreApi;
 
 public class StoreApiExample {
 
@@ -5445,18 +3816,15 @@ public class StoreApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Store-getInventory-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Store-getInventory-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-Configuration *apiConfig = [Configuration sharedConfig];
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Store-getInventory-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Store-getInventory-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure API key authorization: (authentication scheme: api_key)
 [apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"api_key"];
@@ -5478,11 +3846,12 @@ StoreApi *apiInstance = [[StoreApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Store-getInventory-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Store-getInventory-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 var defaultClient = .ApiClient.instance;
 
 // Configure API key authorization: api_key
@@ -5502,16 +3871,15 @@ var callback = function(error, data, response) {
 };
 api.getInventory(callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Store-getInventory-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Store-getInventory-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Store-getInventory-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Store-getInventory-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -5545,13 +3913,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Store-getInventory-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Store-getInventory-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Configure API key authorization: api_key
@@ -5568,58 +3935,34 @@ try {
     echo 'Exception when calling StoreApi->getInventory: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
 
 
 
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-Store-getInventory-schema">Schema</a>
+                                </li>
 
+                              </ul>
 
-                                            <h2>Responses</h2>
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-Store-getInventory-schema">
+                                  <div id='examples-Store-getInventory-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-                                                <h3> Status: 200 - successful operation </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Store-getInventory-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Store-getInventory-schema">
-
-
-
-
-                                                        <div id='examples-Store-getInventory-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "type" : "object",
@@ -5629,132 +3972,67 @@ try {
     }
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-Store-getInventory-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-Store-getInventory-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-Store-getInventory-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Store-getOrderById">
+                      <article id="api-Store-getOrderById-0" data-group="User" data-name="getOrderById" data-version="0">
+                        <div class="pull-left">
+                          <h1>getOrderById</h1>
+                          <p>Find purchase order by ID</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/store/order/{orderId}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Store-getOrderById-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Store-getOrderById-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Store-getOrderById-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Store-getOrderById-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Store-getOrderById-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Store-getOrderById-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Store-getOrderById-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Store-getOrderById-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Store-getOrderById-0-php">PHP</a></li>
+                        </ul>
 
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Store-getInventory-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Store-getInventory-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Store-getInventory-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Store-getOrderById">
-
-                                        <article id="api-Store-getOrderById-0" data-group="User" data-name="getOrderById" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>getOrderById</h1>
-                                                <p>Find purchase order by ID</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/store/order/{orderId}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Store-getOrderById-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Store-getOrderById-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Store-getOrderById-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Store-getOrderById-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Store-getOrderById-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Store-getOrderById-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Store-getOrderById-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Store-getOrderById-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Store-getOrderById-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Store-getOrderById-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/store/order/{orderId}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Store-getOrderById-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Store-getOrderById-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/store/order/{orderId}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Store-getOrderById-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .StoreApi;
@@ -5778,13 +4056,12 @@ public class StoreApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Store-getOrderById-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .StoreApi;
+                          <div class="tab-pane" id="examples-Store-getOrderById-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .StoreApi;
 
 public class StoreApiExample {
 
@@ -5801,18 +4078,15 @@ public class StoreApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Store-getOrderById-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Store-getOrderById-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Store-getOrderById-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Store-getOrderById-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 Long *orderId = 789; // ID of pet that needs to be fetched
 
 StoreApi *apiInstance = [[StoreApi alloc] init];
@@ -5828,11 +4102,12 @@ StoreApi *apiInstance = [[StoreApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Store-getOrderById-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Store-getOrderById-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .StoreApi()
 
@@ -5848,16 +4123,15 @@ var callback = function(error, data, response) {
 };
 api.getOrderById(orderId, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Store-getOrderById-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Store-getOrderById-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Store-getOrderById-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Store-getOrderById-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -5887,13 +4161,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Store-getOrderById-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Store-getOrderById-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\StoreApi();
@@ -5906,27 +4179,19 @@ try {
     echo 'Exception when calling StoreApi->getOrderById: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">orderId*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">orderId*</td>
 <td>
 
 
@@ -5962,329 +4227,99 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
 
 
 
 
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
-                                            <h2>Responses</h2>
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-Store-getOrderById-schema">Schema</a>
+                                </li>
 
-                                                <h3> Status: 200 - successful operation </h3>
+                              </ul>
 
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-Store-getOrderById-schema">
+                                  <div id='examples-Store-getOrderById-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-                                                    <li class="active">
-                                                        <a href="#examples-Store-getOrderById-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Store-getOrderById-schema">
-
-
-
-
-                                                        <div id='examples-Store-getOrderById-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "$ref" : "#/definitions/Order"
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Store-getOrderById-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Store-getOrderById-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Store-getOrderById-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 400 - Invalid ID supplied </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Store-getOrderById-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Store-getOrderById-schema">
-
-
-
-
-                                                        <div id='examples-Store-getOrderById-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid ID supplied"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Store-getOrderById-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Store-getOrderById-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Store-getOrderById-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 404 - Order not found </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Store-getOrderById-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Store-getOrderById-schema">
-
-
-
-
-                                                        <div id='examples-Store-getOrderById-schema-404' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Order not found"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Store-getOrderById-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Store-getOrderById-schema-404');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Store-getOrderById-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-Store-placeOrder">
-
-                                        <article id="api-Store-placeOrder-0" data-group="User" data-name="placeOrder" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>placeOrder</h1>
-                                                <p>Place an order for a pet</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/store/order</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-Store-placeOrder-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Store-placeOrder-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-Store-placeOrder-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-Store-placeOrder-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Store-placeOrder-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-Store-placeOrder-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-Store-placeOrder-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-Store-placeOrder-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-Store-placeOrder-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-Store-placeOrder-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/store/order"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-Store-placeOrder-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-Store-getOrderById-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-Store-getOrderById-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-Store-getOrderById-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                            <h3> Status: 400 - Invalid ID supplied </h3>
+
+                            <h3> Status: 404 - Order not found </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Store-placeOrder">
+                      <article id="api-Store-placeOrder-0" data-group="User" data-name="placeOrder" data-version="0">
+                        <div class="pull-left">
+                          <h1>placeOrder</h1>
+                          <p>Place an order for a pet</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/store/order</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Store-placeOrder-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Store-placeOrder-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Store-placeOrder-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Store-placeOrder-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Store-placeOrder-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Store-placeOrder-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Store-placeOrder-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Store-placeOrder-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Store-placeOrder-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Store-placeOrder-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/store/order"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Store-placeOrder-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .StoreApi;
@@ -6308,13 +4343,12 @@ public class StoreApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-Store-placeOrder-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .StoreApi;
+                          <div class="tab-pane" id="examples-Store-placeOrder-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .StoreApi;
 
 public class StoreApiExample {
 
@@ -6331,18 +4365,15 @@ public class StoreApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-Store-placeOrder-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-Store-placeOrder-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Store-placeOrder-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Store-placeOrder-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 Order *body = ; // order placed for purchasing the pet
 
 StoreApi *apiInstance = [[StoreApi alloc] init];
@@ -6358,11 +4389,12 @@ StoreApi *apiInstance = [[StoreApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-Store-placeOrder-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Store-placeOrder-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .StoreApi()
 
@@ -6378,16 +4410,15 @@ var callback = function(error, data, response) {
 };
 api.placeOrder(body, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-Store-placeOrder-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-Store-placeOrder-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-Store-placeOrder-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Store-placeOrder-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -6417,13 +4448,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-Store-placeOrder-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-Store-placeOrder-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\StoreApi();
@@ -6436,30 +4466,21 @@ try {
     echo 'Exception when calling StoreApi->placeOrder: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Body parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
 <td>
 
 
@@ -6503,255 +4524,98 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 200 - successful operation </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Store-placeOrder-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
+                            </table>
 
 
 
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-Store-placeOrder-schema">Schema</a>
+                                </li>
 
+                              </ul>
 
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-Store-placeOrder-schema">
+                                  <div id='examples-Store-placeOrder-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Store-placeOrder-schema">
-
-
-
-
-                                                        <div id='examples-Store-placeOrder-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "$ref" : "#/definitions/Order"
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Store-placeOrder-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Store-placeOrder-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Store-placeOrder-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 400 - Invalid Order </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-Store-placeOrder-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-Store-placeOrder-schema">
-
-
-
-
-                                                        <div id='examples-Store-placeOrder-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid Order"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-Store-placeOrder-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-Store-placeOrder-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-Store-placeOrder-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-                            </section>
-
-                            <section id="api-User">
-                                <h1>User</h1>
-
-
-
-
-
-
-
-                                    <div id="api-User-createUser">
-
-                                        <article id="api-User-createUser-0" data-group="User" data-name="createUser" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>createUser</h1>
-                                                <p>Create user</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">This can only be done by the logged in user.</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/user</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-User-createUser-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-createUser-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-User-createUser-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-User-createUser-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-createUser-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-User-createUser-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-User-createUser-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-createUser-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-createUser-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-User-createUser-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/user"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-User-createUser-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-Store-placeOrder-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-Store-placeOrder-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-Store-placeOrder-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                            <h3> Status: 400 - Invalid Order </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                  </section>
+                <section id="api-User">
+                  <h1>User</h1>
+                    <div id="api-User-createUser">
+                      <article id="api-User-createUser-0" data-group="User" data-name="createUser" data-version="0">
+                        <div class="pull-left">
+                          <h1>createUser</h1>
+                          <p>Create user</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">This can only be done by the logged in user.</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/user</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-User-createUser-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-User-createUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-createUser-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-User-createUser-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-User-createUser-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-User-createUser-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-User-createUser-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-User-createUser-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-User-createUser-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-User-createUser-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/user"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-User-createUser-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .UserApi;
@@ -6774,13 +4638,12 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-User-createUser-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .UserApi;
+                          <div class="tab-pane" id="examples-User-createUser-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .UserApi;
 
 public class UserApiExample {
 
@@ -6796,18 +4659,15 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-User-createUser-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-User-createUser-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-User-createUser-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-User-createUser-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 User *body = ; // Created user object
 
 UserApi *apiInstance = [[UserApi alloc] init];
@@ -6820,11 +4680,12 @@ UserApi *apiInstance = [[UserApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-User-createUser-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-User-createUser-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .UserApi()
 
@@ -6840,16 +4701,15 @@ var callback = function(error, data, response) {
 };
 api.createUser(body, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-User-createUser-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-User-createUser-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-User-createUser-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-User-createUser-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -6878,13 +4738,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-User-createUser-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-User-createUser-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\UserApi();
@@ -6896,30 +4755,21 @@ try {
     echo 'Exception when calling UserApi->createUser: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Body parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
 <td>
 
 
@@ -6963,172 +4813,53 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 0 - successful operation </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-createUser-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-createUser-schema">
-
-
-
-
-                                                        <div id='examples-User-createUser-schema-0' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "successful operation"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-createUser-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-createUser-schema-0');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-createUser-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-User-createUsersWithArrayInput">
-
-                                        <article id="api-User-createUsersWithArrayInput-0" data-group="User" data-name="createUsersWithArrayInput" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>createUsersWithArrayInput</h1>
-                                                <p>Creates list of users with given input array</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/user/createWithArray</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-User-createUsersWithArrayInput-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-createUsersWithArrayInput-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-User-createUsersWithArrayInput-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-User-createUsersWithArrayInput-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-createUsersWithArrayInput-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-User-createUsersWithArrayInput-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-User-createUsersWithArrayInput-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-createUsersWithArrayInput-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-createUsersWithArrayInput-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-User-createUsersWithArrayInput-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/user/createWithArray"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 0 - successful operation </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-User-createUsersWithArrayInput">
+                      <article id="api-User-createUsersWithArrayInput-0" data-group="User" data-name="createUsersWithArrayInput" data-version="0">
+                        <div class="pull-left">
+                          <h1>createUsersWithArrayInput</h1>
+                          <p>Creates list of users with given input array</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/user/createWithArray</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-User-createUsersWithArrayInput-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithArrayInput-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithArrayInput-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-User-createUsersWithArrayInput-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-User-createUsersWithArrayInput-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithArrayInput-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-User-createUsersWithArrayInput-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-User-createUsersWithArrayInput-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithArrayInput-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-User-createUsersWithArrayInput-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/user/createWithArray"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .UserApi;
@@ -7151,13 +4882,12 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .UserApi;
+                          <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .UserApi;
 
 public class UserApiExample {
 
@@ -7173,18 +4903,15 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 array[User] *body = ; // List of user object
 
 UserApi *apiInstance = [[UserApi alloc] init];
@@ -7197,11 +4924,12 @@ UserApi *apiInstance = [[UserApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .UserApi()
 
@@ -7217,16 +4945,15 @@ var callback = function(error, data, response) {
 };
 api.createUsersWithArrayInput(body, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -7255,13 +4982,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\UserApi();
@@ -7273,30 +4999,21 @@ try {
     echo 'Exception when calling UserApi->createUsersWithArrayInput: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Body parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
 <td>
 
 
@@ -7343,172 +5060,53 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 0 - successful operation </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-createUsersWithArrayInput-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-createUsersWithArrayInput-schema">
-
-
-
-
-                                                        <div id='examples-User-createUsersWithArrayInput-schema-0' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "successful operation"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-createUsersWithArrayInput-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-createUsersWithArrayInput-schema-0');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-createUsersWithArrayInput-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-User-createUsersWithListInput">
-
-                                        <article id="api-User-createUsersWithListInput-0" data-group="User" data-name="createUsersWithListInput" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>createUsersWithListInput</h1>
-                                                <p>Creates list of users with given input array</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/user/createWithList</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-User-createUsersWithListInput-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-createUsersWithListInput-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-User-createUsersWithListInput-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-User-createUsersWithListInput-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-createUsersWithListInput-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-User-createUsersWithListInput-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-User-createUsersWithListInput-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-createUsersWithListInput-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-createUsersWithListInput-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-User-createUsersWithListInput-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/user/createWithList"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithListInput-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 0 - successful operation </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-User-createUsersWithListInput">
+                      <article id="api-User-createUsersWithListInput-0" data-group="User" data-name="createUsersWithListInput" data-version="0">
+                        <div class="pull-left">
+                          <h1>createUsersWithListInput</h1>
+                          <p>Creates list of users with given input array</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/user/createWithList</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-User-createUsersWithListInput-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithListInput-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithListInput-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-User-createUsersWithListInput-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-User-createUsersWithListInput-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithListInput-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-User-createUsersWithListInput-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-User-createUsersWithListInput-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithListInput-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-User-createUsersWithListInput-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">post</span> "http://petstore.swagger.io/v2/user/createWithList"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-User-createUsersWithListInput-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .UserApi;
@@ -7531,13 +5129,12 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithListInput-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .UserApi;
+                          <div class="tab-pane" id="examples-User-createUsersWithListInput-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .UserApi;
 
 public class UserApiExample {
 
@@ -7553,18 +5150,15 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-User-createUsersWithListInput-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithListInput-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-User-createUsersWithListInput-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-User-createUsersWithListInput-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 array[User] *body = ; // List of user object
 
 UserApi *apiInstance = [[UserApi alloc] init];
@@ -7577,11 +5171,12 @@ UserApi *apiInstance = [[UserApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-User-createUsersWithListInput-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-User-createUsersWithListInput-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .UserApi()
 
@@ -7597,16 +5192,15 @@ var callback = function(error, data, response) {
 };
 api.createUsersWithListInput(body, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-User-createUsersWithListInput-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithListInput-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-User-createUsersWithListInput-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-User-createUsersWithListInput-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -7635,13 +5229,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-User-createUsersWithListInput-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-User-createUsersWithListInput-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\UserApi();
@@ -7653,30 +5246,21 @@ try {
     echo 'Exception when calling UserApi->createUsersWithListInput: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Body parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
 <td>
 
 
@@ -7723,172 +5307,53 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 0 - successful operation </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-createUsersWithListInput-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-createUsersWithListInput-schema">
-
-
-
-
-                                                        <div id='examples-User-createUsersWithListInput-schema-0' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "successful operation"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-createUsersWithListInput-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-createUsersWithListInput-schema-0');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-createUsersWithListInput-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-User-deleteUser">
-
-                                        <article id="api-User-deleteUser-0" data-group="User" data-name="deleteUser" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>deleteUser</h1>
-                                                <p>Delete user</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">This can only be done by the logged in user.</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/user/{username}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-User-deleteUser-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-deleteUser-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-User-deleteUser-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-User-deleteUser-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-deleteUser-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-User-deleteUser-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-User-deleteUser-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-deleteUser-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-deleteUser-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-User-deleteUser-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">delete</span> "http://petstore.swagger.io/v2/user/{username}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-User-deleteUser-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 0 - successful operation </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-User-deleteUser">
+                      <article id="api-User-deleteUser-0" data-group="User" data-name="deleteUser" data-version="0">
+                        <div class="pull-left">
+                          <h1>deleteUser</h1>
+                          <p>Delete user</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">This can only be done by the logged in user.</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/user/{username}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-User-deleteUser-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-User-deleteUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-deleteUser-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-User-deleteUser-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-User-deleteUser-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-User-deleteUser-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-User-deleteUser-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-User-deleteUser-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-User-deleteUser-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-User-deleteUser-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">delete</span> "http://petstore.swagger.io/v2/user/{username}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-User-deleteUser-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .UserApi;
@@ -7911,13 +5376,12 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-User-deleteUser-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .UserApi;
+                          <div class="tab-pane" id="examples-User-deleteUser-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .UserApi;
 
 public class UserApiExample {
 
@@ -7933,18 +5397,15 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-User-deleteUser-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-User-deleteUser-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-User-deleteUser-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-User-deleteUser-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 String *username = username_example; // The name that needs to be deleted
 
 UserApi *apiInstance = [[UserApi alloc] init];
@@ -7957,11 +5418,12 @@ UserApi *apiInstance = [[UserApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-User-deleteUser-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-User-deleteUser-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .UserApi()
 
@@ -7977,16 +5439,15 @@ var callback = function(error, data, response) {
 };
 api.deleteUser(username, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-User-deleteUser-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-User-deleteUser-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-User-deleteUser-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-User-deleteUser-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -8015,13 +5476,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-User-deleteUser-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-User-deleteUser-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\UserApi();
@@ -8033,27 +5493,19 @@ try {
     echo 'Exception when calling UserApi->deleteUser: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">username*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">username*</td>
 <td>
 
 
@@ -8086,250 +5538,57 @@ try {
 </td>
 </tr>
 
-                                                </table>
-
-
-
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 400 - Invalid username supplied </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-deleteUser-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-deleteUser-schema">
-
-
-
-
-                                                        <div id='examples-User-deleteUser-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid username supplied"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-deleteUser-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-deleteUser-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-deleteUser-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 404 - User not found </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-deleteUser-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-deleteUser-schema">
-
-
-
-
-                                                        <div id='examples-User-deleteUser-schema-404' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "User not found"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-deleteUser-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-deleteUser-schema-404');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-deleteUser-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-User-getUserByName">
-
-                                        <article id="api-User-getUserByName-0" data-group="User" data-name="getUserByName" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>getUserByName</h1>
-                                                <p>Get user by user name</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/user/{username}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-User-getUserByName-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-getUserByName-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-User-getUserByName-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-User-getUserByName-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-getUserByName-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-User-getUserByName-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-User-getUserByName-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-getUserByName-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-getUserByName-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-User-getUserByName-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/user/{username}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-User-getUserByName-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 400 - Invalid username supplied </h3>
+
+                            <h3> Status: 404 - User not found </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-User-getUserByName">
+                      <article id="api-User-getUserByName-0" data-group="User" data-name="getUserByName" data-version="0">
+                        <div class="pull-left">
+                          <h1>getUserByName</h1>
+                          <p>Get user by user name</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/user/{username}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-User-getUserByName-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-User-getUserByName-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-getUserByName-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-User-getUserByName-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-User-getUserByName-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-User-getUserByName-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-User-getUserByName-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-User-getUserByName-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-User-getUserByName-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-User-getUserByName-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/user/{username}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-User-getUserByName-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .UserApi;
@@ -8353,13 +5612,12 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-User-getUserByName-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .UserApi;
+                          <div class="tab-pane" id="examples-User-getUserByName-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .UserApi;
 
 public class UserApiExample {
 
@@ -8376,18 +5634,15 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-User-getUserByName-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-User-getUserByName-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-User-getUserByName-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-User-getUserByName-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 String *username = username_example; // The name that needs to be fetched. Use user1 for testing. 
 
 UserApi *apiInstance = [[UserApi alloc] init];
@@ -8403,11 +5658,12 @@ UserApi *apiInstance = [[UserApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-User-getUserByName-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-User-getUserByName-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .UserApi()
 
@@ -8423,16 +5679,15 @@ var callback = function(error, data, response) {
 };
 api.getUserByName(username, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-User-getUserByName-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-User-getUserByName-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-User-getUserByName-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-User-getUserByName-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -8462,13 +5717,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-User-getUserByName-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-User-getUserByName-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\UserApi();
@@ -8481,27 +5735,19 @@ try {
     echo 'Exception when calling UserApi->getUserByName: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">username*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">username*</td>
 <td>
 
 
@@ -8534,329 +5780,99 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
 
 
 
 
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
-                                            <h2>Responses</h2>
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-User-getUserByName-schema">Schema</a>
+                                </li>
 
-                                                <h3> Status: 200 - successful operation </h3>
+                              </ul>
 
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-User-getUserByName-schema">
+                                  <div id='examples-User-getUserByName-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-                                                    <li class="active">
-                                                        <a href="#examples-User-getUserByName-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-getUserByName-schema">
-
-
-
-
-                                                        <div id='examples-User-getUserByName-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "$ref" : "#/definitions/User"
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-getUserByName-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-getUserByName-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-getUserByName-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 400 - Invalid username supplied </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-getUserByName-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-getUserByName-schema">
-
-
-
-
-                                                        <div id='examples-User-getUserByName-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid username supplied"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-getUserByName-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-getUserByName-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-getUserByName-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 404 - User not found </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-getUserByName-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-getUserByName-schema">
-
-
-
-
-                                                        <div id='examples-User-getUserByName-schema-404' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "User not found"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-getUserByName-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-getUserByName-schema-404');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-getUserByName-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-User-loginUser">
-
-                                        <article id="api-User-loginUser-0" data-group="User" data-name="loginUser" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>loginUser</h1>
-                                                <p>Logs user into the system</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/user/login</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-User-loginUser-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-loginUser-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-User-loginUser-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-User-loginUser-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-loginUser-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-User-loginUser-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-User-loginUser-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-loginUser-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-loginUser-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-User-loginUser-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/user/login?username=&password="
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-User-loginUser-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-User-getUserByName-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-User-getUserByName-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-User-getUserByName-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                            <h3> Status: 400 - Invalid username supplied </h3>
+
+                            <h3> Status: 404 - User not found </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-User-loginUser">
+                      <article id="api-User-loginUser-0" data-group="User" data-name="loginUser" data-version="0">
+                        <div class="pull-left">
+                          <h1>loginUser</h1>
+                          <p>Logs user into the system</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/user/login</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-User-loginUser-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-User-loginUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-loginUser-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-User-loginUser-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-User-loginUser-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-User-loginUser-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-User-loginUser-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-User-loginUser-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-User-loginUser-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-User-loginUser-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/user/login?username=&password="
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-User-loginUser-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .UserApi;
@@ -8881,13 +5897,12 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-User-loginUser-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .UserApi;
+                          <div class="tab-pane" id="examples-User-loginUser-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .UserApi;
 
 public class UserApiExample {
 
@@ -8905,18 +5920,15 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-User-loginUser-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-User-loginUser-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-User-loginUser-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-User-loginUser-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 String *username = username_example; // The user name for login
 String *password = password_example; // The password for login in clear text
 
@@ -8934,11 +5946,12 @@ UserApi *apiInstance = [[UserApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-User-loginUser-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-User-loginUser-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .UserApi()
 
@@ -8956,16 +5969,15 @@ var callback = function(error, data, response) {
 };
 api.loginUser(username, password, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-User-loginUser-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-User-loginUser-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-User-loginUser-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-User-loginUser-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -8996,13 +6008,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-User-loginUser-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-User-loginUser-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\UserApi();
@@ -9016,32 +6027,23 @@ try {
     echo 'Exception when calling UserApi->loginUser: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
+                          <h2>Parameters</h2>
 
 
 
 
 
-
-
-
-                                                <div class="methodsubtabletitle">Query parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">username*</td>
+                            <div class="methodsubtabletitle">Query parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">username*</td>
 <td>
 
 
@@ -9074,7 +6076,7 @@ try {
 </td>
 </tr>
 
-                                                        <tr><td style="width:150px;">password*</td>
+                                <tr><td style="width:150px;">password*</td>
 <td>
 
 
@@ -9107,41 +6109,25 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
-                                            <h2>Responses</h2>
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - successful operation </h3>
 
-                                                <h3> Status: 200 - successful operation </h3>
+                              <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a href="#examples-User-loginUser-schema">Schema</a>
+                                </li>
 
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
+                              </ul>
 
-                                                    <li class="active">
-                                                        <a href="#examples-User-loginUser-schema">Schema</a>
-                                                    </li>
+                              <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="examples-User-loginUser-schema">
+                                  <div id='examples-User-loginUser-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
 
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-loginUser-schema">
-
-
-
-
-                                                        <div id='examples-User-loginUser-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
   "description" : "successful operation",
   "schema" : {
     "type" : "string"
@@ -9159,208 +6145,69 @@ try {
     }
   }
 };
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-loginUser-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-loginUser-schema-200');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-loginUser-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 400 - Invalid username/password supplied </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-loginUser-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-loginUser-schema">
-
-
-
-
-                                                        <div id='examples-User-loginUser-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid username/password supplied"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-loginUser-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-loginUser-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-loginUser-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-User-logoutUser">
-
-                                        <article id="api-User-logoutUser-0" data-group="User" data-name="logoutUser" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>logoutUser</h1>
-                                                <p>Logs out current logged in user session</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked"></p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/user/logout</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-User-logoutUser-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-logoutUser-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-User-logoutUser-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-User-logoutUser-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-logoutUser-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-User-logoutUser-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-User-logoutUser-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-logoutUser-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-logoutUser-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-User-logoutUser-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/user/logout"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-User-logoutUser-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                                        var schema = schemaWrapper.schema;
+                                        schemaWrapper.definitions = defs;
+                                        //console.log(JSON.stringify(schema))
+                                        JsonRefs.resolveRefs(schemaWrapper, {
+                                            "depth": 3,
+                                            "resolveRemoteRefs": false,
+                                            "resolveFileRefs": false
+                                        }, function(err, resolved, metadata) {
+                                          //console.log(JSON.stringify(resolved));
+                                          var view = new JSONSchemaView(resolved.schema, 3);
+                                          $('#examples-User-loginUser-schema-data').val(JSON.stringify(resolved.schema));
+                                          var result = $('#examples-User-loginUser-schema-200');
+                                          result.empty();
+                                          result.append(view.render());
+                                        });
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='examples-User-loginUser-schema-data' type='hidden' value=''></input>
+                                </div>
+                              </div>
+                            <h3> Status: 400 - Invalid username/password supplied </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-User-logoutUser">
+                      <article id="api-User-logoutUser-0" data-group="User" data-name="logoutUser" data-version="0">
+                        <div class="pull-left">
+                          <h1>logoutUser</h1>
+                          <p>Logs out current logged in user session</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/user/logout</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-User-logoutUser-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-User-logoutUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-logoutUser-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-User-logoutUser-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-User-logoutUser-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-User-logoutUser-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-User-logoutUser-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-User-logoutUser-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-User-logoutUser-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-User-logoutUser-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">get</span> "http://petstore.swagger.io/v2/user/logout"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-User-logoutUser-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .UserApi;
@@ -9382,13 +6229,12 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-User-logoutUser-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .UserApi;
+                          <div class="tab-pane" id="examples-User-logoutUser-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .UserApi;
 
 public class UserApiExample {
 
@@ -9403,18 +6249,15 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-User-logoutUser-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-User-logoutUser-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-User-logoutUser-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-User-logoutUser-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 
 UserApi *apiInstance = [[UserApi alloc] init];
 
@@ -9426,11 +6269,12 @@ UserApi *apiInstance = [[UserApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-User-logoutUser-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-User-logoutUser-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .UserApi()
 
@@ -9443,16 +6287,15 @@ var callback = function(error, data, response) {
 };
 api.logoutUser(callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-User-logoutUser-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-User-logoutUser-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-User-logoutUser-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-User-logoutUser-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -9480,13 +6323,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-User-logoutUser-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-User-logoutUser-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\UserApi();
@@ -9497,186 +6339,60 @@ try {
     echo 'Exception when calling UserApi->logoutUser: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
-
-                                            </div>
-
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-
-
-
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 0 - successful operation </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-logoutUser-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-logoutUser-schema">
-
-
-
-
-                                                        <div id='examples-User-logoutUser-schema-0' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "successful operation"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-logoutUser-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-logoutUser-schema-0');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-logoutUser-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-
-
-
-
-
-
-
-                                    <div id="api-User-updateUser">
-
-                                        <article id="api-User-updateUser-0" data-group="User" data-name="updateUser" data-version="0">
-                                            <div class="pull-left">
-                                                <h1>updateUser</h1>
-                                                <p>Updated user</p>
-                                            </div>
-                                            <div class="pull-right">
-
-                                            </div>
-                                            <div class="clearfix"></div>
-
-                                            <p></p>
-                                            <p class="marked">This can only be done by the logged in user.</p>
-                                            <p></p>
-                                            <br />
-
-                                            <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/user/{username}</span></code></pre>
-
-                                            <p>
-                                                <h3>Usage and SDK Samples</h3>
-                                            </p>
-
-                                            <ul class="nav nav-tabs nav-tabs-examples">
-                                                <li class="active">
-                                                    <a href="#examples-User-updateUser-0-curl">Curl</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-updateUser-0-java">Java</a>
-            </li>
-            <li class="">
-              <a href="#examples-User-updateUser-0-android">Android</a>
-            </li>
-            <!--<li class="">
-              <a href="#examples-User-updateUser-0-groovy">Groovy</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-updateUser-0-objc">Obj-C</a>
-                                                </li>
-                                                <li class="">
-                                                    <a href="#examples-User-updateUser-0-javascript">JavaScript</a>
-                                                </li>
-                                                <!--<li class="">
-              <a href="#examples-User-updateUser-0-angular">Angular</a>
-            </li>-->
-                                                <li class="">
-                                                    <a href="#examples-User-updateUser-0-csharp">C#</a>
-                                                </li>
-                                                <li class="">
-              <a href="#examples-User-updateUser-0-php">PHP</a>
-            </li>
-                                            </ul>
-
-                                            <div class="tab-content">
-                                                <div class="tab-pane active" id="examples-User-updateUser-0-curl">
-                                                    <pre class="prettyprint"><code class="language-bsh">
-curl -X <span style="text-transform: uppercase;">put</span> "http://petstore.swagger.io/v2/user/{username}"
-
-
-</code></pre>
-                                                </div>
-
-                                                <div class="tab-pane" id="examples-User-updateUser-0-java">
-                                                  <pre class="prettyprint"><code class="language-java">
-import io.swagger.client.*;
+                              </code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Parameters</h2>
+
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 0 - successful operation </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-User-updateUser">
+                      <article id="api-User-updateUser-0" data-group="User" data-name="updateUser" data-version="0">
+                        <div class="pull-left">
+                          <h1>updateUser</h1>
+                          <p>Updated user</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">This can only be done by the logged in user.</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/user/{username}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-User-updateUser-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-User-updateUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-updateUser-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-User-updateUser-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-User-updateUser-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-User-updateUser-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-User-updateUser-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-User-updateUser-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-User-updateUser-0-php">PHP</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-User-updateUser-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">
+  curl -X <span style="text-transform: uppercase;">put</span> "http://petstore.swagger.io/v2/user/{username}"
+  </code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-User-updateUser-0-java">
+                            <pre class="prettyprint"><code class="language-java">
+  import io.swagger.client.*;
 import io.swagger.client.auth.*;
 import io.swagger.client.model.*;
 import .UserApi;
@@ -9700,13 +6416,12 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
+                            </code></pre>
+                          </div>
 
-
-                                                <div class="tab-pane" id="examples-User-updateUser-0-android">
-                                                  <pre class="prettyprint"><code class="language-java">
-import .UserApi;
+                          <div class="tab-pane" id="examples-User-updateUser-0-android">
+                            <pre class="prettyprint"><code class="language-java">
+  import .UserApi;
 
 public class UserApiExample {
 
@@ -9723,18 +6438,15 @@ public class UserApiExample {
     }
 }
 
-                                                  </code></pre>
-          </div>
-
-          <!--
-          <div class="tab-pane" id="examples-User-updateUser-0-groovy">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div> -->
-
-
-                                                <div class="tab-pane" id="examples-User-updateUser-0-objc">
-                                                    <pre class="prettyprint"><code class="language-cpp">
-
+                            </code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-User-updateUser-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-User-updateUser-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">
+  
 String *username = username_example; // name that need to be deleted
 User *body = ; // Updated user object
 
@@ -9749,11 +6461,12 @@ UserApi *apiInstance = [[UserApi alloc] init];
                             }
                         }];
 
-                                                    </code></pre>
-                                                </div>
-                                                <div class="tab-pane" id="examples-User-updateUser-0-javascript">
-                                                    <pre class="prettyprint"><code class="language-js">
-var  = require('');
+                              </code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-User-updateUser-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">
+  var  = require('');
 
 var api = new .UserApi()
 
@@ -9771,16 +6484,15 @@ var callback = function(error, data, response) {
 };
 api.updateUser(username, body, callback);
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-                                                <!--<div class="tab-pane" id="examples-User-updateUser-0-angular">
-            <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-          </div>-->
-
-                                                <div class="tab-pane" id="examples-User-updateUser-0-csharp">
-                                                    <pre class="prettyprint"><code class="language-cs">
-using System;
+                            <!--<div class="tab-pane" id="examples-User-updateUser-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-User-updateUser-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">
+  using System;
 using System.Diagnostics;
 using .Api;
 using .Client;
@@ -9810,13 +6522,12 @@ namespace Example
     }
 }
 
-                                                    </code></pre>
-                                                </div>
+                              </code></pre>
+                            </div>
 
-
-                                                <div class="tab-pane" id="examples-User-updateUser-0-php">
-                                                  <pre class="prettyprint"><code class="language-php">
-<?php
+                            <div class="tab-pane" id="examples-User-updateUser-0-php">
+                              <pre class="prettyprint"><code class="language-php">
+  <?php
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new io.swagger.client\Api\UserApi();
@@ -9829,27 +6540,19 @@ try {
     echo 'Exception when calling UserApi->updateUser: ', $e->getMessage(), PHP_EOL;
 }
 
-                                                  </code></pre>
-          </div>
+                              </code></pre>
+                            </div>
+                          </div>
 
-                                            </div>
+                          <h2>Parameters</h2>
 
-
-
-
-
-                                            <h2>Parameters</h2>
-
-
-
-                                                <div class="methodsubtabletitle">Path parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">username*</td>
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">username*</td>
 <td>
 
 
@@ -9882,18 +6585,16 @@ try {
 </td>
 </tr>
 
-                                                </table>
+                            </table>
 
 
-
-                                                <div class="methodsubtabletitle">Body parameters</div>
-                                                <table id="methodsubtable">
-                                                    <tr>
-                                                        <th width="150px">Name</th>
-                                                        <th>Description</th>
-                                                    </tr>
-                                                    <!---->
-                                                        <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
 <td>
 
 
@@ -9937,214 +6638,38 @@ try {
 </td>
 </tr>
 
-
-                                                </table>
-
-
-
-                                            <h2>Responses</h2>
-
-                                                <h3> Status: 400 - Invalid user supplied </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-updateUser-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-updateUser-schema">
-
-
-
-
-                                                        <div id='examples-User-updateUser-schema-400' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "Invalid user supplied"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-updateUser-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-updateUser-schema-400');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-updateUser-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-                                                <h3> Status: 404 - User not found </h3>
-
-                                                <ul class="nav nav-tabs nav-tabs-examples" >
-
-                                                    <li class="active">
-                                                        <a href="#examples-User-updateUser-schema">Schema</a>
-                                                    </li>
-
-
-                                                </ul>
-
-
-
-
-
-
-
-                                                <div class="tab-content" style='margin-bottom: 10px;'>
-
-
-
-                                                    <div class="tab-pane active" id="examples-User-updateUser-schema">
-
-
-
-
-                                                        <div id='examples-User-updateUser-schema-404' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-
-                                                            <script>
-                                                                $(document).ready(function() {
-                                                                    var schemaWrapper = {
-  "description" : "User not found"
-};
-                                                                    var schema = schemaWrapper.schema;
-                                                                    schemaWrapper.definitions = defs;
-                                                                    //console.log(JSON.stringify(schema))
-                                                                    JsonRefs.resolveRefs(schemaWrapper, {
-                                                                        "depth": 3,
-                                                                        "resolveRemoteRefs": false,
-                                                                        "resolveFileRefs": false
-                                                                    }, function(err, resolved, metadata) {
-
-                                                                        //console.log(JSON.stringify(resolved));
-
-
-
-                                                                        var view = new JSONSchemaView(resolved.schema, 3);
-                                                                        $('#examples-User-updateUser-schema-data').val(JSON.stringify(resolved.schema));
-                                                                        var result = $('#examples-User-updateUser-schema-404');
-                                                                        result.empty();
-                                                                        result.append(view.render());
-                                                                    });
-
-
-
-
-                                                                });
-                                                            </script>
-                                                        </div>
-                                                        <input id='examples-User-updateUser-schema-data' type='hidden' value=''></input>
-
-
-
-
-
-
-                                                    </div>
-
-
-
-
-                                                </div>
-
-
-
-
-
-
-
-
-
-                                        </article>
-
-                                    </div>
-
-                                    <hr>
-
-                            </section>
-
-
-
-
-
-
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 400 - Invalid user supplied </h3>
+
+                            <h3> Status: 404 - User not found </h3>
+
+                        </article>
+                      </div>
+                      <hr>
+                  </section>
+          </div>
+          <div id="footer">
+            <div id="api-_footer">
+              <p>Suggestions, contact, support and error reporting;
+                  <div class="app-desc">Contact Info: <a href="apiteam@swagger.io">apiteam@swagger.io</a></div>
+              </p>
+                <div class="license-info">Apache 2.0</div>
+                <div class="license-url">http://www.apache.org/licenses/LICENSE-2.0.html</div>
             </div>
-
-
-
-
-
-
-            <div id="footer">
-                <div id="api-_footer">
-                    <p>Suggestions, contact, support and error reporting;
-                            <div class="app-desc">Contact Info: <a href="apiteam@swagger.io">apiteam@swagger.io</a></div>
-                    </p>
-                        <div class="license-info">Apache 2.0</div>
-                        <div class="license-url">http://www.apache.org/licenses/LICENSE-2.0.html</div>
-                </div>
+          </div>
+          <div id="generator">
+            <div class="content">
+              Generated 2016-11-16T15:33:43.134-08:00
             </div>
-            <div id="generator">
-                <div class="content">
-                    Generated 2016-11-11T12:26:26.280-08:00
-                </div>
-            </div>
-        </div>
+          </div>
+      </div>
     </div>
-</div>
-
-
-
-
-
-
-<script>
+  </div>
+  <script>
 
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.JSONSchemaView = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
@@ -10397,10 +6922,10 @@ var JSONSchemaView = (function () {
       }
 
       if (this.schema['enum']) {
-        var formatter = new JSONFormatter(this.schema['enum'], this.open - 1);
-        var formatterEl = formatter.render();
-        formatterEl.classList.add('inner');
-        element.querySelector('.enums.inner').appendChild(formatterEl);
+        var tempDiv = document.createElement('span');;
+        tempDiv.classList.add('inner');
+        tempDiv.innerHTML = '<code>' + this.schema['enum'].join('</code>, <code>') + '</code>';
+        element.querySelector('.enums.inner').appendChild(tempDiv);
       }
 
       if (this.isArray) {
@@ -10458,11 +6983,11 @@ module.exports = exports['default'];
 
 </script>
 
-<script>
+  <script>
 !function(t){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=t();else if("function"==typeof define&&define.amd)define([],t);else{var e;e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,e.JsonRefs=t()}}(function(){var t;return function e(t,n,r){function o(s,u){if(!n[s]){if(!t[s]){var a="function"==typeof require&&require;if(!u&&a)return a(s,!0);if(i)return i(s,!0);var c=new Error("Cannot find module '"+s+"'");throw c.code="MODULE_NOT_FOUND",c}var f=n[s]={exports:{}};t[s][0].call(f.exports,function(e){var n=t[s][1][e];return o(n?n:e)},f,f.exports,e,t,n,r)}return n[s].exports}for(var i="function"==typeof require&&require,s=0;s<r.length;s++)o(r[s]);return o}({1:[function(t,e,n){"use strict";function r(t,e){var n=p[t],r=Promise.resolve(),o=-1===t.indexOf(":")?void 0:t.split(":")[0];return a.isUndefined(n)?-1!==h.indexOf(o)||a.isUndefined(o)?(r=c.load(t,e),r=r.then(e.processContent?function(n){return e.processContent(n,t)}:JSON.parse),r=r.then(function(e){return p[t]=e,e})):r=r.then(function(){return Promise.reject(new Error("Unsupported remote reference scheme: "+o))}):r=r.then(function(){return n}),r=r.then(function(t){return a.cloneDeep(t)})}function o(t,e){var n=m(t);return v(e)&&(e=-1===e.indexOf("#")?"#":e.substring(e.indexOf("#"))),d(n.concat(m(e))).replace(/\/\$ref/g,"")}function i(t,e){function n(t){".."===t?o.pop():"."!==t&&o.push(t)}var r="#"!==e.charAt(0)&&-1===e.indexOf(":"),o=[],i=(e.indexOf("#")>-1?e.split("#")[0]:e).split("/");return t&&(t.indexOf("#")>-1&&(t=t.substring(0,t.indexOf("#"))),t.length>1&&"/"===t[t.length-1]&&(t=t.substring(0,t.length-1)),t.split("#")[0].split("/").forEach(n)),r?i.forEach(n):o=i,o.join("/")}function s(t,e,n){function r(t){var e=t.slice(0,t.lastIndexOf("allOf")),o=n[d(e)];return a.isUndefined(o)?e.indexOf("allOf")>-1?r(e):void 0:d(e)}function i(t){var e=[],o=t.map(function(){var t,o=d(this.path),i=n[o];this.circular&&(e.push(o),a.isUndefined(i)&&(t=r(this.path),i=n[t]),a.isUndefined(i)||(i.circular=!0),this.update(0===u?{}:f(this.node).map(function(){this.circular&&this.parent.update({})})))});return a.each(e,function(t){var e,n=[],r=m(t),i=f(o).get(r);for(e=0;u>e;e++)n.push.apply(n,r),f(o).set(n,a.cloneDeep(i))}),o}function s(t,e){var r=o(e,"#"),i=t=-1===t.indexOf("#")?"#":t.substring(t.indexOf("#")),s=m(i),u=!c.has(s),a=c.get(s),f=m(e),p=f.slice(0,f.length-1),h=n[r]||{ref:t};u?h.missing=!0:0===p.length?(c.value===a&&(a={},h.circular=!0),c.value=a):(c.get(p)===a&&(a={},h.circular=!0),c.set(p,a)),n[r]=h}var u=a.isUndefined(e.depth)?1:e.depth,c=f(t);return a.each(y(t),function(t,e){v(t)||s(t,e)}),a.isUndefined(e.location)||a.each(n,function(t){var n=t.ref;0===n.indexOf(e.location)&&(n=n.substring(e.location.length),"/"===n.charAt(0)&&(n=n.substring(1))),t.ref=n}),{metadata:n,resolved:i(c)}}function u(t,e,n,c,p){function h(t,e,r,i,s){var u,h=r+("#"===i?"":i),l=o(n,t),d=p[l]||{},y=m(t);a.isUndefined(s)?(d.circular=!0,u=c[r].ref):(u=f(s).get(m(i)),a.isUndefined(u)?d.missing=!0:u.$ref?u=u.$ref:y.pop()),0===y.length?g.value=u:g.set(y,u),d.ref=h,p[l]=d}function l(){return{metadata:p,resolved:g.value}}var d=Promise.resolve(),g=f(t);return a.each(y(t),function(t,s){v(t)&&(d=d.then(function(){var f=i(e.location,t),l=t.split("#"),d="#"+(l[1]||"");return a.isUndefined(c[f])?r(f,e).then(function(t){return t},function(t){return t}).then(function(r){var y=l[0],v=a.cloneDeep(e),m=o(n,s);return y=y.substring(0,y.lastIndexOf("/")+1),v.location=i(e.location,y),a.isError(r)?void(p[m]={err:r,missing:!0,ref:t}):(c[f]={ref:n},u(r,v,m,c,p).then(function(e){return delete c[f],h(s,t,f,d,e.resolved),e}))}):void h(s,t,f,d)}))}),d=d.then(function(){s(g.value,e,p)}).then(l,l)}"undefined"==typeof Promise&&t("native-promise-only");var a=t("./lib/utils"),c=t("path-loader"),f=t("traverse"),p={},h=["file","http","https"];e.exports.clearCache=function(){p={}};var l=e.exports.isJsonReference=function(t){return a.isPlainObject(t)&&a.isString(t.$ref)},d=e.exports.pathToPointer=function(t){if(a.isUndefined(t))throw new Error("path is required");if(!a.isArray(t))throw new Error("path must be an array");var e="#";return t.length>0&&(e+="/"+t.map(function(t){return t.replace(/~/g,"~0").replace(/\//g,"~1")}).join("/")),e},y=e.exports.findRefs=function(t){if(a.isUndefined(t))throw new Error("json is required");if(!a.isPlainObject(t))throw new Error("json must be an object");return f(t).reduce(function(t){var e=this.node;return"$ref"===this.key&&l(this.parent.node)&&(t[d(this.path)]=e),t},{})},v=e.exports.isRemotePointer=function(t){if(a.isUndefined(t))throw new Error("ptr is required");if(!a.isString(t))throw new Error("ptr must be a string");return""!==t&&"#"!==t.charAt(0)},m=e.exports.pathFromPointer=function(t){if(a.isUndefined(t))throw new Error("ptr is required");if(!a.isString(t))throw new Error("ptr must be a string");var e=[],n=["","#","#/"];return v(t)?e=t:-1===n.indexOf(t)&&"#"===t.charAt(0)&&(e=t.substring(t.indexOf("/")).split("/").reduce(function(t,e){return""!==e&&t.push(e.replace(/~0/g,"~").replace(/~1/g,"/")),t},[])),e};e.exports.resolveRefs=function(t,e,n){var r=Promise.resolve();return 2===arguments.length&&a.isFunction(e)&&(n=e,e={}),a.isUndefined(e)&&(e={}),r=r.then(function(){if(a.isUndefined(t))throw new Error("json is required");if(!a.isPlainObject(t))throw new Error("json must be an object");if(!a.isPlainObject(e))throw new Error("options must be an object");if(!a.isUndefined(n)&&!a.isFunction(n))throw new Error("done must be a function");if(!a.isUndefined(e.processContent)&&!a.isFunction(e.processContent))throw new Error("options.processContent must be a function");if(!a.isUndefined(e.prepareRequest)&&!a.isFunction(e.prepareRequest))throw new Error("options.prepareRequest must be a function");if(!a.isUndefined(e.location)&&!a.isString(e.location))throw new Error("options.location must be a string");if(!a.isUndefined(e.depth)&&!a.isNumber(e.depth))throw new Error("options.depth must be a number");if(!a.isUndefined(e.depth)&&e.depth<0)throw new Error("options.depth must be greater or equal to zero")}),t=f(t).clone(),e=f(e).clone(),r=r.then(function(){return u(t,e,"#",{},{})}).then(function(t){return s(t.resolved,e,t.metadata)}),!a.isUndefined(n)&&a.isFunction(n)&&(r=r.then(function(t){n(void 0,t.resolved,t.metadata)},function(t){n(t)})),r}},{"./lib/utils":2,"native-promise-only":3,"path-loader":4,traverse:10}],2:[function(t,e,n){"use strict";function r(t,e){return Object.prototype.toString.call(t)==="[object "+e+"]"}var o=t("traverse");e.exports.cloneDeep=function(t){return o(t).clone()};var i=e.exports.isArray=function(t){return r(t,"Array")};e.exports.isError=function(t){return r(t,"Error")},e.exports.isFunction=function(t){return r(t,"Function")},e.exports.isNumber=function(t){return r(t,"Number")};var s=e.exports.isPlainObject=function(t){return r(t,"Object")};e.exports.isString=function(t){return r(t,"String")},e.exports.isUndefined=function(t){return"undefined"==typeof t},e.exports.each=function(t,e){i(t)?t.forEach(e):s(t)&&Object.keys(t).forEach(function(n){e(t[n],n)})}},{traverse:10}],3:[function(e,n,r){(function(e){!function(e,r,o){r[e]=r[e]||o(),"undefined"!=typeof n&&n.exports?n.exports=r[e]:"function"==typeof t&&t.amd&&t(function(){return r[e]})}("Promise","undefined"!=typeof e?e:this,function(){"use strict";function t(t,e){h.add(t,e),p||(p=d(h.drain))}function e(t){var e,n=typeof t;return null==t||"object"!=n&&"function"!=n||(e=t.then),"function"==typeof e?e:!1}function n(){for(var t=0;t<this.chain.length;t++)r(this,1===this.state?this.chain[t].success:this.chain[t].failure,this.chain[t]);this.chain.length=0}function r(t,n,r){var o,i;try{n===!1?r.reject(t.msg):(o=n===!0?t.msg:n.call(void 0,t.msg),o===r.promise?r.reject(TypeError("Promise-chain cycle")):(i=e(o))?i.call(o,r.resolve,r.reject):r.resolve(o))}catch(s){r.reject(s)}}function o(r){var s,a=this;if(!a.triggered){a.triggered=!0,a.def&&(a=a.def);try{(s=e(r))?t(function(){var t=new u(a);try{s.call(r,function(){o.apply(t,arguments)},function(){i.apply(t,arguments)})}catch(e){i.call(t,e)}}):(a.msg=r,a.state=1,a.chain.length>0&&t(n,a))}catch(c){i.call(new u(a),c)}}}function i(e){var r=this;r.triggered||(r.triggered=!0,r.def&&(r=r.def),r.msg=e,r.state=2,r.chain.length>0&&t(n,r))}function s(t,e,n,r){for(var o=0;o<e.length;o++)!function(o){t.resolve(e[o]).then(function(t){n(o,t)},r)}(o)}function u(t){this.def=t,this.triggered=!1}function a(t){this.promise=t,this.state=0,this.triggered=!1,this.chain=[],this.msg=void 0}function c(e){if("function"!=typeof e)throw TypeError("Not a function");if(0!==this.__NPO__)throw TypeError("Not a promise");this.__NPO__=1;var r=new a(this);this.then=function(e,o){var i={success:"function"==typeof e?e:!0,failure:"function"==typeof o?o:!1};return i.promise=new this.constructor(function(t,e){if("function"!=typeof t||"function"!=typeof e)throw TypeError("Not a function");i.resolve=t,i.reject=e}),r.chain.push(i),0!==r.state&&t(n,r),i.promise},this["catch"]=function(t){return this.then(void 0,t)};try{e.call(void 0,function(t){o.call(r,t)},function(t){i.call(r,t)})}catch(s){i.call(r,s)}}var f,p,h,l=Object.prototype.toString,d="undefined"!=typeof setImmediate?function(t){return setImmediate(t)}:setTimeout;try{Object.defineProperty({},"x",{}),f=function(t,e,n,r){return Object.defineProperty(t,e,{value:n,writable:!0,configurable:r!==!1})}}catch(y){f=function(t,e,n){return t[e]=n,t}}h=function(){function t(t,e){this.fn=t,this.self=e,this.next=void 0}var e,n,r;return{add:function(o,i){r=new t(o,i),n?n.next=r:e=r,n=r,r=void 0},drain:function(){var t=e;for(e=n=p=void 0;t;)t.fn.call(t.self),t=t.next}}}();var v=f({},"constructor",c,!1);return c.prototype=v,f(v,"__NPO__",0,!1),f(c,"resolve",function(t){var e=this;return t&&"object"==typeof t&&1===t.__NPO__?t:new e(function(e,n){if("function"!=typeof e||"function"!=typeof n)throw TypeError("Not a function");e(t)})}),f(c,"reject",function(t){return new this(function(e,n){if("function"!=typeof e||"function"!=typeof n)throw TypeError("Not a function");n(t)})}),f(c,"all",function(t){var e=this;return"[object Array]"!=l.call(t)?e.reject(TypeError("Not an array")):0===t.length?e.resolve([]):new e(function(n,r){if("function"!=typeof n||"function"!=typeof r)throw TypeError("Not a function");var o=t.length,i=Array(o),u=0;s(e,t,function(t,e){i[t]=e,++u===o&&n(i)},r)})}),f(c,"race",function(t){var e=this;return"[object Array]"!=l.call(t)?e.reject(TypeError("Not an array")):new e(function(n,r){if("function"!=typeof n||"function"!=typeof r)throw TypeError("Not a function");s(e,t,function(t,e){n(e)},r)})}),c})}).call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{}],4:[function(t,e,n){"use strict";function r(t){return o[t.split(":")[0]]||i}var o={file:t("./lib/loaders/file"),http:t("./lib/loaders/http"),https:t("./lib/loaders/http")},i="object"==typeof window||"function"==typeof importScripts?o.http:o.file;"undefined"==typeof Promise&&t("native-promise-only"),e.exports.load=function(t,e,n){var o=Promise.resolve();return 2===arguments.length&&"function"==typeof e&&(n=e,e=void 0),o=o.then(function(){if("undefined"==typeof t)throw new TypeError("location is required");if("string"!=typeof t)throw new TypeError("location must be a string");if("undefined"!=typeof e){if("object"!=typeof e)throw new TypeError("options must be an object")}else e={};if("undefined"!=typeof n&&"function"!=typeof n)throw new TypeError("callback must be a function")}),o=o.then(function(){return new Promise(function(n,o){var i=r(t);i.load(t,e,function(t,e){t?o(t):n(e)})})}),"function"==typeof n&&(o=o.then(function(t){n(void 0,t)},function(t){n(t)})),o}},{"./lib/loaders/file":5,"./lib/loaders/http":6,"native-promise-only":3}],5:[function(t,e,n){"use strict";e.exports.load=function(t,e,n){n(new TypeError("The 'file' scheme is not supported in the browser"))}},{}],6:[function(t,e,n){"use strict";var r=t("superagent"),o=["delete","get","head","patch","post","put"];e.exports.load=function(t,e,n){var i,s,u=t.split("#")[0],a=e.method?e.method.toLowerCase():"get";"undefined"!=typeof e.prepareRequest&&"function"!=typeof e.prepareRequest?i=new TypeError("options.prepareRequest must be a function"):"undefined"!=typeof e.method&&("string"!=typeof e.method?i=new TypeError("options.method must be a string"):-1===o.indexOf(e.method)&&(i=new TypeError("options.method must be one of the following: "+o.slice(0,o.length-1).join(", ")+" or "+o[o.length-1]))),i?n(i):(s=r["delete"===a?"del":a](u),e.prepareRequest&&e.prepareRequest(s),"function"==typeof s.buffer&&s.buffer(!0),s.end(function(t,e){n(t,e?e.text:e)}))}},{superagent:7}],7:[function(t,e,n){function r(){}function o(t){var e={}.toString.call(t);switch(e){case"[object File]":case"[object Blob]":case"[object FormData]":return!0;default:return!1}}function i(t){return t===Object(t)}function s(t){if(!i(t))return t;var e=[];for(var n in t)null!=t[n]&&e.push(encodeURIComponent(n)+"="+encodeURIComponent(t[n]));return e.join("&")}function u(t){for(var e,n,r={},o=t.split("&"),i=0,s=o.length;s>i;++i)n=o[i],e=n.split("="),r[decodeURIComponent(e[0])]=decodeURIComponent(e[1]);return r}function a(t){var e,n,r,o,i=t.split(/\r?\n/),s={};i.pop();for(var u=0,a=i.length;a>u;++u)n=i[u],e=n.indexOf(":"),r=n.slice(0,e).toLowerCase(),o=m(n.slice(e+1)),s[r]=o;return s}function c(t){return t.split(/ *; */).shift()}function f(t){return v(t.split(/ *; */),function(t,e){var n=e.split(/ *= */),r=n.shift(),o=n.shift();return r&&o&&(t[r]=o),t},{})}function p(t,e){e=e||{},this.req=t,this.xhr=this.req.xhr,this.text="HEAD"!=this.req.method&&(""===this.xhr.responseType||"text"===this.xhr.responseType)||"undefined"==typeof this.xhr.responseType?this.xhr.responseText:null,this.statusText=this.req.xhr.statusText,this.setStatusProperties(this.xhr.status),this.header=this.headers=a(this.xhr.getAllResponseHeaders()),this.header["content-type"]=this.xhr.getResponseHeader("content-type"),this.setHeaderProperties(this.header),this.body="HEAD"!=this.req.method?this.parseBody(this.text?this.text:this.xhr.response):null}function h(t,e){var n=this;y.call(this),this._query=this._query||[],this.method=t,this.url=e,this.header={},this._header={},this.on("end",function(){var t=null,e=null;try{e=new p(n)}catch(r){return t=new Error("Parser is unable to parse the response"),t.parse=!0,t.original=r,n.callback(t)}if(n.emit("response",e),t)return n.callback(t,e);if(e.status>=200&&e.status<300)return n.callback(t,e);var o=new Error(e.statusText||"Unsuccessful HTTP response");o.original=t,o.response=e,o.status=e.status,n.callback(o,e)})}function l(t,e){return"function"==typeof e?new h("GET",t).end(e):1==arguments.length?new h("GET",t):new h(t,e)}var d,y=t("emitter"),v=t("reduce");d="undefined"!=typeof window?window:"undefined"!=typeof self?self:this,l.getXHR=function(){if(!(!d.XMLHttpRequest||d.location&&"file:"==d.location.protocol&&d.ActiveXObject))return new XMLHttpRequest;try{return new ActiveXObject("Microsoft.XMLHTTP")}catch(t){}try{return new ActiveXObject("Msxml2.XMLHTTP.6.0")}catch(t){}try{return new ActiveXObject("Msxml2.XMLHTTP.3.0")}catch(t){}try{return new ActiveXObject("Msxml2.XMLHTTP")}catch(t){}return!1};var m="".trim?function(t){return t.trim()}:function(t){return t.replace(/(^\s*|\s*$)/g,"")};l.serializeObject=s,l.parseString=u,l.types={html:"text/html",json:"application/json",xml:"application/xml",urlencoded:"application/x-www-form-urlencoded",form:"application/x-www-form-urlencoded","form-data":"application/x-www-form-urlencoded"},l.serialize={"application/x-www-form-urlencoded":s,"application/json":JSON.stringify},l.parse={"application/x-www-form-urlencoded":u,"application/json":JSON.parse},p.prototype.get=function(t){return this.header[t.toLowerCase()]},p.prototype.setHeaderProperties=function(t){var e=this.header["content-type"]||"";this.type=c(e);var n=f(e);for(var r in n)this[r]=n[r]},p.prototype.parse=function(t){return this.parser=t,this},p.prototype.parseBody=function(t){var e=this.parser||l.parse[this.type];return e&&t&&(t.length||t instanceof Object)?e(t):null},p.prototype.setStatusProperties=function(t){1223===t&&(t=204);var e=t/100|0;this.status=this.statusCode=t,this.statusType=e,this.info=1==e,this.ok=2==e,this.clientError=4==e,this.serverError=5==e,this.error=4==e||5==e?this.toError():!1,this.accepted=202==t,this.noContent=204==t,this.badRequest=400==t,this.unauthorized=401==t,this.notAcceptable=406==t,this.notFound=404==t,this.forbidden=403==t},p.prototype.toError=function(){var t=this.req,e=t.method,n=t.url,r="cannot "+e+" "+n+" ("+this.status+")",o=new Error(r);return o.status=this.status,o.method=e,o.url=n,o},l.Response=p,y(h.prototype),h.prototype.use=function(t){return t(this),this},h.prototype.timeout=function(t){return this._timeout=t,this},h.prototype.clearTimeout=function(){return this._timeout=0,clearTimeout(this._timer),this},h.prototype.abort=function(){return this.aborted?void 0:(this.aborted=!0,this.xhr.abort(),this.clearTimeout(),this.emit("abort"),this)},h.prototype.set=function(t,e){if(i(t)){for(var n in t)this.set(n,t[n]);return this}return this._header[t.toLowerCase()]=e,this.header[t]=e,this},h.prototype.unset=function(t){return delete this._header[t.toLowerCase()],delete this.header[t],this},h.prototype.getHeader=function(t){return this._header[t.toLowerCase()]},h.prototype.type=function(t){return this.set("Content-Type",l.types[t]||t),this},h.prototype.accept=function(t){return this.set("Accept",l.types[t]||t),this},h.prototype.auth=function(t,e){var n=btoa(t+":"+e);return this.set("Authorization","Basic "+n),this},h.prototype.query=function(t){return"string"!=typeof t&&(t=s(t)),t&&this._query.push(t),this},h.prototype.field=function(t,e){return this._formData||(this._formData=new d.FormData),this._formData.append(t,e),this},h.prototype.attach=function(t,e,n){return this._formData||(this._formData=new d.FormData),this._formData.append(t,e,n),this},h.prototype.send=function(t){var e=i(t),n=this.getHeader("Content-Type");if(e&&i(this._data))for(var r in t)this._data[r]=t[r];else"string"==typeof t?(n||this.type("form"),n=this.getHeader("Content-Type"),this._data="application/x-www-form-urlencoded"==n?this._data?this._data+"&"+t:t:(this._data||"")+t):this._data=t;return!e||o(t)?this:(n||this.type("json"),this)},h.prototype.callback=function(t,e){var n=this._callback;this.clearTimeout(),n(t,e)},h.prototype.crossDomainError=function(){var t=new Error("Origin is not allowed by Access-Control-Allow-Origin");t.crossDomain=!0,this.callback(t)},h.prototype.timeoutError=function(){var t=this._timeout,e=new Error("timeout of "+t+"ms exceeded");e.timeout=t,this.callback(e)},h.prototype.withCredentials=function(){return this._withCredentials=!0,this},h.prototype.end=function(t){var e=this,n=this.xhr=l.getXHR(),i=this._query.join("&"),s=this._timeout,u=this._formData||this._data;this._callback=t||r,n.onreadystatechange=function(){if(4==n.readyState){var t;try{t=n.status}catch(r){t=0}if(0==t){if(e.timedout)return e.timeoutError();if(e.aborted)return;return e.crossDomainError()}e.emit("end")}};var a=function(t){t.total>0&&(t.percent=t.loaded/t.total*100),e.emit("progress",t)};this.hasListeners("progress")&&(n.onprogress=a);try{n.upload&&this.hasListeners("progress")&&(n.upload.onprogress=a)}catch(c){}if(s&&!this._timer&&(this._timer=setTimeout(function(){e.timedout=!0,e.abort()},s)),i&&(i=l.serializeObject(i),this.url+=~this.url.indexOf("?")?"&"+i:"?"+i),n.open(this.method,this.url,!0),this._withCredentials&&(n.withCredentials=!0),"GET"!=this.method&&"HEAD"!=this.method&&"string"!=typeof u&&!o(u)){var f=this.getHeader("Content-Type"),p=l.serialize[f?f.split(";")[0]:""];p&&(u=p(u))}for(var h in this.header)null!=this.header[h]&&n.setRequestHeader(h,this.header[h]);return this.emit("request",this),n.send(u),this},h.prototype.then=function(t,e){return this.end(function(n,r){n?e(n):t(r)})},l.Request=h,l.get=function(t,e,n){var r=l("GET",t);return"function"==typeof e&&(n=e,e=null),e&&r.query(e),n&&r.end(n),r},l.head=function(t,e,n){var r=l("HEAD",t);return"function"==typeof e&&(n=e,e=null),e&&r.send(e),n&&r.end(n),r},l.del=function(t,e){var n=l("DELETE",t);return e&&n.end(e),n},l.patch=function(t,e,n){var r=l("PATCH",t);return"function"==typeof e&&(n=e,e=null),e&&r.send(e),n&&r.end(n),r},l.post=function(t,e,n){var r=l("POST",t);return"function"==typeof e&&(n=e,e=null),e&&r.send(e),n&&r.end(n),r},l.put=function(t,e,n){var r=l("PUT",t);return"function"==typeof e&&(n=e,e=null),e&&r.send(e),n&&r.end(n),r},e.exports=l},{emitter:8,reduce:9}],8:[function(t,e,n){function r(t){return t?o(t):void 0}function o(t){for(var e in r.prototype)t[e]=r.prototype[e];return t}e.exports=r,r.prototype.on=r.prototype.addEventListener=function(t,e){return this._callbacks=this._callbacks||{},(this._callbacks[t]=this._callbacks[t]||[]).push(e),this},r.prototype.once=function(t,e){function n(){r.off(t,n),e.apply(this,arguments)}var r=this;return this._callbacks=this._callbacks||{},n.fn=e,this.on(t,n),this},r.prototype.off=r.prototype.removeListener=r.prototype.removeAllListeners=r.prototype.removeEventListener=function(t,e){if(this._callbacks=this._callbacks||{},0==arguments.length)return this._callbacks={},this;var n=this._callbacks[t];if(!n)return this;if(1==arguments.length)return delete this._callbacks[t],this;for(var r,o=0;o<n.length;o++)if(r=n[o],r===e||r.fn===e){n.splice(o,1);break}return this},r.prototype.emit=function(t){this._callbacks=this._callbacks||{};var e=[].slice.call(arguments,1),n=this._callbacks[t];if(n){n=n.slice(0);for(var r=0,o=n.length;o>r;++r)n[r].apply(this,e)}return this},r.prototype.listeners=function(t){return this._callbacks=this._callbacks||{},this._callbacks[t]||[]},r.prototype.hasListeners=function(t){return!!this.listeners(t).length}},{}],9:[function(t,e,n){e.exports=function(t,e,n){for(var r=0,o=t.length,i=3==arguments.length?n:t[r++];o>r;)i=e.call(null,i,t[r],++r,t);return i}},{}],10:[function(t,e,n){function r(t){this.value=t}function o(t,e,n){var r=[],o=[],s=!0;return function u(t){function a(){if("object"==typeof h.node&&null!==h.node){h.keys&&h.node_===h.node||(h.keys=d(h.node)),h.isLeaf=0==h.keys.length;for(var e=0;e<o.length;e++)if(o[e].node_===t){h.circular=o[e];break}}else h.isLeaf=!0,h.keys=null;h.notLeaf=!h.isLeaf,h.notRoot=!h.isRoot}var c=n?i(t):t,f={},p=!0,h={node:c,node_:t,path:[].concat(r),parent:o[o.length-1],parents:o,key:r.slice(-1)[0],isRoot:0===r.length,level:r.length,circular:null,update:function(t,e){h.isRoot||(h.parent.node[h.key]=t),h.node=t,e&&(p=!1)},"delete":function(t){delete h.parent.node[h.key],t&&(p=!1)},remove:function(t){y(h.parent.node)?h.parent.node.splice(h.key,1):delete h.parent.node[h.key],t&&(p=!1)},keys:null,before:function(t){f.before=t},after:function(t){f.after=t},pre:function(t){f.pre=t},post:function(t){f.post=t},stop:function(){s=!1},block:function(){p=!1}};if(!s)return h;a();var l=e.call(h,h.node);return void 0!==l&&h.update&&h.update(l),f.before&&f.before.call(h,h.node),p?("object"!=typeof h.node||null===h.node||h.circular||(o.push(h),a(),v(h.keys,function(t,e){r.push(t),f.pre&&f.pre.call(h,h.node[t],t);var o=u(h.node[t]);n&&m.call(h.node,t)&&(h.node[t]=o.node),o.isLast=e==h.keys.length-1,o.isFirst=0==e,f.post&&f.post.call(h,o),r.pop()}),o.pop()),f.after&&f.after.call(h,h.node),h):h}(t).node}function i(t){if("object"==typeof t&&null!==t){var e;if(y(t))e=[];else if(u(t))e=new Date(t.getTime?t.getTime():t);else if(a(t))e=new RegExp(t);else if(c(t))e={message:t.message};else if(f(t))e=new Boolean(t);else if(p(t))e=new Number(t);else if(h(t))e=new String(t);else if(Object.create&&Object.getPrototypeOf)e=Object.create(Object.getPrototypeOf(t));else if(t.constructor===Object)e={};else{var n=t.constructor&&t.constructor.prototype||t.__proto__||{},r=function(){};r.prototype=n,e=new r}return v(d(t),function(n){e[n]=t[n]}),e}return t}function s(t){return Object.prototype.toString.call(t)}function u(t){return"[object Date]"===s(t)}function a(t){return"[object RegExp]"===s(t)}function c(t){return"[object Error]"===s(t)}function f(t){return"[object Boolean]"===s(t)}function p(t){return"[object Number]"===s(t)}function h(t){return"[object String]"===s(t)}var l=e.exports=function(t){return new r(t)};r.prototype.get=function(t){for(var e=this.value,n=0;n<t.length;n++){var r=t[n];if(!e||!m.call(e,r)){e=void 0;break}e=e[r]}return e},r.prototype.has=function(t){for(var e=this.value,n=0;n<t.length;n++){var r=t[n];if(!e||!m.call(e,r))return!1;e=e[r]}return!0},r.prototype.set=function(t,e){for(var n=this.value,r=0;r<t.length-1;r++){var o=t[r];m.call(n,o)||(n[o]={}),n=n[o]}return n[t[r]]=e,e},r.prototype.map=function(t){return o(this.value,t,!0)},r.prototype.forEach=function(t){return this.value=o(this.value,t,!1),this.value},r.prototype.reduce=function(t,e){var n=1===arguments.length,r=n?this.value:e;return this.forEach(function(e){this.isRoot&&n||(r=t.call(this,r,e))}),r},r.prototype.paths=function(){var t=[];return this.forEach(function(e){t.push(this.path)}),t},r.prototype.nodes=function(){var t=[];return this.forEach(function(e){t.push(this.node)}),t},r.prototype.clone=function(){var t=[],e=[];return function n(r){for(var o=0;o<t.length;o++)if(t[o]===r)return e[o];if("object"==typeof r&&null!==r){var s=i(r);return t.push(r),e.push(s),v(d(r),function(t){s[t]=n(r[t])}),t.pop(),e.pop(),s}return r}(this.value)};var d=Object.keys||function(t){var e=[];for(var n in t)e.push(n);return e},y=Array.isArray||function(t){return"[object Array]"===Object.prototype.toString.call(t)},v=function(t,e){if(t.forEach)return t.forEach(e);for(var n=0;n<t.length;n++)e(t[n],n,t)};v(d(r.prototype),function(t){l[t]=function(e){var n=[].slice.call(arguments,1),o=new r(e);return o[t].apply(o,n)}});var m=Object.hasOwnProperty||function(t,e){return e in t}},{}]},{},[1])(1)});
 </script>
 
-<script>
+  <script>
 /* Web Font Loader v1.6.24 - (c) Adobe Systems, Google. License: Apache 2.0 */
 (function(){function aa(a,b,d){return a.call.apply(a.bind,arguments)}function ba(a,b,d){if(!a)throw Error();if(2<arguments.length){var c=Array.prototype.slice.call(arguments,2);return function(){var d=Array.prototype.slice.call(arguments);Array.prototype.unshift.apply(d,c);return a.apply(b,d)}}return function(){return a.apply(b,arguments)}}function p(a,b,d){p=Function.prototype.bind&&-1!=Function.prototype.bind.toString().indexOf("native code")?aa:ba;return p.apply(null,arguments)}var q=Date.now||function(){return+new Date};function ca(a,b){this.a=a;this.m=b||a;this.c=this.m.document}var da=!!window.FontFace;function t(a,b,d,c){b=a.c.createElement(b);if(d)for(var e in d)d.hasOwnProperty(e)&&("style"==e?b.style.cssText=d[e]:b.setAttribute(e,d[e]));c&&b.appendChild(a.c.createTextNode(c));return b}function u(a,b,d){a=a.c.getElementsByTagName(b)[0];a||(a=document.documentElement);a.insertBefore(d,a.lastChild)}function v(a){a.parentNode&&a.parentNode.removeChild(a)}
 function w(a,b,d){b=b||[];d=d||[];for(var c=a.className.split(/\s+/),e=0;e<b.length;e+=1){for(var f=!1,g=0;g<c.length;g+=1)if(b[e]===c[g]){f=!0;break}f||c.push(b[e])}b=[];for(e=0;e<c.length;e+=1){f=!1;for(g=0;g<d.length;g+=1)if(c[e]===d[g]){f=!0;break}f||b.push(c[e])}a.className=b.join(" ").replace(/\s+/g," ").replace(/^\s+|\s+$/,"")}function y(a,b){for(var d=a.className.split(/\s+/),c=0,e=d.length;c<e;c++)if(d[c]==b)return!0;return!1}
@@ -10482,16 +7007,11 @@ function Ea(a){for(var b=a.f.length,d=0;d<b;d++){var c=a.f[d].split(":"),e=c[0].
 g,0<c.length&&(c=Aa[c[0]])&&(a.c[e]=c))}a.c[e]||(c=Aa[e])&&(a.c[e]=c);for(c=0;c<f.length;c+=1)a.a.push(new H(e,f[c]))}};function Fa(a,b){this.c=a;this.a=b}var Ga={Arimo:!0,Cousine:!0,Tinos:!0};Fa.prototype.load=function(a){var b=new C,d=this.c,c=new va(this.a.api,z(d),this.a.text),e=this.a.families;xa(c,e);var f=new za(e);Ea(f);A(d,ya(c),D(b));F(b,function(){a(f.a,f.c,Ga)})};function Ha(a,b){this.c=a;this.a=b}Ha.prototype.load=function(a){var b=this.a.id,d=this.c.m;b?B(this.c,(this.a.api||"https://use.typekit.net")+"/"+b+".js",function(b){if(b)a([]);else if(d.Typekit&&d.Typekit.config&&d.Typekit.config.fn){b=d.Typekit.config.fn;for(var e=[],f=0;f<b.length;f+=2)for(var g=b[f],k=b[f+1],h=0;h<k.length;h++)e.push(new H(g,k[h]));try{d.Typekit.load({events:!1,classes:!1,async:!0})}catch(m){}a(e)}},2E3):a([])};function Ia(a,b){this.c=a;this.f=b;this.a=[]}Ia.prototype.load=function(a){var b=this.f.id,d=this.c.m,c=this;b?(d.__webfontfontdeckmodule__||(d.__webfontfontdeckmodule__={}),d.__webfontfontdeckmodule__[b]=function(b,d){for(var g=0,k=d.fonts.length;g<k;++g){var h=d.fonts[g];c.a.push(new H(h.name,ga("font-weight:"+h.weight+";font-style:"+h.style)))}a(c.a)},B(this.c,z(this.c)+(this.f.api||"//f.fontdeck.com/s/css/js/")+ea(this.c)+"/"+b+".js",function(b){b&&a([])})):a([])};var Y=new pa(window);Y.a.c.custom=function(a,b){return new ua(b,a)};Y.a.c.fontdeck=function(a,b){return new Ia(b,a)};Y.a.c.monotype=function(a,b){return new sa(b,a)};Y.a.c.typekit=function(a,b){return new Ha(b,a)};Y.a.c.google=function(a,b){return new Fa(b,a)};var Z={load:p(Y.load,Y)};"function"===typeof define&&define.amd?define(function(){return Z}):"undefined"!==typeof module&&module.exports?module.exports=Z:(window.WebFont=Z,window.WebFontConfig&&Y.load(window.WebFontConfig));}());
 </script>
 
-
-
-
-
-<script>
-$(document).ready(function () {
-$('.nav-tabs-examples').find('a:first').tab('show');
-$(this).scrollspy({ target: '#scrollingNav', offset: 18 });
-});
-</script>
+  <script>
+  $(document).ready(function () {
+    $('.nav-tabs-examples').find('a:first').tab('show');
+    $(this).scrollspy({ target: '#scrollingNav', offset: 18 });
+  });
+  </script>
 </body>
-
 </html>


### PR DESCRIPTION
`enum` values were not being displayed in the **Parameters** section. Enums are now displayed next to the **Enums:** label, as a comma separated list.

I also cleaned up the HTML formatting if the index.mustache page, to make it easier to read and debug.

Lastly, I hid the **Schema** block below the response code, if no schema was defined. For example, when a 401 error is defined, if there's no `schema` specified, the empty schema tab and panel body below that header are no longer rendered. It was taking up a lot of vertical space having a bunch of empty schema blocks for each endpoint.