### PR TITLE
Add a useTags flag to allow tags to be used to generate interface / c…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
@@ -18,6 +18,7 @@ public class SpringCodegen extends AbstractJavaCodegen {
     public static final String JAVA_8 = "java8";
     public static final String ASYNC = "async";
     public static final String RESPONSE_WRAPPER = "responseWrapper";
+    public static final String USE_TAGS = "useTags";
     public static final String SPRING_MVC_LIBRARY = "spring-mvc";
     public static final String SPRING_CLOUD_LIBRARY = "spring-cloud";
 
@@ -29,6 +30,7 @@ public class SpringCodegen extends AbstractJavaCodegen {
     protected boolean java8 = false;
     protected boolean async = false;
     protected String responseWrapper = "";
+    protected boolean useTags = false;
 
     public SpringCodegen() {
         super();
@@ -54,6 +56,7 @@ public class SpringCodegen extends AbstractJavaCodegen {
         cliOptions.add(CliOption.newBoolean(JAVA_8, "use java8 default interface"));
         cliOptions.add(CliOption.newBoolean(ASYNC, "use async Callable controllers"));
         cliOptions.add(new CliOption(RESPONSE_WRAPPER, "wrap the responses in given type (Future,Callable,CompletableFuture,ListenableFuture,DeferredResult,HystrixCommand,RxObservable,RxSingle or fully qualified type)"));
+        cliOptions.add(CliOption.newBoolean(USE_TAGS, "use tags for creating interface and controller classnames"));
 
         supportedLibraries.put(DEFAULT_LIBRARY, "Spring-boot Server application using the SpringFox integration.");
         supportedLibraries.put(SPRING_MVC_LIBRARY, "Spring-MVC Server application using the SpringFox integration.");
@@ -122,6 +125,10 @@ public class SpringCodegen extends AbstractJavaCodegen {
 
         if (additionalProperties.containsKey(RESPONSE_WRAPPER)) {
             this.setResponseWrapper((String) additionalProperties.get(RESPONSE_WRAPPER));
+        }
+
+        if (additionalProperties.containsKey(USE_TAGS)) {
+            this.setUseTags(Boolean.valueOf(additionalProperties.get(USE_TAGS).toString()));
         }
 
         supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
@@ -221,7 +228,7 @@ public class SpringCodegen extends AbstractJavaCodegen {
 
     @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
-        if(library.equals(DEFAULT_LIBRARY) || library.equals(SPRING_MVC_LIBRARY)) {
+        if((library.equals(DEFAULT_LIBRARY) || library.equals(SPRING_MVC_LIBRARY)) && !useTags) {
             String basePath = resourcePath;
             if (basePath.startsWith("/")) {
                 basePath = basePath.substring(1);
@@ -399,6 +406,10 @@ public class SpringCodegen extends AbstractJavaCodegen {
     public void setAsync(boolean async) { this.async = async; }
 
     public void setResponseWrapper(String responseWrapper) { this.responseWrapper = responseWrapper; }
+
+    public void setUseTags(boolean useTags) {
+        this.useTags = useTags;
+    }
 
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
@@ -16,6 +16,7 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
     public static final String JAVA_8 = "true";
     public static final String ASYNC = "true";
     public static final String RESPONSE_WRAPPER = "Callable";
+    public static final String USE_TAGS = "useTags";
 
     @Override
     public String getLanguage() {
@@ -34,6 +35,7 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
         options.put(SpringCodegen.JAVA_8, JAVA_8);
         options.put(SpringCodegen.ASYNC, ASYNC);
         options.put(SpringCodegen.RESPONSE_WRAPPER, RESPONSE_WRAPPER);
+        options.put(SpringCodegen.USE_TAGS, USE_TAGS);
 
         return options;
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/spring/SpringOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/spring/SpringOptionsTest.java
@@ -66,6 +66,8 @@ public class SpringOptionsTest extends JavaClientOptionsTest {
             times = 1;
             clientCodegen.setResponseWrapper(SpringOptionsProvider.RESPONSE_WRAPPER);
             times = 1;
+            clientCodegen.setUseTags(Boolean.valueOf(SpringOptionsProvider.USE_TAGS));
+            times = 1;
 
         }};
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Issue: #4387 

Add a useTags flag to allow tags to be used to generate interface / controller classnames