### PR TITLE
[nancyfx/csharp] Customize interface prefix

### DIFF
--- a/bin/nancyfx-petstore-server.sh
+++ b/bin/nancyfx-petstore-server.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/nancyfx -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l nancyfx -o samples/server/petstore/nancyfx"
+ags="generate $@ -t modules/swagger-codegen/src/main/resources/nancyfx -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l nancyfx -o samples/server/petstore/nancyfx"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -86,6 +86,9 @@ public class CodegenConstants {
     public static final String USE_COLLECTION = "useCollection";
     public static final String USE_COLLECTION_DESC = "Deserialize array types to Collection<T> instead of List<T>.";
 
+    public static final String INTERFACE_PREFIX = "interfacePrefix";
+    public static final String INTERFACE_PREFIX_DESC = "Prefix interfaces with a community standard or widely accepted prefix.";
+
     public static final String RETURN_ICOLLECTION = "returnICollection";
     public static final String RETURN_ICOLLECTION_DESC = "Return ICollection<T> instead of the concrete type.";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
@@ -27,6 +27,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
     protected String packageCompany = "Swagger";
     protected String packageCopyright = "No Copyright";
 
+    protected String interfacePrefix = "I";
+
     protected String sourceFolder = "src";
 
     // TODO: Add option for test folder output location. Nice to allow e.g. ./test instead of ./src.
@@ -253,6 +255,18 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
         if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES)) {
             setOptionalEmitDefaultValue(Boolean.valueOf(additionalProperties.get(CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.INTERFACE_PREFIX)) {
+            String useInterfacePrefix = additionalProperties.get(CodegenConstants.INTERFACE_PREFIX).toString();
+            if("false".equals(useInterfacePrefix)) {
+                setInterfacePrefix("");
+            } else if(!"true".equals(useInterfacePrefix)) {
+                // NOTE: if user passes "true" explicitly, we use the default I- prefix. The other supported case here is a custom prefix.
+                setInterfacePrefix(sanitizeName(useInterfacePrefix));
+            }
+
+            additionalProperties.put(CodegenConstants.INTERFACE_PREFIX, interfacePrefix);
         }
     }
 
@@ -614,6 +628,14 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
     
     public void setSourceFolder(String sourceFolder) {
         this.sourceFolder = sourceFolder;
+    }
+
+    public String getInterfacePrefix() {
+        return interfacePrefix;
+    }
+
+    public void setInterfacePrefix(final String interfacePrefix) {
+        this.interfacePrefix = interfacePrefix;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -72,6 +72,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 CodegenConstants.OPTIONAL_PROJECT_GUID_DESC,
                 null);
 
+        addOption(CodegenConstants.INTERFACE_PREFIX,
+                CodegenConstants.INTERFACE_PREFIX_DESC,
+                interfacePrefix);
+
         CliOption framework = new CliOption(
                 CodegenConstants.DOTNET_FRAMEWORK,
                 CodegenConstants.DOTNET_FRAMEWORK_DESC

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NancyFXServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NancyFXServerCodegen.java
@@ -1,20 +1,7 @@
 package io.swagger.codegen.languages;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static io.swagger.codegen.CodegenConstants.OPTIONAL_PROJECT_FILE;
-import static io.swagger.codegen.CodegenConstants.OPTIONAL_PROJECT_FILE_DESC;
-import static io.swagger.codegen.CodegenConstants.PACKAGE_NAME;
-import static io.swagger.codegen.CodegenConstants.PACKAGE_VERSION;
-import static io.swagger.codegen.CodegenConstants.RETURN_ICOLLECTION;
-import static io.swagger.codegen.CodegenConstants.RETURN_ICOLLECTION_DESC;
-import static io.swagger.codegen.CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG;
-import static io.swagger.codegen.CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG_DESC;
-import static io.swagger.codegen.CodegenConstants.SOURCE_FOLDER;
-import static io.swagger.codegen.CodegenConstants.SOURCE_FOLDER_DESC;
-import static io.swagger.codegen.CodegenConstants.USE_COLLECTION;
-import static io.swagger.codegen.CodegenConstants.USE_COLLECTION_DESC;
-import static io.swagger.codegen.CodegenConstants.USE_DATETIME_OFFSET;
-import static io.swagger.codegen.CodegenConstants.USE_DATETIME_OFFSET_DESC;
+import static io.swagger.codegen.CodegenConstants.*;
 import static io.swagger.codegen.CodegenType.SERVER;
 import static java.util.Arrays.asList;
 import static java.util.UUID.randomUUID;
@@ -71,6 +58,9 @@ public class NancyFXServerCodegen extends AbstractCSharpCodegen {
         outputFolder = "generated-code" + File.separator + getName();
         apiTemplateFiles.put("api.mustache", ".cs");
 
+        // Early versions use no prefix for interfaces. Defaulting to I- common practice would break existing users.
+        setInterfacePrefix("");
+
         // contextually reserved words
         setReservedWordsLowerCase(
             asList("var", "async", "await", "dynamic", "yield")
@@ -82,6 +72,7 @@ public class NancyFXServerCodegen extends AbstractCSharpCodegen {
         addOption(PACKAGE_NAME, "C# package name (convention: Title.Case).", packageName);
         addOption(PACKAGE_VERSION, "C# package version.", packageVersion);
         addOption(SOURCE_FOLDER, SOURCE_FOLDER_DESC, sourceFolder);
+        addOption(INTERFACE_PREFIX, INTERFACE_PREFIX_DESC, interfacePrefix);
 
         // CLI Switches
         addSwitch(SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_BY_REQUIRED_FLAG_DESC, sortParamsByRequiredFlag);

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -14,7 +14,7 @@ namespace {{packageName}}.{{apiPackage}}
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public interface I{{classname}} : IApiAccessor
+    public interface {{interfacePrefix}}{{classname}} : IApiAccessor
     {
         #region Synchronous Operations
         {{#operation}}
@@ -73,7 +73,7 @@ namespace {{packageName}}.{{apiPackage}}
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class {{classname}} : I{{classname}}
+    public partial class {{classname}} : {{interfacePrefix}}{{classname}}
     {
         private {{packageName}}.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
 

--- a/modules/swagger-codegen/src/main/resources/nancyfx/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/nancyfx/api.mustache
@@ -40,7 +40,7 @@ namespace {{packageName}}.{{packageContext}}.Modules
     /// <summary>
     /// Service handling {{classname}} requests.
     /// </summary>
-    public interface {{classname}}Service
+    public interface {{interfacePrefix}}{{classname}}Service
     {
         {{#operation}}/// <summary>
         /// {{notes}}
@@ -56,7 +56,7 @@ namespace {{packageName}}.{{packageContext}}.Modules
     /// <summary>
     /// Abstraction of {{classname}}Service.
     /// </summary>
-    public abstract class Abstract{{classname}}Service: {{classname}}Service
+    public abstract class Abstract{{classname}}Service: {{interfacePrefix}}{{classname}}Service
     {
         {{#operation}}public virtual {{#returnType}}{{&returnType}}{{/returnType}}{{^returnType}}void{{/returnType}} {{operationId}}(NancyContext context{{#allParams.0}}, {{/allParams.0}}{{>paramsList}})
         {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpClientOptionsTest.java
@@ -50,6 +50,8 @@ public class CSharpClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setGeneratePropertyChanged(true);
             times = 1;
+            clientCodegen.setInterfacePrefix("X");
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/CSharpClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/CSharpClientOptionsProvider.java
@@ -35,6 +35,7 @@ public class CSharpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES, "true")
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")
                 .put(CodegenConstants.GENERATE_PROPERTY_CHANGED, "true")
+                .put(CodegenConstants.INTERFACE_PREFIX, "X")
                 .build();
     }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/NancyFXServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/NancyFXServerOptionsProvider.java
@@ -1,16 +1,10 @@
 package io.swagger.codegen.options;
 
-import static io.swagger.codegen.CodegenConstants.PACKAGE_NAME;
-import static io.swagger.codegen.CodegenConstants.PACKAGE_VERSION;
-import static io.swagger.codegen.CodegenConstants.RETURN_ICOLLECTION;
-import static io.swagger.codegen.CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG;
-import static io.swagger.codegen.CodegenConstants.SOURCE_FOLDER;
-import static io.swagger.codegen.CodegenConstants.USE_COLLECTION;
-import static io.swagger.codegen.CodegenConstants.USE_DATETIME_OFFSET;
-
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+
+import static io.swagger.codegen.CodegenConstants.*;
 
 public class NancyFXServerOptionsProvider implements OptionsProvider {
     public static final String PACKAGE_NAME_VALUE = "swagger_server_nancyfx";
@@ -32,6 +26,7 @@ public class NancyFXServerOptionsProvider implements OptionsProvider {
                 .put(USE_DATETIME_OFFSET, "true")
                 .put(USE_COLLECTION, "false")
                 .put(RETURN_ICOLLECTION, "false")
+                .put(INTERFACE_PREFIX, "X")
                 .build();
     }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Per #4486, this allows user to specify the use of a standard or custom
prefix for interfaces. For C# based languages, this follows Microsoft's
Framework Design Guidelines and uses an I- prefix. However, to avoid
breaking changes with existing nancyfx generated code, the default is
unset.

The option supports true, false, or a custom prefix.

To test:

**NancyFX**:

```
./bin/nancyfx-petstore-server.sh --additional-properties interfacePrefix=I
```

NOTE: true/false don't apply here because there is no default set. This assumes NancyFX community preference is no prefix.

**C# Client**

```
# Default behavior, prefix with I-
./bin/csharp-petstore.sh --additional-properties interfacePrefix=true

# Customize without the default prefix
./bin/csharp-petstore.sh --additional-properties interfacePrefix=false

# Customize using your own prefix
./bin/csharp-petstore.sh --additional-properties interfacePrefix=ZZ
```

Questions...

I'd rather have NancyFX default to the I prefix and allow for the generator to also support the true/false/custom in the same way as the C# generator here.  If this is cool, we'll just need to remove the `setInterfacePrefix("")` line (and its comment) in `NancyFXServerCodegen`.