### PR TITLE
[codegen ignore] normalize path separator for Windows, add *.ext tests

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -474,7 +474,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 if (!of.isDirectory()) {
                     of.mkdirs();
                 }
-                String outputFilename = outputFolder + File.separator + support.destinationFilename;
+                String outputFilename = outputFolder + File.separator + support.destinationFilename.replace('/', File.separatorChar);
                 if (!config.shouldOverwrite(outputFilename)) {
                     LOGGER.info("Skipped overwriting " + outputFilename);
                     continue;
@@ -657,7 +657,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     }
 
     private File processTemplateToFile(Map<String, Object> templateData, String templateName, String outputFilename) throws IOException {
-        if(ignoreProcessor.allowsFile(new File(outputFilename.replaceAll("//", "/")))) {
+        String adjustedOutputFilename = outputFilename.replaceAll("//", "/").replace('/', File.separatorChar);
+        if(ignoreProcessor.allowsFile(new File(adjustedOutputFilename))) {
             String templateFile = getFullTemplateFile(config, templateName);
             String template = readTemplate(templateFile);
             Mustache.Compiler compiler = Mustache.compiler();
@@ -672,11 +673,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     .defaultValue("")
                     .compile(template);
 
-            writeToFile(outputFilename, tmpl.execute(templateData));
-            return new File(outputFilename);
+            writeToFile(adjustedOutputFilename, tmpl.execute(templateData));
+            return new File(adjustedOutputFilename);
         }
 
-        LOGGER.info("Skipped generation of " + outputFilename + " due to rule in .swagger-codegen-ignore");
+        LOGGER.info("Skipped generation of " + adjustedOutputFilename + " due to rule in .swagger-codegen-ignore");
         return null;
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/ignore/CodegenIgnoreProcessorTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/ignore/CodegenIgnoreProcessorTest.java
@@ -107,6 +107,8 @@ public class CodegenIgnoreProcessorTest {
         return new Object[] {
                 // Matching filenames
                 new CodegenIgnoreProcessorTest("build.sh", "build.sh", "A file when matching should ignore.").ignored(),
+                new CodegenIgnoreProcessorTest("build.sh", "*.sh", "A file when matching glob should ignore.").ignored(),
+                new CodegenIgnoreProcessorTest("src/build.sh", "*.sh", "A nested file when matching non-nested simple glob should allow.").allowed(),
                 new CodegenIgnoreProcessorTest("src/build.sh", "**/build.sh", "A file when matching nested files should ignore.").ignored(),
                 new CodegenIgnoreProcessorTest("Build.sh", "build.sh", "A file when non-matching should allow.").allowed().skipOnCondition(SystemUtils.IS_OS_WINDOWS),
                 new CodegenIgnoreProcessorTest("build.sh", "/build.sh", "A rooted file when matching should ignore.").ignored(),

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/ignore/rules/FileRuleTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/ignore/rules/FileRuleTest.java
@@ -67,4 +67,43 @@ public class FileRuleTest {
         assertFalse(actual);
     }
 
+    @Test
+    public void testGlobbingRecursive() throws Exception {
+        // Arrange
+        final String definition = "*.txt";
+        final String relativePath = "path/to/some/nested/location/xyzzy.txt";
+
+        // Act
+        final List<Part> syntax = Arrays.asList(
+                new Part(IgnoreLineParser.Token.MATCH_ALL),
+                new Part(IgnoreLineParser.Token.DIRECTORY_MARKER),
+                new Part(IgnoreLineParser.Token.MATCH_ANY),
+                new Part(IgnoreLineParser.Token.TEXT, ".txt")
+        );
+
+        Rule rule = new FileRule(syntax, definition);
+        Boolean actual = rule.matches(relativePath);
+
+        // Assert
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testGlobbingNotRecursive() throws Exception {
+        // Arrange
+        final String definition = "*.txt";
+        final String relativePath = "path/to/some/nested/location/xyzzy.txt";
+
+        // Act
+        final List<Part> syntax = Arrays.asList(
+                new Part(IgnoreLineParser.Token.MATCH_ANY),
+                new Part(IgnoreLineParser.Token.TEXT, ".txt")
+        );
+
+        Rule rule = new FileRule(syntax, definition);
+        Boolean actual = rule.matches(relativePath);
+
+        // Assert
+        assertFalse(actual);
+    }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add missing tests for simple globbed ignore pattern which is not nested and not explicitly rooted...

See comment in `Rule.java`:

```
// case 1
//: If the pattern does not contain a slash '/', Git treats it as
//: a shell glob pattern and checks for a match against the
//: pathname relative to the location of the `.gitignore` file
//: (relative to the toplevel of the work tree if not from a
//: `.gitignore` file).
```

see #4452