### PR TITLE
[Swift 3] Use ISOFullDate for date format

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -116,8 +116,7 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("array", "Array");
         typeMapping.put("List", "Array");
         typeMapping.put("map", "Dictionary");
-        typeMapping.put("date", "Date");
-        typeMapping.put("Date", "Date");
+        typeMapping.put("date", "ISOFullDate");
         typeMapping.put("DateTime", "Date");
         typeMapping.put("boolean", "Bool");
         typeMapping.put("string", "String");

--- a/modules/swagger-codegen/src/main/resources/swift3/Extensions.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Extensions.mustache
@@ -84,6 +84,106 @@ extension UUID: JSONEncodable {
     }
 }
 
+/// Represents an ISO-8601 full-date (RFC-3339).
+/// ex: 12-31-1999
+/// https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
+public final class ISOFullDate: CustomStringConvertible {
+
+    public let year: Int
+    public let month: Int
+    public let day: Int
+
+    public init(year: Int, month: Int, day: Int) {
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /**
+     Converts a Date to an ISOFullDate. Only interested in the year, month, day components.
+
+     - parameter date: The date to convert.
+
+     - returns: An ISOFullDate constructed from the year, month, day of the date.
+     */
+    public static func from(date: Date) -> ISOFullDate? {
+        let calendar = Calendar(identifier: .gregorian)
+
+        let components = calendar.dateComponents(
+            [
+                .year,
+                .month,
+                .day,
+            ],
+            from: date
+        )
+
+        guard
+            let year = components.year,
+            let month = components.month,
+            let day = components.day
+        else {
+            return nil
+        }
+
+        return ISOFullDate(
+            year: year,
+            month: month,
+            day: day
+        )
+    }
+
+    /**
+     Converts a ISO-8601 full-date string to an ISOFullDate.
+
+     - parameter string: The ISO-8601 full-date format string to convert.
+
+     - returns: An ISOFullDate constructed from the string.
+     */
+    public static func from(string: String) -> ISOFullDate? {
+        let components = string
+            .characters
+            .split(separator: "-")
+            .map(String.init)
+            .flatMap { Int($0) }
+        guard components.count == 3 else { return nil }
+
+        return ISOFullDate(
+            year: components[0],
+            month: components[1],
+            day: components[2]
+        )
+    }
+
+    /**
+     Converts the receiver to a Date, in the default time zone.
+
+     - returns: A Date from the components of the receiver, in the default time zone.
+     */
+    public func toDate() -> Date? {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.timeZone = TimeZone.ReferenceType.default
+        let calendar = Calendar(identifier: .gregorian)
+        return calendar.date(from: components)
+    }
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        return "\(year)-\(month)-\(day)"
+    }
+
+}
+
+extension ISOFullDate: JSONEncodable {
+    public func encodeToJSON() -> Any {
+        return "\(year)-\(month)-\(day)"
+    }
+}
+
 {{#usePromiseKit}}extension RequestBuilder {
     public func execute() -> Promise<Response<T>>  {
         let deferred = Promise<Response<T>>.pending()

--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -146,6 +146,15 @@ class Decoders {
                 return Date(timeIntervalSince1970: Double(sourceInt / 1000) )
             }
             fatalError("formatter failed to parse \(source)")
+        }
+
+        // Decoder for ISOFullDate
+        Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> ISOFullDate in
+            if let string = source as? String,
+               let isoDate = ISOFullDate.from(string: string) {
+                return isoDate
+            }
+            fatalError("formatter failed to parse \(source)")
         } {{#models}}{{#model}}
 
         // Decoder for [{{{classname}}}]

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3CodegenTest.java
@@ -62,6 +62,18 @@ public class Swift3CodegenTest {
         Assert.assertTrue(op.responses.get(0).isBinary);
     }
 
+    @Test(description = "returns ISOFullDate when response format is date")
+    public void dateTest() {
+        final Swagger model = new SwaggerParser().read("src/test/resources/2_0/datePropertyTest.json");
+        final DefaultCodegen codegen = new Swift3Codegen();
+        final String path = "/tests/dateResponse";
+        final Operation p = model.getPaths().get(path).getPost();
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, model.getDefinitions());
+
+        Assert.assertEquals(op.returnType, "ISOFullDate");
+        Assert.assertEquals(op.bodyParam.dataType, "ISOFullDate");
+    }
+
     @Test
     public void testDefaultPodAuthors() throws Exception {
         // Given

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3ModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3ModelTest.java
@@ -23,6 +23,7 @@ public class Swift3ModelTest {
                 .property("binary", new BinaryProperty())
                 .property("byte", new ByteArrayProperty())
                 .property("uuid", new UUIDProperty())
+                .property("dateOfBirth", new DateProperty())
                 .required("id")
                 .required("name")
                 .discriminator("test");
@@ -32,7 +33,7 @@ public class Swift3ModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 6);
+        Assert.assertEquals(cm.vars.size(), 7);
         Assert.assertEquals(cm.discriminator,"test");
 
         final CodegenProperty property1 = cm.vars.get(0);
@@ -93,9 +94,19 @@ public class Swift3ModelTest {
         Assert.assertEquals(property6.name, "uuid");
         Assert.assertNull(property6.defaultValue);
         Assert.assertEquals(property6.baseType, "UUID");
-        Assert.assertNull(property6.hasMore);
+        Assert.assertTrue(property6.hasMore);
         Assert.assertNull(property6.required);
         Assert.assertTrue(property6.isNotContainer);
+
+        final CodegenProperty property7 = cm.vars.get(6);
+        Assert.assertEquals(property7.baseName, "dateOfBirth");
+        Assert.assertEquals(property7.datatype, "ISOFullDate");
+        Assert.assertEquals(property7.name, "dateOfBirth");
+        Assert.assertNull(property7.defaultValue);
+        Assert.assertEquals(property7.baseType, "ISOFullDate");
+        Assert.assertNull(property7.hasMore);
+        Assert.assertNull(property7.required);
+        Assert.assertTrue(property7.isNotContainer);
     }
 
 }

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -108,13 +108,13 @@ public class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example={
+     - examples: [{contentType=application/json, example={
   "name" : "Puma",
   "type" : "Dog",
   "color" : "Black",
   "gender" : "Female",
   "breed" : "Mixed"
-}, contentType=application/json}]
+}}]
      
      - parameter status: (query) Status values that need to be considered for filter (optional, default to available)
 
@@ -157,20 +157,20 @@ public class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -179,21 +179,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -202,7 +202,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter tags: (query) Tags to filter by (optional)
 
