### PR TITLE
Refactor Boolean properties to boolean in CodegenProperty, CodegenOperation and CodegenModel classes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -39,8 +39,8 @@ public class CodegenModel {
     public Set<String> allMandatory;
 
     public Set<String> imports = new TreeSet<String>();
-    public Boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, isArrayModel, hasChildren;
-    public Boolean hasOnlyReadOnly = true; // true if all properties are read-only
+    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, isArrayModel, hasChildren;
+    public boolean hasOnlyReadOnly = true; // true if all properties are read-only
     public ExternalDocs externalDocs;
 
     public Map<String, Object> vendorExtensions;
@@ -115,15 +115,15 @@ public class CodegenModel {
             return false;
         if (imports != null ? !imports.equals(that.imports) : that.imports != null)
             return false;
-        if (hasVars != null ? !hasVars.equals(that.hasVars) : that.hasVars != null)
+        if (hasVars != that.hasVars)
             return false;
-        if (emptyVars != null ? !emptyVars.equals(that.emptyVars) : that.emptyVars != null)
+        if (emptyVars != that.emptyVars)
             return false;
-        if (hasMoreModels != null ? !hasMoreModels.equals(that.hasMoreModels) : that.hasMoreModels != null)
+        if (hasMoreModels != that.hasMoreModels)
             return false;
-        if (hasEnums != null ? !hasEnums.equals(that.hasEnums) : that.hasEnums != null)
+        if (hasEnums != that.hasEnums)
             return false;
-        if (isEnum != null ? !isEnum.equals(that.isEnum) : that.isEnum != null)
+        if (isEnum != that.isEnum)
             return false;
         if (externalDocs != null ? !externalDocs.equals(that.externalDocs) : that.externalDocs != null)
             return false;
@@ -163,11 +163,11 @@ public class CodegenModel {
         result = 31 * result + (mandatory != null ? mandatory.hashCode() : 0);
         result = 31 * result + (allMandatory != null ? allMandatory.hashCode() : 0);
         result = 31 * result + (imports != null ? imports.hashCode() : 0);
-        result = 31 * result + (hasVars != null ? hasVars.hashCode() : 0);
-        result = 31 * result + (emptyVars != null ? emptyVars.hashCode() : 0);
-        result = 31 * result + (hasMoreModels != null ? hasMoreModels.hashCode() : 0);
-        result = 31 * result + (hasEnums != null ? hasEnums.hashCode() : 0);
-        result = 31 * result + (isEnum != null ? isEnum.hashCode() : 0);
+        result = 31 * result + (hasVars ? 13:31);
+        result = 31 * result + (emptyVars ? 13:31);
+        result = 31 * result + (hasMoreModels ? 13:31);
+        result = 31 * result + (hasEnums ? 13:31);
+        result = 31 * result + (isEnum ? 13:31);
         result = 31 * result + (externalDocs != null ? externalDocs.hashCode() : 0);
         result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
         result = 31 * result + Objects.hash(hasOnlyReadOnly);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
@@ -11,10 +11,10 @@ import java.util.Arrays;
 
 public class CodegenOperation {
     public final List<CodegenProperty> responseHeaders = new ArrayList<CodegenProperty>();
-    public Boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams,
+    public boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams,
             returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMapContainer,
-            isListContainer, isMultipart, hasMore = Boolean.TRUE,
-            isResponseBinary = Boolean.FALSE, hasReference = Boolean.FALSE,
+            isListContainer, isMultipart, hasMore = true,
+            isResponseBinary = false, hasReference = false,
             isRestfulIndex, isRestfulShow, isRestfulCreate, isRestfulUpdate, isRestfulDestroy,
             isRestful;
     public String path, operationId, returnType, httpMethod, returnBaseType,
@@ -189,33 +189,33 @@ public class CodegenOperation {
 
         if (responseHeaders != null ? !responseHeaders.equals(that.responseHeaders) : that.responseHeaders != null)
             return false;
-        if (hasAuthMethods != null ? !hasAuthMethods.equals(that.hasAuthMethods) : that.hasAuthMethods != null)
+        if (hasAuthMethods != that.hasAuthMethods)
             return false;
-        if (hasConsumes != null ? !hasConsumes.equals(that.hasConsumes) : that.hasConsumes != null)
+        if (hasConsumes != that.hasConsumes)
             return false;
-        if (hasProduces != null ? !hasProduces.equals(that.hasProduces) : that.hasProduces != null)
+        if (hasProduces != that.hasProduces)
             return false;
-        if (hasParams != null ? !hasParams.equals(that.hasParams) : that.hasParams != null)
+        if (hasParams != that.hasParams)
             return false;
-        if (hasOptionalParams != null ? !hasOptionalParams.equals(that.hasOptionalParams) : that.hasOptionalParams != null)
+        if (hasOptionalParams != that.hasOptionalParams)
             return false;
-        if (returnTypeIsPrimitive != null ? !returnTypeIsPrimitive.equals(that.returnTypeIsPrimitive) : that.returnTypeIsPrimitive != null)
+        if (returnTypeIsPrimitive != that.returnTypeIsPrimitive)
             return false;
-        if (returnSimpleType != null ? !returnSimpleType.equals(that.returnSimpleType) : that.returnSimpleType != null)
+        if (returnSimpleType != that.returnSimpleType)
             return false;
-        if (subresourceOperation != null ? !subresourceOperation.equals(that.subresourceOperation) : that.subresourceOperation != null)
+        if (subresourceOperation != that.subresourceOperation)
             return false;
-        if (isMapContainer != null ? !isMapContainer.equals(that.isMapContainer) : that.isMapContainer != null)
+        if (isMapContainer != that.isMapContainer)
             return false;
-        if (isListContainer != null ? !isListContainer.equals(that.isListContainer) : that.isListContainer != null)
+        if (isListContainer != that.isListContainer)
             return false;
-        if (isMultipart != null ? !isMultipart.equals(that.isMultipart) : that.isMultipart != null)
+        if (isMultipart != that.isMultipart)
             return false;
-        if (hasMore != null ? !hasMore.equals(that.hasMore) : that.hasMore != null)
+        if (hasMore != that.hasMore)
             return false;
-        if (isResponseBinary != null ? !isResponseBinary.equals(that.isResponseBinary) : that.isResponseBinary != null)
+        if (isResponseBinary != that.isResponseBinary)
             return false;
-        if (hasReference != null ? !hasReference.equals(that.hasReference) : that.hasReference != null)
+        if (hasReference != that.hasReference)
             return false;
         if (path != null ? !path.equals(that.path) : that.path != null)
             return false;
@@ -284,20 +284,20 @@ public class CodegenOperation {
     @Override
     public int hashCode() {
         int result = responseHeaders.hashCode();
-        result = 31 * result + (hasAuthMethods != null ? hasAuthMethods.hashCode() : 0);
-        result = 31 * result + (hasConsumes != null ? hasConsumes.hashCode() : 0);
-        result = 31 * result + (hasProduces != null ? hasProduces.hashCode() : 0);
-        result = 31 * result + (hasParams != null ? hasParams.hashCode() : 0);
-        result = 31 * result + (hasOptionalParams != null ? hasOptionalParams.hashCode() : 0);
-        result = 31 * result + (returnTypeIsPrimitive != null ? returnTypeIsPrimitive.hashCode() : 0);
-        result = 31 * result + (returnSimpleType != null ? returnSimpleType.hashCode() : 0);
-        result = 31 * result + (subresourceOperation != null ? subresourceOperation.hashCode() : 0);
-        result = 31 * result + (isMapContainer != null ? isMapContainer.hashCode() : 0);
-        result = 31 * result + (isListContainer != null ? isListContainer.hashCode() : 0);
-        result = 31 * result + (isMultipart != null ? isMultipart.hashCode() : 0);
-        result = 31 * result + (hasMore != null ? hasMore.hashCode() : 0);
-        result = 31 * result + (isResponseBinary != null ? isResponseBinary.hashCode() : 0);
-        result = 31 * result + (hasReference != null ? hasReference.hashCode() : 0);
+        result = 31 * result + (hasAuthMethods ? 13:31);
+        result = 31 * result + (hasConsumes ? 13:31);
+        result = 31 * result + (hasProduces ? 13:31);
+        result = 31 * result + (hasParams ? 13:31);
+        result = 31 * result + (hasOptionalParams ? 13:31);
+        result = 31 * result + (returnTypeIsPrimitive ? 13:31);
+        result = 31 * result + (returnSimpleType ? 13:31);
+        result = 31 * result + (subresourceOperation ? 13:31);
+        result = 31 * result + (isMapContainer ? 13:31);
+        result = 31 * result + (isListContainer ? 13:31);
+        result = 31 * result + (isMultipart ? 13:31);
+        result = 31 * result + (hasMore ? 13:31);
+        result = 31 * result + (isResponseBinary ? 13:31);
+        result = 31 * result + (hasReference ? 13:31);
         result = 31 * result + (path != null ? path.hashCode() : 0);
         result = 31 * result + (operationId != null ? operationId.hashCode() : 0);
         result = 31 * result + (returnType != null ? returnType.hashCode() : 0);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -32,21 +32,21 @@ public class CodegenProperty implements Cloneable {
     public String jsonSchema;
     public String minimum;
     public String maximum;
-    public Boolean exclusiveMinimum;
-    public Boolean exclusiveMaximum;
-    public Boolean hasMore, required, secondaryParam;
-    public Boolean hasMoreNonReadOnly; // for model constructor, true if next properyt is not readonly
-    public Boolean isPrimitiveType, isContainer, isNotContainer;
-    public Boolean isString, isInteger, isLong, isFloat, isDouble, isByteArray, isBinary, isBoolean, isDate, isDateTime;
-    public Boolean isListContainer, isMapContainer;
+    public boolean exclusiveMinimum;
+    public boolean exclusiveMaximum;
+    public boolean hasMore, required, secondaryParam;
+    public boolean hasMoreNonReadOnly; // for model constructor, true if next properyt is not readonly
+    public boolean isPrimitiveType, isContainer, isNotContainer;
+    public boolean isString, isInteger, isLong, isFloat, isDouble, isByteArray, isBinary, isBoolean, isDate, isDateTime;
+    public boolean isListContainer, isMapContainer;
     public boolean isEnum;
-    public Boolean isReadOnly = false;
+    public boolean isReadOnly = false;
     public List<String> _enum;
     public Map<String, Object> allowableValues;
     public CodegenProperty items;
     public Map<String, Object> vendorExtensions;
-    public Boolean hasValidation; // true if pattern, maximum, etc are set (only used in the mustache template)
-    public Boolean isInherited;
+    public boolean hasValidation; // true if pattern, maximum, etc are set (only used in the mustache template)
+    public boolean isInherited;
     public String nameInCamelCase; // property name in camel case
     // enum name based on the property name, usually use as a prefix (e.g. VAR_NAME) for enum name (e.g. VAR_NAME_VALUE1)
     public String enumName; 
@@ -75,16 +75,16 @@ public class CodegenProperty implements Cloneable {
         result = prime * result + ((defaultValueWithParam == null) ? 0 : defaultValueWithParam.hashCode());
         result = prime * result + ((description == null) ? 0 : description.hashCode());
         result = prime * result + ((example == null) ? 0 : example.hashCode());
-        result = prime * result + ((exclusiveMaximum == null) ? 0 : exclusiveMaximum.hashCode());
-        result = prime * result + ((exclusiveMinimum == null) ? 0 : exclusiveMinimum.hashCode());
+        result = prime * result + (exclusiveMaximum ? 13:31);
+        result = prime * result + (exclusiveMinimum ? 13:31);
         result = prime * result + ((getter == null) ? 0 : getter.hashCode());
-        result = prime * result + ((hasMore == null) ? 0 : hasMore.hashCode());
-        result = prime * result + ((hasMoreNonReadOnly == null) ? 0 : hasMoreNonReadOnly.hashCode());
-        result = prime * result + ((isContainer == null) ? 0 : isContainer.hashCode());
+        result = prime * result + (hasMore  ? 13:31);
+        result = prime * result + ((hasMoreNonReadOnly  ? 13:31));
+        result = prime * result + ((isContainer  ? 13:31));
         result = prime * result + (isEnum ? 1231 : 1237);
-        result = prime * result + ((isNotContainer == null) ? 0 : isNotContainer.hashCode());
-        result = prime * result + ((isPrimitiveType == null) ? 0 : isPrimitiveType.hashCode());
-        result = prime * result + ((isReadOnly == null) ? 0 : isReadOnly.hashCode());
+        result = prime * result + ((isNotContainer ? 13:31));
+        result = prime * result + ((isPrimitiveType  ? 13:31));
+        result = prime * result + ((isReadOnly  ? 13:31));
         result = prime * result + ((items == null) ? 0 : items.hashCode());
         result = prime * result + ((jsonSchema == null) ? 0 : jsonSchema.hashCode());
         result = prime * result + ((max == null) ? 0 : max.hashCode());
@@ -95,24 +95,24 @@ public class CodegenProperty implements Cloneable {
         result = prime * result + ((minimum == null) ? 0 : minimum.hashCode());
         result = prime * result + ((name == null) ? 0 : name.hashCode());
         result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
-        result = prime * result + ((required == null) ? 0 : required.hashCode());
-        result = prime * result + ((secondaryParam == null) ? 0 : secondaryParam.hashCode());
+        result = prime * result + ((required  ? 13:31));
+        result = prime * result + ((secondaryParam ? 13:31));
         result = prime * result + ((setter == null) ? 0 : setter.hashCode());
         result = prime * result + ((unescapedDescription == null) ? 0 : unescapedDescription.hashCode());
         result = prime * result + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
-        result = prime * result + ((hasValidation == null) ? 0 : hasValidation.hashCode());
-        result = prime * result + ((isString == null) ? 0 : isString.hashCode());
-        result = prime * result + ((isInteger == null) ? 0 : isInteger.hashCode());
-        result = prime * result + ((isLong == null) ? 0 : isLong.hashCode());
-        result = prime * result + ((isFloat == null) ? 0 : isFloat.hashCode());
-        result = prime * result + ((isDouble == null) ? 0 : isDouble.hashCode());
-        result = prime * result + ((isByteArray == null) ? 0 : isByteArray.hashCode());
-        result = prime * result + ((isBinary == null) ? 0 : isBinary.hashCode());
-        result = prime * result + ((isBoolean == null) ? 0 : isBoolean.hashCode());
-        result = prime * result + ((isDate == null) ? 0 : isDate.hashCode());
-        result = prime * result + ((isDateTime == null) ? 0 : isDateTime.hashCode());
-        result = prime * result + ((isMapContainer == null) ? 0 : isMapContainer.hashCode());
-        result = prime * result + ((isListContainer == null) ? 0 : isListContainer.hashCode());
+        result = prime * result + ((hasValidation  ? 13:31));
+        result = prime * result + ((isString  ? 13:31));
+        result = prime * result + ((isInteger ? 13:31));
+        result = prime * result + ((isLong  ?13:31));
+        result = prime * result + ((isFloat ? 13:31));
+        result = prime * result + ((isDouble  ? 13:31));
+        result = prime * result + ((isByteArray  ? 13:31));
+        result = prime * result + ((isBinary  ? 13:31));
+        result = prime * result + ((isBoolean  ? 13:31));
+        result = prime * result + ((isDate  ? 13:31));
+        result = prime * result + ((isDateTime ? 13:31));
+        result = prime * result + ((isMapContainer ? 13:31));
+        result = prime * result + ((isListContainer  ? 13:31));
         result = prime * result + Objects.hashCode(isInherited);
         result = prime * result + Objects.hashCode(nameInCamelCase);
         result = prime * result + Objects.hashCode(enumName);
@@ -191,31 +191,31 @@ public class CodegenProperty implements Cloneable {
         if (this.maximum != other.maximum && (this.maximum == null || !this.maximum.equals(other.maximum))) {
             return false;
         }
-        if (this.exclusiveMinimum != other.exclusiveMinimum && (this.exclusiveMinimum == null || !this.exclusiveMinimum.equals(other.exclusiveMinimum))) {
+        if (this.exclusiveMinimum != other.exclusiveMinimum) {
             return false;
         }
-        if (this.exclusiveMaximum != other.exclusiveMaximum && (this.exclusiveMaximum == null || !this.exclusiveMaximum.equals(other.exclusiveMaximum))) {
+        if (this.exclusiveMaximum != other.exclusiveMaximum) {
             return false;
         }
-        if (this.required != other.required && (this.required == null || !this.required.equals(other.required))) {
+        if (this.required != other.required) {
             return false;
         }
-        if (this.secondaryParam != other.secondaryParam && (this.secondaryParam == null || !this.secondaryParam.equals(other.secondaryParam))) {
+        if (this.secondaryParam != other.secondaryParam) {
             return false;
         }
-        if (this.isPrimitiveType != other.isPrimitiveType && (this.isPrimitiveType == null || !this.isPrimitiveType.equals(other.isPrimitiveType))) {
+        if (this.isPrimitiveType != other.isPrimitiveType) {
             return false;
         }
-        if (this.isContainer != other.isContainer && (this.isContainer == null || !this.isContainer.equals(other.isContainer))) {
+        if (this.isContainer != other.isContainer) {
             return false;
         }
-        if (this.isNotContainer != other.isNotContainer && (this.isNotContainer == null || !this.isNotContainer.equals(other.isNotContainer))) {
+        if (this.isNotContainer != other.isNotContainer) {
             return false;
         }
         if (this.isEnum != other.isEnum) {
             return false;
         }
-        if (this.isReadOnly != other.isReadOnly && (this.isReadOnly == null || !this.isReadOnly.equals(other.isReadOnly))) {
+        if (this.isReadOnly != other.isReadOnly) {
             return false;
         }
         if (this._enum != other._enum && (this._enum == null || !this._enum.equals(other._enum))) {
@@ -229,45 +229,45 @@ public class CodegenProperty implements Cloneable {
             return false;
         }
 
-        if (this.hasValidation != other.hasValidation && (this.hasValidation == null || !this.hasValidation.equals(other.hasValidation))) {
+        if (this.hasValidation != other.hasValidation) {
             return false;
         }
 
-        if (this.isString != other.isString && (this.isString == null || !this.isString.equals(other.isString))) {
+        if (this.isString != other.isString) {
             return false;
         }
 
-        if (this.isInteger != other.isInteger && (this.isInteger == null || !this.isInteger.equals(other.isInteger))) {
+        if (this.isInteger != other.isInteger) {
             return false;
         }
-        if (this.isLong != other.isLong && (this.isLong == null || !this.isLong.equals(other.isLong))) {
+        if (this.isLong != other.isLong) {
             return false;
         }
-        if (this.isFloat != other.isFloat && (this.isFloat == null || !this.isFloat.equals(other.isFloat))) {
+        if (this.isFloat != other.isFloat) {
             return false;
         }
-        if (this.isDouble != other.isDouble && (this.isDouble == null || !this.isDouble.equals(other.isDouble))) {
+        if (this.isDouble != other.isDouble) {
             return false;
         }
-        if (this.isByteArray != other.isByteArray && (this.isByteArray == null || !this.isByteArray.equals(other.isByteArray))) {
+        if (this.isByteArray != other.isByteArray) {
             return false;
         }
-        if (this.isBoolean != other.isBoolean && (this.isBoolean == null || !this.isBoolean.equals(other.isBoolean))) {
+        if (this.isBoolean != other.isBoolean) {
             return false;
         }
-        if (this.isDate != other.isDate && (this.isDate == null || !this.isDate.equals(other.isDate))) {
+        if (this.isDate != other.isDate) {
             return false;
         }
-        if (this.isDateTime != other.isDateTime && (this.isDateTime == null || !this.isDateTime.equals(other.isDateTime))) {
+        if (this.isDateTime != other.isDateTime) {
             return false;
         }
-        if (this.isBinary != other.isBinary && (this.isBinary == null || !this.isBinary.equals(other.isBinary))) {
+        if (this.isBinary != other.isBinary) {
             return false;
         }
-        if (this.isListContainer != other.isListContainer && (this.isListContainer == null || !this.isListContainer.equals(other.isListContainer))) {
+        if (this.isListContainer != other.isListContainer) {
             return false;
         }
-        if (this.isMapContainer != other.isMapContainer && (this.isMapContainer == null || !this.isMapContainer.equals(other.isMapContainer))) {
+        if (this.isMapContainer != other.isMapContainer) {
             return false;
         }
         if (!Objects.equals(this.isInherited, other.isInherited)) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -870,7 +870,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
             if (os != null && os.size() > 0) {
                 CodegenOperation op = os.get(os.size() - 1);
-                op.hasMore = null;
+                op.hasMore = false;
             }
         }
         return operations;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -863,7 +863,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             int count = 0, numVars = codegenProperties.size();
             for(CodegenProperty codegenProperty : codegenProperties) {
                 count += 1;
-                codegenProperty.hasMore = (count < numVars) ? true : null;
+                codegenProperty.hasMore = (count < numVars) ? true : false;
             }
             codegenModel.vars = codegenProperties;
         }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -345,7 +345,7 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
             opsByPathEntry.put("path", entry.getKey());
             opsByPathEntry.put("operation", entry.getValue());
             List<CodegenOperation> operationsForThisPath = Lists.newArrayList(entry.getValue());
-            operationsForThisPath.get(operationsForThisPath.size() - 1).hasMore = null;
+            operationsForThisPath.get(operationsForThisPath.size() - 1).hasMore = false;
             if (opsByPathList.size() < opsByPath.asMap().size()) {
                 opsByPathEntry.put("hasMore", "true");
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -927,14 +927,14 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
             // set vendor-extension: x-codegen-hasMoreRequired
             CodegenProperty lastRequired = null;
             for (CodegenProperty var : cm.vars) {
-                if (var.required != null && var.required) {
+                if (var.required) {
                     lastRequired = var;
                 }
             }
             for (CodegenProperty var : cm.vars) {
                 if (var == lastRequired) {
                     var.vendorExtensions.put("x-codegen-hasMoreRequired", false);
-                } else if (var.required != null && var.required) {
+                } else if (var.required) {
                     var.vendorExtensions.put("x-codegen-hasMoreRequired", true);
                 }
             }
@@ -996,7 +996,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
                 int count = 0, numVars = codegenProperties.size();
                 for(CodegenProperty codegenProperty : codegenProperties) {
                     count += 1;
-                    codegenProperty.hasMore = (count < numVars) ? true : null;
+                    codegenProperty.hasMore = (count < numVars) ? true : false;
                 }
                 codegenModel.vars = codegenProperties;
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -231,7 +231,7 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
             opsByPathEntry.put("path", entry.getKey());
             opsByPathEntry.put("operation", entry.getValue());
             List<CodegenOperation> operationsForThisPath = Lists.newArrayList(entry.getValue());
-            operationsForThisPath.get(operationsForThisPath.size() - 1).hasMore = null;
+            operationsForThisPath.get(operationsForThisPath.size() - 1).hasMore = false;
             if (opsByPathList.size() < opsByPath.asMap().size()) {
                 opsByPathEntry.put("hasMore", "true");
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -621,7 +621,7 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
             int count = 0, numVars = codegenProperties.size();
             for(CodegenProperty codegenProperty : codegenProperties) {
                 count += 1;
-                codegenProperty.hasMore = (count < numVars) ? true : null;
+                codegenProperty.hasMore = (count < numVars) ? true : false;
             }
             codegenModel.vars = codegenProperties;
         }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpModelTest.java
@@ -47,7 +47,7 @@ public class CSharpModelTest {
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -70,7 +70,7 @@ public class CSharpModelTest {
         Assert.assertEquals(property.datatype, "Collection<string>");
         Assert.assertEquals(property.baseType, "Collection");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -96,7 +96,7 @@ public class CSharpModelTest {
         Assert.assertEquals(property.baseType, "Collection",
                 "returnICollection option should not modify property baseType");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -153,8 +153,8 @@ public class CSharpModelTest {
         Assert.assertEquals(property3.name, "CreatedAt");
         Assert.assertNull(property3.defaultValue);
         Assert.assertEquals(property3.baseType, "DateTime?");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -191,9 +191,9 @@ public class CSharpModelTest {
         Assert.assertEquals(property2.name, "Urls");
         Assert.assertNull(property2.defaultValue);
         Assert.assertEquals(property2.baseType, "List");
-        Assert.assertNull(property2.hasMore);
+        Assert.assertFalse(property2.hasMore);
         Assert.assertEquals(property2.containerType, "array");
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
         Assert.assertTrue(property2.isContainer);
     }
@@ -219,7 +219,7 @@ public class CSharpModelTest {
         Assert.assertEquals(property1.name, "Translations");
         Assert.assertEquals(property1.baseType, "Dictionary");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
         Assert.assertTrue(property1.isPrimitiveType);
     }
@@ -242,7 +242,7 @@ public class CSharpModelTest {
         Assert.assertEquals(property1.datatype, "Children");
         Assert.assertEquals(property1.name, "Children");
         Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -267,7 +267,7 @@ public class CSharpModelTest {
         Assert.assertEquals(property1.name, "Children");
         Assert.assertEquals(property1.baseType, "List");
         Assert.assertEquals(property1.containerType, "array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -293,9 +293,9 @@ public class CSharpModelTest {
         Assert.assertEquals(property1.name, "Children");
         Assert.assertEquals(property1.baseType, "Dictionary");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertNull(property1.isNotContainer);
+        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/go/GoModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/go/GoModelTest.java
@@ -69,8 +69,8 @@ public class GoModelTest {
         Assert.assertEquals(property3.name, "CreatedAt");
         Assert.assertEquals(property3.defaultValue, "null");
         Assert.assertEquals(property3.baseType, "time.Time");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -106,9 +106,9 @@ public class GoModelTest {
         Assert.assertEquals(property2.datatype, "[]string");
         Assert.assertEquals(property2.name, "Urls");
         Assert.assertEquals(property2.baseType, "array");
-        Assert.assertNull(property2.hasMore);
+        Assert.assertFalse(property2.hasMore);
         Assert.assertEquals(property2.containerType, "array");
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
         Assert.assertTrue(property2.isContainer);
     }
@@ -134,7 +134,7 @@ public class GoModelTest {
         Assert.assertEquals(property1.name, "Translations");
         Assert.assertEquals(property1.baseType, "map");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
         Assert.assertTrue(property1.isPrimitiveType);
     }
@@ -157,7 +157,7 @@ public class GoModelTest {
         Assert.assertEquals(property1.datatype, "Children");
         Assert.assertEquals(property1.name, "Children");
         Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -181,7 +181,7 @@ public class GoModelTest {
         Assert.assertEquals(property1.name, "Children");
         Assert.assertEquals(property1.baseType, "array");
         Assert.assertEquals(property1.containerType, "array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -207,9 +207,9 @@ public class GoModelTest {
         Assert.assertEquals(property1.name, "Children");
         Assert.assertEquals(property1.baseType, "map");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertNull(property1.isNotContainer);
+        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -81,8 +81,8 @@ public class JavaModelTest {
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
         Assert.assertEquals(property3.baseType, "Date");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -111,7 +111,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, "new ArrayList<String>()");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -139,7 +139,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, "new HashMap<String, String>()");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -167,7 +167,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, "new HashMap<String, List<Pet>>()");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -189,7 +189,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, "new ArrayList<List<Pet>>()");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -213,7 +213,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.name, "children");
         Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "Children");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
 
@@ -240,7 +240,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, "new ArrayList<Children>()");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -268,9 +268,9 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, "new HashMap<String, Children>()");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
-        Assert.assertNull(property.isNotContainer);
+        Assert.assertFalse(property.isNotContainer);
 
     }
 
@@ -329,7 +329,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.name, "NAME");
         Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "String");
-        Assert.assertNull(property.hasMore);
+        Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
@@ -355,7 +355,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.name, "pId");
         Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "String");
-        Assert.assertNull(property.hasMore);
+        Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
@@ -381,7 +381,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.name, "atTName");
         Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "String");
-        Assert.assertNull(property.hasMore);
+        Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
@@ -443,8 +443,8 @@ public class JavaModelTest {
         Assert.assertEquals(property.name, "inputBinaryData");
         Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "byte[]");
-        Assert.assertNull(property.hasMore);
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.hasMore);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
 
@@ -468,7 +468,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.name, "u");
         Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "String");
-        Assert.assertNull(property.hasMore);
+        Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.isNotContainer);
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavaScriptModelEnumTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavaScriptModelEnumTest.java
@@ -137,7 +137,7 @@ public class JavaScriptModelEnumTest {
         Assert.assertEquals(prope.datatypeWithEnum, "EnumIntegerEnum");
         Assert.assertEquals(prope.enumName, "EnumIntegerEnum");
         Assert.assertTrue(prope.isEnum);
-        Assert.assertNull(prope.isContainer);
+        Assert.assertFalse(prope.isContainer);
         Assert.assertNull(prope.items);
         Assert.assertEquals(prope.allowableValues.get("values"), Arrays.asList(1, -1));
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavaScriptModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/javascript/JavaScriptModelTest.java
@@ -81,8 +81,8 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, null);
         Assert.assertEquals(property3.baseType, "Date");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -112,7 +112,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.defaultValue, /*"[]"*/null);
         Assert.assertEquals(property.baseType, "Array");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -141,7 +141,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.defaultValue, /*"{}"*/null);
         Assert.assertEquals(property.baseType, "Object");
         Assert.assertEquals(property.containerType, "map");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -170,7 +170,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.defaultValue, /*"{}"*/null);
         Assert.assertEquals(property.baseType, "Object");
         Assert.assertEquals(property.containerType, "map");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -193,7 +193,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.defaultValue, /*"[]"*/null);
         Assert.assertEquals(property.baseType, "Array");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -217,7 +217,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.name, "children");
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "Children");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
 
@@ -246,7 +246,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.defaultValue, /*"[]"*/null);
         Assert.assertEquals(property.baseType, "Array");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -276,9 +276,9 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.defaultValue, /*"{}"*/ null);
         Assert.assertEquals(property.baseType, "Object");
         Assert.assertEquals(property.containerType, "map");
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
-        Assert.assertNull(property.isNotContainer);
+        Assert.assertFalse(property.isNotContainer);
     }
 
     @Test(description = "convert an array model")
@@ -336,7 +336,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.name, "NAME");
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "String");
-        Assert.assertNull(property.hasMore);
+        Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
@@ -362,7 +362,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.name, "pId");
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "String");
-        Assert.assertNull(property.hasMore);
+        Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
@@ -424,8 +424,8 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.name, "inputBinaryData");
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "String");
-        Assert.assertNull(property.hasMore);
-        Assert.assertNull(property.required);
+        Assert.assertFalse(property.hasMore);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isNotContainer);
     }
 
@@ -449,7 +449,7 @@ public class JavaScriptModelTest {
         Assert.assertEquals(property.name, "u");
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "String");
-        Assert.assertNull(property.hasMore);
+        Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.isNotContainer);
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/objc/ObjcModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/objc/ObjcModelTest.java
@@ -36,7 +36,7 @@ public class ObjcModelTest {
         Assert.assertEquals(property1.name, "translations");
         Assert.assertEquals(property1.baseType, "NSDictionary");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
     
@@ -87,8 +87,8 @@ public class ObjcModelTest {
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertNull(property3.defaultValue);
         Assert.assertEquals(property3.baseType, "NSDate");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -125,9 +125,9 @@ public class ObjcModelTest {
         Assert.assertEquals(property2.name, "urls");
         Assert.assertNull(property2.defaultValue);
         Assert.assertEquals(property2.baseType, "NSArray");
-        Assert.assertNull(property2.hasMore);
+        Assert.assertFalse(property2.hasMore);
         Assert.assertEquals(property2.containerType, "array");
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
         Assert.assertTrue(property2.isContainer);
     }
@@ -153,7 +153,7 @@ public class ObjcModelTest {
         Assert.assertEquals(property1.name, "translations");
         Assert.assertEquals(property1.baseType, "NSDictionary");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
         Assert.assertTrue(property1.isPrimitiveType);
     }
@@ -177,7 +177,7 @@ public class ObjcModelTest {
         Assert.assertEquals(property1.datatype, "SWGChildren*");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "SWGChildren");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -202,7 +202,7 @@ public class ObjcModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "NSArray");
         Assert.assertEquals(property1.containerType, "array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -228,9 +228,9 @@ public class ObjcModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "NSDictionary");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertNull(property1.isNotContainer);
+        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")
@@ -299,7 +299,7 @@ public class ObjcModelTest {
         final Model definition = model.getDefinitions().get("AnimalFarm");
         final CodegenModel codegenModel = codegen.fromModel("AnimalFarm",definition);
 
-        Assert.assertEquals(codegenModel.isArrayModel,Boolean.TRUE);
+        Assert.assertEquals(codegenModel.isArrayModel, true);
         Assert.assertEquals(codegenModel.arrayModelType,"SWGAnimal");
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
@@ -78,8 +78,8 @@ public class PhpModelTest {
         Assert.assertEquals(property3.name, "created_at");
         Assert.assertEquals(property3.defaultValue, null);
         Assert.assertEquals(property3.baseType, "\\DateTime");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -115,9 +115,9 @@ public class PhpModelTest {
         Assert.assertEquals(property2.datatype, "string[]");
         Assert.assertEquals(property2.name, "urls");
         Assert.assertEquals(property2.baseType, "array");
-        Assert.assertNull(property2.hasMore);
+        Assert.assertFalse(property2.hasMore);
         Assert.assertEquals(property2.containerType, "array");
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
         Assert.assertTrue(property2.isContainer);
     }
@@ -143,7 +143,7 @@ public class PhpModelTest {
         Assert.assertEquals(property1.name, "translations");
         Assert.assertEquals(property1.baseType, "map");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
         Assert.assertTrue(property1.isPrimitiveType);
     }
@@ -166,7 +166,7 @@ public class PhpModelTest {
         Assert.assertEquals(property1.datatype, "\\Swagger\\Client\\Model\\Children");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -190,7 +190,7 @@ public class PhpModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "array");
         Assert.assertEquals(property1.containerType, "array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -217,9 +217,9 @@ public class PhpModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "map");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertNull(property1.isNotContainer);
+        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")
@@ -320,7 +320,7 @@ public class PhpModelTest {
         Assert.assertEquals(prope.datatypeWithEnum, "ENUM_INTEGER");
         Assert.assertEquals(prope.enumName, "ENUM_INTEGER");
         Assert.assertTrue(prope.isEnum);
-        Assert.assertNull(prope.isContainer);
+        Assert.assertFalse(prope.isContainer);
         Assert.assertNull(prope.items);
         Assert.assertEquals(prope.allowableValues.get("values"), Arrays.asList(1, -1));
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/python/PythonTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/python/PythonTest.java
@@ -95,8 +95,8 @@ public class PythonTest {
         Assert.assertEquals(property3.name, "created_at");
         Assert.assertNull(property3.defaultValue);
         Assert.assertEquals(property3.baseType, "datetime");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -133,9 +133,9 @@ public class PythonTest {
         Assert.assertEquals(property2.name, "urls");
         Assert.assertNull(property2.defaultValue);
         Assert.assertEquals(property2.baseType, "list");
-        Assert.assertNull(property2.hasMore);
+        Assert.assertFalse(property2.hasMore);
         Assert.assertEquals(property2.containerType, "array");
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
         Assert.assertTrue(property2.isContainer);
     }
@@ -161,7 +161,7 @@ public class PythonTest {
         Assert.assertEquals(property1.name, "translations");
         Assert.assertEquals(property1.baseType, "dict");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
         Assert.assertTrue(property1.isPrimitiveType);
     }
@@ -184,7 +184,7 @@ public class PythonTest {
         Assert.assertEquals(property1.datatype, "Children");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -209,7 +209,7 @@ public class PythonTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "list");
         Assert.assertEquals(property1.containerType, "array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -235,9 +235,9 @@ public class PythonTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "dict");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertNull(property1.isNotContainer);
+        Assert.assertFalse(property1.isNotContainer);
     }
 
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/scala/ScalaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/scala/ScalaModelTest.java
@@ -70,8 +70,8 @@ public class ScalaModelTest {
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
         Assert.assertEquals(property3.baseType, "DateTime");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -100,7 +100,7 @@ public class ScalaModelTest {
         Assert.assertEquals(property1.defaultValue, "new ListBuffer[String]() ");
         Assert.assertEquals(property1.baseType, "List");
         Assert.assertEquals(property1.containerType, "array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -128,7 +128,7 @@ public class ScalaModelTest {
         Assert.assertEquals(property1.defaultValue, "new HashMap[String, String]() ");
         Assert.assertEquals(property1.baseType, "Map");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -153,7 +153,7 @@ public class ScalaModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.defaultValue, "null");
         Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -181,7 +181,7 @@ public class ScalaModelTest {
         Assert.assertEquals(property1.defaultValue, "new ListBuffer[Children]() ");
         Assert.assertEquals(property1.baseType, "List");
         Assert.assertEquals(property1.containerType, "array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -210,9 +210,9 @@ public class ScalaModelTest {
         Assert.assertEquals(property1.defaultValue, "new HashMap[String, Children]() ");
         Assert.assertEquals(property1.baseType, "Map");
         Assert.assertEquals(property1.containerType, "map");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertNull(property1.isNotContainer);
+        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift/SwiftModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift/SwiftModelTest.java
@@ -62,7 +62,7 @@ public class SwiftModelTest {
         Assert.assertNull(property3.defaultValue);
         Assert.assertEquals(property3.baseType, "NSDate");
         Assert.assertTrue(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
 
         final CodegenProperty property4 = cm.vars.get(3);
@@ -72,7 +72,7 @@ public class SwiftModelTest {
         Assert.assertNull(property4.defaultValue);
         Assert.assertEquals(property4.baseType, "NSData");
         Assert.assertTrue(property4.hasMore);
-        Assert.assertNull(property4.required);
+        Assert.assertFalse(property4.required);
         Assert.assertTrue(property4.isNotContainer);
 
         final CodegenProperty property5 = cm.vars.get(4);
@@ -82,7 +82,7 @@ public class SwiftModelTest {
         Assert.assertNull(property5.defaultValue);
         Assert.assertEquals(property5.baseType, "NSData");
         Assert.assertTrue(property5.hasMore);
-        Assert.assertNull(property5.required);
+        Assert.assertFalse(property5.required);
         Assert.assertTrue(property5.isNotContainer);
 
         final CodegenProperty property6 = cm.vars.get(5);
@@ -91,8 +91,8 @@ public class SwiftModelTest {
         Assert.assertEquals(property6.name, "uuid");
         Assert.assertNull(property6.defaultValue);
         Assert.assertEquals(property6.baseType, "NSUUID");
-        Assert.assertNull(property6.hasMore);
-        Assert.assertNull(property6.required);
+        Assert.assertFalse(property6.hasMore);
+        Assert.assertFalse(property6.required);
         Assert.assertTrue(property6.isNotContainer);
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3ModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3ModelTest.java
@@ -64,7 +64,7 @@ public class Swift3ModelTest {
         Assert.assertNull(property3.defaultValue);
         Assert.assertEquals(property3.baseType, "Date");
         Assert.assertTrue(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
 
         final CodegenProperty property4 = cm.vars.get(3);
@@ -74,7 +74,7 @@ public class Swift3ModelTest {
         Assert.assertNull(property4.defaultValue);
         Assert.assertEquals(property4.baseType, "Data");
         Assert.assertTrue(property4.hasMore);
-        Assert.assertNull(property4.required);
+        Assert.assertFalse(property4.required);
         Assert.assertTrue(property4.isNotContainer);
 
         final CodegenProperty property5 = cm.vars.get(4);
@@ -84,7 +84,7 @@ public class Swift3ModelTest {
         Assert.assertNull(property5.defaultValue);
         Assert.assertEquals(property5.baseType, "Data");
         Assert.assertTrue(property5.hasMore);
-        Assert.assertNull(property5.required);
+        Assert.assertFalse(property5.required);
         Assert.assertTrue(property5.isNotContainer);
 
         final CodegenProperty property6 = cm.vars.get(5);
@@ -93,8 +93,8 @@ public class Swift3ModelTest {
         Assert.assertEquals(property6.name, "uuid");
         Assert.assertNull(property6.defaultValue);
         Assert.assertEquals(property6.baseType, "UUID");
-        Assert.assertNull(property6.hasMore);
-        Assert.assertNull(property6.required);
+        Assert.assertFalse(property6.hasMore);
+        Assert.assertFalse(property6.required);
         Assert.assertTrue(property6.isNotContainer);
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -70,8 +70,8 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -105,8 +105,8 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property2.datatype, "Array<string>");
         Assert.assertEquals(property2.name, "urls");
         Assert.assertEquals(property2.baseType, "Array");
-        Assert.assertNull(property2.hasMore);
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.hasMore);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isContainer);
     }
 
@@ -129,7 +129,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.defaultValue, "null");
         Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -153,7 +153,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property1.datatype, "Array<Children>");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 
@@ -233,7 +233,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(prope.datatypeWithEnum, "EnumIntegerEnum");
         Assert.assertEquals(prope.enumName, "EnumIntegerEnum");
         Assert.assertTrue(prope.isEnum);
-        Assert.assertNull(prope.isContainer);
+        Assert.assertFalse(prope.isContainer);
         Assert.assertNull(prope.items);
         Assert.assertEquals(prope.allowableValues.get("values"), Arrays.asList(1, -1));
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
@@ -63,8 +63,8 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -98,8 +98,8 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property2.datatype, "Array<string>");
         Assert.assertEquals(property2.name, "urls");
         Assert.assertEquals(property2.baseType, "Array");
-        Assert.assertNull(property2.hasMore);
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.hasMore);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isContainer);
     }
 
@@ -122,7 +122,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.defaultValue, "null");
         Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -146,7 +146,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property1.datatype, "Array<Children>");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular2/TypeScriptAngular2ModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular2/TypeScriptAngular2ModelTest.java
@@ -64,8 +64,8 @@ public class TypeScriptAngular2ModelTest {
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -99,8 +99,8 @@ public class TypeScriptAngular2ModelTest {
         Assert.assertEquals(property2.datatype, "Array<string>");
         Assert.assertEquals(property2.name, "urls");
         Assert.assertEquals(property2.baseType, "Array");
-        Assert.assertNull(property2.hasMore);
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.hasMore);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isContainer);
     }
 
@@ -123,7 +123,7 @@ public class TypeScriptAngular2ModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.defaultValue, "null");
         Assert.assertEquals(property1.baseType, "models.Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -147,7 +147,7 @@ public class TypeScriptAngular2ModelTest {
         Assert.assertEquals(property1.datatype, "Array<models.Children>");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
@@ -63,8 +63,8 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
-        Assert.assertNull(property3.hasMore);
-        Assert.assertNull(property3.required);
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
     }
 
@@ -98,8 +98,8 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property2.datatype, "Array<string>");
         Assert.assertEquals(property2.name, "urls");
         Assert.assertEquals(property2.baseType, "Array");
-        Assert.assertNull(property2.hasMore);
-        Assert.assertNull(property2.required);
+        Assert.assertFalse(property2.hasMore);
+        Assert.assertFalse(property2.required);
         Assert.assertTrue(property2.isContainer);
     }
 
@@ -121,7 +121,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property1.datatype, "Children");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Children");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isNotContainer);
     }
 
@@ -145,7 +145,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property1.datatype, "Array<Children>");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Array");
-        Assert.assertNull(property1.required);
+        Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
 


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

There is no good reason to use Boolean instead of boolean.
Using Boolean will lead to handling "null" state which is confusing.
This change replaces Boolean properties to boolean.