### PR TITLE
[Typscript][Fetch] remove trailing space in TS Fetch template, add npm test to pom.xml

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
@@ -94,8 +94,10 @@ export const {{classname}}FetchParamCreactor = {
         let contentTypeHeader: Dictionary<string>;
 {{#hasFormParams}}
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ {{#formParams}}
-            "{{baseName}}": params["{{paramName}}"],{{/formParams}}
+        fetchOptions.body = querystring.stringify({
+        {{#formParams}}
+            "{{baseName}}": params["{{paramName}}"],
+        {{/formParams}}
         });
 {{/hasFormParams}}
 {{#hasBodyParam}}

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -250,7 +250,7 @@ export const PetApiFetchParamCreactor = {
 
         let contentTypeHeader: Dictionary<string>;
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ 
+        fetchOptions.body = querystring.stringify({
             "name": params["name"],
             "status": params["status"],
         });
@@ -281,7 +281,7 @@ export const PetApiFetchParamCreactor = {
 
         let contentTypeHeader: Dictionary<string>;
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ 
+        fetchOptions.body = querystring.stringify({
             "additionalMetadata": params["additionalMetadata"],
             "file": params["file"],
         });

--- a/samples/client/petstore/typescript-fetch/builds/default/pom.xml
+++ b/samples/client/petstore/typescript-fetch/builds/default/pom.xml
@@ -39,6 +39,19 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>npm-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/api.ts
@@ -249,7 +249,7 @@ export const PetApiFetchParamCreactor = {
 
         let contentTypeHeader: Dictionary<string>;
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ 
+        fetchOptions.body = querystring.stringify({
             "name": params["name"],
             "status": params["status"],
         });
@@ -280,7 +280,7 @@ export const PetApiFetchParamCreactor = {
 
         let contentTypeHeader: Dictionary<string>;
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ 
+        fetchOptions.body = querystring.stringify({
             "additionalMetadata": params["additionalMetadata"],
             "file": params["file"],
         });

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/pom.xml
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/pom.xml
@@ -39,6 +39,19 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>npm-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/api.ts
@@ -250,7 +250,7 @@ export const PetApiFetchParamCreactor = {
 
         let contentTypeHeader: Dictionary<string>;
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ 
+        fetchOptions.body = querystring.stringify({
             "name": params["name"],
             "status": params["status"],
         });
@@ -281,7 +281,7 @@ export const PetApiFetchParamCreactor = {
 
         let contentTypeHeader: Dictionary<string>;
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ 
+        fetchOptions.body = querystring.stringify({
             "additionalMetadata": params["additionalMetadata"],
             "file": params["file"],
         });

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/pom.xml
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/pom.xml
@@ -39,6 +39,19 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>npm-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- remove trailing space in TS Fetch template and update the sample so that `npm test` passes
- add `npm test` to pom.xml so that Travis will run it as part of the CI

