### PR TITLE
Use JavaScript codegen in JavaScript test (instead of Java)

### DIFF
--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavaScriptModelEnumTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavaScriptModelEnumTest.java
@@ -3,7 +3,6 @@ package io.swagger.codegen.javascript;
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.DefaultCodegen;
-import io.swagger.codegen.languages.JavaClientCodegen;
 import io.swagger.codegen.languages.JavascriptClientCodegen;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Model;
@@ -74,7 +73,7 @@ public class JavaScriptModelEnumTest {
                 .child(subModel)
                 .interfaces(new ArrayList<RefModel>());
 
-        final DefaultCodegen codegen = new JavaClientCodegen();
+        final DefaultCodegen codegen = new JavascriptClientCodegen();
         final Map<String, Model> allModels = new HashMap<String, Model>();
         allModels.put(parentModel.getName(), parentModel);
         allModels.put(subModel.getName(), subModel);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

While examining for usages of JavaClientCodegen, I saw it was used in a JavaScript test. I assume this was a typo.

NOTE: I ran ./bin/javascript-petstore.sh, and it did generate some extra bits. However, this PR doesn't actually touch any of that code, since it's just a test fix, so I did not include the results of this output.

