### PR TITLE
Add hasDiscriminator property to CodegenProperty and CodegenParameter.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
@@ -23,6 +23,11 @@ public class CodegenParameter {
     public Boolean hasValidation;
 
     /**
+     * Set to true, if type associated with <code>CodegenParameter</code> contains a discriminator.
+     */
+    public boolean hasDiscriminator;
+
+    /**
      * Determines whether this parameter is mandatory. If the parameter is in "path",
      * this property is required and its value MUST be true. Otherwise, the property
      * MAY be included and its default value is false.
@@ -138,7 +143,7 @@ public class CodegenParameter {
         output.isDateTime = this.isDateTime;
         output.isListContainer = this.isListContainer;
         output.isMapContainer = this.isMapContainer;
-
+        output.hasDiscriminator = this.hasDiscriminator;
         return output;
     }
 
@@ -263,6 +268,9 @@ public class CodegenParameter {
             return false;
         if (uniqueItems != null ? !uniqueItems.equals(that.uniqueItems) : that.uniqueItems != null)
             return false;
+        if (hasDiscriminator != that.hasDiscriminator) {
+            return false;
+        }
         return multipleOf != null ? multipleOf.equals(that.multipleOf) : that.multipleOf == null;
 
     }
@@ -325,6 +333,7 @@ public class CodegenParameter {
         result = 31 * result + (minItems != null ? minItems.hashCode() : 0);
         result = 31 * result + (uniqueItems != null ? uniqueItems.hashCode() : 0);
         result = 31 * result + (multipleOf != null ? multipleOf.hashCode() : 0);
+        result = 31 * result + (hasDiscriminator ? 13: 31);
         return result;
     }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -49,7 +49,12 @@ public class CodegenProperty implements Cloneable {
     public boolean isInherited;
     public String nameInCamelCase; // property name in camel case
     // enum name based on the property name, usually use as a prefix (e.g. VAR_NAME) for enum name (e.g. VAR_NAME_VALUE1)
-    public String enumName; 
+    public String enumName;
+
+    /**
+     * Set to true if type associated with <code>CodegenProperty</code> has a discriminator.
+     */
+    public boolean hasDiscriminator;
 
     @Override
     public String toString() {
@@ -113,6 +118,7 @@ public class CodegenProperty implements Cloneable {
         result = prime * result + ((isDateTime ? 13:31));
         result = prime * result + ((isMapContainer ? 13:31));
         result = prime * result + ((isListContainer  ? 13:31));
+        result = prime * result + ((hasDiscriminator ? 13:31));
         result = prime * result + Objects.hashCode(isInherited);
         result = prime * result + Objects.hashCode(nameInCamelCase);
         result = prime * result + Objects.hashCode(enumName);
@@ -268,6 +274,9 @@ public class CodegenProperty implements Cloneable {
             return false;
         }
         if (this.isMapContainer != other.isMapContainer) {
+            return false;
+        }
+        if (this.hasDiscriminator != other.hasDiscriminator) {
             return false;
         }
         if (!Objects.equals(this.isInherited, other.isInherited)) {


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This change adds hasDiscriminator property to CodegenModel. 
hasDiscriminator can be used in model.mustache to identify a model which declares discriminator.