### PR TITLE
Fix for #4344 - update compile.mustache with new dependencies

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/compile.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/compile.mustache
@@ -17,5 +17,9 @@ if not exist ".\bin" mkdir bin
 
 copy packages\Newtonsoft.Json.8.0.3\lib\{{targetFrameworkNuget}}\Newtonsoft.Json.dll bin\Newtonsoft.Json.dll
 copy packages\RestSharp.105.1.0\lib\{{targetFrameworkNuget}}\RestSharp.dll bin\RestSharp.dll
+copy packages\Fody.1.29.2\Fody.dll bin\Fody.dll
+copy packages\PropertyChanged.Fody.1.51.3\PropertyChanged.Fody.dll bin\PropertyChanged.Fody.dll
+copy packages\PropertyChanged.Fody.1.51.3\Lib\dotnet\PropertyChanged.dll bin\PropertyChanged.dll
 
-%CSCPATH%\csc /reference:bin\Newtonsoft.Json.dll;bin\RestSharp.dll /target:library /out:bin\{{packageName}}.dll /recurse:src\{{packageName}}\*.cs /doc:bin\{{packageName}}.xml
+%CSCPATH%\csc  /reference:bin\Newtonsoft.Json.dll;bin\RestSharp.dll;bin\Fody.dll;bin\PropertyChanged.Fody.dll;bin\PropertyChanged.dll;System.ComponentModel.DataAnnotations.dll /target:library /out:bin\IO.Swagger.dll /recurse:src\IO.Swagger\*.cs /doc:bin\IO.Swagger.xml
+

--- a/modules/swagger-codegen/src/main/resources/csharp/compile.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/compile.mustache
@@ -17,9 +17,10 @@ if not exist ".\bin" mkdir bin
 
 copy packages\Newtonsoft.Json.8.0.3\lib\{{targetFrameworkNuget}}\Newtonsoft.Json.dll bin\Newtonsoft.Json.dll
 copy packages\RestSharp.105.1.0\lib\{{targetFrameworkNuget}}\RestSharp.dll bin\RestSharp.dll
+{{#generatePropertyChanged}}
 copy packages\Fody.1.29.2\Fody.dll bin\Fody.dll
 copy packages\PropertyChanged.Fody.1.51.3\PropertyChanged.Fody.dll bin\PropertyChanged.Fody.dll
 copy packages\PropertyChanged.Fody.1.51.3\Lib\dotnet\PropertyChanged.dll bin\PropertyChanged.dll
-
-%CSCPATH%\csc  /reference:bin\Newtonsoft.Json.dll;bin\RestSharp.dll;bin\Fody.dll;bin\PropertyChanged.Fody.dll;bin\PropertyChanged.dll;System.ComponentModel.DataAnnotations.dll /target:library /out:bin\IO.Swagger.dll /recurse:src\IO.Swagger\*.cs /doc:bin\IO.Swagger.xml
+{{/generatePropertyChanged}}
+%CSCPATH%\csc  /reference:bin\Newtonsoft.Json.dll;bin\RestSharp.dll;System.ComponentModel.DataAnnotations.dll {{#generatePropertyChanged}}/r:bin\Fody.dll;bin\PropertyChanged.Fody.dll;bin\PropertyChanged.dll{{/generatePropertyChanged}} /target:library /out:bin\IO.Swagger.dll /recurse:src\IO.Swagger\*.cs /doc:bin\IO.Swagger.xml
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)

Note: I'm not sure what all this is doing because I'm not that familiar with swagger-codegen, but it builds the build.bat fine. These .sh files did not run for me.

- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixed the build.bat file generation. I don't have the proper build tool chain setup for the build.sh file fix. 


