### PR TITLE
Additional parameters to test additional cases.

### DIFF
--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -559,7 +559,29 @@ paths:
           description: Invalid username supplied
         '404':
           description: User not found
-
+  /fake_classname_test_optional:
+    patch:
+      tags:
+        - "fake_classname_tags 123#$%^"
+      summary: To test class name in snake case
+      descriptions: To test class name in snake case
+      operationId: testClassname
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: client model
+          required: false
+          schema:
+            $ref: '#/definitions/Client'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Client'
   /fake_classname_test:
     patch:
       tags:
@@ -797,7 +819,23 @@ paths:
         - name: callback
           type: string
           in: formData
+          description: None  
+        - name: integerArrayRequired
+          in: query
           description: None
+          required: true
+          type: array
+          items:
+            type: integer
+            format: int64   
+        - name: integerArrayNotRequired
+          in: query
+          description: None
+          required: false
+          type: array
+          items:
+            type: integer
+            format: int64     
       responses:
         '400':
           description: Invalid username supplied


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [!!!] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Adds some observed cases that cause compile errors on some clients.

1. required queryParam of array integers 
2. optional queryParam of array integers 
3. optional bodyParam 

This will legitimately break some of the affected clients.

- Go failed: PR #4415 fixes.
- Java feign passed.