### PR TITLE
[dockerfile] Replace 'maven:3.3-jdk-7' with 'maven:3-jdk-7-alpine'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM maven:3.3-jdk-7
+
+FROM maven:3-jdk-7-alpine
 
 WORKDIR /src
 VOLUME  /src


### PR DESCRIPTION
Signed-off-by: weiyang <weiyang.ones@gmail.com>

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Reduse image size from 815M to 374M.

