### PR TITLE
Disable Appveyor cache (which seems broken)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,5 +38,5 @@ test_script:
   # generate all petstore clients
   - .\bin\windows\run-all-petstore.cmd
 cache:
-  - C:\maven\
-  - C:\Users\appveyor\.m2
+#  - C:\maven\
+#  - C:\Users\appveyor\.m2


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Disable Appveyor cache (which seems broken at the moment)

We'll re-enable it after the issue is fixed.

(without caching, the job probably needs more time to run)

