### PR TITLE
Enable support for vendor extensions in CodegenResponse.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
@@ -19,6 +19,7 @@ public class CodegenResponse {
     public Boolean isFile = Boolean.FALSE;
     public Object schema;
     public String jsonSchema;
+    public Map<String, Object> vendorExtensions;
 
     public boolean isWildcard() {
         return "0".equals(code) || "default".equals(code);
@@ -68,6 +69,8 @@ public class CodegenResponse {
             return false;
         if (schema != null ? !schema.equals(that.schema) : that.schema != null)
             return false;
+        if (vendorExtensions != null ? !vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions != null)
+            return false;
         return jsonSchema != null ? jsonSchema.equals(that.jsonSchema) : that.jsonSchema == null;
 
     }
@@ -91,6 +94,7 @@ public class CodegenResponse {
         result = 31 * result + (isFile != null ? isFile.hashCode() : 0);
         result = 31 * result + (schema != null ? schema.hashCode() : 0);
         result = 31 * result + (jsonSchema != null ? jsonSchema.hashCode() : 0);
+        result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
         return result;
     }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2190,6 +2190,7 @@ public class DefaultCodegen {
         r.schema = response.getSchema();
         r.examples = toExamples(response.getExamples());
         r.jsonSchema = Json.pretty(response);
+        r.vendorExtensions = response.getVendorExtensions();
         addHeaders(response, r.headers);
 
         if (r.schema != null) {


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Swagger-Codegen's CodegenResponse class did not support vendor extensions even though OpenAPI Spec supported it. This change enables support for vendor extensions in CodegenResponse.

Issue #4022 has more details.
