### PR TITLE
Extends obj using Object.assign

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.mustache
@@ -24,15 +24,6 @@ namespace {{package}} {
             }
         }
 
-        private extendObj<T1,T2>(objA: T1, objB: T2) {
-            for(let key in objB){
-                if(objB.hasOwnProperty(key)){
-                    objA[key] = objB[key];
-                }
-            }
-            return <T1&T2>objA;
-        }
-
 {{#operation}}
         /**
          * {{summary}}
@@ -44,7 +35,7 @@ namespace {{package}} {
                 .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
 {{#hasFormParams}}
             let formParams: any = {};
 
@@ -75,10 +66,9 @@ namespace {{package}} {
             formParams['{{baseName}}'] = {{paramName}};
 
 {{/formParams}}
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: '{{httpMethod}}',
                 url: localVarPath,
-                json: {{#hasFormParams}}false{{/hasFormParams}}{{^hasFormParams}}true{{/hasFormParams}},
                 {{#bodyParam}}data: {{paramName}},
                 {{/bodyParam}}
                 {{#hasFormParams}}data: this.$httpParamSerializer(formParams),
@@ -88,7 +78,7 @@ namespace {{package}} {
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -35,21 +35,6 @@ export class {{classname}} {
         }
     }
 
-    /**
-     * 
-     * Extends object by coping non-existing properties.
-     * @param objA object to be extended
-     * @param objB source object
-     */
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                (objA as any)[key] = (objB as any)[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
-
 {{#operation}}
     /**
      * {{summary}}
@@ -213,7 +198,7 @@ export class {{classname}} {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);

--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -183,14 +183,6 @@ export class {{classname}} {
     }
 {{/isOAuth}}
 {{/authMethods}}
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                objA[key] = objB[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
 {{#operation}}
     /**
      * {{summary}}
@@ -201,7 +193,7 @@ export class {{classname}} {
         const localVarPath = this.basePath + '{{path}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 {{#allParams}}{{#required}}

--- a/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/PetApi.ts
@@ -29,15 +29,6 @@ namespace API.Client {
             }
         }
 
-        private extendObj<T1,T2>(objA: T1, objB: T2) {
-            for(let key in objB){
-                if(objB.hasOwnProperty(key)){
-                    objA[key] = objB[key];
-                }
-            }
-            return <T1&T2>objA;
-        }
-
         /**
          * Add a new pet to the store
          * 
@@ -47,18 +38,17 @@ namespace API.Client {
             const localVarPath = this.basePath + '/pet';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
-            let httpRequestParams: any = {
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'POST',
                 url: localVarPath,
-                json: true,
                 data: body,
                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -74,23 +64,22 @@ namespace API.Client {
                 .replace('{' + 'petId' + '}', String(petId));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             // verify required parameter 'petId' is not null or undefined
             if (petId === null || petId === undefined) {
                 throw new Error('Required parameter petId was null or undefined when calling deletePet.');
             }
             headerParams['api_key'] = apiKey;
 
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'DELETE',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -104,21 +93,20 @@ namespace API.Client {
             const localVarPath = this.basePath + '/pet/findByStatus';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             if (status !== undefined) {
                 queryParameters['status'] = status;
             }
 
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'GET',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -132,21 +120,20 @@ namespace API.Client {
             const localVarPath = this.basePath + '/pet/findByTags';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             if (tags !== undefined) {
                 queryParameters['tags'] = tags;
             }
 
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'GET',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -161,21 +148,20 @@ namespace API.Client {
                 .replace('{' + 'petId' + '}', String(petId));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             // verify required parameter 'petId' is not null or undefined
             if (petId === null || petId === undefined) {
                 throw new Error('Required parameter petId was null or undefined when calling getPetById.');
             }
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'GET',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -189,18 +175,17 @@ namespace API.Client {
             const localVarPath = this.basePath + '/pet';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
-            let httpRequestParams: any = {
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'PUT',
                 url: localVarPath,
-                json: true,
                 data: body,
                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -217,7 +202,7 @@ namespace API.Client {
                 .replace('{' + 'petId' + '}', String(petId));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             let formParams: any = {};
 
             // verify required parameter 'petId' is not null or undefined
@@ -230,17 +215,16 @@ namespace API.Client {
 
             formParams['status'] = status;
 
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'POST',
                 url: localVarPath,
-                json: false,
                                 data: this.$httpParamSerializer(formParams),
                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -257,7 +241,7 @@ namespace API.Client {
                 .replace('{' + 'petId' + '}', String(petId));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             let formParams: any = {};
 
             // verify required parameter 'petId' is not null or undefined
@@ -270,17 +254,16 @@ namespace API.Client {
 
             formParams['file'] = file;
 
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'POST',
                 url: localVarPath,
-                json: false,
                                 data: this.$httpParamSerializer(formParams),
                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);

--- a/samples/client/petstore/typescript-angular/API/Client/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/StoreApi.ts
@@ -29,15 +29,6 @@ namespace API.Client {
             }
         }
 
-        private extendObj<T1,T2>(objA: T1, objB: T2) {
-            for(let key in objB){
-                if(objB.hasOwnProperty(key)){
-                    objA[key] = objB[key];
-                }
-            }
-            return <T1&T2>objA;
-        }
-
         /**
          * Delete purchase order by ID
          * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
@@ -48,21 +39,20 @@ namespace API.Client {
                 .replace('{' + 'orderId' + '}', String(orderId));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             // verify required parameter 'orderId' is not null or undefined
             if (orderId === null || orderId === undefined) {
                 throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
             }
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'DELETE',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -75,17 +65,16 @@ namespace API.Client {
             const localVarPath = this.basePath + '/store/inventory';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
-            let httpRequestParams: any = {
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'GET',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -100,21 +89,20 @@ namespace API.Client {
                 .replace('{' + 'orderId' + '}', String(orderId));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             // verify required parameter 'orderId' is not null or undefined
             if (orderId === null || orderId === undefined) {
                 throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
             }
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'GET',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -128,18 +116,17 @@ namespace API.Client {
             const localVarPath = this.basePath + '/store/order';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
-            let httpRequestParams: any = {
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'POST',
                 url: localVarPath,
-                json: true,
                 data: body,
                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);

--- a/samples/client/petstore/typescript-angular/API/Client/UserApi.ts
+++ b/samples/client/petstore/typescript-angular/API/Client/UserApi.ts
@@ -29,15 +29,6 @@ namespace API.Client {
             }
         }
 
-        private extendObj<T1,T2>(objA: T1, objB: T2) {
-            for(let key in objB){
-                if(objB.hasOwnProperty(key)){
-                    objA[key] = objB[key];
-                }
-            }
-            return <T1&T2>objA;
-        }
-
         /**
          * Create user
          * This can only be done by the logged in user.
@@ -47,18 +38,17 @@ namespace API.Client {
             const localVarPath = this.basePath + '/user';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
-            let httpRequestParams: any = {
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'POST',
                 url: localVarPath,
-                json: true,
                 data: body,
                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -72,18 +62,17 @@ namespace API.Client {
             const localVarPath = this.basePath + '/user/createWithArray';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
-            let httpRequestParams: any = {
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'POST',
                 url: localVarPath,
-                json: true,
                 data: body,
                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -97,18 +86,17 @@ namespace API.Client {
             const localVarPath = this.basePath + '/user/createWithList';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
-            let httpRequestParams: any = {
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'POST',
                 url: localVarPath,
-                json: true,
                 data: body,
                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -123,21 +111,20 @@ namespace API.Client {
                 .replace('{' + 'username' + '}', String(username));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             // verify required parameter 'username' is not null or undefined
             if (username === null || username === undefined) {
                 throw new Error('Required parameter username was null or undefined when calling deleteUser.');
             }
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'DELETE',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -152,21 +139,20 @@ namespace API.Client {
                 .replace('{' + 'username' + '}', String(username));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             // verify required parameter 'username' is not null or undefined
             if (username === null || username === undefined) {
                 throw new Error('Required parameter username was null or undefined when calling getUserByName.');
             }
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'GET',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -181,7 +167,7 @@ namespace API.Client {
             const localVarPath = this.basePath + '/user/login';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             if (username !== undefined) {
                 queryParameters['username'] = username;
             }
@@ -190,16 +176,15 @@ namespace API.Client {
                 queryParameters['password'] = password;
             }
 
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'GET',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -212,17 +197,16 @@ namespace API.Client {
             const localVarPath = this.basePath + '/user/logout';
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
-            let httpRequestParams: any = {
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'GET',
                 url: localVarPath,
-                json: true,
                                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);
@@ -238,22 +222,21 @@ namespace API.Client {
                 .replace('{' + 'username' + '}', String(username));
 
             let queryParameters: any = {};
-            let headerParams: any = this.extendObj({}, this.defaultHeaders);
+            let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
             // verify required parameter 'username' is not null or undefined
             if (username === null || username === undefined) {
                 throw new Error('Required parameter username was null or undefined when calling updateUser.');
             }
-            let httpRequestParams: any = {
+            let httpRequestParams: ng.IRequestConfig = {
                 method: 'PUT',
                 url: localVarPath,
-                json: true,
                 data: body,
                                 params: queryParameters,
                 headers: headerParams
             };
 
             if (extraHttpRequestParams) {
-                httpRequestParams = this.extendObj(httpRequestParams, extraHttpRequestParams);
+                httpRequestParams = (<any>Object).assign(httpRequestParams, extraHttpRequestParams);
             }
 
             return this.$http(httpRequestParams);

--- a/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
@@ -41,21 +41,6 @@ export class PetApi {
     }
 
     /**
-     * 
-     * Extends object by coping non-existing properties.
-     * @param objA object to be extended
-     * @param objB source object
-     */
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                (objA as any)[key] = (objB as any)[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
-
-    /**
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -231,7 +216,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -281,7 +266,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -330,7 +315,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -379,7 +364,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -409,11 +394,6 @@ export class PetApi {
             'application/xml'
         ];
         
-        // authentication (api_key) required
-        if (this.configuration.apiKey) {
-            headers.set('api_key', this.configuration.apiKey);
-        }
-
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -421,6 +401,11 @@ export class PetApi {
                 ? this.configuration.accessToken()
                 : this.configuration.accessToken;
             headers.set('Authorization', 'Bearer ' + accessToken);
+        }
+
+        // authentication (api_key) required
+        if (this.configuration.apiKey) {
+            headers.set('api_key', this.configuration.apiKey);
         }
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -431,7 +416,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -479,7 +464,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -542,7 +527,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -605,7 +590,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);

--- a/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
@@ -41,21 +41,6 @@ export class StoreApi {
     }
 
     /**
-     * 
-     * Extends object by coping non-existing properties.
-     * @param objA object to be extended
-     * @param objB source object
-     */
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                (objA as any)[key] = (objB as any)[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
-
-    /**
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -151,7 +136,7 @@ export class StoreApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -189,7 +174,7 @@ export class StoreApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -227,7 +212,7 @@ export class StoreApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -264,7 +249,7 @@ export class StoreApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);

--- a/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
@@ -41,21 +41,6 @@ export class UserApi {
     }
 
     /**
-     * 
-     * Extends object by coping non-existing properties.
-     * @param objA object to be extended
-     * @param objB source object
-     */
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                (objA as any)[key] = (objB as any)[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
-
-    /**
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -216,7 +201,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -253,7 +238,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -290,7 +275,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -328,7 +313,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -366,7 +351,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -409,7 +394,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -442,7 +427,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -484,7 +469,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201701111439
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201701160843
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201701111439 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201701160843 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
@@ -41,21 +41,6 @@ export class PetApi {
     }
 
     /**
-     * 
-     * Extends object by coping non-existing properties.
-     * @param objA object to be extended
-     * @param objB source object
-     */
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                (objA as any)[key] = (objB as any)[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
-
-    /**
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -231,7 +216,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -281,7 +266,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -330,7 +315,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -379,7 +364,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -409,11 +394,6 @@ export class PetApi {
             'application/xml'
         ];
         
-        // authentication (api_key) required
-        if (this.configuration.apiKey) {
-            headers.set('api_key', this.configuration.apiKey);
-        }
-
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -421,6 +401,11 @@ export class PetApi {
                 ? this.configuration.accessToken()
                 : this.configuration.accessToken;
             headers.set('Authorization', 'Bearer ' + accessToken);
+        }
+
+        // authentication (api_key) required
+        if (this.configuration.apiKey) {
+            headers.set('api_key', this.configuration.apiKey);
         }
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -431,7 +416,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -479,7 +464,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -542,7 +527,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -605,7 +590,7 @@ export class PetApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);

--- a/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
@@ -41,21 +41,6 @@ export class StoreApi {
     }
 
     /**
-     * 
-     * Extends object by coping non-existing properties.
-     * @param objA object to be extended
-     * @param objB source object
-     */
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                (objA as any)[key] = (objB as any)[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
-
-    /**
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -151,7 +136,7 @@ export class StoreApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -189,7 +174,7 @@ export class StoreApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -227,7 +212,7 @@ export class StoreApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -264,7 +249,7 @@ export class StoreApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);

--- a/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
@@ -41,21 +41,6 @@ export class UserApi {
     }
 
     /**
-     * 
-     * Extends object by coping non-existing properties.
-     * @param objA object to be extended
-     * @param objB source object
-     */
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                (objA as any)[key] = (objB as any)[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
-
-    /**
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -216,7 +201,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -253,7 +238,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -290,7 +275,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -328,7 +313,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -366,7 +351,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -409,7 +394,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -442,7 +427,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);
@@ -484,7 +469,7 @@ export class UserApi {
         
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
-            requestOptions = this.extendObj(requestOptions, extraHttpRequestParams);
+            requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
         }
 
         return this.http.request(path, requestOptions);

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201701111439",
+  "version": "0.0.1-SNAPSHOT.201701160843",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -174,14 +174,6 @@ export class PetApi {
     set accessToken(token: string) {
         this.authentications.petstore_auth.accessToken = token;
     }
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                objA[key] = objB[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
     /**
      * Add a new pet to the store
      * 
@@ -190,7 +182,7 @@ export class PetApi {
     public addPet (body?: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -202,7 +194,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -242,7 +233,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -261,7 +252,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -298,7 +288,7 @@ export class PetApi {
     public findPetsByStatus (status?: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -314,7 +304,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -351,7 +340,7 @@ export class PetApi {
     public findPetsByTags (tags?: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -367,7 +356,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -405,7 +393,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -422,7 +410,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -461,7 +448,7 @@ export class PetApi {
     public updatePet (body?: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -473,7 +460,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -514,7 +500,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -539,7 +525,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -575,11 +560,11 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: any) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -605,7 +590,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -674,14 +658,6 @@ export class StoreApi {
     set accessToken(token: string) {
         this.authentications.petstore_auth.accessToken = token;
     }
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                objA[key] = objB[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
     /**
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
@@ -691,7 +667,7 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', String(orderId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -708,7 +684,6 @@ export class StoreApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -742,7 +717,7 @@ export class StoreApi {
     public getInventory () : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -754,7 +729,6 @@ export class StoreApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -792,7 +766,7 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', String(orderId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -809,7 +783,6 @@ export class StoreApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -844,7 +817,7 @@ export class StoreApi {
     public placeOrder (body?: Order) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -856,7 +829,6 @@ export class StoreApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -924,14 +896,6 @@ export class UserApi {
     set accessToken(token: string) {
         this.authentications.petstore_auth.accessToken = token;
     }
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                objA[key] = objB[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
     /**
      * Create user
      * This can only be done by the logged in user.
@@ -940,7 +904,7 @@ export class UserApi {
     public createUser (body?: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -952,7 +916,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -988,7 +951,7 @@ export class UserApi {
     public createUsersWithArrayInput (body?: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1000,7 +963,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -1036,7 +998,7 @@ export class UserApi {
     public createUsersWithListInput (body?: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1048,7 +1010,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -1085,7 +1046,7 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', String(username));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1102,7 +1063,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -1138,7 +1098,7 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', String(username));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1155,7 +1115,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -1191,7 +1150,7 @@ export class UserApi {
     public loginUser (username?: string, password?: string) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1211,7 +1170,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -1245,7 +1203,7 @@ export class UserApi {
     public logoutUser () : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1257,7 +1215,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -1294,7 +1251,7 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', String(username));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1311,7 +1268,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };

--- a/samples/client/petstore/typescript-node/npm/api.ts
+++ b/samples/client/petstore/typescript-node/npm/api.ts
@@ -174,14 +174,6 @@ export class PetApi {
     set accessToken(token: string) {
         this.authentications.petstore_auth.accessToken = token;
     }
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                objA[key] = objB[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
     /**
      * Add a new pet to the store
      * 
@@ -190,7 +182,7 @@ export class PetApi {
     public addPet (body?: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -202,7 +194,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -242,7 +233,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -261,7 +252,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -298,7 +288,7 @@ export class PetApi {
     public findPetsByStatus (status?: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -314,7 +304,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -351,7 +340,7 @@ export class PetApi {
     public findPetsByTags (tags?: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -367,7 +356,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -405,7 +393,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -422,7 +410,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -461,7 +448,7 @@ export class PetApi {
     public updatePet (body?: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -473,7 +460,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -514,7 +500,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -539,7 +525,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -575,11 +560,11 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: any) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', String(petId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -605,7 +590,6 @@ export class PetApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -674,14 +658,6 @@ export class StoreApi {
     set accessToken(token: string) {
         this.authentications.petstore_auth.accessToken = token;
     }
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                objA[key] = objB[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
     /**
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
@@ -691,7 +667,7 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', String(orderId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -708,7 +684,6 @@ export class StoreApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -742,7 +717,7 @@ export class StoreApi {
     public getInventory () : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -754,7 +729,6 @@ export class StoreApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -792,7 +766,7 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', String(orderId));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -809,7 +783,6 @@ export class StoreApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -844,7 +817,7 @@ export class StoreApi {
     public placeOrder (body?: Order) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -856,7 +829,6 @@ export class StoreApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -924,14 +896,6 @@ export class UserApi {
     set accessToken(token: string) {
         this.authentications.petstore_auth.accessToken = token;
     }
-    private extendObj<T1,T2>(objA: T1, objB: T2) {
-        for(let key in objB){
-            if(objB.hasOwnProperty(key)){
-                objA[key] = objB[key];
-            }
-        }
-        return <T1&T2>objA;
-    }
     /**
      * Create user
      * This can only be done by the logged in user.
@@ -940,7 +904,7 @@ export class UserApi {
     public createUser (body?: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -952,7 +916,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -988,7 +951,7 @@ export class UserApi {
     public createUsersWithArrayInput (body?: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1000,7 +963,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -1036,7 +998,7 @@ export class UserApi {
     public createUsersWithListInput (body?: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1048,7 +1010,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };
@@ -1085,7 +1046,7 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', String(username));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1102,7 +1063,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -1138,7 +1098,7 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', String(username));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1155,7 +1115,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -1191,7 +1150,7 @@ export class UserApi {
     public loginUser (username?: string, password?: string) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1211,7 +1170,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -1245,7 +1203,7 @@ export class UserApi {
     public logoutUser () : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1257,7 +1215,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
         };
 
@@ -1294,7 +1251,7 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', String(username));
         let queryParameters: any = {};
-        let headerParams: any = this.extendObj({}, this.defaultHeaders);
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let formParams: any = {};
 
 
@@ -1311,7 +1268,6 @@ export class UserApi {
             headers: headerParams,
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
-
             json: true,
             body: body,
         };

--- a/samples/client/petstore/typescript-node/npm/client.ts
+++ b/samples/client/petstore/typescript-node/npm/client.ts
@@ -34,7 +34,7 @@ petApi.addPet(pet)
     })
     .then((res) => {
         console.log('Updated pet using POST form');
-        return petApi.uploadFile(petId, undefined, fs.createReadStream('sample.png'));
+        return petApi.uploadFile(petId, undefined, fs.readFileSync('sample.png'));
     })
     .then((res) => {
         console.log('Uploaded image');


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
 Resolves #4407 (replacing PR #4409 with better backwards compatibility) by using `Object.assign` for object copying.
