### PR TITLE
Added support for datetime query parameters in cpprest

### DIFF
--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
@@ -38,6 +38,7 @@ public:
     static utility::string_t parameterToString(utility::string_t value);
     static utility::string_t parameterToString(int32_t value);
     static utility::string_t parameterToString(int64_t value);
+    static utility::string_t parameterToString(const utility::datetime &value);
 
     template<class T>
     static utility::string_t parameterToArrayString(std::vector<T> value)

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
@@ -40,6 +40,11 @@ utility::string_t ApiClient::parameterToString(int32_t value)
     return utility::conversions::to_string_t(std::to_string(value));
 }
 
+utility::string_t ApiClient::parameterToString(const utility::datetime &value)
+{
+    return utility::conversions::to_string_t(value.to_string(utility::datetime::ISO_8601));
+}
+
 pplx::task<web::http::http_response> ApiClient::callApi(
     const utility::string_t& path,
     const utility::string_t& method,

--- a/samples/client/petstore/cpprest/ApiClient.cpp
+++ b/samples/client/petstore/cpprest/ApiClient.cpp
@@ -52,6 +52,11 @@ utility::string_t ApiClient::parameterToString(int32_t value)
     return utility::conversions::to_string_t(std::to_string(value));
 }
 
+utility::string_t ApiClient::parameterToString(const utility::datetime &value)
+{
+    return utility::conversions::to_string_t(value.to_string(utility::datetime::ISO_8601));
+}
+
 pplx::task<web::http::http_response> ApiClient::callApi(
     const utility::string_t& path,
     const utility::string_t& method,

--- a/samples/client/petstore/cpprest/ApiClient.h
+++ b/samples/client/petstore/cpprest/ApiClient.h
@@ -50,6 +50,7 @@ public:
     static utility::string_t parameterToString(utility::string_t value);
     static utility::string_t parameterToString(int32_t value);
     static utility::string_t parameterToString(int64_t value);
+    static utility::string_t parameterToString(const utility::datetime &value);
 
     template<class T>
     static utility::string_t parameterToArrayString(std::vector<T> value)

--- a/samples/client/petstore/cpprest/api/PetApi.cpp
+++ b/samples/client/petstore/cpprest/api/PetApi.cpp
@@ -438,7 +438,7 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
 
     
     {
-        queryParams[U("tags")] = ApiClient::parameterToArrayString<utility::string_t>(tags);
+        queryParams[U("tags")] = ApiClient::parameterToArrayString<>(tags);
     }
 
     std::shared_ptr<IHttpBody> httpBody;

--- a/samples/client/petstore/cpprest/api/PetApi.h
+++ b/samples/client/petstore/cpprest/api/PetApi.h
@@ -22,10 +22,10 @@
 
 #include "ApiClient.h"
 
-#include "ApiResponse.h"
-#include "HttpContent.h"
 #include "Pet.h"
 #include <cpprest/details/basic_types.h>
+#include "ApiResponse.h"
+#include "HttpContent.h"
 
 namespace io {
 namespace swagger {

--- a/samples/client/petstore/cpprest/api/StoreApi.h
+++ b/samples/client/petstore/cpprest/api/StoreApi.h
@@ -22,9 +22,9 @@
 
 #include "ApiClient.h"
 
-#include "Order.h"
-#include <map>
 #include <cpprest/details/basic_types.h>
+#include <map>
+#include "Order.h"
 
 namespace io {
 namespace swagger {

--- a/samples/client/petstore/cpprest/model/Category.cpp
+++ b/samples/client/petstore/cpprest/model/Category.cpp
@@ -21,7 +21,7 @@ namespace model {
 
 Category::Category()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Name = U("");
     m_NameIsSet = false;

--- a/samples/client/petstore/cpprest/model/Order.cpp
+++ b/samples/client/petstore/cpprest/model/Order.cpp
@@ -21,9 +21,9 @@ namespace model {
 
 Order::Order()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
-    m_PetId = 0;
+    m_PetId = 0L;
     m_PetIdIsSet = false;
     m_Quantity = 0;
     m_QuantityIsSet = false;

--- a/samples/client/petstore/cpprest/model/Pet.cpp
+++ b/samples/client/petstore/cpprest/model/Pet.cpp
@@ -21,7 +21,7 @@ namespace model {
 
 Pet::Pet()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_CategoryIsSet = false;
     m_Name = U("");

--- a/samples/client/petstore/cpprest/model/Pet.h
+++ b/samples/client/petstore/cpprest/model/Pet.h
@@ -22,10 +22,10 @@
 
 #include "ModelBase.h"
 
-#include "Category.h"
-#include <cpprest/details/basic_types.h>
-#include <vector>
 #include "Tag.h"
+#include <cpprest/details/basic_types.h>
+#include "Category.h"
+#include <vector>
 
 namespace io {
 namespace swagger {

--- a/samples/client/petstore/cpprest/model/Tag.cpp
+++ b/samples/client/petstore/cpprest/model/Tag.cpp
@@ -21,7 +21,7 @@ namespace model {
 
 Tag::Tag()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Name = U("");
     m_NameIsSet = false;

--- a/samples/client/petstore/cpprest/model/User.cpp
+++ b/samples/client/petstore/cpprest/model/User.cpp
@@ -21,7 +21,7 @@ namespace model {
 
 User::User()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Username = U("");
     m_UsernameIsSet = false;


### PR DESCRIPTION
Signed-off-by: Gene Chang <gene.chang@anyconnect.com>

### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Added an overload in apiclient-header.mustache and apiclient-source.mustache files to parameterToString for utility:datetime.  It will use datetime.to_string to convert to ISO_8601.  This was tested by generating code from our swagger and verifying the datetime object is properly converted to a URL for the GET request on the server.

