### PR TITLE
[Android] add Object as reserved keyword in Android generator

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
@@ -54,6 +54,9 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
                     "localVarFormParams", "localVarContentTypes", "localVarContentType",
                     "localVarResponse", "localVarBuilder", "authNames", "basePath", "apiInvoker",
 
+                    // due to namespace collusion
+                    "Object",
+
                     // android reserved words
                     "abstract", "continue", "for", "new", "switch", "assert",
                     "default", "if", "package", "synchronized", "boolean", "do", "goto", "private",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add "Object" as reserved keyword in Android generator (for https://github.com/swagger-api/swagger-codegen/issues/4279)