### PR TITLE
Fix maximum, minimum for `Integer`

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
@@ -32,7 +32,7 @@ public class CodegenParameter {
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
 	 */
-    public Number maximum;
+    public String maximum;
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor17
 	 */
@@ -40,7 +40,7 @@ public class CodegenParameter {
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor21
 	 */
-    public Number minimum;
+    public String minimum;
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor21
 	 */

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -30,8 +30,8 @@ public class CodegenProperty implements Cloneable {
     public String example;
 
     public String jsonSchema;
-    public Double minimum;
-    public Double maximum;
+    public String minimum;
+    public String maximum;
     public Boolean exclusiveMinimum;
     public Boolean exclusiveMaximum;
     public Boolean hasMore, required, secondaryParam;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1446,7 +1446,7 @@ public class DefaultCodegen {
             AbstractNumericProperty np = (AbstractNumericProperty) p;
             if (np.getMinimum() != null) {
                 if (p instanceof BaseIntegerProperty) { // int, long
-                    property.minimum = String.valueOf(np.getMinimum().intValue());
+                    property.minimum = String.valueOf(np.getMinimum().longValue());
                 } else { // double, decimal
                     property.minimum = String.valueOf(np.getMinimum());
                 }
@@ -1457,7 +1457,7 @@ public class DefaultCodegen {
 
             if (np.getMaximum() != null) {
                 if (p instanceof BaseIntegerProperty) { // int, long
-                    property.maximum = String.valueOf(np.getMaximum().intValue());
+                    property.maximum = String.valueOf(np.getMaximum().longValue());
                 } else { // double, decimal
                     property.maximum = String.valueOf(np.getMaximum());
                 }
@@ -2335,14 +2335,14 @@ public class DefaultCodegen {
 
             // validation
             // handle maximum, minimum properly for int/long by removing the trailing ".0"
-            if ("long".equals(type)) {
-                p.maximum = qp.getMaximum() == null ? null : String.valueOf(qp.getMaximum().intValue());
+            if ("integer".equals(type)) {
+                p.maximum = qp.getMaximum() == null ? null : String.valueOf(qp.getMaximum().longValue());
+                p.minimum = qp.getMinimum() == null ? null : String.valueOf(qp.getMinimum().longValue());
             } else {
                 p.maximum = qp.getMaximum() == null ? null : String.valueOf(qp.getMaximum());
+                p.minimum = qp.getMinimum() == null ? null : String.valueOf(qp.getMinimum());
             }
-            LOGGER.info("#### type = " + type);
             p.exclusiveMaximum = qp.isExclusiveMaximum();
-            p.minimum = String.valueOf(qp.getMinimum());
             p.exclusiveMinimum = qp.isExclusiveMinimum();
             p.maxLength = qp.getMaxLength();
             p.minLength = qp.getMinLength();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1444,8 +1444,28 @@ public class DefaultCodegen {
         String type = getSwaggerType(p);
         if (p instanceof AbstractNumericProperty) {
             AbstractNumericProperty np = (AbstractNumericProperty) p;
-            property.minimum = np.getMinimum();
-            property.maximum = np.getMaximum();
+            if (np.getMinimum() != null) {
+                if (p instanceof BaseIntegerProperty) { // int, long
+                    property.minimum = String.valueOf(np.getMinimum().intValue());
+                } else { // double, decimal
+                    property.minimum = String.valueOf(np.getMinimum());
+                }
+            } else {
+                // set to null (empty) in mustache
+                property.minimum =  null;
+            }
+
+            if (np.getMaximum() != null) {
+                if (p instanceof BaseIntegerProperty) { // int, long
+                    property.maximum = String.valueOf(np.getMaximum().intValue());
+                } else { // double, decimal
+                    property.maximum = String.valueOf(np.getMaximum());
+                }
+            } else {
+                // set to null (empty) in mustache
+                property.maximum =  null;
+            }
+
             property.exclusiveMinimum = np.getExclusiveMinimum();
             property.exclusiveMaximum = np.getExclusiveMaximum();
 
@@ -2314,9 +2334,15 @@ public class DefaultCodegen {
             }
 
             // validation
-            p.maximum = qp.getMaximum();
+            // handle maximum, minimum properly for int/long by removing the trailing ".0"
+            if ("long".equals(type)) {
+                p.maximum = qp.getMaximum() == null ? null : String.valueOf(qp.getMaximum().intValue());
+            } else {
+                p.maximum = qp.getMaximum() == null ? null : String.valueOf(qp.getMaximum());
+            }
+            LOGGER.info("#### type = " + type);
             p.exclusiveMaximum = qp.isExclusiveMaximum();
-            p.minimum = qp.getMinimum();
+            p.minimum = String.valueOf(qp.getMinimum());
             p.exclusiveMinimum = qp.isExclusiveMinimum();
             p.maxLength = qp.getMaxLength();
             p.minLength = qp.getMinLength();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -553,20 +553,20 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
             example = "'" + escapeText(example) + "'";
         } else if ("Integer".equals(type) || "int".equals(type)) {
             if(p.minimum != null) {
-                example = "" + (p.minimum.intValue() + 1);
+                example = "" + (Integer.valueOf(p.minimum) + 1);
             }
             if(p.maximum != null) {
-                example = "" + p.maximum.intValue();
+                example = "" + p.maximum;
             } else if (example == null) {
                 example = "56";
             }
 
         } else if ("Long".equalsIgnoreCase(type)) {
             if(p.minimum != null) {
-                example = "" + (p.minimum.longValue() + 1);
+                example = "" + (Long.valueOf(p.minimum) + 1);
             }
             if(p.maximum != null) {
-                example = "" + p.maximum.longValue();
+                example = "" + p.maximum;
             } else if (example == null) {
                 example = "789";
             }

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -145,20 +145,20 @@ module Petstore
 
       # verify the required parameter 'byte' is set
       fail ArgumentError, "Missing the required parameter 'byte' when calling FakeApi.test_endpoint_parameters" if byte.nil?
-      if !opts[:'integer'].nil? && opts[:'integer'] > 100.0
-        fail ArgumentError, 'invalid value for "opts[:"integer"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 100.0.'
+      if !opts[:'integer'].nil? && opts[:'integer'] > 100
+        fail ArgumentError, 'invalid value for "opts[:"integer"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 100.'
       end
 
-      if !opts[:'integer'].nil? && opts[:'integer'] < 10.0
-        fail ArgumentError, 'invalid value for "opts[:"integer"]" when calling FakeApi.test_endpoint_parameters, must be greater than or equal to 10.0.'
+      if !opts[:'integer'].nil? && opts[:'integer'] < 10
+        fail ArgumentError, 'invalid value for "opts[:"integer"]" when calling FakeApi.test_endpoint_parameters, must be greater than or equal to 10.'
       end
 
-      if !opts[:'int32'].nil? && opts[:'int32'] > 200.0
-        fail ArgumentError, 'invalid value for "opts[:"int32"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 200.0.'
+      if !opts[:'int32'].nil? && opts[:'int32'] > 200
+        fail ArgumentError, 'invalid value for "opts[:"int32"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 200.'
       end
 
-      if !opts[:'int32'].nil? && opts[:'int32'] < 20.0
-        fail ArgumentError, 'invalid value for "opts[:"int32"]" when calling FakeApi.test_endpoint_parameters, must be greater than or equal to 20.0.'
+      if !opts[:'int32'].nil? && opts[:'int32'] < 20
+        fail ArgumentError, 'invalid value for "opts[:"int32"]" when calling FakeApi.test_endpoint_parameters, must be greater than or equal to 20.'
       end
 
       if !opts[:'float'].nil? && opts[:'float'] > 987.6

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -141,12 +141,12 @@ module Petstore
       end
       # verify the required parameter 'order_id' is set
       fail ArgumentError, "Missing the required parameter 'order_id' when calling StoreApi.get_order_by_id" if order_id.nil?
-      if order_id > 5.0
-        fail ArgumentError, 'invalid value for "order_id" when calling StoreApi.get_order_by_id, must be smaller than or equal to 5.0.'
+      if order_id > 5
+        fail ArgumentError, 'invalid value for "order_id" when calling StoreApi.get_order_by_id, must be smaller than or equal to 5.'
       end
 
-      if order_id < 1.0
-        fail ArgumentError, 'invalid value for "order_id" when calling StoreApi.get_order_by_id, must be greater than or equal to 1.0.'
+      if order_id < 1
+        fail ArgumentError, 'invalid value for "order_id" when calling StoreApi.get_order_by_id, must be greater than or equal to 1.'
       end
 
       # resource path

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -145,20 +145,20 @@ module Petstore
     # @return Array for valid properies with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
-      if !@integer.nil? && @integer > 100.0
-        invalid_properties.push("invalid value for 'integer', must be smaller than or equal to 100.0.")
+      if !@integer.nil? && @integer > 100
+        invalid_properties.push("invalid value for 'integer', must be smaller than or equal to 100.")
       end
 
-      if !@integer.nil? && @integer < 10.0
-        invalid_properties.push("invalid value for 'integer', must be greater than or equal to 10.0.")
+      if !@integer.nil? && @integer < 10
+        invalid_properties.push("invalid value for 'integer', must be greater than or equal to 10.")
       end
 
-      if !@int32.nil? && @int32 > 200.0
-        invalid_properties.push("invalid value for 'int32', must be smaller than or equal to 200.0.")
+      if !@int32.nil? && @int32 > 200
+        invalid_properties.push("invalid value for 'int32', must be smaller than or equal to 200.")
       end
 
-      if !@int32.nil? && @int32 < 20.0
-        invalid_properties.push("invalid value for 'int32', must be greater than or equal to 20.0.")
+      if !@int32.nil? && @int32 < 20
+        invalid_properties.push("invalid value for 'int32', must be greater than or equal to 20.")
       end
 
       if @number.nil?
@@ -219,10 +219,10 @@ module Petstore
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      return false if !@integer.nil? && @integer > 100.0
-      return false if !@integer.nil? && @integer < 10.0
-      return false if !@int32.nil? && @int32 > 200.0
-      return false if !@int32.nil? && @int32 < 20.0
+      return false if !@integer.nil? && @integer > 100
+      return false if !@integer.nil? && @integer < 10
+      return false if !@int32.nil? && @int32 > 200
+      return false if !@int32.nil? && @int32 < 20
       return false if @number.nil?
       return false if @number > 543.2
       return false if @number < 32.1
@@ -243,12 +243,12 @@ module Petstore
     # @param [Object] integer Value to be assigned
     def integer=(integer)
 
-      if !integer.nil? && integer > 100.0
-        fail ArgumentError, "invalid value for 'integer', must be smaller than or equal to 100.0."
+      if !integer.nil? && integer > 100
+        fail ArgumentError, "invalid value for 'integer', must be smaller than or equal to 100."
       end
 
-      if !integer.nil? && integer < 10.0
-        fail ArgumentError, "invalid value for 'integer', must be greater than or equal to 10.0."
+      if !integer.nil? && integer < 10
+        fail ArgumentError, "invalid value for 'integer', must be greater than or equal to 10."
       end
 
       @integer = integer
@@ -258,12 +258,12 @@ module Petstore
     # @param [Object] int32 Value to be assigned
     def int32=(int32)
 
-      if !int32.nil? && int32 > 200.0
-        fail ArgumentError, "invalid value for 'int32', must be smaller than or equal to 200.0."
+      if !int32.nil? && int32 > 200
+        fail ArgumentError, "invalid value for 'int32', must be smaller than or equal to 200."
       end
 
-      if !int32.nil? && int32 < 20.0
-        fail ArgumentError, "invalid value for 'int32', must be greater than or equal to 20.0."
+      if !int32.nil? && int32 < 20
+        fail ArgumentError, "invalid value for 'int32', must be greater than or equal to 20."
       end
 
       @int32 = int32


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fix maximum, minimum for `Integer` by removing the trailing ".0" (which becomes double/decimal) and storing the value as string instead of Double/Number in Java.
