### PR TITLE
[csharp] Fix interfacePrefix sensitivity + default

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCSharpCodegen.java
@@ -259,15 +259,16 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
         if (additionalProperties.containsKey(CodegenConstants.INTERFACE_PREFIX)) {
             String useInterfacePrefix = additionalProperties.get(CodegenConstants.INTERFACE_PREFIX).toString();
-            if("false".equals(useInterfacePrefix)) {
+            if("false".equals(useInterfacePrefix.toLowerCase())) {
                 setInterfacePrefix("");
-            } else if(!"true".equals(useInterfacePrefix)) {
+            } else if(!"true".equals(useInterfacePrefix.toLowerCase())) {
                 // NOTE: if user passes "true" explicitly, we use the default I- prefix. The other supported case here is a custom prefix.
                 setInterfacePrefix(sanitizeName(useInterfacePrefix));
             }
-
-            additionalProperties.put(CodegenConstants.INTERFACE_PREFIX, interfacePrefix);
         }
+
+        // This either updates additionalProperties with the above fixes, or sets the default if the option was not specified.
+        additionalProperties.put(CodegenConstants.INTERFACE_PREFIX, interfacePrefix);
     }
 
     @Override


### PR DESCRIPTION
After merging the fix with another C# change, noticed case sensitivity
issue for the true/false checks. Also noticed my original implementation
wasn't setting the default I- prefix as intended. This commit resolves
those three issues.

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

#4557 added support for customizing the interface prefix used in NancyFX Server and C# Client generators. That implementation did a case sensitive comparison in the true and false checks. It also didn't set the default I prefix unless the `interfacePrefix` option was supplied.

In addition to the checks from the original PR:

```
# Default behavior, prefix with I-
./bin/csharp-petstore.sh --additional-properties interfacePrefix=true

# Customize without the default prefix
./bin/csharp-petstore.sh --additional-properties interfacePrefix=false

# Customize using your own prefix
./bin/csharp-petstore.sh --additional-properties interfacePrefix=ZZ
```

Also evaluate:

```
./bin/csharp-petstore.sh
```

To ensure I- prefix default has not changed.
