### PR TITLE
[Swift3] make sure to camelize properly before checking for reserved words

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -518,25 +518,33 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
             return camelize(WordUtils.capitalizeFully(getSymbolName(name).toUpperCase()), true);
         }
 
+	// Camelize only when we have a structure defined below
+	Boolean camelized = false;
+	if (name.matches("[A-Z][a-z0-9]+[a-zA-Z0-9]*")) {
+	    name = camelize(name, true);
+	    camelized = true;
+	}
+
         // Reserved Name
         if (isReservedWord(name)) {
             return escapeReservedWord(name);
         }
 
+	// Check for numerical conversions
         if ("Int".equals(datatype) || "Int32".equals(datatype) || "Int64".equals(datatype) ||
                 "Float".equals(datatype) || "Double".equals(datatype)) {
             String varName = "number" + camelize(name);
             varName = varName.replaceAll("-", "minus");
             varName = varName.replaceAll("\\+", "plus");
             varName = varName.replaceAll("\\.", "dot");
-
             return varName;
         }
 
-        // Prevent from breaking properly cased identifier
-        if (name.matches("[A-Z][a-z0-9]+[a-zA-Z0-9]*")) {
-            return camelize(name, true);
-        }
+	// If we have already camelized the word, don't progress
+	// any further
+	if (camelized) {
+	    return name;
+	}
 
         char[] separators = {'-', '_', ' ', ':', '(', ')'};
         return camelize(WordUtils.capitalizeFully(StringUtils.lowerCase(name), separators).replaceAll("[-_ :\\(\\)]", ""), true);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3CodegenTest.java
@@ -14,6 +14,16 @@ public class Swift3CodegenTest {
     Swift3Codegen swiftCodegen = new Swift3Codegen();
 
     @Test
+    public void testReservedWord() throws Exception {
+	Assert.assertEquals(swiftCodegen.toEnumVarName("Public", null), "_public");
+    }
+
+    @Test
+    public void shouldNotBreakNonReservedWord() throws Exception {
+	Assert.assertEquals(swiftCodegen.toEnumVarName("Error", null), "error");
+    }
+
+    @Test
     public void shouldNotBreakCorrectName() throws Exception {
         Assert.assertEquals(swiftCodegen.toEnumVarName("EntryName", null), "entryName");
     }


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

We were checking to see if an enum name was reserved before actually performing the camelization that was going to be returned from the function which made it possible to still return a reserved word.
Added new tests to check for this.
