### PR TITLE
Minor fix to issue with Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
   - cmd: dir/w
-  - cmd: RMDIR "C:\projects\swagger-codegen\swagger-samples" /S /Q
+#  - cmd: RMDIR "C:\projects\swagger-codegen\swagger-samples" /S /Q
   - git clone https://github.com/wing328/swagger-samples
   - ps: Start-Process -FilePath 'C:\maven\apache-maven-3.2.5\bin\mvn' -ArgumentList 'jetty:run' -WorkingDirectory "$env:appveyor_build_folder\swagger-samples\java\java-jersey-jaxrs"
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,6 @@ test_script:
 
   # generate all petstore clients
   - .\bin\windows\run-all-petstore.cmd
-cache:
+#cache:
 #  - C:\maven\
 #  - C:\Users\appveyor\.m2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ install:
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
+  - cmd: dir/w
   - cmd: RMDIR "C:\projects\swagger-codegen\swagger-samples" /S /Q
   - git clone https://github.com/wing328/swagger-samples
   - ps: Start-Process -FilePath 'C:\maven\apache-maven-3.2.5\bin\mvn' -ArgumentList 'jetty:run' -WorkingDirectory "$env:appveyor_build_folder\swagger-samples\java\java-jersey-jaxrs"


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

For some reasons, `git clone` failed due to existing swagger-samples folder. Update appveyor config to delete the folder and comment out "cache" 
