### PR TITLE
[csharp] Support internal access of generated code

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -141,4 +141,7 @@ public class CodegenConstants {
 
     public static final String GENERATE_PROPERTY_CHANGED = "generatePropertyChanged";
     public static final String GENERATE_PROPERTY_CHANGED_DESC = "Specifies that models support raising property changed events.";
+
+    public static final String NON_PUBLIC_API = "nonPublicApi";
+    public static final String NON_PUBLIC_API_DESC = "Generates code with reduced access modifiers; allows embedding elsewhere without exposing non-public API calls to consumers.";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -45,6 +45,9 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     protected Map<Character, String> regexModifiers;
     protected final Map<String, String> frameworks;
 
+    // By default, generated code is considered public
+    protected boolean nonPublicApi = Boolean.FALSE;
+
     public CSharpClientCodegen() {
         super();
         modelTemplateFiles.put("model.mustache", ".cs");
@@ -125,6 +128,14 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         addSwitch(CodegenConstants.GENERATE_PROPERTY_CHANGED,
                 CodegenConstants.PACKAGE_DESCRIPTION_DESC,
                 this.generatePropertyChanged);
+
+        // NOTE: This will reduce visibility of all public members in templates. Users can use InternalsVisibleTo
+        // https://msdn.microsoft.com/en-us/library/system.runtime.compilerservices.internalsvisibletoattribute(v=vs.110).aspx
+        // to expose to shared code if the generated code is not embedded into another project. Otherwise, users of codegen
+        // should rely on default public visibility.
+        addSwitch(CodegenConstants.NON_PUBLIC_API,
+                CodegenConstants.NON_PUBLIC_API_DESC,
+                this.nonPublicApi);
 
         regexModifiers = new HashMap<Character, String>();
         regexModifiers.put('i', "IgnoreCase");
@@ -226,6 +237,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_ASSEMBLY_INFO)) {
             setOptionalAssemblyInfoFlag(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.OPTIONAL_ASSEMBLY_INFO).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.NON_PUBLIC_API)) {
+            setNonPublicApi(Boolean.valueOf(additionalProperties.get(CodegenConstants.NON_PUBLIC_API).toString()));
         }
 
         final String testPackageName = testPackageName();
