### PR TITLE
Add option to re-enable common prefix for enum names

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -117,6 +117,9 @@ public class Generate implements Runnable {
 
     @Option(name = {"--http-user-agent"}, title = "http user agent", description = CodegenConstants.HTTP_USER_AGENT_DESC)
     private String httpUserAgent;
+    
+    @Option(name = {"--use-enum-common-prefix"}, title = "use enum common prefix", description = CodegenConstants.USE_ENUM_COMMON_PREFIX)
+    private Boolean useEnumCommonPrefix;
 
     @Override
     public void run() {
@@ -209,6 +212,10 @@ public class Generate implements Runnable {
 
         if (isNotEmpty(httpUserAgent)) {
             configurator.setHttpUserAgent(httpUserAgent);
+        }
+
+        if (useEnumCommonPrefix != null) {
+            configurator.setUseEnumCommonPrefix(useEnumCommonPrefix);
         }
 
         applySystemPropertiesKvp(systemProperties, configurator);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -133,4 +133,6 @@ public class CodegenConstants {
     public static final String GENERATE_PROPERTY_CHANGED = "generatePropertyChanged";
     public static final String GENERATE_PROPERTY_CHANGED_DESC = "Specifies that models support raising property changed events.";
 
+    public static final String USE_ENUM_COMMON_PREFIX = "useEnumCommonPrefix";
+    public static final String USE_ENUM_COMMON_PREFIX_DESC = "Use common prefix from Enum names.";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -108,6 +108,7 @@ public class DefaultCodegen {
     protected String gitUserId, gitRepoId, releaseNote;
     protected String httpUserAgent;
     protected Boolean hideGenerationTimestamp = true;
+    protected Boolean useEnumCommonPrefix = false;
     // How to encode special characters like $
     // They are translated to words like "Dollar" and prefixed with '
     // Then translated back during JSON encoding and decoding
@@ -148,6 +149,10 @@ public class DefaultCodegen {
             this.setModelNameSuffix((String) additionalProperties.get(CodegenConstants.MODEL_NAME_SUFFIX));
         }
 
+        if(additionalProperties.containsKey(CodegenConstants.USE_ENUM_COMMON_PREFIX)){
+            LOGGER.info(" ##### additionalProperties.get(CodegenConstants.USE_ENUM_COMMON_PREFIX)" + (String) additionalProperties.get(CodegenConstants.USE_ENUM_COMMON_PREFIX));
+            this.setUseEnumCommonPrefix(Boolean.valueOf((String) additionalProperties.get(CodegenConstants.USE_ENUM_COMMON_PREFIX)));
+        }
     }
 
     // override with any special post-processing for all models
@@ -219,7 +224,12 @@ public class DefaultCodegen {
                 Map<String, Object> allowableValues = cm.allowableValues;
                 List<Object> values = (List<Object>) allowableValues.get("values");
                 List<Map<String, String>> enumVars = new ArrayList<Map<String, String>>();
-                String commonPrefix = findCommonPrefixOfVars(values);
+                String commonPrefix;
+                if (useEnumCommonPrefix) { // find common prefix for enum names
+                    commonPrefix = findCommonPrefixOfVars(values);
+                } else {
+                    commonPrefix = ""; 
+                }
                 int truncateIdx = commonPrefix.length();
                 for (Object value : values) {
                     Map<String, String> enumVar = new HashMap<String, String>();
@@ -3045,6 +3055,24 @@ public class DefaultCodegen {
     }
 
     /**
+     * Set boolean value to enable common prefix for enum names
+     *
+     * @param useEnumCommonPrefix Boolean value for useEnumCommonPrefix
+     */
+    public void setUseEnumCommonPrefix(Boolean useEnumCommonPrefix) {
+        this.useEnumCommonPrefix = useEnumCommonPrefix;
+    }
+
+    /**
+     * Get boolean value to enable common prefix for enum names
+     *
+     * @return True if using common prefix for enum names
+     */
+    public Boolean getUseEnumCommonPrefix() {
+        return useEnumCommonPrefix;
+    }
+
+    /**
      * Set Git user ID.
      *
      * @param gitUserId Git user ID 
@@ -3300,7 +3328,13 @@ public class DefaultCodegen {
 
         // put "enumVars" map into `allowableValues", including `name` and `value`
         List<Map<String, String>> enumVars = new ArrayList<Map<String, String>>();
-        String commonPrefix = findCommonPrefixOfVars(values);
+        LOGGER.info("### useEnumCommonPrefix = " + useEnumCommonPrefix);
+        String commonPrefix;
+        if (useEnumCommonPrefix) { // use common prefix for enum names
+            commonPrefix = findCommonPrefixOfVars(values);
+        } else {
+            commonPrefix = "";
+        }
         int truncateIdx = commonPrefix.length();
         for (Object value : values) {
             Map<String, String> enumVar = new HashMap<String, String>();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -64,6 +64,7 @@ public class CodegenConfigurator {
     private String gitRepoId="GIT_REPO_ID";
     private String releaseNote="Minor update";
     private String httpUserAgent;
+    private Boolean useEnumCommonPrefix = true;
 
     private final Map<String, String> dynamicProperties = new HashMap<String, String>(); //the map that holds the JsonAnySetter/JsonAnyGetter values
 
@@ -342,6 +343,15 @@ public class CodegenConfigurator {
         return this;
     }
 
+    public Boolean getUseEnumCommonPrefix() {
+        return useEnumCommonPrefix;
+    }
+
+    public CodegenConfigurator setUseEnumCommonPrefix(Boolean useEnumCommonPrefix) {
+        this.useEnumCommonPrefix = useEnumCommonPrefix;
+        return this;
+    }
+
     public ClientOptInput toClientOptInput() {
 
         Validate.notEmpty(lang, "language must be specified");
@@ -374,6 +384,10 @@ public class CodegenConfigurator {
         checkAndSetAdditionalProperty(gitRepoId, CodegenConstants.GIT_REPO_ID);
         checkAndSetAdditionalProperty(releaseNote, CodegenConstants.RELEASE_NOTE);
         checkAndSetAdditionalProperty(httpUserAgent, CodegenConstants.HTTP_USER_AGENT);
+
+        // set enum common prefix (boolean)
+        //additionalProperties.put(useEnumCommonPrefix, CodegenConstants.USE_ENUM_COMMON_PREFIX);
+        checkAndSetAdditionalProperty(String.valueOf(useEnumCommonPrefix), CodegenConstants.USE_ENUM_COMMON_PREFIX);
 
         handleDynamicProperties(config);
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -64,7 +64,7 @@ public class CodegenConfigurator {
     private String gitRepoId="GIT_REPO_ID";
     private String releaseNote="Minor update";
     private String httpUserAgent;
-    private Boolean useEnumCommonPrefix = true;
+    private Boolean useEnumCommonPrefix = false;
 
     private final Map<String, String> dynamicProperties = new HashMap<String, String>(); //the map that holds the JsonAnySetter/JsonAnyGetter values
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

We'll disable common prefix for enum names by default and add an option to re-enable it if needed.

For https://github.com/swagger-api/swagger-codegen/issues/4261