### PR TITLE
Support for standalone enums in Typescript-Angular2 and primitive type detection improvements

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -26,6 +26,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 
     protected String modelPropertyNaming= "camelCase";
     protected Boolean supportsES6 = true;
+    protected HashSet<String> languageGenericTypes;
 
     public AbstractTypeScriptClientCodegen() {
         super();
@@ -58,6 +59,11 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
                 "any",
                 "Error"
         ));
+
+        languageGenericTypes = new HashSet<String>(Arrays.asList(
+                "Array"
+        ));
+
         instantiationTypes.put("array", "Array");
 
         typeMapping = new HashMap<String, String>();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -132,7 +132,7 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
     @Override
     public String getSwaggerType(Property p) {
         String swaggerType = super.getSwaggerType(p);
-        if(languageSpecificPrimitives.contains(swaggerType)) {
+        if(isLanguagePrimitive(swaggerType) || isLanguageGenericType(swaggerType)) {
             return swaggerType;
         }
         return addModelPrefix(swaggerType);
@@ -146,15 +146,19 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
             type = swaggerType;
         }
 
-        if (!startsWithLanguageSpecificPrimitiv(type)) {
+        if (!isLanguagePrimitive(type) && !isLanguageGenericType(type)) {
             type = "models." + swaggerType;
         }
         return type;
     }
 
-    private boolean startsWithLanguageSpecificPrimitiv(String type) {
-        for (String langPrimitive:languageSpecificPrimitives) {
-            if (type.startsWith(langPrimitive))  {
+    private boolean isLanguagePrimitive(String type) {
+        return languageSpecificPrimitives.contains(type);
+    }
+
+    private boolean isLanguageGenericType(String type) {
+        for (String genericType: languageGenericTypes) {
+            if (type.startsWith(genericType + "<"))  {
                 return true;
             }
         }

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/model.mustache
@@ -8,35 +8,6 @@ import * as models from './models';
  * {{{description}}}
  */
 {{/description}}
-export interface {{classname}} {{#parent}}extends models.{{{parent}}} {{/parent}}{
-{{#additionalPropertiesType}}
-    [key: string]: {{{additionalPropertiesType}}}{{#hasVars}} | any{{/hasVars}};
-
-{{/additionalPropertiesType}}
-{{#vars}}
-{{#description}}
-    /**
-     * {{{description}}}
-     */
-{{/description}}
-    {{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
-
-{{/vars}}
-}
-{{#hasEnums}}
-export namespace {{classname}} {
-{{#vars}}
-{{#isEnum}}
-    export enum {{enumName}} {
-    {{#allowableValues}}
-    {{#enumVars}}
-        {{{name}}} = <any> {{{value}}}{{^-last}},{{/-last}}
-    {{/enumVars}}
-    {{/allowableValues}}
-    }
-{{/isEnum}}
-{{/vars}}
-}
-{{/hasEnums}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>modelGeneric}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/modelEnum.mustache
@@ -1,0 +1,12 @@
+{{#description}}
+    /**
+    * {{{description}}}
+    */
+{{/description}}
+export enum {{classname}} {
+{{#allowableValues}}
+{{#enumVars}}
+    {{{name}}} = <any> {{{value}}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/modelGeneric.mustache
@@ -1,0 +1,28 @@
+export interface {{classname}} {{#parent}}extends models.{{{parent}}} {{/parent}}{
+{{#additionalPropertiesType}}
+    [key: string]: {{{additionalPropertiesType}}}{{#hasVars}} | any{{/hasVars}};
+
+{{/additionalPropertiesType}}
+{{#vars}}
+    {{#description}}
+    /**
+     * {{{description}}}
+     */
+    {{/description}}
+    {{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
+
+{{/vars}}
+}{{#hasEnums}}
+export namespace {{classname}} {
+{{#vars}}
+    {{#isEnum}}
+    export enum {{enumName}} {
+    {{#allowableValues}}
+        {{#enumVars}}
+        {{{name}}} = <any> {{{value}}}{{^-last}},{{/-last}}
+        {{/enumVars}}
+    {{/allowableValues}}
+    }
+    {{/isEnum}}
+{{/vars}}
+}{{/hasEnums}}

--- a/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
@@ -27,7 +27,7 @@ import { Configuration }                                     from '../configurat
 
 @Injectable()
 export class PetApi {
-    protected basePath = 'http://petstore.swagger.io/v2';
+    protected basePath = '';
     public defaultHeaders: Headers = new Headers();
     public configuration: Configuration = new Configuration();
 

--- a/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
@@ -27,7 +27,7 @@ import { Configuration }                                     from '../configurat
 
 @Injectable()
 export class StoreApi {
-    protected basePath = 'http://petstore.swagger.io/v2';
+    protected basePath = '';
     public defaultHeaders: Headers = new Headers();
     public configuration: Configuration = new Configuration();
 

--- a/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
@@ -27,7 +27,7 @@ import { Configuration }                                     from '../configurat
 
 @Injectable()
 export class UserApi {
-    protected basePath = 'http://petstore.swagger.io/v2';
+    protected basePath = '';
     public defaultHeaders: Headers = new Headers();
     public configuration: Configuration = new Configuration();
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

All changes target the typescript-angular2 language:

1. Add support to generate standalone enum models. This allows to reuse the same enums in multiple definitions or operations. Before this change, the generator would output an empty interface for the enum.

2. Improve primitive type detection when determining if we prefix the "models" namespace or not. For example, a custom model starting with "Error" would not get its namespace. Fixes #4182.