### PR TITLE
Added missing package name for Configuration in api.mustache.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -83,7 +83,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <returns></returns>
         public {{classname}}(String basePath)
         {
-            this.Configuration = new Configuration(new ApiClient(basePath));
+            this.Configuration = new {{packageName}}.Client.Configuration(new ApiClient(basePath));
 
             ExceptionFactory = {{packageName}}.Client.Configuration.DefaultExceptionFactory;
 
@@ -100,10 +100,10 @@ namespace {{packageName}}.{{apiPackage}}
         /// </summary>
         /// <param name="configuration">An instance of Configuration</param>
         /// <returns></returns>
-        public {{classname}}(Configuration configuration = null)
+        public {{classname}}({{packageName}}.Client.Configuration configuration = null)
         {
             if (configuration == null) // use the default one in Configuration
-                this.Configuration = Configuration.Default;
+                this.Configuration = {{packageName}}.Client.Configuration.Default;
             else
                 this.Configuration = configuration;
 
@@ -139,7 +139,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// Gets or sets the configuration object
         /// </summary>
         /// <value>An instance of the Configuration</value>
-        public Configuration Configuration {get; set;}
+        public {{packageName}}.Client.Configuration Configuration {get; set;}
 
         /// <summary>
         /// Provides a factory method hook for the creation of exceptions.


### PR DESCRIPTION
This is needed when the package contains "Configuration", e.g. MyApp.Configuration.Network.