### PR TITLE
Fix Gson parsing of Joda DateTime without millis

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/JSON.mustache
@@ -172,14 +172,15 @@ class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+    private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
+    private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
 
     @Override
     public void write(JsonWriter out, DateTime date) throws IOException {
         if (date == null) {
             out.nullValue();
         } else {
-            out.value(formatter.print(date));
+            out.value(printFormatter.print(date));
         }
     }
 
@@ -191,7 +192,7 @@ class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
                 return null;
             default:
                 String date = in.nextString();
-                return formatter.parseDateTime(date);
+                return parseFormatter.parseDateTime(date);
         }
     }
 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
@@ -354,14 +354,15 @@ class GsonConverterWrapper implements Converter {
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+    private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
+    private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
 
     @Override
     public void write(JsonWriter out, DateTime date) throws IOException {
         if (date == null) {
             out.nullValue();
         } else {
-            out.value(formatter.print(date));
+            out.value(printFormatter.print(date));
         }
     }
 
@@ -373,7 +374,7 @@ class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
                 return null;
             default:
                 String date = in.nextString();
-                return formatter.parseDateTime(date);
+                return parseFormatter.parseDateTime(date);
         }
     }
 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -374,14 +374,15 @@ class GsonCustomConverterFactory extends Converter.Factory
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+    private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
+    private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
 
     @Override
     public void write(JsonWriter out, DateTime date) throws IOException {
         if (date == null) {
             out.nullValue();
         } else {
-            out.value(formatter.print(date));
+            out.value(printFormatter.print(date));
         }
     }
 
@@ -393,7 +394,7 @@ class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
                 return null;
             default:
                 String date = in.nextString();
-                return formatter.parseDateTime(date);
+                return parseFormatter.parseDateTime(date);
         }
     }
 }

--- a/modules/swagger-codegen/src/main/resources/akka-scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/akka-scala/apiInvoker.mustache
@@ -85,10 +85,10 @@ object ApiInvoker {
 
   case object DateTimeSerializer extends CustomSerializer[DateTime](format => ( {
     case JString(s) =>
-      ISODateTimeFormat.dateTimeParser().parseDateTime(s)
+      ISODateTimeFormat.dateOptionalTimeParser().parseDateTime(s)
   }, {
     case d: DateTime =>
-      JString(ISODateTimeFormat.dateTimeParser().print(d))
+      JString(ISODateTimeFormat.dateTime().print(d))
   }))
 }
 

--- a/samples/client/petstore-security-test/java/okhttp-gson/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore-security-test/java/okhttp-gson/src/main/java/io/swagger/client/JSON.java
@@ -170,14 +170,15 @@ class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+    private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
+    private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
 
     @Override
     public void write(JsonWriter out, DateTime date) throws IOException {
         if (date == null) {
             out.nullValue();
         } else {
-            out.value(formatter.print(date));
+            out.value(printFormatter.print(date));
         }
     }
 
@@ -189,7 +190,7 @@ class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
                 return null;
             default:
                 String date = in.nextString();
-                return formatter.parseDateTime(date);
+                return parseFormatter.parseDateTime(date);
         }
     }
 }

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/core/ApiInvoker.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/core/ApiInvoker.scala
@@ -85,10 +85,10 @@ object ApiInvoker {
 
   case object DateTimeSerializer extends CustomSerializer[DateTime](format => ( {
     case JString(s) =>
-      ISODateTimeFormat.dateTimeParser().parseDateTime(s)
+      ISODateTimeFormat.dateOptionalTimeParser().parseDateTime(s)
   }, {
     case d: DateTime =>
-      JString(ISODateTimeFormat.dateTimeParser().print(d))
+      JString(ISODateTimeFormat.dateTime().print(d))
   }))
 }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/JSON.java
@@ -182,14 +182,15 @@ class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+    private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
+    private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
 
     @Override
     public void write(JsonWriter out, DateTime date) throws IOException {
         if (date == null) {
             out.nullValue();
         } else {
-            out.value(formatter.print(date));
+            out.value(printFormatter.print(date));
         }
     }
 
@@ -201,7 +202,7 @@ class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
                 return null;
             default:
                 String date = in.nextString();
-                return formatter.parseDateTime(date);
+                return parseFormatter.parseDateTime(date);
         }
     }
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/JSON.java
@@ -170,14 +170,15 @@ class DateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+    private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
+    private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
 
     @Override
     public void write(JsonWriter out, DateTime date) throws IOException {
         if (date == null) {
             out.nullValue();
         } else {
-            out.value(formatter.print(date));
+            out.value(printFormatter.print(date));
         }
     }
 
@@ -189,7 +190,7 @@ class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
                 return null;
             default:
                 String date = in.nextString();
-                return formatter.parseDateTime(date);
+                return parseFormatter.parseDateTime(date);
         }
     }
 }

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/ApiClient.java
@@ -362,14 +362,15 @@ class GsonCustomConverterFactory extends Converter.Factory
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+    private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
+    private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
 
     @Override
     public void write(JsonWriter out, DateTime date) throws IOException {
         if (date == null) {
             out.nullValue();
         } else {
-            out.value(formatter.print(date));
+            out.value(printFormatter.print(date));
         }
     }
 
@@ -381,7 +382,7 @@ class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
                 return null;
             default:
                 String date = in.nextString();
-                return formatter.parseDateTime(date);
+                return parseFormatter.parseDateTime(date);
         }
     }
 }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
@@ -362,14 +362,15 @@ class GsonCustomConverterFactory extends Converter.Factory
  */
 class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-    private final DateTimeFormatter formatter = ISODateTimeFormat.dateTime();
+    private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
+    private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
 
     @Override
     public void write(JsonWriter out, DateTime date) throws IOException {
         if (date == null) {
             out.nullValue();
         } else {
-            out.value(formatter.print(date));
+            out.value(printFormatter.print(date));
         }
     }
 
@@ -381,7 +382,7 @@ class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
                 return null;
             default:
                 String date = in.nextString();
-                return formatter.parseDateTime(date);
+                return parseFormatter.parseDateTime(date);
         }
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The `DateTimeFormatter` returned by `ISODateTimeFormat.dateTime()` only parses dates with millisecond values, and throws `IllegalArgumentException` when milliseconds are not present.  The
date-time construct from RFC 3339 Section 5.6 referenced by the Swagger/OpenAPI spec allows fractional second values to be omitted.  This results in valid date-time values being rejected by the generated code.

This PR fixes the problem by using `ISODateTimeFormat.dateTimeParser()` for parsing, which correctly handles date-time values without fractional seconds.  Note that `.dateTime()` must
still be used for printing, which is not supported by `.dateTimeParser()`.