### PR TITLE
Support the empty string as an enumeration value

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -303,6 +303,10 @@ public class DefaultCodegen {
      * @return the sanitized variable name for enum
      */
     public String toEnumVarName(String value, String datatype) {
+        if (value.length() == 0) {
+            return "EMPTY";
+        }
+
         String var = value.replaceAll("\\W+", "_").toUpperCase();
         if (var.matches("\\d.*")) {
             return "_" + var;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
@@ -615,6 +615,10 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (name.length() == 0) {
+            return "Empty";
+        }
+
         // for symbol, e.g. $, #
         if (getSymbolName(name) != null) {
             return camelize(getSymbolName(name));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -808,6 +808,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toEnumVarName(String value, String datatype) {
+        if (value.length() == 0) {
+            return "EMPTY";
+        }
+
         // for symbol, e.g. $, #
         if (getSymbolName(value) != null) {
             return getSymbolName(value).toUpperCase();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractPhpCodegen.java
@@ -589,6 +589,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (name.length() == 0) {
+            return "EMPTY";
+        }
+
         // for symbol, e.g. $, #
         if (getSymbolName(name) != null) {
             return (getSymbolName(name)).toUpperCase();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -286,6 +286,10 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (name.length() == 0) {
+            return "Empty";
+        }
+
         // for symbol, e.g. $, #
         if (getSymbolName(name) != null) {
             return camelize(getSymbolName(name));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -494,6 +494,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
     @Override
     public String toEnumVarName(String value, String datatype) {
+        if (value.length() == 0) {
+            return "Empty";
+        }
+
         // for symbol, e.g. $, #
         if (getSymbolName(value) != null) {
             return camelize(getSymbolName(value));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -1021,6 +1021,10 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
 
     @Override
     public String toEnumVarName(String value, String datatype) {
+        if (value.length() == 0) {
+            return "empty";
+        }
+
         // for symbol, e.g. $, #
         if (getSymbolName(value) != null) {
             return (getSymbolName(value)).toUpperCase();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NancyFXServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NancyFXServerCodegen.java
@@ -292,6 +292,10 @@ public class NancyFXServerCodegen extends AbstractCSharpCodegen {
 
     @Override
     public String toEnumVarName(final String name, final String datatype) {
+        if (name.length() == 0) {
+            return "Empty";
+        }
+
         final String enumName = camelize(
                 sanitizeName(name)
                 .replaceFirst("^_", "")

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -644,6 +644,10 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (name.length() == 0) {
+            return "EMPTY";
+        }
+
         // number
         if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
             String varName = name;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -566,6 +566,10 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (name.length() == 0) {
+            return "EMPTY";
+        }
+
         // number
         if ("Integer".equals(datatype) || "Float".equals(datatype)) {
             String varName = name;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -513,6 +513,10 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (name.length() == 0) {
+            return "empty";
+        }
+
         // for symbol, e.g. $, #
         if (getSymbolName(name) != null) {
             return camelize(WordUtils.capitalizeFully(getSymbolName(name).toUpperCase()), true);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -388,6 +388,10 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
 
     @SuppressWarnings("static-method")
     public String toSwiftyEnumName(String value) {
+        if (value.length() == 0) {
+            return "Empty";
+        }
+
         if (value.matches("^-?\\d*\\.{0,1}\\d+.*")) { // starts with number
             value = "Number" + value;
             value = value.replaceAll("-", "Minus");

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1067,6 +1067,7 @@ definitions:
         enum:
           - UPPER
           - lower
+          - ''
       enum_integer:
         type: integer
         format: int32

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/EnumTest.cs
@@ -46,7 +46,13 @@ namespace IO.Swagger.Model
             /// Enum Lower for "lower"
             /// </summary>
             [EnumMember(Value = "lower")]
-            Lower
+            Lower,
+            
+            /// <summary>
+            /// Enum Empty for ""
+            /// </summary>
+            [EnumMember(Value = "")]
+            Empty
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/EnumTest.cs
@@ -49,7 +49,13 @@ namespace IO.Swagger.Model
             /// Enum Lower for "lower"
             /// </summary>
             [EnumMember(Value = "lower")]
-            Lower
+            Lower,
+            
+            /// <summary>
+            /// Enum Empty for ""
+            /// </summary>
+            [EnumMember(Value = "")]
+            Empty
         }
 
         /// <summary>

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
@@ -31,7 +31,9 @@ public class EnumTest {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/jersey1/docs/EnumTest.md
+++ b/samples/client/petstore/java/jersey1/docs/EnumTest.md
@@ -16,6 +16,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumTest.java
@@ -31,7 +31,9 @@ public class EnumTest {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/jersey2-java6/docs/EnumTest.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/EnumTest.md
@@ -15,6 +15,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/EnumTest.java
@@ -42,7 +42,9 @@ public class EnumTest {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/jersey2-java8/docs/EnumTest.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/EnumTest.md
@@ -16,6 +16,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumTest.java
@@ -31,7 +31,9 @@ public class EnumTest {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/jersey2/docs/EnumTest.md
+++ b/samples/client/petstore/java/jersey2/docs/EnumTest.md
@@ -16,6 +16,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumTest.java
@@ -31,7 +31,9 @@ public class EnumTest {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/EnumTest.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/EnumTest.md
@@ -15,6 +15,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/EnumTest.java
@@ -45,7 +45,10 @@ public class EnumTest  implements Parcelable {
     UPPER("UPPER"),
     
     @SerializedName("lower")
-    LOWER("lower");
+    LOWER("lower"),
+    
+    @SerializedName("")
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/okhttp-gson/docs/EnumTest.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/EnumTest.md
@@ -16,6 +16,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumTest.java
@@ -32,7 +32,10 @@ public class EnumTest {
     UPPER("UPPER"),
     
     @SerializedName("lower")
-    LOWER("lower");
+    LOWER("lower"),
+    
+    @SerializedName("")
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumTest.java
@@ -32,7 +32,10 @@ public class EnumTest {
     UPPER("UPPER"),
     
     @SerializedName("lower")
-    LOWER("lower");
+    LOWER("lower"),
+    
+    @SerializedName("")
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/EnumTest.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/EnumTest.md
@@ -16,6 +16,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumTest.java
@@ -32,7 +32,9 @@ public class EnumTest {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/retrofit2/docs/EnumTest.md
+++ b/samples/client/petstore/java/retrofit2/docs/EnumTest.md
@@ -16,6 +16,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumTest.java
@@ -32,7 +32,10 @@ public class EnumTest {
     UPPER("UPPER"),
     
     @SerializedName("lower")
-    LOWER("lower");
+    LOWER("lower"),
+    
+    @SerializedName("")
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/java/retrofit2rx/docs/EnumTest.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/EnumTest.md
@@ -16,6 +16,7 @@ Name | Value
 ---- | -----
 UPPER | &quot;UPPER&quot;
 LOWER | &quot;lower&quot;
+EMPTY | &quot;&quot;
 
 
 <a name="EnumIntegerEnum"></a>

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumTest.java
@@ -32,7 +32,10 @@ public class EnumTest {
     UPPER("UPPER"),
     
     @SerializedName("lower")
-    LOWER("lower");
+    LOWER("lower"),
+    
+    @SerializedName("")
+    EMPTY("");
 
     private String value;
 

--- a/samples/client/petstore/javascript-promise/docs/EnumTest.md
+++ b/samples/client/petstore/javascript-promise/docs/EnumTest.md
@@ -17,6 +17,8 @@ Name | Type | Description | Notes
 
 * `lower` (value: `"lower"`)
 
+* `empty` (value: `""`)
+
 
 
 

--- a/samples/client/petstore/javascript-promise/src/model/EnumTest.js
+++ b/samples/client/petstore/javascript-promise/src/model/EnumTest.js
@@ -111,7 +111,12 @@
      * value: "lower"
      * @const
      */
-    "lower": "lower"  };
+    "lower": "lower",
+    /**
+     * value: ""
+     * @const
+     */
+    "empty": ""  };
 
   /**
    * Allowed values for the <code>enum_integer</code> property.

--- a/samples/client/petstore/javascript/docs/EnumTest.md
+++ b/samples/client/petstore/javascript/docs/EnumTest.md
@@ -17,6 +17,8 @@ Name | Type | Description | Notes
 
 * `lower` (value: `"lower"`)
 
+* `empty` (value: `""`)
+
 
 
 

--- a/samples/client/petstore/javascript/src/model/EnumTest.js
+++ b/samples/client/petstore/javascript/src/model/EnumTest.js
@@ -111,7 +111,12 @@
      * value: "lower"
      * @const
      */
-    "lower": "lower"  };
+    "lower": "lower",
+    /**
+     * value: ""
+     * @const
+     */
+    "empty": ""  };
 
   /**
    * Allowed values for the <code>enum_integer</code> property.

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
@@ -118,6 +118,7 @@ class EnumTest implements ArrayAccess
 
     const ENUM_STRING_UPPER = 'UPPER';
     const ENUM_STRING_LOWER = 'lower';
+    const ENUM_STRING_EMPTY = '';
     const ENUM_INTEGER_1 = 1;
     const ENUM_INTEGER_MINUS_1 = -1;
     const ENUM_NUMBER_1_DOT_1 = 1.1;
@@ -134,6 +135,7 @@ class EnumTest implements ArrayAccess
         return [
             self::ENUM_STRING_UPPER,
             self::ENUM_STRING_LOWER,
+            self::ENUM_STRING_EMPTY,
         ];
     }
     
@@ -188,7 +190,7 @@ class EnumTest implements ArrayAccess
     public function listInvalidProperties()
     {
         $invalid_properties = [];
-        $allowed_values = ["UPPER", "lower"];
+        $allowed_values = ["UPPER", "lower", ""];
         if (!in_array($this->container['enum_string'], $allowed_values)) {
             $invalid_properties[] = "invalid value for 'enum_string', must be one of #{allowed_values}.";
         }
@@ -214,7 +216,7 @@ class EnumTest implements ArrayAccess
      */
     public function valid()
     {
-        $allowed_values = ["UPPER", "lower"];
+        $allowed_values = ["UPPER", "lower", ""];
         if (!in_array($this->container['enum_string'], $allowed_values)) {
             return false;
         }
@@ -246,9 +248,9 @@ class EnumTest implements ArrayAccess
      */
     public function setEnumString($enum_string)
     {
-        $allowed_values = array('UPPER', 'lower');
+        $allowed_values = array('UPPER', 'lower', '');
         if (!is_null($enum_string) && (!in_array($enum_string, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'enum_string', must be one of 'UPPER', 'lower'");
+            throw new \InvalidArgumentException("Invalid value for 'enum_string', must be one of 'UPPER', 'lower', ''");
         }
         $this->container['enum_string'] = $enum_string;
 

--- a/samples/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_test.py
@@ -67,7 +67,7 @@ class EnumTest(object):
         :param enum_string: The enum_string of this EnumTest.
         :type: str
         """
-        allowed_values = ["UPPER", "lower"]
+        allowed_values = ["UPPER", "lower", ""]
         if enum_string not in allowed_values:
             raise ValueError(
                 "Invalid value for `enum_string` ({0}), must be one of {1}"

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -100,7 +100,7 @@ module Petstore
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      enum_string_validator = EnumAttributeValidator.new('String', ["UPPER", "lower"])
+      enum_string_validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       return false unless enum_string_validator.valid?(@enum_string)
       enum_integer_validator = EnumAttributeValidator.new('Integer', ["1", "-1"])
       return false unless enum_integer_validator.valid?(@enum_integer)
@@ -112,7 +112,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_string Object to be assigned
     def enum_string=(enum_string)
-      validator = EnumAttributeValidator.new('String', ["UPPER", "lower"])
+      validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       unless validator.valid?(enum_string)
         fail ArgumentError, "invalid value for 'enum_string', must be one of #{validator.allowable_values}."
       end

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -12,6 +12,7 @@ open class EnumTest: JSONEncodable {
     public enum EnumString: String { 
         case upper = "UPPER"
         case lower = "lower"
+        case empty = ""
     }
     public enum EnumInteger: Int32 { 
         case number1 = 1

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -12,6 +12,7 @@ open class EnumTest: JSONEncodable {
     public enum EnumString: String { 
         case upper = "UPPER"
         case lower = "lower"
+        case empty = ""
     }
     public enum EnumInteger: Int32 { 
         case number1 = 1

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -12,6 +12,7 @@ open class EnumTest: JSONEncodable {
     public enum EnumString: String { 
         case upper = "UPPER"
         case lower = "lower"
+        case empty = ""
     }
     public enum EnumInteger: Int32 { 
         case number1 = 1

--- a/samples/server/petstore/java-inflector/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/java-inflector/src/gen/java/io/swagger/model/EnumTest.java
@@ -19,7 +19,9 @@ public class EnumTest   {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/server/petstore/java-inflector/src/main/swagger/swagger.yaml
+++ b/samples/server/petstore/java-inflector/src/main/swagger/swagger.yaml
@@ -1100,6 +1100,7 @@ definitions:
         enum:
         - "UPPER"
         - "lower"
+        - ""
       enum_integer:
         type: "integer"
         format: "int32"

--- a/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/io/swagger/model/EnumTest.java
@@ -18,7 +18,9 @@ public class EnumTest   {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/model/EnumTest.java
@@ -31,7 +31,9 @@ public class EnumTest   {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/model/EnumTest.java
@@ -31,7 +31,9 @@ public class EnumTest   {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/EnumTest.java
@@ -18,7 +18,9 @@ public class EnumTest   {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/EnumTest.java
@@ -18,7 +18,9 @@ public class EnumTest   {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/model/EnumTest.java
@@ -18,7 +18,9 @@ public class EnumTest   {
   public enum EnumStringEnum {
     UPPER("UPPER"),
     
-    LOWER("lower");
+    LOWER("lower"),
+    
+    EMPTY("");
 
     private String value;
 


### PR DESCRIPTION
When a string enumeration has the empty string as one of its available values, the generated code for many languages is invalid because the empty string can not be used as an identifier.  As with numbers and symbols, provide a mapping to an English name which can be used as a replacement.  In this case, "empty" for the empty string/empty value.

**Reviewer Note:** I have updated all of the languages that I could find and updated the samples by running `./bin/run-all-petstore` and everything looks good.  However, I have been unable to get Travis CI to run on my repo due to [`nexus.codehaus.org: Unknown host nexus.codehaus.org](https://travis-ci.org/kevinoid/swagger-codegen/jobs/186034333) and I was unable to run the integration tests on my machine.  So some additional sanity checking would be greatly appreciated.