### PR TITLE
Still respect super.equals even for models without own vars

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -92,7 +92,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
         {{/hasMore}}{{/vars}}{{#parent}} &&
         super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
   }
 
   @Override


### PR DESCRIPTION
### Description of the PR

The Java equals method does not call super.equals but directly returns true if the class has no own vars


