### PR TITLE
[csharp] Remove generatePropertyChanged when explicitly false

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -199,6 +199,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
             } else {
                 setGeneratePropertyChanged(Boolean.valueOf(additionalProperties.get(CodegenConstants.GENERATE_PROPERTY_CHANGED).toString()));
             }
+
+            if(Boolean.FALSE.equals(this.generatePropertyChanged)) {
+                additionalProperties.remove(CodegenConstants.GENERATE_PROPERTY_CHANGED);
+            }
         }
 
         additionalProperties.put("targetFrameworkNuget", this.targetFrameworkNuget);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

When explicitly passing `--additional-properties=generatePropertyChanged=false` to the C# generator, Fody's PropertyChanged stuff was still randomly referenced or generated because `additionalProperties` still held a false value for the property used in templates (which is truthy in mustache)

Samples aren't regenerated because this option is more of an edge case and doesn't affect the C# client (`generatePropertyChanged` is not provided`) or the property-changed sample (`generatePropertyChanged` is set to true).

For more information, see #4206


