### PR TITLE
Fix Integer stub value defaulting to String in nodejs-server if format not specified

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -97,7 +97,7 @@ public class ExampleGenerator {
             return "2000-01-23";
         } else if (property instanceof DateTimeProperty) {
             return "2000-01-23T04:56:07.000+00:00";
-        } else if (property instanceof DecimalProperty) {
+        }  else if (property instanceof DecimalProperty) {
             return new BigDecimal(1.3579);
         } else if (property instanceof DoubleProperty) {
             return 3.149;
@@ -107,10 +107,11 @@ public class ExampleGenerator {
             return 1.23f;
         } else if (property instanceof IntegerProperty) {
             return 123;
-        } else if (property.getClass().equals(BaseIntegerProperty.class)) {
-            return 123;
         } else if (property instanceof LongProperty) {
             return 123456789L;
+        // Properties that are not Integer or Long may still be BaseInteger
+        } else if (property instanceof BaseIntegerProperty) {
+            return 123;
         } else if (property instanceof MapProperty) {
             Map<String, Object> mp = new HashMap<String, Object>();
             if (property.getName() != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/ExampleGenerator.java
@@ -3,6 +3,7 @@ package io.swagger.codegen.examples;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BaseIntegerProperty;
 import io.swagger.models.properties.BooleanProperty;
 import io.swagger.models.properties.DateProperty;
 import io.swagger.models.properties.DateTimeProperty;
@@ -105,6 +106,8 @@ public class ExampleGenerator {
         } else if (property instanceof FloatProperty) {
             return 1.23f;
         } else if (property instanceof IntegerProperty) {
+            return 123;
+        } else if (property.getClass().equals(BaseIntegerProperty.class)) {
             return 123;
         } else if (property instanceof LongProperty) {
             return 123456789L;


### PR DESCRIPTION
fixes issue [[NODE-SERVER] Integer stub value not generated if format not defined](https://github.com/swagger-api/swagger-codegen/issues/4360)

### PR checklist

- [x ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixed an issue where properties specifying Integer as the type but not specifying a format (int32 or int64) would default to String when generated as nodejs-server.