@@ -549,6 +564,14 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
 
     public void setGeneratePropertyChanged(final Boolean generatePropertyChanged){
         this.generatePropertyChanged = generatePropertyChanged;
+    }
+
+    public boolean isNonPublicApi() {
+        return nonPublicApi;
+    }
+
+    public void setNonPublicApi(final boolean nonPublicApi) {
+        this.nonPublicApi = nonPublicApi;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -19,7 +19,7 @@ namespace {{packageName}}.Client
     /// <summary>
     /// API client is mainly responsible for making the HTTP call to the API backend.
     /// </summary>
-    public partial class ApiClient
+    {{>visibility}} partial class ApiClient
     {
         private JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiException.mustache
@@ -6,7 +6,7 @@ namespace {{packageName}}.Client
     /// <summary>
     /// API Exception
     /// </summary>
-    public class ApiException : Exception
+    {{>visibility}} class ApiException : Exception
     {
         /// <summary>
         /// Gets or sets the error code (HTTP status code)

--- a/modules/swagger-codegen/src/main/resources/csharp/ApiResponse.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiResponse.mustache
@@ -7,7 +7,7 @@ namespace {{packageName}}.Client
     /// <summary>
     /// API Response
     /// </summary>
-    public class ApiResponse<T>
+    {{>visibility}} class ApiResponse<T>
     {
         /// <summary>
         /// Gets or sets the status code (HTTP status code)

--- a/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Configuration.mustache
@@ -11,7 +11,7 @@ namespace {{packageName}}.Client
     /// <summary>
     /// Represents a set of configuration settings
     /// </summary>
-    public class Configuration
+    {{>visibility}} class Configuration
     {
         /// <summary>
         /// Initializes a new instance of the Configuration class with different settings

--- a/modules/swagger-codegen/src/main/resources/csharp/ExceptionFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ExceptionFactory.mustache
@@ -10,6 +10,6 @@ namespace {{packageName}}.Client
     /// </summary>
     /// <param name="methodName">Method name</param>
     /// <param name="response">Response</param>
-    /// <returns>Exceptions</returns>    
-    public delegate Exception ExceptionFactory(string methodName, IRestResponse response);
+    /// <returns>Exceptions</returns>
+    {{>visibility}} delegate Exception ExceptionFactory(string methodName, IRestResponse response);
 }

--- a/modules/swagger-codegen/src/main/resources/csharp/IApiAccessor.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/IApiAccessor.mustache
@@ -11,7 +11,7 @@ namespace {{packageName}}.Client
     /// <summary>
     /// Represents configuration aspects required to interact with the API endpoints.
     /// </summary>
-    public interface IApiAccessor
+    {{>visibility}} interface IApiAccessor
     {
         /// <summary>
         /// Gets or sets the configuration object

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -14,7 +14,7 @@ namespace {{packageName}}.{{apiPackage}}
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public interface I{{classname}} : IApiAccessor
+    {{>visibility}} interface I{{classname}} : IApiAccessor
     {
         #region Synchronous Operations
         {{#operation}}
@@ -73,7 +73,7 @@ namespace {{packageName}}.{{apiPackage}}
     /// <summary>
     /// Represents a collection of functions to interact with the API endpoints
     /// </summary>
-    public partial class {{classname}} : I{{classname}}
+    {{>visibility}} partial class {{classname}} : I{{classname}}
     {
         private {{packageName}}.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
 

--- a/modules/swagger-codegen/src/main/resources/csharp/enumClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/enumClass.mustache
@@ -3,7 +3,7 @@
         /// </summary>{{#description}}
         /// <value>{{{description}}}</value>{{/description}}
         [JsonConverter(typeof(StringEnumConverter))]
-        public enum {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
+        {{>visibility}} enum {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
         {
             {{#allowableValues}}{{#enumVars}}
             /// <summary>

--- a/modules/swagger-codegen/src/main/resources/csharp/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelEnum.mustache
@@ -3,7 +3,7 @@
     /// </summary>{{#description}}
     /// <value>{{{description}}}</value>{{/description}}
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
+    {{>visibility}} enum {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
     {
         {{#allowableValues}}{{#enumVars}}
         /// <summary>

--- a/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
@@ -5,7 +5,7 @@
     {{#generatePropertyChanged}}
     [ImplementPropertyChanged]
     {{/generatePropertyChanged}}
-    public partial class {{classname}} : {{#parent}}{{{parent}}}, {{/parent}} IEquatable<{{classname}}>, IValidatableObject
+    {{>visibility}} partial class {{classname}} : {{#parent}}{{{parent}}}, {{/parent}} IEquatable<{{classname}}>, IValidatableObject
     {
         {{#vars}}
         {{#isEnum}}

--- a/modules/swagger-codegen/src/main/resources/csharp/modelInnerEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelInnerEnum.mustache
@@ -4,7 +4,7 @@
         /// </summary>{{#description}}
         /// <value>{{{description}}}</value>{{/description}}
         [JsonConverter(typeof(StringEnumConverter))]
-        public enum {{#datatypeWithEnum}}{{&.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
+        {{>visibility}} enum {{#datatypeWithEnum}}{{&.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
         {
             {{#allowableValues}}{{#enumVars}}
             /// <summary>

--- a/modules/swagger-codegen/src/main/resources/csharp/visibility.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/visibility.mustache
@@ -1,0 +1,1 @@
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpClientOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpClientOptionsTest.java
@@ -50,6 +50,8 @@ public class CSharpClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setGeneratePropertyChanged(true);
             times = 1;
+            clientCodegen.setNonPublicApi(true);
+            times = 1;
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/CSharpClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/CSharpClientOptionsProvider.java
@@ -35,6 +35,7 @@ public class CSharpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.OPTIONAL_EMIT_DEFAULT_VALUES, "true")
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")
                 .put(CodegenConstants.GENERATE_PROPERTY_CHANGED, "true")
+                .put(CodegenConstants.NON_PUBLIC_API, "true")
                 .build();
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Allows users to specify 'nonPublicApi' additional property (and C#
client CLI switch) to reduce visibility of classes created by the
generator. This includes API and Models as well as supporting code like
ApiClient and other infrastructure.

The requirement is to support codegen generated code to be embedded
within other applications where the generated code is not intended to be
publicly consumable or publicy exposed. An example would be an SDK which
internally consumes an API via the generated code; we wouldn't want the
internal API implementation exposed as part of that SDK.

Reducing visibility of the classes effectively makes the entire
implementation internal, regardless of the public modifier on methods or
static members. To fully make all members internal it would require
explicit interface implementation, which is not ideal.

see #4401

To evaluate, run the following then inspect the diff:

```
./bin/csharp-petstore.sh --additional-properties nonPublicApi=true
```
