### PR TITLE
[ObjC][Swift] add travis configuration file to test Objc/Swift clients

### DIFF
--- a/.travis.objc_swift_test.yml
+++ b/.travis.objc_swift_test.yml
@@ -1,0 +1,52 @@
+sudo: required
+language: objective-c 
+osx_image: xcode7.3 
+
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.gem
+  - $HOME/.rvm
+  - $HOME/.cocoapods
+  - swagger-api/swagger-codegen/samples/client/petstore/objc/default/SwaggerClientTests/Pods
+  - swagger-api/swagger-codegen/samples/client/petstore/objc/core-data/SwaggerClientTests/Pods
+  - swagger-api/swagger-codegen/samples/client/petstore/swift/default/SwaggerClientTests/Pods
+  - swagger-api/swagger-codegen/samples/client/petstore/swift/promisekit/SwaggerClientTests/Pods
+
+services:
+  - docker
+
+addons:
+  hosts:
+    - petstore.swagger.io
+
+before_install:
+   - export SW=`pwd`
+   # show host table to confirm petstore.swagger.io is mapped to localhost
+   - cat /private/etc/hosts
+   #- rvm install 2.2.2 > /dev/null 2>&1
+   - rvm use 2.2.4
+   - gem environment 
+   - gem install cocoapods -v 1.0.1 -N --no-ri --no-rdoc
+   - gem install xcpretty -N --no-ri --no-rdoc
+   - pod --version
+   - pod setup --silent > /dev/null
+   - brew install xctool
+   - git clone https://github.com/wing328/swagger-samples
+   - cd swagger-samples/java/java-jersey-jaxrs && sudo mvn -q jetty:run &
+
+install:
+
+script:
+   # test default objc client
+   - cd $SW/samples/client/petstore/objc/default/SwaggerClientTests && pod install && xctool -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient-Example" -destination platform='iOS Simulator',OS=8.4,name='iPhone 6' test -test-sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+   # test objc client with coredata
+   - cd $SW/samples/client/petstore/objc/core-data/SwaggerClientTests && pod install && xctool -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient-Example" -destination platform='iOS Simulator',OS=8.4,name='iPhone 6' test -test-sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+   - set -o pipefail
+   # test swift client with promisekit
+   - cd $SW/samples/client/petstore/swift/promisekit/SwaggerClientTests && pod install && xcodebuild clean test -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -sdk iphonesimulator GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
+   # test default swift client
+   - cd $SW/samples/client/petstore/swift/default/SwaggerClientTests && pod install && xcodebuild clean test -workspace "SwaggerClient.xcworkspace" -scheme "SwaggerClient" -sdk iphonesimulator GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
+
+env:
+  - DOCKER_IMAGE_NAME=swaggerapi/swagger-generator


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add travis configuration file (.travis.objc_swift_test.yml) to test Objc/Swift clients

