### PR TITLE
#4499 Adding Curl connect timeout configuration to PHP generation templates

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
@@ -153,6 +153,11 @@ class ApiClient
         if ($this->config->getCurlTimeout() !== 0) {
             curl_setopt($curl, CURLOPT_TIMEOUT, $this->config->getCurlTimeout());
         }
+        // set connect timeout, if needed
+        if ($this->config->getCurlConnectTimeout() != 0) {
+            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->config->getCurlConnectTimeout());
+        }
+        
         // return the result on success, rather than just true
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 

--- a/modules/swagger-codegen/src/main/resources/php/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/configuration.mustache
@@ -88,6 +88,13 @@ class Configuration
     protected $curlTimeout = 0;
 
     /**
+     * Timeout (second) of the HTTP connection, by default set to 0, no timeout
+     *
+     * @var string
+     */
+    protected $curlConnectTimeout = 0;
+
+    /**
      * User agent of the HTTP request, set to "PHP-Swagger" by default
      *
      * @var string
@@ -368,6 +375,33 @@ class Configuration
     public function getCurlTimeout()
     {
         return $this->curlTimeout;
+    }
+
+    /**
+     * Sets the HTTP connect timeout value
+     *
+     * @param integer $seconds Number of seconds before connection times out [set to 0 for no timeout]
+     *
+     * @return Configuration
+     */
+    public function setCurlConnectTimeout($seconds)
+    {
+        if (!is_numeric($seconds) || $seconds < 0) {
+            throw new \InvalidArgumentException('Connect timeout value must be numeric and a non-negative number.');
+        }
+
+        $this->curlConnectTimeout = $seconds;
+        return $this;
+    }
+
+    /**
+     * Gets the HTTP connect timeout value
+     *
+     * @return string HTTP connect timeout value
+     */
+    public function getCurlConnectTimeout()
+    {
+        return $this->curlConnectTimeout;
     }
 
     /**


### PR DESCRIPTION
### PR checklist

- [√] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [√] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [√] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR adds a Curl Connect Timeout setting to generated PHP API clients.  This is desirable to prevent an app attempting to use a service that is down from hanging while waiting for a connection timeout.  Fixes #4499
(details of the change, additional tests that have been done, reference to the issue for tracking, etc)