@@ -242,26 +242,26 @@ public class PetAPI: APIBase {
      Find pet by ID
      - GET /pet/{petId}
      - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -270,21 +270,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -293,7 +293,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter petId: (path) ID of pet that needs to be fetched 
 

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -67,12 +67,12 @@ public class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{example={
+     - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
-     - examples: [{example={
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
+     - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -108,36 +108,36 @@ public class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{orderId}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{example={
-  "id" : 123456789,
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -176,36 +176,36 @@ public class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{example={
-  "id" : 123456789,
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter body: (body) order placed for purchasing the pet (optional)
 

--- a/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -167,16 +167,16 @@ public class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{example={
-  "id" : 123456789,
-  "lastName" : "aeiou",
-  "phone" : "aeiou",
-  "username" : "aeiou",
-  "email" : "aeiou",
-  "userStatus" : 123,
+     - examples: [{contentType=application/json, example={
   "firstName" : "aeiou",
-  "password" : "aeiou"
-}, contentType=application/json}, {example=<User>
+  "lastName" : "aeiou",
+  "password" : "aeiou",
+  "userStatus" : 123,
+  "phone" : "aeiou",
+  "id" : 123456789,
+  "email" : "aeiou",
+  "username" : "aeiou"
+}}, {contentType=application/xml, example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -185,17 +185,17 @@ public class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
-  "lastName" : "aeiou",
-  "phone" : "aeiou",
-  "username" : "aeiou",
-  "email" : "aeiou",
-  "userStatus" : 123,
+</User>}]
+     - examples: [{contentType=application/json, example={
   "firstName" : "aeiou",
-  "password" : "aeiou"
-}, contentType=application/json}, {example=<User>
+  "lastName" : "aeiou",
+  "password" : "aeiou",
+  "userStatus" : 123,
+  "phone" : "aeiou",
+  "id" : 123456789,
+  "email" : "aeiou",
+  "username" : "aeiou"
+}}, {contentType=application/xml, example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -204,7 +204,7 @@ public class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>, contentType=application/xml}]
+</User>}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -244,8 +244,8 @@ public class UserAPI: APIBase {
      Logs user into the system
      - GET /user/login
      - 
-     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
-     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
+     - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
+     - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
      
      - parameter username: (query) The user name for login (optional)
      - parameter password: (query) The password for login in clear text (optional)

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -160,13 +160,13 @@ public class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example={
+     - examples: [{contentType=application/json, example={
   "name" : "Puma",
   "type" : "Dog",
   "color" : "Black",
   "gender" : "Female",
   "breed" : "Mixed"
-}, contentType=application/json}]
+}}]
      
      - parameter status: (query) Status values that need to be considered for filter (optional, default to available)
 
@@ -226,20 +226,20 @@ public class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -248,21 +248,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -271,7 +271,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter tags: (query) Tags to filter by (optional)
 
@@ -328,26 +328,26 @@ public class PetAPI: APIBase {
      Find pet by ID
      - GET /pet/{petId}
      - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -356,21 +356,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -379,7 +379,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter petId: (path) ID of pet that needs to be fetched 
 

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -101,12 +101,12 @@ public class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{example={
+     - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
-     - examples: [{example={
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
+     - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -159,36 +159,36 @@ public class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{orderId}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{example={
-  "id" : 123456789,
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -244,36 +244,36 @@ public class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{example={
-  "id" : 123456789,
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter body: (body) order placed for purchasing the pet (optional)
 

--- a/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -253,16 +253,16 @@ public class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{example={
-  "id" : 123456789,
-  "lastName" : "aeiou",
-  "phone" : "aeiou",
-  "username" : "aeiou",
-  "email" : "aeiou",
-  "userStatus" : 123,
+     - examples: [{contentType=application/json, example={
   "firstName" : "aeiou",
-  "password" : "aeiou"
-}, contentType=application/json}, {example=<User>
+  "lastName" : "aeiou",
+  "password" : "aeiou",
+  "userStatus" : 123,
+  "phone" : "aeiou",
+  "id" : 123456789,
+  "email" : "aeiou",
+  "username" : "aeiou"
+}}, {contentType=application/xml, example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -271,17 +271,17 @@ public class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
-  "lastName" : "aeiou",
-  "phone" : "aeiou",
-  "username" : "aeiou",
-  "email" : "aeiou",
-  "userStatus" : 123,
+</User>}]
+     - examples: [{contentType=application/json, example={
   "firstName" : "aeiou",
-  "password" : "aeiou"
-}, contentType=application/json}, {example=<User>
+  "lastName" : "aeiou",
+  "password" : "aeiou",
+  "userStatus" : 123,
+  "phone" : "aeiou",
+  "id" : 123456789,
+  "email" : "aeiou",
+  "username" : "aeiou"
+}}, {contentType=application/xml, example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -290,7 +290,7 @@ public class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>, contentType=application/xml}]
+</User>}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -348,8 +348,8 @@ public class UserAPI: APIBase {
      Logs user into the system
      - GET /user/login
      - 
-     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
-     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
+     - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
+     - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
      
      - parameter username: (query) The user name for login (optional)
      - parameter password: (query) The password for login in clear text (optional)

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -166,13 +166,13 @@ public class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example={
+     - examples: [{contentType=application/json, example={
   "name" : "Puma",
   "type" : "Dog",
   "color" : "Black",
   "gender" : "Female",
   "breed" : "Mixed"
-}, contentType=application/json}]
+}}]
      
      - parameter status: (query) Status values that need to be considered for filter (optional, default to available)
 
@@ -234,20 +234,20 @@ public class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -256,21 +256,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example=[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example=[ {
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-} ], contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+} ]}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -279,7 +279,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter tags: (query) Tags to filter by (optional)
 
@@ -338,26 +338,26 @@ public class PetAPI: APIBase {
      Find pet by ID
      - GET /pet/{petId}
      - Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+     - API Key:
+       - type: apiKey api_key 
+       - name: api_key
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -366,21 +366,21 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
-     - examples: [{example={
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+</Pet>}]
+     - examples: [{contentType=application/json, example={
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
-}, contentType=application/json}, {example=<Pet>
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -389,7 +389,7 @@ public class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>, contentType=application/xml}]
+</Pet>}]
      
      - parameter petId: (path) ID of pet that needs to be fetched 
 

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -105,12 +105,12 @@ public class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{example={
+     - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
-     - examples: [{example={
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
+     - examples: [{contentType=application/json, example={
   "key" : 123
-}, contentType=application/json}, {example=not implemented io.swagger.models.properties.MapProperty@d1e580af, contentType=application/xml}]
+}}, {contentType=application/xml, example=not implemented io.swagger.models.properties.MapProperty@d1e580af}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -165,36 +165,36 @@ public class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{orderId}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{example={
-  "id" : 123456789,
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -252,36 +252,36 @@ public class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{example={
-  "id" : 123456789,
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
+</Order>}]
+     - examples: [{contentType=application/json, example={
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
-}, contentType=application/json}, {example=<Order>
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
+}}, {contentType=application/xml, example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>, contentType=application/xml}]
+</Order>}]
      
      - parameter body: (body) order placed for purchasing the pet (optional)
 

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -263,16 +263,16 @@ public class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{example={
-  "id" : 123456789,
-  "lastName" : "aeiou",
-  "phone" : "aeiou",
-  "username" : "aeiou",
-  "email" : "aeiou",
-  "userStatus" : 123,
+     - examples: [{contentType=application/json, example={
   "firstName" : "aeiou",
-  "password" : "aeiou"
-}, contentType=application/json}, {example=<User>
+  "lastName" : "aeiou",
+  "password" : "aeiou",
+  "userStatus" : 123,
+  "phone" : "aeiou",
+  "id" : 123456789,
+  "email" : "aeiou",
+  "username" : "aeiou"
+}}, {contentType=application/xml, example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -281,17 +281,17 @@ public class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>, contentType=application/xml}]
-     - examples: [{example={
-  "id" : 123456789,
-  "lastName" : "aeiou",
-  "phone" : "aeiou",
-  "username" : "aeiou",
-  "email" : "aeiou",
-  "userStatus" : 123,
+</User>}]
+     - examples: [{contentType=application/json, example={
   "firstName" : "aeiou",
-  "password" : "aeiou"
-}, contentType=application/json}, {example=<User>
+  "lastName" : "aeiou",
+  "password" : "aeiou",
+  "userStatus" : 123,
+  "phone" : "aeiou",
+  "id" : 123456789,
+  "email" : "aeiou",
+  "username" : "aeiou"
+}}, {contentType=application/xml, example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -300,7 +300,7 @@ public class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>, contentType=application/xml}]
+</User>}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -360,8 +360,8 @@ public class UserAPI: APIBase {
      Logs user into the system
      - GET /user/login
      - 
-     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
-     - examples: [{example="aeiou", contentType=application/json}, {example=string, contentType=application/xml}]
+     - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
+     - examples: [{contentType=application/json, example="aeiou"}, {contentType=application/xml, example=string}]
      
      - parameter username: (query) The user name for login (optional)
      - parameter password: (query) The password for login in clear text (optional)

--- a/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -139,7 +139,7 @@ class Decoders {
                     return NSDate(timeIntervalSince1970: Double(sourceInt / 1000) )
                 }
                 fatalError("formatter failed to parse \(source)")
-            } 
+            }
 
             // Decoder for ISOFullDate
             Decoders.addDecoder(clazz: ISOFullDate.self, decoder: { (source: AnyObject) -> ISOFullDate in

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Extensions.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Extensions.swift
@@ -83,4 +83,104 @@ extension UUID: JSONEncodable {
     }
 }
 
+/// Represents an ISO-8601 full-date (RFC-3339).
+/// ex: 12-31-1999
+/// https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
+public final class ISOFullDate: CustomStringConvertible {
+
+    public let year: Int
+    public let month: Int
+    public let day: Int
+
+    public init(year: Int, month: Int, day: Int) {
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /**
+     Converts a Date to an ISOFullDate. Only interested in the year, month, day components.
+
+     - parameter date: The date to convert.
+
+     - returns: An ISOFullDate constructed from the year, month, day of the date.
+     */
+    public static func from(date: Date) -> ISOFullDate? {
+        let calendar = Calendar(identifier: .gregorian)
+
+        let components = calendar.dateComponents(
+            [
+                .year,
+                .month,
+                .day,
+            ],
+            from: date
+        )
+
+        guard
+            let year = components.year,
+            let month = components.month,
+            let day = components.day
+        else {
+            return nil
+        }
+
+        return ISOFullDate(
+            year: year,
+            month: month,
+            day: day
+        )
+    }
+
+    /**
+     Converts a ISO-8601 full-date string to an ISOFullDate.
+
+     - parameter string: The ISO-8601 full-date format string to convert.
+
+     - returns: An ISOFullDate constructed from the string.
+     */
+    public static func from(string: String) -> ISOFullDate? {
+        let components = string
+            .characters
+            .split(separator: "-")
+            .map(String.init)
+            .flatMap { Int($0) }
+        guard components.count == 3 else { return nil }
+
+        return ISOFullDate(
+            year: components[0],
+            month: components[1],
+            day: components[2]
+        )
+    }
+
+    /**
+     Converts the receiver to a Date, in the default time zone.
+
+     - returns: A Date from the components of the receiver, in the default time zone.
+     */
+    public func toDate() -> Date? {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.timeZone = TimeZone.ReferenceType.default
+        let calendar = Calendar(identifier: .gregorian)
+        return calendar.date(from: components)
+    }
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        return "\(year)-\(month)-\(day)"
+    }
+
+}
+
+extension ISOFullDate: JSONEncodable {
+    public func encodeToJSON() -> Any {
+        return "\(year)-\(month)-\(day)"
+    }
+}
+
 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -146,6 +146,15 @@ class Decoders {
                 return Date(timeIntervalSince1970: Double(sourceInt / 1000) )
             }
             fatalError("formatter failed to parse \(source)")
+        }
+
+        // Decoder for ISOFullDate
+        Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> ISOFullDate in
+            if let string = source as? String,
+               let isoDate = ISOFullDate.from(string: string) {
+                return isoDate
+            }
+            fatalError("formatter failed to parse \(source)")
         } 
 
         // Decoder for [AdditionalPropertiesClass]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -100,7 +100,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if stringResponse.result.isFailure {
                     completion(
                         nil,
-                        ErrorResponse.Error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
+                        ErrorResponse.Error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error as Error!)
                     )
                     return
                 }
@@ -159,6 +159,13 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if response.result.isFailure {
                     completion(nil, ErrorResponse.Error(response.response?.statusCode ?? 500, response.data, response.result.error!))
                     return
+                }
+
+                // handle HTTP 204 No Content
+                // NSNull would crash decoders
+                if response.response?.statusCode == 204 && response.result.value is NSNull{
+                    completion(nil, nil)
+                    return;
                 }
 
                 if () is T {

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Extensions.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Extensions.swift
@@ -84,6 +84,106 @@ extension UUID: JSONEncodable {
     }
 }
 
+/// Represents an ISO-8601 full-date (RFC-3339).
+/// ex: 12-31-1999
+/// https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
+public final class ISOFullDate: CustomStringConvertible {
+
+    public let year: Int
+    public let month: Int
+    public let day: Int
+
+    public init(year: Int, month: Int, day: Int) {
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /**
+     Converts a Date to an ISOFullDate. Only interested in the year, month, day components.
+
+     - parameter date: The date to convert.
+
+     - returns: An ISOFullDate constructed from the year, month, day of the date.
+     */
+    public static func from(date: Date) -> ISOFullDate? {
+        let calendar = Calendar(identifier: .gregorian)
+
+        let components = calendar.dateComponents(
+            [
+                .year,
+                .month,
+                .day,
+            ],
+            from: date
+        )
+
+        guard
+            let year = components.year,
+            let month = components.month,
+            let day = components.day
+        else {
+            return nil
+        }
+
+        return ISOFullDate(
+            year: year,
+            month: month,
+            day: day
+        )
+    }
+
+    /**
+     Converts a ISO-8601 full-date string to an ISOFullDate.
+
+     - parameter string: The ISO-8601 full-date format string to convert.
+
+     - returns: An ISOFullDate constructed from the string.
+     */
+    public static func from(string: String) -> ISOFullDate? {
+        let components = string
+            .characters
+            .split(separator: "-")
+            .map(String.init)
+            .flatMap { Int($0) }
+        guard components.count == 3 else { return nil }
+
+        return ISOFullDate(
+            year: components[0],
+            month: components[1],
+            day: components[2]
+        )
+    }
+
+    /**
+     Converts the receiver to a Date, in the default time zone.
+
+     - returns: A Date from the components of the receiver, in the default time zone.
+     */
+    public func toDate() -> Date? {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.timeZone = TimeZone.ReferenceType.default
+        let calendar = Calendar(identifier: .gregorian)
+        return calendar.date(from: components)
+    }
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        return "\(year)-\(month)-\(day)"
+    }
+
+}
+
+extension ISOFullDate: JSONEncodable {
+    public func encodeToJSON() -> Any {
+        return "\(year)-\(month)-\(day)"
+    }
+}
+
 extension RequestBuilder {
     public func execute() -> Promise<Response<T>>  {
         let deferred = Promise<Response<T>>.pending()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -44,6 +44,15 @@ class Decoders {
         decoders[key] = { decoder($0) as AnyObject }
     }
 
+    static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> T {
+        let key = discriminator;
+        if let decoder = decoders[key] {
+            return decoder(source) as! T
+        } else {
+            fatalError("Source \(source) is not convertible to type \(clazz): Maybe swagger file is insufficient")
+        }
+    }
+
     static func decode<T>(clazz: [T].Type, source: AnyObject) -> [T] {
         let array = source as! [AnyObject]
         return array.map { Decoders.decode(clazz: T.self, source: $0) }
@@ -137,6 +146,15 @@ class Decoders {
                 return Date(timeIntervalSince1970: Double(sourceInt / 1000) )
             }
             fatalError("formatter failed to parse \(source)")
+        }
+
+        // Decoder for ISOFullDate
+        Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> ISOFullDate in
+            if let string = source as? String,
+               let isoDate = ISOFullDate.from(string: string) {
+                return isoDate
+            }
+            fatalError("formatter failed to parse \(source)")
         } 
 
         // Decoder for [AdditionalPropertiesClass]
@@ -146,6 +164,7 @@ class Decoders {
         // Decoder for AdditionalPropertiesClass
         Decoders.addDecoder(clazz: AdditionalPropertiesClass.self) { (source: AnyObject) -> AdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = AdditionalPropertiesClass()
             instance.mapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_property"] as AnyObject?)
             instance.mapOfMapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_of_map_property"] as AnyObject?)
@@ -160,6 +179,11 @@ class Decoders {
         // Decoder for Animal
         Decoders.addDecoder(clazz: Animal.self) { (source: AnyObject) -> Animal in
             let sourceDictionary = source as! [AnyHashable: Any]
+            // Check discriminator to support inheritance
+            if let discriminator = sourceDictionary["className"] as? String, discriminator != "Animal"{
+                return Decoders.decode(clazz: Animal.self, discriminator: discriminator, source: source)
+            }
+
             let instance = Animal()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -185,6 +209,7 @@ class Decoders {
         // Decoder for ApiResponse
         Decoders.addDecoder(clazz: ApiResponse.self) { (source: AnyObject) -> ApiResponse in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ApiResponse()
             instance.code = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["code"] as AnyObject?)
             instance.type = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["type"] as AnyObject?)
@@ -200,6 +225,7 @@ class Decoders {
         // Decoder for ArrayOfArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfArrayOfNumberOnly.self) { (source: AnyObject) -> ArrayOfArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayOfArrayOfNumberOnly()
             instance.arrayArrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayArrayNumber"] as AnyObject?)
             return instance
@@ -213,6 +239,7 @@ class Decoders {
         // Decoder for ArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfNumberOnly.self) { (source: AnyObject) -> ArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayOfNumberOnly()
             instance.arrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayNumber"] as AnyObject?)
             return instance
@@ -226,6 +253,7 @@ class Decoders {
         // Decoder for ArrayTest
         Decoders.addDecoder(clazz: ArrayTest.self) { (source: AnyObject) -> ArrayTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayTest()
             instance.arrayOfString = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_of_string"] as AnyObject?)
             instance.arrayArrayOfInteger = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_array_of_integer"] as AnyObject?)
@@ -241,6 +269,7 @@ class Decoders {
         // Decoder for Cat
         Decoders.addDecoder(clazz: Cat.self) { (source: AnyObject) -> Cat in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Cat()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -256,6 +285,7 @@ class Decoders {
         // Decoder for Category
         Decoders.addDecoder(clazz: Category.self) { (source: AnyObject) -> Category in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Category()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"] as AnyObject?)
@@ -270,6 +300,7 @@ class Decoders {
         // Decoder for Client
         Decoders.addDecoder(clazz: Client.self) { (source: AnyObject) -> Client in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Client()
             instance.client = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["client"] as AnyObject?)
             return instance
@@ -283,6 +314,7 @@ class Decoders {
         // Decoder for Dog
         Decoders.addDecoder(clazz: Dog.self) { (source: AnyObject) -> Dog in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Dog()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -298,6 +330,7 @@ class Decoders {
         // Decoder for EnumArrays
         Decoders.addDecoder(clazz: EnumArrays.self) { (source: AnyObject) -> EnumArrays in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = EnumArrays()
             if let justSymbol = sourceDictionary["just_symbol"] as? String { 
                 instance.justSymbol = EnumArrays.JustSymbol(rawValue: (justSymbol))
@@ -333,6 +366,7 @@ class Decoders {
         // Decoder for EnumTest
         Decoders.addDecoder(clazz: EnumTest.self) { (source: AnyObject) -> EnumTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = EnumTest()
             if let enumString = sourceDictionary["enum_string"] as? String { 
                 instance.enumString = EnumTest.EnumString(rawValue: (enumString))
@@ -357,6 +391,7 @@ class Decoders {
         // Decoder for FormatTest
         Decoders.addDecoder(clazz: FormatTest.self) { (source: AnyObject) -> FormatTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = FormatTest()
             instance.integer = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["integer"] as AnyObject?)
             instance.int32 = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["int32"] as AnyObject?)
@@ -382,6 +417,7 @@ class Decoders {
         // Decoder for HasOnlyReadOnly
         Decoders.addDecoder(clazz: HasOnlyReadOnly.self) { (source: AnyObject) -> HasOnlyReadOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = HasOnlyReadOnly()
             instance.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
             instance.foo = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["foo"] as AnyObject?)
@@ -396,6 +432,7 @@ class Decoders {
         // Decoder for List
         Decoders.addDecoder(clazz: List.self) { (source: AnyObject) -> List in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = List()
             instance._123List = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["123-list"] as AnyObject?)
             return instance
@@ -409,6 +446,7 @@ class Decoders {
         // Decoder for MapTest
         Decoders.addDecoder(clazz: MapTest.self) { (source: AnyObject) -> MapTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = MapTest()
             instance.mapMapOfString = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_map_of_string"] as AnyObject?)
             if let mapOfEnumString = sourceDictionary["map_of_enum_string"] as? [String:String] { //TODO: handle enum map scenario
@@ -425,6 +463,7 @@ class Decoders {
         // Decoder for MixedPropertiesAndAdditionalPropertiesClass
         Decoders.addDecoder(clazz: MixedPropertiesAndAdditionalPropertiesClass.self) { (source: AnyObject) -> MixedPropertiesAndAdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = MixedPropertiesAndAdditionalPropertiesClass()
             instance.uuid = Decoders.decodeOptional(clazz: UUID.self, source: sourceDictionary["uuid"] as AnyObject?)
             instance.dateTime = Decoders.decodeOptional(clazz: Date.self, source: sourceDictionary["dateTime"] as AnyObject?)
@@ -440,6 +479,7 @@ class Decoders {
         // Decoder for Model200Response
         Decoders.addDecoder(clazz: Model200Response.self) { (source: AnyObject) -> Model200Response in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Model200Response()
             instance.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
             instance._class = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["class"] as AnyObject?)
@@ -454,6 +494,7 @@ class Decoders {
         // Decoder for Name
         Decoders.addDecoder(clazz: Name.self) { (source: AnyObject) -> Name in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Name()
             instance.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
             instance.snakeCase = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["snake_case"] as AnyObject?)
@@ -470,6 +511,7 @@ class Decoders {
         // Decoder for NumberOnly
         Decoders.addDecoder(clazz: NumberOnly.self) { (source: AnyObject) -> NumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = NumberOnly()
             instance.justNumber = Decoders.decodeOptional(clazz: Double.self, source: sourceDictionary["JustNumber"] as AnyObject?)
             return instance
@@ -483,6 +525,7 @@ class Decoders {
         // Decoder for Order
         Decoders.addDecoder(clazz: Order.self) { (source: AnyObject) -> Order in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Order()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.petId = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["petId"] as AnyObject?)
@@ -504,6 +547,7 @@ class Decoders {
         // Decoder for Pet
         Decoders.addDecoder(clazz: Pet.self) { (source: AnyObject) -> Pet in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Pet()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.category = Decoders.decodeOptional(clazz: Category.self, source: sourceDictionary["category"] as AnyObject?)
@@ -525,6 +569,7 @@ class Decoders {
         // Decoder for ReadOnlyFirst
         Decoders.addDecoder(clazz: ReadOnlyFirst.self) { (source: AnyObject) -> ReadOnlyFirst in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ReadOnlyFirst()
             instance.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
             instance.baz = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["baz"] as AnyObject?)
@@ -539,6 +584,7 @@ class Decoders {
         // Decoder for Return
         Decoders.addDecoder(clazz: Return.self) { (source: AnyObject) -> Return in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Return()
             instance._return = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["return"] as AnyObject?)
             return instance
@@ -552,6 +598,7 @@ class Decoders {
         // Decoder for SpecialModelName
         Decoders.addDecoder(clazz: SpecialModelName.self) { (source: AnyObject) -> SpecialModelName in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = SpecialModelName()
             instance.specialPropertyName = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["$special[property.name]"] as AnyObject?)
             return instance
@@ -565,6 +612,7 @@ class Decoders {
         // Decoder for Tag
         Decoders.addDecoder(clazz: Tag.self) { (source: AnyObject) -> Tag in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Tag()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"] as AnyObject?)
@@ -579,6 +627,7 @@ class Decoders {
         // Decoder for User
         Decoders.addDecoder(clazz: User.self) { (source: AnyObject) -> User in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = User()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.username = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["username"] as AnyObject?)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -15,7 +15,7 @@ open class AdditionalPropertiesClass: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_property"] = self.mapProperty?.encodeToJSON()
         nillableDictionary["map_of_map_property"] = self.mapOfMapProperty?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -15,7 +15,7 @@ open class Animal: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["className"] = self.className
         nillableDictionary["color"] = self.color

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -16,7 +16,7 @@ open class ApiResponse: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["code"] = self.code?.encodeToJSON()
         nillableDictionary["type"] = self.type

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,7 +14,7 @@ open class ArrayOfArrayOfNumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayArrayNumber"] = self.arrayArrayNumber?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -14,7 +14,7 @@ open class ArrayOfNumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayNumber"] = self.arrayNumber?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -16,7 +16,7 @@ open class ArrayTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["array_of_string"] = self.arrayOfString?.encodeToJSON()
         nillableDictionary["array_array_of_integer"] = self.arrayArrayOfInteger?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -8,18 +8,14 @@
 import Foundation
 
 
-open class Cat: JSONEncodable {
-    public var className: String?
-    public var color: String?
+open class Cat: Animal {
     public var declawed: Bool?
 
-    public init() {}
+    
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        var nillableDictionary = [String:Any?]()
-        nillableDictionary["className"] = self.className
-        nillableDictionary["color"] = self.color
+    override open func encodeToJSON() -> Any {
+        var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["declawed"] = self.declawed
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -15,7 +15,7 @@ open class Category: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -14,7 +14,7 @@ open class Client: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["client"] = self.client
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -8,18 +8,14 @@
 import Foundation
 
 
-open class Dog: JSONEncodable {
-    public var className: String?
-    public var color: String?
+open class Dog: Animal {
     public var breed: String?
 
-    public init() {}
+    
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        var nillableDictionary = [String:Any?]()
-        nillableDictionary["className"] = self.className
-        nillableDictionary["color"] = self.color
+    override open func encodeToJSON() -> Any {
+        var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["breed"] = self.breed
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -23,7 +23,7 @@ open class EnumArrays: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["just_symbol"] = self.justSymbol?.rawValue
         nillableDictionary["array_enum"] = self.arrayEnum?.map({$0.rawValue}).encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -28,7 +28,7 @@ open class EnumTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["enum_string"] = self.enumString?.rawValue
         nillableDictionary["enum_integer"] = self.enumInteger?.rawValue

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -26,7 +26,7 @@ open class FormatTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["integer"] = self.integer?.encodeToJSON()
         nillableDictionary["int32"] = self.int32?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -15,7 +15,7 @@ open class HasOnlyReadOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["foo"] = self.foo

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -14,7 +14,7 @@ open class List: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["123-list"] = self._123List
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -19,7 +19,7 @@ open class MapTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_map_of_string"] = self.mapMapOfString?.encodeToJSON()//TODO: handle enum map scenario
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -16,7 +16,7 @@ open class MixedPropertiesAndAdditionalPropertiesClass: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["uuid"] = self.uuid?.encodeToJSON()
         nillableDictionary["dateTime"] = self.dateTime?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -16,7 +16,7 @@ open class Model200Response: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["class"] = self._class

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -18,7 +18,7 @@ open class Name: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["snake_case"] = self.snakeCase?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -14,7 +14,7 @@ open class NumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["JustNumber"] = self.justNumber
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -25,7 +25,7 @@ open class Order: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["petId"] = self.petId?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -25,7 +25,7 @@ open class Pet: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["category"] = self.category?.encodeToJSON()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -15,7 +15,7 @@ open class ReadOnlyFirst: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["baz"] = self.baz

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -15,7 +15,7 @@ open class Return: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["return"] = self._return?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -14,7 +14,7 @@ open class SpecialModelName: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["$special[property.name]"] = self.specialPropertyName?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -15,7 +15,7 @@ open class Tag: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -22,7 +22,7 @@ open class User: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["username"] = self.username

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -100,7 +100,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if stringResponse.result.isFailure {
                     completion(
                         nil,
-                        ErrorResponse.Error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error!)
+                        ErrorResponse.Error(stringResponse.response?.statusCode ?? 500, stringResponse.data, stringResponse.result.error as Error!)
                     )
                     return
                 }
@@ -159,6 +159,13 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 if response.result.isFailure {
                     completion(nil, ErrorResponse.Error(response.response?.statusCode ?? 500, response.data, response.result.error!))
                     return
+                }
+
+                // handle HTTP 204 No Content
+                // NSNull would crash decoders
+                if response.response?.statusCode == 204 && response.result.value is NSNull{
+                    completion(nil, nil)
+                    return;
                 }
 
                 if () is T {

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Extensions.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Extensions.swift
@@ -83,4 +83,104 @@ extension UUID: JSONEncodable {
     }
 }
 
+/// Represents an ISO-8601 full-date (RFC-3339).
+/// ex: 12-31-1999
+/// https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
+public final class ISOFullDate: CustomStringConvertible {
+
+    public let year: Int
+    public let month: Int
+    public let day: Int
+
+    public init(year: Int, month: Int, day: Int) {
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /**
+     Converts a Date to an ISOFullDate. Only interested in the year, month, day components.
+
+     - parameter date: The date to convert.
+
+     - returns: An ISOFullDate constructed from the year, month, day of the date.
+     */
+    public static func from(date: Date) -> ISOFullDate? {
+        let calendar = Calendar(identifier: .gregorian)
+
+        let components = calendar.dateComponents(
+            [
+                .year,
+                .month,
+                .day,
+            ],
+            from: date
+        )
+
+        guard
+            let year = components.year,
+            let month = components.month,
+            let day = components.day
+        else {
+            return nil
+        }
+
+        return ISOFullDate(
+            year: year,
+            month: month,
+            day: day
+        )
+    }
+
+    /**
+     Converts a ISO-8601 full-date string to an ISOFullDate.
+
+     - parameter string: The ISO-8601 full-date format string to convert.
+
+     - returns: An ISOFullDate constructed from the string.
+     */
+    public static func from(string: String) -> ISOFullDate? {
+        let components = string
+            .characters
+            .split(separator: "-")
+            .map(String.init)
+            .flatMap { Int($0) }
+        guard components.count == 3 else { return nil }
+
+        return ISOFullDate(
+            year: components[0],
+            month: components[1],
+            day: components[2]
+        )
+    }
+
+    /**
+     Converts the receiver to a Date, in the default time zone.
+
+     - returns: A Date from the components of the receiver, in the default time zone.
+     */
+    public func toDate() -> Date? {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.timeZone = TimeZone.ReferenceType.default
+        let calendar = Calendar(identifier: .gregorian)
+        return calendar.date(from: components)
+    }
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        return "\(year)-\(month)-\(day)"
+    }
+
+}
+
+extension ISOFullDate: JSONEncodable {
+    public func encodeToJSON() -> Any {
+        return "\(year)-\(month)-\(day)"
+    }
+}
+
 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -44,6 +44,15 @@ class Decoders {
         decoders[key] = { decoder($0) as AnyObject }
     }
 
+    static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> T {
+        let key = discriminator;
+        if let decoder = decoders[key] {
+            return decoder(source) as! T
+        } else {
+            fatalError("Source \(source) is not convertible to type \(clazz): Maybe swagger file is insufficient")
+        }
+    }
+
     static func decode<T>(clazz: [T].Type, source: AnyObject) -> [T] {
         let array = source as! [AnyObject]
         return array.map { Decoders.decode(clazz: T.self, source: $0) }
@@ -137,6 +146,15 @@ class Decoders {
                 return Date(timeIntervalSince1970: Double(sourceInt / 1000) )
             }
             fatalError("formatter failed to parse \(source)")
+        }
+
+        // Decoder for ISOFullDate
+        Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> ISOFullDate in
+            if let string = source as? String,
+               let isoDate = ISOFullDate.from(string: string) {
+                return isoDate
+            }
+            fatalError("formatter failed to parse \(source)")
         } 
 
         // Decoder for [AdditionalPropertiesClass]
@@ -146,6 +164,7 @@ class Decoders {
         // Decoder for AdditionalPropertiesClass
         Decoders.addDecoder(clazz: AdditionalPropertiesClass.self) { (source: AnyObject) -> AdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = AdditionalPropertiesClass()
             instance.mapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_property"] as AnyObject?)
             instance.mapOfMapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_of_map_property"] as AnyObject?)
@@ -160,6 +179,11 @@ class Decoders {
         // Decoder for Animal
         Decoders.addDecoder(clazz: Animal.self) { (source: AnyObject) -> Animal in
             let sourceDictionary = source as! [AnyHashable: Any]
+            // Check discriminator to support inheritance
+            if let discriminator = sourceDictionary["className"] as? String, discriminator != "Animal"{
+                return Decoders.decode(clazz: Animal.self, discriminator: discriminator, source: source)
+            }
+
             let instance = Animal()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -185,6 +209,7 @@ class Decoders {
         // Decoder for ApiResponse
         Decoders.addDecoder(clazz: ApiResponse.self) { (source: AnyObject) -> ApiResponse in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ApiResponse()
             instance.code = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["code"] as AnyObject?)
             instance.type = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["type"] as AnyObject?)
@@ -200,6 +225,7 @@ class Decoders {
         // Decoder for ArrayOfArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfArrayOfNumberOnly.self) { (source: AnyObject) -> ArrayOfArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayOfArrayOfNumberOnly()
             instance.arrayArrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayArrayNumber"] as AnyObject?)
             return instance
@@ -213,6 +239,7 @@ class Decoders {
         // Decoder for ArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfNumberOnly.self) { (source: AnyObject) -> ArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayOfNumberOnly()
             instance.arrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayNumber"] as AnyObject?)
             return instance
@@ -226,6 +253,7 @@ class Decoders {
         // Decoder for ArrayTest
         Decoders.addDecoder(clazz: ArrayTest.self) { (source: AnyObject) -> ArrayTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ArrayTest()
             instance.arrayOfString = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_of_string"] as AnyObject?)
             instance.arrayArrayOfInteger = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_array_of_integer"] as AnyObject?)
@@ -241,6 +269,7 @@ class Decoders {
         // Decoder for Cat
         Decoders.addDecoder(clazz: Cat.self) { (source: AnyObject) -> Cat in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Cat()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -256,6 +285,7 @@ class Decoders {
         // Decoder for Category
         Decoders.addDecoder(clazz: Category.self) { (source: AnyObject) -> Category in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Category()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"] as AnyObject?)
@@ -270,6 +300,7 @@ class Decoders {
         // Decoder for Client
         Decoders.addDecoder(clazz: Client.self) { (source: AnyObject) -> Client in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Client()
             instance.client = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["client"] as AnyObject?)
             return instance
@@ -283,6 +314,7 @@ class Decoders {
         // Decoder for Dog
         Decoders.addDecoder(clazz: Dog.self) { (source: AnyObject) -> Dog in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Dog()
             instance.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             instance.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -298,6 +330,7 @@ class Decoders {
         // Decoder for EnumArrays
         Decoders.addDecoder(clazz: EnumArrays.self) { (source: AnyObject) -> EnumArrays in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = EnumArrays()
             if let justSymbol = sourceDictionary["just_symbol"] as? String { 
                 instance.justSymbol = EnumArrays.JustSymbol(rawValue: (justSymbol))
@@ -333,6 +366,7 @@ class Decoders {
         // Decoder for EnumTest
         Decoders.addDecoder(clazz: EnumTest.self) { (source: AnyObject) -> EnumTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = EnumTest()
             if let enumString = sourceDictionary["enum_string"] as? String { 
                 instance.enumString = EnumTest.EnumString(rawValue: (enumString))
@@ -357,6 +391,7 @@ class Decoders {
         // Decoder for FormatTest
         Decoders.addDecoder(clazz: FormatTest.self) { (source: AnyObject) -> FormatTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = FormatTest()
             instance.integer = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["integer"] as AnyObject?)
             instance.int32 = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["int32"] as AnyObject?)
@@ -382,6 +417,7 @@ class Decoders {
         // Decoder for HasOnlyReadOnly
         Decoders.addDecoder(clazz: HasOnlyReadOnly.self) { (source: AnyObject) -> HasOnlyReadOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = HasOnlyReadOnly()
             instance.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
             instance.foo = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["foo"] as AnyObject?)
@@ -396,6 +432,7 @@ class Decoders {
         // Decoder for List
         Decoders.addDecoder(clazz: List.self) { (source: AnyObject) -> List in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = List()
             instance._123List = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["123-list"] as AnyObject?)
             return instance
@@ -409,6 +446,7 @@ class Decoders {
         // Decoder for MapTest
         Decoders.addDecoder(clazz: MapTest.self) { (source: AnyObject) -> MapTest in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = MapTest()
             instance.mapMapOfString = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_map_of_string"] as AnyObject?)
             if let mapOfEnumString = sourceDictionary["map_of_enum_string"] as? [String:String] { //TODO: handle enum map scenario
@@ -425,6 +463,7 @@ class Decoders {
         // Decoder for MixedPropertiesAndAdditionalPropertiesClass
         Decoders.addDecoder(clazz: MixedPropertiesAndAdditionalPropertiesClass.self) { (source: AnyObject) -> MixedPropertiesAndAdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = MixedPropertiesAndAdditionalPropertiesClass()
             instance.uuid = Decoders.decodeOptional(clazz: UUID.self, source: sourceDictionary["uuid"] as AnyObject?)
             instance.dateTime = Decoders.decodeOptional(clazz: Date.self, source: sourceDictionary["dateTime"] as AnyObject?)
@@ -440,6 +479,7 @@ class Decoders {
         // Decoder for Model200Response
         Decoders.addDecoder(clazz: Model200Response.self) { (source: AnyObject) -> Model200Response in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Model200Response()
             instance.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
             instance._class = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["class"] as AnyObject?)
@@ -454,6 +494,7 @@ class Decoders {
         // Decoder for Name
         Decoders.addDecoder(clazz: Name.self) { (source: AnyObject) -> Name in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Name()
             instance.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
             instance.snakeCase = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["snake_case"] as AnyObject?)
@@ -470,6 +511,7 @@ class Decoders {
         // Decoder for NumberOnly
         Decoders.addDecoder(clazz: NumberOnly.self) { (source: AnyObject) -> NumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = NumberOnly()
             instance.justNumber = Decoders.decodeOptional(clazz: Double.self, source: sourceDictionary["JustNumber"] as AnyObject?)
             return instance
@@ -483,6 +525,7 @@ class Decoders {
         // Decoder for Order
         Decoders.addDecoder(clazz: Order.self) { (source: AnyObject) -> Order in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Order()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.petId = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["petId"] as AnyObject?)
@@ -504,6 +547,7 @@ class Decoders {
         // Decoder for Pet
         Decoders.addDecoder(clazz: Pet.self) { (source: AnyObject) -> Pet in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Pet()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.category = Decoders.decodeOptional(clazz: Category.self, source: sourceDictionary["category"] as AnyObject?)
@@ -525,6 +569,7 @@ class Decoders {
         // Decoder for ReadOnlyFirst
         Decoders.addDecoder(clazz: ReadOnlyFirst.self) { (source: AnyObject) -> ReadOnlyFirst in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = ReadOnlyFirst()
             instance.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
             instance.baz = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["baz"] as AnyObject?)
@@ -539,6 +584,7 @@ class Decoders {
         // Decoder for Return
         Decoders.addDecoder(clazz: Return.self) { (source: AnyObject) -> Return in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Return()
             instance._return = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["return"] as AnyObject?)
             return instance
@@ -552,6 +598,7 @@ class Decoders {
         // Decoder for SpecialModelName
         Decoders.addDecoder(clazz: SpecialModelName.self) { (source: AnyObject) -> SpecialModelName in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = SpecialModelName()
             instance.specialPropertyName = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["$special[property.name]"] as AnyObject?)
             return instance
@@ -565,6 +612,7 @@ class Decoders {
         // Decoder for Tag
         Decoders.addDecoder(clazz: Tag.self) { (source: AnyObject) -> Tag in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = Tag()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.name = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["name"] as AnyObject?)
@@ -579,6 +627,7 @@ class Decoders {
         // Decoder for User
         Decoders.addDecoder(clazz: User.self) { (source: AnyObject) -> User in
             let sourceDictionary = source as! [AnyHashable: Any]
+
             let instance = User()
             instance.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
             instance.username = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["username"] as AnyObject?)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -15,7 +15,7 @@ open class AdditionalPropertiesClass: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_property"] = self.mapProperty?.encodeToJSON()
         nillableDictionary["map_of_map_property"] = self.mapOfMapProperty?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -15,7 +15,7 @@ open class Animal: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["className"] = self.className
         nillableDictionary["color"] = self.color

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -16,7 +16,7 @@ open class ApiResponse: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["code"] = self.code?.encodeToJSON()
         nillableDictionary["type"] = self.type

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,7 +14,7 @@ open class ArrayOfArrayOfNumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayArrayNumber"] = self.arrayArrayNumber?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -14,7 +14,7 @@ open class ArrayOfNumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayNumber"] = self.arrayNumber?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -16,7 +16,7 @@ open class ArrayTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["array_of_string"] = self.arrayOfString?.encodeToJSON()
         nillableDictionary["array_array_of_integer"] = self.arrayArrayOfInteger?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -8,18 +8,14 @@
 import Foundation
 
 
-open class Cat: JSONEncodable {
-    public var className: String?
-    public var color: String?
+open class Cat: Animal {
     public var declawed: Bool?
 
-    public init() {}
+    
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        var nillableDictionary = [String:Any?]()
-        nillableDictionary["className"] = self.className
-        nillableDictionary["color"] = self.color
+    override open func encodeToJSON() -> Any {
+        var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["declawed"] = self.declawed
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -15,7 +15,7 @@ open class Category: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -14,7 +14,7 @@ open class Client: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["client"] = self.client
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -8,18 +8,14 @@
 import Foundation
 
 
-open class Dog: JSONEncodable {
-    public var className: String?
-    public var color: String?
+open class Dog: Animal {
     public var breed: String?
 
-    public init() {}
+    
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
-        var nillableDictionary = [String:Any?]()
-        nillableDictionary["className"] = self.className
-        nillableDictionary["color"] = self.color
+    override open func encodeToJSON() -> Any {
+        var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["breed"] = self.breed
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -23,7 +23,7 @@ open class EnumArrays: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["just_symbol"] = self.justSymbol?.rawValue
         nillableDictionary["array_enum"] = self.arrayEnum?.map({$0.rawValue}).encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -28,7 +28,7 @@ open class EnumTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["enum_string"] = self.enumString?.rawValue
         nillableDictionary["enum_integer"] = self.enumInteger?.rawValue

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -26,7 +26,7 @@ open class FormatTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["integer"] = self.integer?.encodeToJSON()
         nillableDictionary["int32"] = self.int32?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -15,7 +15,7 @@ open class HasOnlyReadOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["foo"] = self.foo

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -14,7 +14,7 @@ open class List: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["123-list"] = self._123List
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -19,7 +19,7 @@ open class MapTest: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_map_of_string"] = self.mapMapOfString?.encodeToJSON()//TODO: handle enum map scenario
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -16,7 +16,7 @@ open class MixedPropertiesAndAdditionalPropertiesClass: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["uuid"] = self.uuid?.encodeToJSON()
         nillableDictionary["dateTime"] = self.dateTime?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -16,7 +16,7 @@ open class Model200Response: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["class"] = self._class

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -18,7 +18,7 @@ open class Name: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["snake_case"] = self.snakeCase?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -14,7 +14,7 @@ open class NumberOnly: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["JustNumber"] = self.justNumber
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -25,7 +25,7 @@ open class Order: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["petId"] = self.petId?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -25,7 +25,7 @@ open class Pet: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["category"] = self.category?.encodeToJSON()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -15,7 +15,7 @@ open class ReadOnlyFirst: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["baz"] = self.baz

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -15,7 +15,7 @@ open class Return: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["return"] = self._return?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -14,7 +14,7 @@ open class SpecialModelName: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["$special[property.name]"] = self.specialPropertyName?.encodeToJSON()
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -15,7 +15,7 @@ open class Tag: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -22,7 +22,7 @@ open class User: JSONEncodable {
     public init() {}
 
     // MARK: JSONEncodable
-    func encodeToJSON() -> Any {
+    open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["username"] = self.username


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Adds support for the `date` format (ISO-8601 RFC 3339). A common use case is 'date of birth', where we do not care about units beyond the 'day'.


