### PR TITLE
Update DefaultGenerator.java to call close()

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -526,6 +526,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         if (in != null) {
                             LOGGER.info("writing file " + outputFile);
                             IOUtils.copy(in, out);
+                            out.close();
                         } else {
                             LOGGER.error("can't open " + templateFile + " for input");
                         }


### PR DESCRIPTION
Need to call out.close() after IOUtils.copy(in, out); when writing supporting files since IOUtils does not close the stream.

I'm using Java code generation in-process and I need to delete the generated files within the same VM they were created in. Since the streams are not closed I am unable to delete gradle\wrapper\gradle-wrapper.jar. Issue seen on a Windows 7 x64 system with Java 1.8.0_102.


