### PR TITLE
boolean values from JSON are treated as strings

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -57,7 +57,7 @@ public class CodegenConfigurator {
     private Map<String, String> systemProperties = new HashMap<String, String>();
     private Map<String, String> instantiationTypes = new HashMap<String, String>();
     private Map<String, String> typeMappings = new HashMap<String, String>();
-    private Map<String, String> additionalProperties = new HashMap<String, String>();
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
     private Map<String, String> importMappings = new HashMap<String, String>();
     private Set<String> languageSpecificPrimitives = new HashSet<String>();
     private String gitUserId="GIT_USER_ID";
@@ -65,7 +65,7 @@ public class CodegenConfigurator {
     private String releaseNote="Minor update";
     private String httpUserAgent;
 
-    private final Map<String, String> dynamicProperties = new HashMap<String, String>(); //the map that holds the JsonAnySetter/JsonAnyGetter values
+    private final Map<String, Object> dynamicProperties = new HashMap<String, Object>(); //the map that holds the JsonAnySetter/JsonAnyGetter values
 
     public CodegenConfigurator() {
         this.setOutputDir(".");
@@ -255,16 +255,16 @@ public class CodegenConfigurator {
         return this;
     }
 
-    public Map<String, String> getAdditionalProperties() {
+    public Map<String, Object> getAdditionalProperties() {
         return additionalProperties;
     }
 
-    public CodegenConfigurator setAdditionalProperties(Map<String, String> additionalProperties) {
+    public CodegenConfigurator setAdditionalProperties(Map<String, Object> additionalProperties) {
         this.additionalProperties = additionalProperties;
         return this;
     }
 
-    public CodegenConfigurator addAdditionalProperty(String key, String value) {
+    public CodegenConfigurator addAdditionalProperty(String key, Object value) {
         this.additionalProperties.put(key, value);
         return this;
     }
@@ -398,12 +398,12 @@ public class CodegenConfigurator {
 
     @JsonAnySetter
     public CodegenConfigurator addDynamicProperty(String name, Object value) {
-        dynamicProperties.put(name, value.toString());
+        dynamicProperties.put(name, value);
         return this;
     }
 
     @JsonAnyGetter
-    public Map<String, String> getDynamicProperties() {
+    public Map<String, Object> getDynamicProperties() {
         return dynamicProperties;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -97,7 +97,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SUPPORTS_ES6)) {
-            setSupportsES6(Boolean.valueOf((String)additionalProperties.get(CodegenConstants.SUPPORTS_ES6)));
+            setSupportsES6(Boolean.valueOf(additionalProperties.get(CodegenConstants.SUPPORTS_ES6).toString()));
             additionalProperties.put("supportsES6", getSupportsES6());
         }
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/config/CodegenConfiguratorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/config/CodegenConfiguratorTest.java
@@ -156,12 +156,16 @@ public class CodegenConfiguratorTest {
     public void testAdditionalProperties() throws Exception {
 
         configurator.addAdditionalProperty("foo", "bar")
-                .addAdditionalProperty("hello", "world");
+                .addAdditionalProperty("hello", "world")
+                .addAdditionalProperty("supportJava6", false)
+                .addAdditionalProperty("useRxJava", true);
 
         final ClientOptInput clientOptInput = setupAndRunGenericTest(configurator);
 
         assertValueInMap(clientOptInput.getConfig().additionalProperties(), "foo", "bar");
         assertValueInMap(clientOptInput.getConfig().additionalProperties(), "hello", "world");
+        assertValueInMap(clientOptInput.getConfig().additionalProperties(), "supportJava6", false);
+        assertValueInMap(clientOptInput.getConfig().additionalProperties(), "useRxJava", true);
     }
 
     @Test
@@ -241,10 +245,14 @@ public class CodegenConfiguratorTest {
     @Test
     public void testDynamicProperties() throws Exception {
         configurator.addDynamicProperty(CodegenConstants.LOCAL_VARIABLE_PREFIX, "_");
+        configurator.addDynamicProperty("supportJava6", false);
+        configurator.addDynamicProperty("useRxJava", true);
 
         final ClientOptInput clientOptInput = setupAndRunGenericTest(configurator);
 
         assertValueInMap(clientOptInput.getConfig().additionalProperties(), CodegenConstants.LOCAL_VARIABLE_PREFIX, "_");
+        assertValueInMap(clientOptInput.getConfig().additionalProperties(), "supportJava6", false);
+        assertValueInMap(clientOptInput.getConfig().additionalProperties(), "useRxJava", true);
     }
 
     @Test
@@ -344,7 +352,7 @@ public class CodegenConfiguratorTest {
         }};
     }
 
-    private static void assertValueInMap(Map<?, ?> map, String propertyKey, String expectedPropertyValue) {
+    private static void assertValueInMap(Map<?, ?> map, String propertyKey, Object expectedPropertyValue) {
         assertTrue(map.containsKey(propertyKey));
         assertEquals(map.get(propertyKey), expectedPropertyValue);
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

For #4228 

Running the *petstore.sh scripts has unwanted result, it changed many files where it should not.  Any suggestion? 

These are a non-breaking changes.

##Changes:
Change the value types in additionalProperties and dynamicProperties to Object instead of String.
Change methods that insert values to these maps to use Object as the type of the value instead of String.