### PR TITLE
Overriden objectmapper wasn't used in deserialisation (Scala) #4532

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/api.mustache
@@ -113,7 +113,7 @@ class {{classname}}(val defBasePath: String = "{{basePath}}",
     try {
       apiInvoker.invokeApi(basePath, path, "{{httpMethod}}", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-          {{#returnType}} Some(ApiInvoker.deserialize(s, "{{returnContainer}}", classOf[{{returnBaseType}}]).asInstanceOf[{{returnType}}])
+          {{#returnType}} Some(apiInvoker.deserialize(s, "{{returnContainer}}", classOf[{{returnBaseType}}]).asInstanceOf[{{returnType}}])
         {{/returnType}} 
         case _ => None
       }

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/api/PetApi.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/api/PetApi.scala
@@ -148,7 +148,7 @@ class PetApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "GET", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "array", classOf[Pet]).asInstanceOf[List[Pet]])
+           Some(apiInvoker.deserialize(s, "array", classOf[Pet]).asInstanceOf[List[Pet]])
         case _ => None
       }
     } catch {
@@ -190,7 +190,7 @@ class PetApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "GET", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "array", classOf[Pet]).asInstanceOf[List[Pet]])
+           Some(apiInvoker.deserialize(s, "array", classOf[Pet]).asInstanceOf[List[Pet]])
         case _ => None
       }
     } catch {
@@ -229,7 +229,7 @@ class PetApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "GET", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "", classOf[Pet]).asInstanceOf[Pet])
+           Some(apiInvoker.deserialize(s, "", classOf[Pet]).asInstanceOf[Pet])
         case _ => None
       }
     } catch {
@@ -358,7 +358,7 @@ class PetApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "POST", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "", classOf[ApiResponse]).asInstanceOf[ApiResponse])
+           Some(apiInvoker.deserialize(s, "", classOf[ApiResponse]).asInstanceOf[ApiResponse])
         case _ => None
       }
     } catch {

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/api/StoreApi.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/api/StoreApi.scala
@@ -102,7 +102,7 @@ class StoreApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "GET", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "map", classOf[Integer]).asInstanceOf[Map[String, Integer]])
+           Some(apiInvoker.deserialize(s, "map", classOf[Integer]).asInstanceOf[Map[String, Integer]])
         case _ => None
       }
     } catch {
@@ -141,7 +141,7 @@ class StoreApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "GET", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "", classOf[Order]).asInstanceOf[Order])
+           Some(apiInvoker.deserialize(s, "", classOf[Order]).asInstanceOf[Order])
         case _ => None
       }
     } catch {
@@ -182,7 +182,7 @@ class StoreApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "POST", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "", classOf[Order]).asInstanceOf[Order])
+           Some(apiInvoker.deserialize(s, "", classOf[Order]).asInstanceOf[Order])
         case _ => None
       }
     } catch {

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/api/UserApi.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/api/UserApi.scala
@@ -225,7 +225,7 @@ class UserApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "GET", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "", classOf[User]).asInstanceOf[User])
+           Some(apiInvoker.deserialize(s, "", classOf[User]).asInstanceOf[User])
         case _ => None
       }
     } catch {
@@ -271,7 +271,7 @@ class UserApi(val defBasePath: String = "http://petstore.swagger.io/v2",
     try {
       apiInvoker.invokeApi(basePath, path, "GET", queryParams.toMap, formParams.toMap, postBody, headerParams.toMap, contentType) match {
         case s: String =>
-           Some(ApiInvoker.deserialize(s, "", classOf[String]).asInstanceOf[String])
+           Some(apiInvoker.deserialize(s, "", classOf[String]).asInstanceOf[String])
         case _ => None
       }
     } catch {


### PR DESCRIPTION
Use previously provided apiInvoker instead of creating a new instance at deserialisation stage
See issue #4532