### PR TITLE
Fix basePath set to null when generating API files.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -78,18 +78,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         generateApis = System.getProperty("apis") != null ? true:null;
         generateModels = System.getProperty("models") != null ? true: null;
         generateSupportingFiles = System.getProperty("supportingFiles") != null ? true:null;
-        // model/api tests and documentation options rely on parent generate options (api or model) and no other options.
-        // They default to true in all scenarios and can only be marked false explicitly
-        generateModelTests = System.getProperty("modelTests") != null ? Boolean.valueOf(System.getProperty("modelTests")): true;
-        generateModelDocumentation = System.getProperty("modelDocs") != null ? Boolean.valueOf(System.getProperty("modelDocs")):true;
-        generateApiTests = System.getProperty("apiTests") != null ? Boolean.valueOf(System.getProperty("apiTests")): true;
-        generateApiDocumentation = System.getProperty("apiDocs") != null ? Boolean.valueOf(System.getProperty("apiDocs")):true;
 
-        if(generateApis == null && generateModels == null && generateSupportingFiles == null) {
+        if (generateApis == null && generateModels == null && generateSupportingFiles == null) {
             // no specifics are set, generate everything
             generateApis = generateModels = generateSupportingFiles = true;
-        }
-        else {
+        } else {
             if(generateApis == null) {
                 generateApis = false;
             }
@@ -100,6 +93,14 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 generateSupportingFiles = false;
             }
         }
+        // model/api tests and documentation options rely on parent generate options (api or model) and no other options.
+        // They default to true in all scenarios and can only be marked false explicitly
+        generateModelTests = System.getProperty("modelTests") != null ? Boolean.valueOf(System.getProperty("modelTests")): true;
+        generateModelDocumentation = System.getProperty("modelDocs") != null ? Boolean.valueOf(System.getProperty("modelDocs")):true;
+        generateApiTests = System.getProperty("apiTests") != null ? Boolean.valueOf(System.getProperty("apiTests")): true;
+        generateApiDocumentation = System.getProperty("apiDocs") != null ? Boolean.valueOf(System.getProperty("apiDocs")):true;
+
+
         // Additional properties added for tests to exclude references in project related files
         config.additionalProperties().put(CodegenConstants.GENERATE_API_TESTS, generateApiTests);
         config.additionalProperties().put(CodegenConstants.GENERATE_MODEL_TESTS, generateModelTests);
@@ -117,6 +118,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if (swagger.getVendorExtensions() != null) {
             config.vendorExtensions().putAll(swagger.getVendorExtensions());
         }
+
+        contextPath = config.escapeText(swagger.getBasePath() == null ? "" : swagger.getBasePath());
+        basePath = config.escapeText(getHost());
+        basePathWithoutHost = config.escapeText(swagger.getBasePath());
+
     }
 
     private void configureSwaggerInfo() {
@@ -581,9 +587,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if (swagger.getHost() != null) {
             bundle.put("host", swagger.getHost());
         }
-        contextPath = config.escapeText(swagger.getBasePath() == null ? "" : swagger.getBasePath());
-        basePath = config.escapeText(getHost());
-        basePathWithoutHost = config.escapeText(swagger.getBasePath());
+
         bundle.put("swagger", this.swagger);
         bundle.put("basePath", basePath);
         bundle.put("basePathWithoutHost",basePathWithoutHost);


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Default Generator's common variables needs to be initialized earlier during the generation process. 
This PR fixes issue https://github.com/swagger-api/swagger-codegen/issues/4297 by initializing common variables during configuration of generator properties. 




