### PR TITLE
[Python] Add safe argument to quote method in python template to avoid unquote…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -107,7 +107,7 @@ class ApiClient(object):
                                                     collection_formats)
             for k, v in path_params:
                 resource_path = resource_path.replace(
-                    '{%s}' % k, quote(str(v)))
+                    '{%s}' % k, quote(str(v), safe=""))
 
         # query parameters
         if query_params:

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -116,7 +116,7 @@ class ApiClient(object):
                                                     collection_formats)
             for k, v in path_params:
                 resource_path = resource_path.replace(
-                    '{%s}' % k, quote(str(v)))
+                    '{%s}' % k, quote(str(v), safe=""))
 
         # query parameters
         if query_params:


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Fix for issue #4391.

My fix is including adding `safe` argument to `quote` method in python template to avoid unquoted parameter appearing in using path parameter.

