### PR TITLE
When reading mustache template files assume UTF-8 encoding, fixes #4544.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/AbstractGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/AbstractGenerator.java
@@ -56,7 +56,7 @@ public abstract class AbstractGenerator {
             if (is == null) {
                 is = new FileInputStream(new File(name)); // May throw but never return a null value
             }
-            return new InputStreamReader(is);
+            return new InputStreamReader(is, "UTF-8");
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
         }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Enforce **UTF-8** encoding when reading mustache template files, similar to how **UTF-8** is enforced when the resulting files are written to disk. Fixes #4544.