### PR TITLE
[Flask] fix parameter naming

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -10,8 +10,7 @@ import io.swagger.models.HttpMethod;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
-import io.swagger.models.parameters.BodyParameter;
-import io.swagger.models.parameters.FormParameter;
+import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.*;
 import io.swagger.util.Yaml;
 
@@ -317,6 +316,15 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
                                     controllerPackage + "." + toApiFilename(tag)
                             );
                         }
+                        for (Parameter param: operation.getParameters()) {
+                            // sanitize the param name but don't underscore it since it's used for request mapping
+                            String name = param.getName();
+                            String paramName = sanitizeName(name);
+                            if (!paramName.equals(name)) {
+                                LOGGER.warn(name + " cannot be used as parameter name with flask-connexion and was sanitized as " + paramName);
+                            }
+                            param.setName(paramName);
+                        }
                     }
                 }
             }
@@ -402,6 +410,12 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
             name = escapeReservedWord(name);
         }
 
+        return name;
+    }
+
+    @Override
+    public String toParamName(String name) {
+        // Param name is already sanitized in swagger spec processing
         return name;
     }
 

--- a/samples/server/petstore/flaskConnexion-python2/controllers/pet_controller.py
+++ b/samples/server/petstore/flaskConnexion-python2/controllers/pet_controller.py
@@ -21,14 +21,14 @@ def add_pet(body):
     return 'do some magic!'
 
 
-def delete_pet(petId, apiKey=None):
+def delete_pet(petId, api_key=None):
     """
     Deletes a pet
     
     :param petId: Pet id to delete
     :type petId: int
-    :param apiKey: 
-    :type apiKey: str
+    :param api_key: 
+    :type api_key: str
 
     :rtype: None
     """

--- a/samples/server/petstore/flaskConnexion-python2/test/test_pet_controller.py
+++ b/samples/server/petstore/flaskConnexion-python2/test/test_pet_controller.py
@@ -31,7 +31,7 @@ class TestPetController(BaseTestCase):
 
         Deletes a pet
         """
-        headers = [('apiKey', 'apiKey_example')]
+        headers = [('api_key', 'api_key_example')]
         response = self.client.open('/v2/pet/{petId}'.format(petId=789),
                                     method='DELETE',
                                     headers=headers)

--- a/samples/server/petstore/flaskConnexion/controllers/pet_controller.py
+++ b/samples/server/petstore/flaskConnexion/controllers/pet_controller.py
@@ -21,14 +21,14 @@ def add_pet(body):
     return 'do some magic!'
 
 
-def delete_pet(petId, apiKey=None):
+def delete_pet(petId, api_key=None):
     """
     Deletes a pet
     
     :param petId: Pet id to delete
     :type petId: int
-    :param apiKey: 
-    :type apiKey: str
+    :param api_key: 
+    :type api_key: str
 
     :rtype: None
     """

--- a/samples/server/petstore/flaskConnexion/test/test_pet_controller.py
+++ b/samples/server/petstore/flaskConnexion/test/test_pet_controller.py
@@ -31,7 +31,7 @@ class TestPetController(BaseTestCase):
 
         Deletes a pet
         """
-        headers = [('apiKey', 'apiKey_example')]
+        headers = [('api_key', 'api_key_example')]
         response = self.client.open('/v2/pet/{petId}'.format(petId=789),
                                     method='DELETE',
                                     headers=headers)


### PR DESCRIPTION
Flask-connexion maps directly the param name in the swagger spec to the param name in the controller method so it must not be changed in the method during generation.
If santitization is needed then a warning log will be emitted.