### PR TITLE
fix the value for @Generated java annotation

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -113,7 +113,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         config.processOpts();
         config.preprocessSwagger(swagger);
         config.additionalProperties().put("generatedDate", DateTime.now().toString());
-        config.additionalProperties().put("generatorClass", config.getClass().toString());
+        config.additionalProperties().put("generatorClass", config.getClass().getName());
         config.additionalProperties().put("inputSpec", config.getInputSpec());
         if (swagger.getVendorExtensions() != null) {
             config.vendorExtensions().putAll(swagger.getVendorExtensions());


### PR DESCRIPTION
com.my.Generator.class.toString() returns "class com.my.Generator", and this value is then used in the javax.annotation.Generated annotation like that: @Generated(value = "class com.my.Generator").
Should use Generator.class.getName() instead, so we end up with @Generated(value = "com.my.Generator")