### PR TITLE
Initial implementation to deserialize date-time strings into Date objects for TypeScript-Angular2

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -11,6 +11,7 @@ import io.swagger.codegen.CliOption;
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenParameter;
 import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.ArrayProperty;

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -8,6 +8,7 @@ import { Observable }                                        from 'rxjs/Observab
 import 'rxjs/add/operator/map';
 
 import * as models                                           from '../model/models';
+import * as serializers                                      from '../model/serializers';
 import { BASE_PATH }                                         from '../variables';
 import { Configuration }                                     from '../configuration';
 
@@ -62,7 +63,19 @@ export class {{classname}} {
                 if (response.status === 204) {
                     return undefined;
                 } else {
+{{#returnType}}
+{{#isListContainer}}
+                    return response.json().map((responseObj: any) => {
+                        return serializers.{{baseName}}Serializer.deserialize(responseObj);
+                    });
+{{/isListContainer}}
+{{^isListContainer}}
+                    return serializers.{{baseName}}Serializer.deserialize(response.json());
+{{/isListContainer}}
+{{/returnType}}
+{{^returnType}}
                     return response.json();
+{{/returnType}}
                 }
             });
     }

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/serializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/serializer.mustache
@@ -1,0 +1,28 @@
+{{>licenseInfo}}
+{{#models}}
+{{#model}}
+import * as models from './models';
+
+{{#description}}
+/**
+ * {{{description}}}
+ */
+{{/description}}
+export class {{classname}}Serializer {
+
+    /**
+     * De-serializes an endpoint's response into a {{{classname}}} instance.
+     *
+     * For example, converts date-time strings into Date objects.
+     */
+    deserialize(responseObj: any): {{{classname}}} {
+        let {{{classVarName}}}: {{{classname}}} = {};
+{{#vars}}
+        {{{classVarName}}}.{{{name}}} = {{{vendorExtensions.deserializeSnippet}}};
+{{/vars}}
+        return {{{classVarName}}};
+    }
+
+}
+{{/model}}
+{{/models}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/serializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/serializer.mustache
@@ -15,8 +15,8 @@ export class {{classname}}Serializer {
      *
      * For example, converts date-time strings into Date objects.
      */
-    deserialize(responseObj: any): {{{classname}}} {
-        let {{{classVarName}}}: {{{classname}}} = {};
+    deserialize(responseObj: any): models.{{{classname}}} {
+        let {{{classVarName}}}: models.{{{classname}}} = {};
 {{#vars}}
         {{{classVarName}}}.{{{name}}} = {{{vendorExtensions.deserializeSnippet}}};
 {{/vars}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/serializers.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/serializers.mustache
@@ -1,0 +1,5 @@
+{{#models}}
+{{#model}}
+export * from './{{{ classname }}}Serializer';
+{{/model}}
+{{/models}}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This implementation creates an `[ModelName]Serializer` class to deserialize `date-time` strings from a response into `Date` objects. In the future, this Serializer class would also handle any other types that need deserialization. 

Not quite finished yet as it needs tests, but wanted to put this up to see if this would be an acceptable approach or if there is a better way.

Ref issues #3105, #2776, and PR #3986 