### PR TITLE
[Typescript-Fetch] Issue#4498 - fixed typescript-fetch issues caused by conflicting request op…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
@@ -74,7 +74,7 @@ export const {{classname}}FetchParamCreator = {
      * {{notes}}{{/notes}}{{#allParams}}
      * @param {{paramName}} {{description}}{{/allParams}}
      */
-    {{nickname}}({{#hasParams}}params: { {{#allParams}} {{paramName}}{{^required}}?{{/required}}: {{{dataType}}};{{/allParams}} }{{/hasParams}}{{#hasParams}}, {{/hasParams}}{{#hasAuthMethods}}configuration: Configuration, {{/hasAuthMethods}}options?: any): FetchArgs {
+    {{nickname}}({{#hasParams}}params: { {{#allParams}} {{paramName}}{{^required}}?{{/required}}: {{{dataType}}};{{/allParams}} }, {{/hasParams}}{{#hasAuthMethods}}configuration: Configuration, {{/hasAuthMethods}}options: any = {}): FetchArgs {
 {{#allParams}}
 {{#required}}
         // verify required parameter "{{paramName}}" is set
@@ -175,8 +175,8 @@ export const {{classname}}Fp = {
      * {{notes}}{{/notes}}{{#allParams}}
      * @param {{paramName}} {{description}}{{/allParams}}
      */
-    {{nickname}}({{#hasParams}}params: { {{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}; {{/allParams}} }{{/hasParams}}{{#hasAuthMethods}}{{#hasParams}}, {{/hasParams}}configuration: Configuration{{/hasAuthMethods}}): (fetch: FetchAPI, basePath?: string) => Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}any{{/returnType}}> {
-        const fetchArgs = {{classname}}FetchParamCreator.{{nickname}}({{#hasParams}}params{{/hasParams}}{{#hasAuthMethods}}{{#hasParams}}, {{/hasParams}}configuration{{/hasAuthMethods}});
+    {{nickname}}({{#hasParams}}params: { {{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}; {{/allParams}} }, {{/hasParams}}{{#hasAuthMethods}}configuration: Configuration, {{/hasAuthMethods}}options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}any{{/returnType}}> {
+        const fetchArgs = {{classname}}FetchParamCreator.{{nickname}}({{#hasParams}}params, {{/hasParams}}{{#hasAuthMethods}}configuration, {{/hasAuthMethods}}options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -201,8 +201,8 @@ export class {{classname}} extends BaseAPI {
      * {{notes}}{{/notes}}{{#allParams}}
      * @param {{paramName}} {{description}}{{/allParams}}
      */
-    {{nickname}}({{#hasParams}}params: { {{#allParams}} {{paramName}}{{^required}}?{{/required}}: {{{dataType}}};{{/allParams}} }{{/hasParams}}) {
-        return {{classname}}Fp.{{nickname}}({{#hasParams}}params{{/hasParams}}{{#hasAuthMethods}}{{#hasParams}}, {{/hasParams}}this.configuration{{/hasAuthMethods}})(this.fetch, this.basePath);
+    {{nickname}}({{#hasParams}}params: { {{#allParams}} {{paramName}}{{^required}}?{{/required}}: {{{dataType}}};{{/allParams}} }, {{/hasParams}}options: any = {}) {
+        return {{classname}}Fp.{{nickname}}({{#hasParams}}params, {{/hasParams}}{{#hasAuthMethods}}this.configuration, {{/hasAuthMethods}}options)(this.fetch, this.basePath);
     }
 {{/operation}}
 };
@@ -219,8 +219,8 @@ export const {{classname}}Factory = function (fetch?: FetchAPI, basePath?: strin
          * {{notes}}{{/notes}}{{#allParams}}
          * @param {{paramName}} {{description}}{{/allParams}}
          */
-        {{nickname}}({{#hasParams}}params: { {{#allParams}} {{paramName}}{{^required}}?{{/required}}: {{{dataType}}};{{/allParams}} }{{/hasParams}}{{#hasAuthMethods}}{{#hasParams}}, {{/hasParams}}configuration: Configuration{{/hasAuthMethods}}) {
-            return {{classname}}Fp.{{nickname}}({{#hasParams}}params{{/hasParams}}{{#hasAuthMethods}}{{#hasParams}}, {{/hasParams}}configuration{{/hasAuthMethods}})(fetch, basePath);
+        {{nickname}}({{#hasParams}}params: { {{#allParams}} {{paramName}}{{^required}}?{{/required}}: {{{dataType}}};{{/allParams}} }, {{/hasParams}}{{#hasAuthMethods}}configuration: Configuration, {{/hasAuthMethods}}options: any = {}) {
+            return {{classname}}Fp.{{nickname}}({{#hasParams}}params, {{/hasParams}}{{#hasAuthMethods}}configuration, {{/hasAuthMethods}}options)(fetch, basePath);
         },
 {{/operation}}
     };

--- a/pom.xml
+++ b/pom.xml
@@ -763,7 +763,7 @@
                 <module>samples/client/petstore/typescript-fetch/builds/default</module>
                 <module>samples/client/petstore/typescript-fetch/builds/es6-target</module>
                 <module>samples/client/petstore/typescript-fetch/builds/with-npm-version</module>
-                <!--<module>samples/client/petstore/typescript-fetch/tests/default</module>-->
+                <module>samples/client/petstore/typescript-fetch/tests/default</module>
                 <module>samples/client/petstore/typescript-angular</module>
                 <module>samples/client/petstore/typescript-node/npm</module>
                 <!-- servers -->

--- a/samples/client/petstore-security-test/typescript-fetch/api.ts
+++ b/samples/client/petstore-security-test/typescript-fetch/api.ts
@@ -16,6 +16,8 @@ import * as url from "url";
 import * as isomorphicFetch from "isomorphic-fetch";
 import * as assign from "core-js/library/fn/object/assign";
 
+import { Configuration } from "./configuration";
+
 interface Dictionary<T> { [index: string]: T; }
 export interface FetchAPI { (url: string, init?: any): Promise<any>; }
 
@@ -29,10 +31,12 @@ export interface FetchArgs {
 export class BaseAPI {
     basePath: string;
     fetch: FetchAPI;
+    public configuration: Configuration;
 
-    constructor(fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) {
+    constructor(fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH, configuration: Configuration = new Configuration()) {
         this.basePath = basePath;
         this.fetch = fetch;
+        this.configuration = configuration;
     }
 };
 
@@ -51,24 +55,25 @@ export interface ModelReturn {
 /**
  * FakeApi - fetch parameter creator
  */
-export const FakeApiFetchParamCreactor = {
+export const FakeApiFetchParamCreator = {
     /** 
      * To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      * @param test code inject * &#39; &quot; &#x3D;end  rn n r To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      */
-    testCodeInjectEndRnNR(params: {  "test code inject * &#39; &quot; &#x3D;end  rn n r"?: string; }, options?: any): FetchArgs {
+    testCodeInjectEndRnNR(params: {  test code inject * &#39; &quot; &#x3D;end  rn n r?: string; }, options: any = {}): FetchArgs {
         const baseUrl = `/fake`;
         let urlObj = url.parse(baseUrl, true);
         let fetchOptions: RequestInit = assign({}, { method: "PUT" }, options);
 
         let contentTypeHeader: Dictionary<string>;
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ 
+        fetchOptions.body = querystring.stringify({
             "test code inject */ &#39; &quot; &#x3D;end -- \r\n \n \r": params["test code inject * &#39; &quot; &#x3D;end  rn n r"],
         });
         if (contentTypeHeader) {
             fetchOptions.headers = contentTypeHeader;
         }
+
         return {
             url: url.format(urlObj),
             options: fetchOptions,
@@ -84,8 +89,8 @@ export const FakeApiFp = {
      * To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      * @param test code inject * &#39; &quot; &#x3D;end  rn n r To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      */
-    testCodeInjectEndRnNR(params: { "test code inject * &#39; &quot; &#x3D;end  rn n r"?: string;  }, options?: any): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = FakeApiFetchParamCreactor.testCodeInjectEndRnNR(params, options);
+    testCodeInjectEndRnNR(params: { test code inject * &#39; &quot; &#x3D;end  rn n r?: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = FakeApiFetchParamCreator.testCodeInjectEndRnNR(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -106,7 +111,7 @@ export class FakeApi extends BaseAPI {
      * To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      * @param test code inject * &#39; &quot; &#x3D;end  rn n r To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      */
-    testCodeInjectEndRnNR(params: {  "test code inject * &#39; &quot; &#x3D;end  rn n r"?: string; }, options?: any) {
+    testCodeInjectEndRnNR(params: {  test code inject * &#39; &quot; &#x3D;end  rn n r?: string; }, options: any = {}) {
         return FakeApiFp.testCodeInjectEndRnNR(params, options)(this.fetch, this.basePath);
     }
 };
@@ -120,7 +125,7 @@ export const FakeApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
          * @param test code inject * &#39; &quot; &#x3D;end  rn n r To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
          */
-        testCodeInjectEndRnNR(params: {  "test code inject * &#39; &quot; &#x3D;end  rn n r"?: string; }, options?: any) {
+        testCodeInjectEndRnNR(params: {  test code inject * &#39; &quot; &#x3D;end  rn n r?: string; }, options: any = {}) {
             return FakeApiFp.testCodeInjectEndRnNR(params, options)(fetch, basePath);
         },
     };

--- a/samples/client/petstore-security-test/typescript-fetch/configuration.ts
+++ b/samples/client/petstore-security-test/typescript-fetch/configuration.ts
@@ -1,0 +1,8 @@
+export class Configuration {
+    apiKey: {
+        api_key  */ &#39; &quot; &#x3D;end -- \r\n \n \r: string;
+    };
+    username: string;
+    password: string;
+    accessToken: string;
+}

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -125,7 +125,7 @@ export const PetApiFetchParamCreator = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: {  body: Pet; }, configuration: Configuration, options?: any): FetchArgs {
+    addPet(params: {  body: Pet; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling addPet");
@@ -161,7 +161,7 @@ export const PetApiFetchParamCreator = {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options?: any): FetchArgs {
+    deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling deletePet");
@@ -193,7 +193,7 @@ export const PetApiFetchParamCreator = {
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options?: any): FetchArgs {
+    findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "status" is set
         if (params["status"] == null) {
             throw new Error("Missing required parameter status when calling findPetsByStatus");
@@ -227,7 +227,7 @@ export const PetApiFetchParamCreator = {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options?: any): FetchArgs {
+    findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "tags" is set
         if (params["tags"] == null) {
             throw new Error("Missing required parameter tags when calling findPetsByTags");
@@ -261,7 +261,7 @@ export const PetApiFetchParamCreator = {
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: {  petId: number; }, configuration: Configuration, options?: any): FetchArgs {
+    getPetById(params: {  petId: number; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling getPetById");
@@ -292,7 +292,7 @@ export const PetApiFetchParamCreator = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: {  body: Pet; }, configuration: Configuration, options?: any): FetchArgs {
+    updatePet(params: {  body: Pet; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling updatePet");
@@ -329,7 +329,7 @@ export const PetApiFetchParamCreator = {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options?: any): FetchArgs {
+    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling updatePetWithForm");
@@ -368,7 +368,7 @@ export const PetApiFetchParamCreator = {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options?: any): FetchArgs {
+    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling uploadFile");
@@ -411,8 +411,8 @@ export const PetApiFp = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: { body: Pet;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.addPet(params, configuration);
+    addPet(params: { body: Pet;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.addPet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -429,8 +429,8 @@ export const PetApiFp = {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: { petId: number; apiKey?: string;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.deletePet(params, configuration);
+    deletePet(params: { petId: number; apiKey?: string;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.deletePet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -446,8 +446,8 @@ export const PetApiFp = {
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: { status: Array<string>;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
-        const fetchArgs = PetApiFetchParamCreator.findPetsByStatus(params, configuration);
+    findPetsByStatus(params: { status: Array<string>;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
+        const fetchArgs = PetApiFetchParamCreator.findPetsByStatus(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -463,8 +463,8 @@ export const PetApiFp = {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: { tags: Array<string>;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
-        const fetchArgs = PetApiFetchParamCreator.findPetsByTags(params, configuration);
+    findPetsByTags(params: { tags: Array<string>;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
+        const fetchArgs = PetApiFetchParamCreator.findPetsByTags(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -480,8 +480,8 @@ export const PetApiFp = {
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: { petId: number;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Pet> {
-        const fetchArgs = PetApiFetchParamCreator.getPetById(params, configuration);
+    getPetById(params: { petId: number;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Pet> {
+        const fetchArgs = PetApiFetchParamCreator.getPetById(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -497,8 +497,8 @@ export const PetApiFp = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: { body: Pet;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.updatePet(params, configuration);
+    updatePet(params: { body: Pet;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.updatePet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -516,8 +516,8 @@ export const PetApiFp = {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: { petId: number; name?: string; status?: string;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.updatePetWithForm(params, configuration);
+    updatePetWithForm(params: { petId: number; name?: string; status?: string;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.updatePetWithForm(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -535,8 +535,8 @@ export const PetApiFp = {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: { petId: number; additionalMetadata?: string; file?: any;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<ApiResponse> {
-        const fetchArgs = PetApiFetchParamCreator.uploadFile(params, configuration);
+    uploadFile(params: { petId: number; additionalMetadata?: string; file?: any;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<ApiResponse> {
+        const fetchArgs = PetApiFetchParamCreator.uploadFile(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -558,8 +558,8 @@ export class PetApi extends BaseAPI {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: {  body: Pet; }) {
-        return PetApiFp.addPet(params, this.configuration)(this.fetch, this.basePath);
+    addPet(params: {  body: Pet; }, options: any = {}) {
+        return PetApiFp.addPet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Deletes a pet
@@ -567,40 +567,40 @@ export class PetApi extends BaseAPI {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: {  petId: number; apiKey?: string; }) {
-        return PetApiFp.deletePet(params, this.configuration)(this.fetch, this.basePath);
+    deletePet(params: {  petId: number; apiKey?: string; }, options: any = {}) {
+        return PetApiFp.deletePet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: {  status: Array<string>; }) {
-        return PetApiFp.findPetsByStatus(params, this.configuration)(this.fetch, this.basePath);
+    findPetsByStatus(params: {  status: Array<string>; }, options: any = {}) {
+        return PetApiFp.findPetsByStatus(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: {  tags: Array<string>; }) {
-        return PetApiFp.findPetsByTags(params, this.configuration)(this.fetch, this.basePath);
+    findPetsByTags(params: {  tags: Array<string>; }, options: any = {}) {
+        return PetApiFp.findPetsByTags(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: {  petId: number; }) {
-        return PetApiFp.getPetById(params, this.configuration)(this.fetch, this.basePath);
+    getPetById(params: {  petId: number; }, options: any = {}) {
+        return PetApiFp.getPetById(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: {  body: Pet; }) {
-        return PetApiFp.updatePet(params, this.configuration)(this.fetch, this.basePath);
+    updatePet(params: {  body: Pet; }, options: any = {}) {
+        return PetApiFp.updatePet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Updates a pet in the store with form data
@@ -609,8 +609,8 @@ export class PetApi extends BaseAPI {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }) {
-        return PetApiFp.updatePetWithForm(params, this.configuration)(this.fetch, this.basePath);
+    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, options: any = {}) {
+        return PetApiFp.updatePetWithForm(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * uploads an image
@@ -619,8 +619,8 @@ export class PetApi extends BaseAPI {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }) {
-        return PetApiFp.uploadFile(params, this.configuration)(this.fetch, this.basePath);
+    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, options: any = {}) {
+        return PetApiFp.uploadFile(params, this.configuration, options)(this.fetch, this.basePath);
     }
 };
 
@@ -634,8 +634,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * 
          * @param body Pet object that needs to be added to the store
          */
-        addPet(params: {  body: Pet; }, configuration: Configuration) {
-            return PetApiFp.addPet(params, configuration)(fetch, basePath);
+        addPet(params: {  body: Pet; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.addPet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Deletes a pet
@@ -643,40 +643,40 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param petId Pet id to delete
          * @param apiKey 
          */
-        deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration) {
-            return PetApiFp.deletePet(params, configuration)(fetch, basePath);
+        deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.deletePet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Finds Pets by status
          * Multiple status values can be provided with comma separated strings
          * @param status Status values that need to be considered for filter
          */
-        findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration) {
-            return PetApiFp.findPetsByStatus(params, configuration)(fetch, basePath);
+        findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.findPetsByStatus(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Finds Pets by tags
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @param tags Tags to filter by
          */
-        findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration) {
-            return PetApiFp.findPetsByTags(params, configuration)(fetch, basePath);
+        findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.findPetsByTags(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Find pet by ID
          * Returns a single pet
          * @param petId ID of pet to return
          */
-        getPetById(params: {  petId: number; }, configuration: Configuration) {
-            return PetApiFp.getPetById(params, configuration)(fetch, basePath);
+        getPetById(params: {  petId: number; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.getPetById(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Update an existing pet
          * 
          * @param body Pet object that needs to be added to the store
          */
-        updatePet(params: {  body: Pet; }, configuration: Configuration) {
-            return PetApiFp.updatePet(params, configuration)(fetch, basePath);
+        updatePet(params: {  body: Pet; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.updatePet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Updates a pet in the store with form data
@@ -685,8 +685,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param name Updated name of the pet
          * @param status Updated status of the pet
          */
-        updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration) {
-            return PetApiFp.updatePetWithForm(params, configuration)(fetch, basePath);
+        updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.updatePetWithForm(params, configuration, options)(fetch, basePath);
         },
         /** 
          * uploads an image
@@ -695,8 +695,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param additionalMetadata Additional data to pass to server
          * @param file file to upload
          */
-        uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration) {
-            return PetApiFp.uploadFile(params, configuration)(fetch, basePath);
+        uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.uploadFile(params, configuration, options)(fetch, basePath);
         },
     };
 };
@@ -711,7 +711,7 @@ export const StoreApiFetchParamCreator = {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: {  orderId: string; }, options?: any): FetchArgs {
+    deleteOrder(params: {  orderId: string; }, options: any = {}): FetchArgs {
         // verify required parameter "orderId" is set
         if (params["orderId"] == null) {
             throw new Error("Missing required parameter orderId when calling deleteOrder");
@@ -735,7 +735,7 @@ export const StoreApiFetchParamCreator = {
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory(configuration: Configuration, options?: any): FetchArgs {
+    getInventory(configuration: Configuration, options: any = {}): FetchArgs {
         const baseUrl = `/store/inventory`;
         let urlObj = url.parse(baseUrl, true);
         let fetchOptions: RequestInit = assign({}, { method: "GET" }, options);
@@ -761,7 +761,7 @@ export const StoreApiFetchParamCreator = {
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: {  orderId: number; }, options?: any): FetchArgs {
+    getOrderById(params: {  orderId: number; }, options: any = {}): FetchArgs {
         // verify required parameter "orderId" is set
         if (params["orderId"] == null) {
             throw new Error("Missing required parameter orderId when calling getOrderById");
@@ -786,7 +786,7 @@ export const StoreApiFetchParamCreator = {
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: {  body: Order; }, options?: any): FetchArgs {
+    placeOrder(params: {  body: Order; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling placeOrder");
@@ -820,8 +820,8 @@ export const StoreApiFp = {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: { orderId: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = StoreApiFetchParamCreator.deleteOrder(params);
+    deleteOrder(params: { orderId: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = StoreApiFetchParamCreator.deleteOrder(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -836,8 +836,8 @@ export const StoreApiFp = {
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory(configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<{ [key: string]: number; }> {
-        const fetchArgs = StoreApiFetchParamCreator.getInventory(configuration);
+    getInventory(configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<{ [key: string]: number; }> {
+        const fetchArgs = StoreApiFetchParamCreator.getInventory(configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -853,8 +853,8 @@ export const StoreApiFp = {
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: { orderId: number;  }): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
-        const fetchArgs = StoreApiFetchParamCreator.getOrderById(params);
+    getOrderById(params: { orderId: number;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
+        const fetchArgs = StoreApiFetchParamCreator.getOrderById(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -870,8 +870,8 @@ export const StoreApiFp = {
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: { body: Order;  }): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
-        const fetchArgs = StoreApiFetchParamCreator.placeOrder(params);
+    placeOrder(params: { body: Order;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
+        const fetchArgs = StoreApiFetchParamCreator.placeOrder(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -893,31 +893,31 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: {  orderId: string; }) {
-        return StoreApiFp.deleteOrder(params)(this.fetch, this.basePath);
+    deleteOrder(params: {  orderId: string; }, options: any = {}) {
+        return StoreApiFp.deleteOrder(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory() {
-        return StoreApiFp.getInventory(this.configuration)(this.fetch, this.basePath);
+    getInventory(options: any = {}) {
+        return StoreApiFp.getInventory(this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: {  orderId: number; }) {
-        return StoreApiFp.getOrderById(params)(this.fetch, this.basePath);
+    getOrderById(params: {  orderId: number; }, options: any = {}) {
+        return StoreApiFp.getOrderById(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: {  body: Order; }) {
-        return StoreApiFp.placeOrder(params)(this.fetch, this.basePath);
+    placeOrder(params: {  body: Order; }, options: any = {}) {
+        return StoreApiFp.placeOrder(params, options)(this.fetch, this.basePath);
     }
 };
 
@@ -931,31 +931,31 @@ export const StoreApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
          * @param orderId ID of the order that needs to be deleted
          */
-        deleteOrder(params: {  orderId: string; }) {
-            return StoreApiFp.deleteOrder(params)(fetch, basePath);
+        deleteOrder(params: {  orderId: string; }, options: any = {}) {
+            return StoreApiFp.deleteOrder(params, options)(fetch, basePath);
         },
         /** 
          * Returns pet inventories by status
          * Returns a map of status codes to quantities
          */
-        getInventory(configuration: Configuration) {
-            return StoreApiFp.getInventory(configuration)(fetch, basePath);
+        getInventory(configuration: Configuration, options: any = {}) {
+            return StoreApiFp.getInventory(configuration, options)(fetch, basePath);
         },
         /** 
          * Find purchase order by ID
          * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
          * @param orderId ID of pet that needs to be fetched
          */
-        getOrderById(params: {  orderId: number; }) {
-            return StoreApiFp.getOrderById(params)(fetch, basePath);
+        getOrderById(params: {  orderId: number; }, options: any = {}) {
+            return StoreApiFp.getOrderById(params, options)(fetch, basePath);
         },
         /** 
          * Place an order for a pet
          * 
          * @param body order placed for purchasing the pet
          */
-        placeOrder(params: {  body: Order; }) {
-            return StoreApiFp.placeOrder(params)(fetch, basePath);
+        placeOrder(params: {  body: Order; }, options: any = {}) {
+            return StoreApiFp.placeOrder(params, options)(fetch, basePath);
         },
     };
 };
@@ -970,7 +970,7 @@ export const UserApiFetchParamCreator = {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: {  body: User; }, options?: any): FetchArgs {
+    createUser(params: {  body: User; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUser");
@@ -998,7 +998,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: {  body: Array<User>; }, options?: any): FetchArgs {
+    createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUsersWithArrayInput");
@@ -1026,7 +1026,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: {  body: Array<User>; }, options?: any): FetchArgs {
+    createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUsersWithListInput");
@@ -1054,7 +1054,7 @@ export const UserApiFetchParamCreator = {
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: {  username: string; }, options?: any): FetchArgs {
+    deleteUser(params: {  username: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling deleteUser");
@@ -1079,7 +1079,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: {  username: string; }, options?: any): FetchArgs {
+    getUserByName(params: {  username: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling getUserByName");
@@ -1105,7 +1105,7 @@ export const UserApiFetchParamCreator = {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: {  username: string; password: string; }, options?: any): FetchArgs {
+    loginUser(params: {  username: string; password: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling loginUser");
@@ -1136,7 +1136,7 @@ export const UserApiFetchParamCreator = {
      * Logs out current logged in user session
      * 
      */
-    logoutUser(options?: any): FetchArgs {
+    logoutUser(options: any = {}): FetchArgs {
         const baseUrl = `/user/logout`;
         let urlObj = url.parse(baseUrl, true);
         let fetchOptions: RequestInit = assign({}, { method: "GET" }, options);
@@ -1157,7 +1157,7 @@ export const UserApiFetchParamCreator = {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: {  username: string; body: User; }, options?: any): FetchArgs {
+    updateUser(params: {  username: string; body: User; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling updateUser");
@@ -1196,8 +1196,8 @@ export const UserApiFp = {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: { body: User;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUser(params);
+    createUser(params: { body: User;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1213,8 +1213,8 @@ export const UserApiFp = {
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: { body: Array<User>;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUsersWithArrayInput(params);
+    createUsersWithArrayInput(params: { body: Array<User>;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUsersWithArrayInput(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1230,8 +1230,8 @@ export const UserApiFp = {
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: { body: Array<User>;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUsersWithListInput(params);
+    createUsersWithListInput(params: { body: Array<User>;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUsersWithListInput(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1247,8 +1247,8 @@ export const UserApiFp = {
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: { username: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.deleteUser(params);
+    deleteUser(params: { username: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.deleteUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1264,8 +1264,8 @@ export const UserApiFp = {
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: { username: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<User> {
-        const fetchArgs = UserApiFetchParamCreator.getUserByName(params);
+    getUserByName(params: { username: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<User> {
+        const fetchArgs = UserApiFetchParamCreator.getUserByName(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1282,8 +1282,8 @@ export const UserApiFp = {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: { username: string; password: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<string> {
-        const fetchArgs = UserApiFetchParamCreator.loginUser(params);
+    loginUser(params: { username: string; password: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<string> {
+        const fetchArgs = UserApiFetchParamCreator.loginUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1298,8 +1298,8 @@ export const UserApiFp = {
      * Logs out current logged in user session
      * 
      */
-    logoutUser(): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.logoutUser();
+    logoutUser(options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.logoutUser(options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1316,8 +1316,8 @@ export const UserApiFp = {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: { username: string; body: User;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.updateUser(params);
+    updateUser(params: { username: string; body: User;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.updateUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1339,40 +1339,40 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: {  body: User; }) {
-        return UserApiFp.createUser(params)(this.fetch, this.basePath);
+    createUser(params: {  body: User; }, options: any = {}) {
+        return UserApiFp.createUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Creates list of users with given input array
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: {  body: Array<User>; }) {
-        return UserApiFp.createUsersWithArrayInput(params)(this.fetch, this.basePath);
+    createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}) {
+        return UserApiFp.createUsersWithArrayInput(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Creates list of users with given input array
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: {  body: Array<User>; }) {
-        return UserApiFp.createUsersWithListInput(params)(this.fetch, this.basePath);
+    createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}) {
+        return UserApiFp.createUsersWithListInput(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: {  username: string; }) {
-        return UserApiFp.deleteUser(params)(this.fetch, this.basePath);
+    deleteUser(params: {  username: string; }, options: any = {}) {
+        return UserApiFp.deleteUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: {  username: string; }) {
-        return UserApiFp.getUserByName(params)(this.fetch, this.basePath);
+    getUserByName(params: {  username: string; }, options: any = {}) {
+        return UserApiFp.getUserByName(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Logs user into the system
@@ -1380,15 +1380,15 @@ export class UserApi extends BaseAPI {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: {  username: string; password: string; }) {
-        return UserApiFp.loginUser(params)(this.fetch, this.basePath);
+    loginUser(params: {  username: string; password: string; }, options: any = {}) {
+        return UserApiFp.loginUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Logs out current logged in user session
      * 
      */
-    logoutUser() {
-        return UserApiFp.logoutUser()(this.fetch, this.basePath);
+    logoutUser(options: any = {}) {
+        return UserApiFp.logoutUser(options)(this.fetch, this.basePath);
     }
     /** 
      * Updated user
@@ -1396,8 +1396,8 @@ export class UserApi extends BaseAPI {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: {  username: string; body: User; }) {
-        return UserApiFp.updateUser(params)(this.fetch, this.basePath);
+    updateUser(params: {  username: string; body: User; }, options: any = {}) {
+        return UserApiFp.updateUser(params, options)(this.fetch, this.basePath);
     }
 };
 
@@ -1411,40 +1411,40 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * This can only be done by the logged in user.
          * @param body Created user object
          */
-        createUser(params: {  body: User; }) {
-            return UserApiFp.createUser(params)(fetch, basePath);
+        createUser(params: {  body: User; }, options: any = {}) {
+            return UserApiFp.createUser(params, options)(fetch, basePath);
         },
         /** 
          * Creates list of users with given input array
          * 
          * @param body List of user object
          */
-        createUsersWithArrayInput(params: {  body: Array<User>; }) {
-            return UserApiFp.createUsersWithArrayInput(params)(fetch, basePath);
+        createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}) {
+            return UserApiFp.createUsersWithArrayInput(params, options)(fetch, basePath);
         },
         /** 
          * Creates list of users with given input array
          * 
          * @param body List of user object
          */
-        createUsersWithListInput(params: {  body: Array<User>; }) {
-            return UserApiFp.createUsersWithListInput(params)(fetch, basePath);
+        createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}) {
+            return UserApiFp.createUsersWithListInput(params, options)(fetch, basePath);
         },
         /** 
          * Delete user
          * This can only be done by the logged in user.
          * @param username The name that needs to be deleted
          */
-        deleteUser(params: {  username: string; }) {
-            return UserApiFp.deleteUser(params)(fetch, basePath);
+        deleteUser(params: {  username: string; }, options: any = {}) {
+            return UserApiFp.deleteUser(params, options)(fetch, basePath);
         },
         /** 
          * Get user by user name
          * 
          * @param username The name that needs to be fetched. Use user1 for testing. 
          */
-        getUserByName(params: {  username: string; }) {
-            return UserApiFp.getUserByName(params)(fetch, basePath);
+        getUserByName(params: {  username: string; }, options: any = {}) {
+            return UserApiFp.getUserByName(params, options)(fetch, basePath);
         },
         /** 
          * Logs user into the system
@@ -1452,15 +1452,15 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param username The user name for login
          * @param password The password for login in clear text
          */
-        loginUser(params: {  username: string; password: string; }) {
-            return UserApiFp.loginUser(params)(fetch, basePath);
+        loginUser(params: {  username: string; password: string; }, options: any = {}) {
+            return UserApiFp.loginUser(params, options)(fetch, basePath);
         },
         /** 
          * Logs out current logged in user session
          * 
          */
-        logoutUser() {
-            return UserApiFp.logoutUser()(fetch, basePath);
+        logoutUser(options: any = {}) {
+            return UserApiFp.logoutUser(options)(fetch, basePath);
         },
         /** 
          * Updated user
@@ -1468,8 +1468,8 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param username name that need to be deleted
          * @param body Updated user object
          */
-        updateUser(params: {  username: string; body: User; }) {
-            return UserApiFp.updateUser(params)(fetch, basePath);
+        updateUser(params: {  username: string; body: User; }, options: any = {}) {
+            return UserApiFp.updateUser(params, options)(fetch, basePath);
         },
     };
 };

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/api.ts
@@ -124,7 +124,7 @@ export const PetApiFetchParamCreator = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: {  body: Pet; }, configuration: Configuration, options?: any): FetchArgs {
+    addPet(params: {  body: Pet; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling addPet");
@@ -160,7 +160,7 @@ export const PetApiFetchParamCreator = {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options?: any): FetchArgs {
+    deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling deletePet");
@@ -192,7 +192,7 @@ export const PetApiFetchParamCreator = {
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options?: any): FetchArgs {
+    findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "status" is set
         if (params["status"] == null) {
             throw new Error("Missing required parameter status when calling findPetsByStatus");
@@ -226,7 +226,7 @@ export const PetApiFetchParamCreator = {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options?: any): FetchArgs {
+    findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "tags" is set
         if (params["tags"] == null) {
             throw new Error("Missing required parameter tags when calling findPetsByTags");
@@ -260,7 +260,7 @@ export const PetApiFetchParamCreator = {
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: {  petId: number; }, configuration: Configuration, options?: any): FetchArgs {
+    getPetById(params: {  petId: number; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling getPetById");
@@ -291,7 +291,7 @@ export const PetApiFetchParamCreator = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: {  body: Pet; }, configuration: Configuration, options?: any): FetchArgs {
+    updatePet(params: {  body: Pet; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling updatePet");
@@ -328,7 +328,7 @@ export const PetApiFetchParamCreator = {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options?: any): FetchArgs {
+    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling updatePetWithForm");
@@ -367,7 +367,7 @@ export const PetApiFetchParamCreator = {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options?: any): FetchArgs {
+    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling uploadFile");
@@ -410,8 +410,8 @@ export const PetApiFp = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: { body: Pet;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.addPet(params, configuration);
+    addPet(params: { body: Pet;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.addPet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -428,8 +428,8 @@ export const PetApiFp = {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: { petId: number; apiKey?: string;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.deletePet(params, configuration);
+    deletePet(params: { petId: number; apiKey?: string;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.deletePet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -445,8 +445,8 @@ export const PetApiFp = {
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: { status: Array<string>;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
-        const fetchArgs = PetApiFetchParamCreator.findPetsByStatus(params, configuration);
+    findPetsByStatus(params: { status: Array<string>;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
+        const fetchArgs = PetApiFetchParamCreator.findPetsByStatus(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -462,8 +462,8 @@ export const PetApiFp = {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: { tags: Array<string>;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
-        const fetchArgs = PetApiFetchParamCreator.findPetsByTags(params, configuration);
+    findPetsByTags(params: { tags: Array<string>;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
+        const fetchArgs = PetApiFetchParamCreator.findPetsByTags(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -479,8 +479,8 @@ export const PetApiFp = {
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: { petId: number;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Pet> {
-        const fetchArgs = PetApiFetchParamCreator.getPetById(params, configuration);
+    getPetById(params: { petId: number;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Pet> {
+        const fetchArgs = PetApiFetchParamCreator.getPetById(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -496,8 +496,8 @@ export const PetApiFp = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: { body: Pet;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.updatePet(params, configuration);
+    updatePet(params: { body: Pet;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.updatePet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -515,8 +515,8 @@ export const PetApiFp = {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: { petId: number; name?: string; status?: string;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.updatePetWithForm(params, configuration);
+    updatePetWithForm(params: { petId: number; name?: string; status?: string;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.updatePetWithForm(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -534,8 +534,8 @@ export const PetApiFp = {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: { petId: number; additionalMetadata?: string; file?: any;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<ApiResponse> {
-        const fetchArgs = PetApiFetchParamCreator.uploadFile(params, configuration);
+    uploadFile(params: { petId: number; additionalMetadata?: string; file?: any;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<ApiResponse> {
+        const fetchArgs = PetApiFetchParamCreator.uploadFile(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -557,8 +557,8 @@ export class PetApi extends BaseAPI {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: {  body: Pet; }) {
-        return PetApiFp.addPet(params, this.configuration)(this.fetch, this.basePath);
+    addPet(params: {  body: Pet; }, options: any = {}) {
+        return PetApiFp.addPet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Deletes a pet
@@ -566,40 +566,40 @@ export class PetApi extends BaseAPI {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: {  petId: number; apiKey?: string; }) {
-        return PetApiFp.deletePet(params, this.configuration)(this.fetch, this.basePath);
+    deletePet(params: {  petId: number; apiKey?: string; }, options: any = {}) {
+        return PetApiFp.deletePet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: {  status: Array<string>; }) {
-        return PetApiFp.findPetsByStatus(params, this.configuration)(this.fetch, this.basePath);
+    findPetsByStatus(params: {  status: Array<string>; }, options: any = {}) {
+        return PetApiFp.findPetsByStatus(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: {  tags: Array<string>; }) {
-        return PetApiFp.findPetsByTags(params, this.configuration)(this.fetch, this.basePath);
+    findPetsByTags(params: {  tags: Array<string>; }, options: any = {}) {
+        return PetApiFp.findPetsByTags(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: {  petId: number; }) {
-        return PetApiFp.getPetById(params, this.configuration)(this.fetch, this.basePath);
+    getPetById(params: {  petId: number; }, options: any = {}) {
+        return PetApiFp.getPetById(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: {  body: Pet; }) {
-        return PetApiFp.updatePet(params, this.configuration)(this.fetch, this.basePath);
+    updatePet(params: {  body: Pet; }, options: any = {}) {
+        return PetApiFp.updatePet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Updates a pet in the store with form data
@@ -608,8 +608,8 @@ export class PetApi extends BaseAPI {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }) {
-        return PetApiFp.updatePetWithForm(params, this.configuration)(this.fetch, this.basePath);
+    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, options: any = {}) {
+        return PetApiFp.updatePetWithForm(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * uploads an image
@@ -618,8 +618,8 @@ export class PetApi extends BaseAPI {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }) {
-        return PetApiFp.uploadFile(params, this.configuration)(this.fetch, this.basePath);
+    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, options: any = {}) {
+        return PetApiFp.uploadFile(params, this.configuration, options)(this.fetch, this.basePath);
     }
 };
 
@@ -633,8 +633,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * 
          * @param body Pet object that needs to be added to the store
          */
-        addPet(params: {  body: Pet; }, configuration: Configuration) {
-            return PetApiFp.addPet(params, configuration)(fetch, basePath);
+        addPet(params: {  body: Pet; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.addPet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Deletes a pet
@@ -642,40 +642,40 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param petId Pet id to delete
          * @param apiKey 
          */
-        deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration) {
-            return PetApiFp.deletePet(params, configuration)(fetch, basePath);
+        deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.deletePet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Finds Pets by status
          * Multiple status values can be provided with comma separated strings
          * @param status Status values that need to be considered for filter
          */
-        findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration) {
-            return PetApiFp.findPetsByStatus(params, configuration)(fetch, basePath);
+        findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.findPetsByStatus(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Finds Pets by tags
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @param tags Tags to filter by
          */
-        findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration) {
-            return PetApiFp.findPetsByTags(params, configuration)(fetch, basePath);
+        findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.findPetsByTags(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Find pet by ID
          * Returns a single pet
          * @param petId ID of pet to return
          */
-        getPetById(params: {  petId: number; }, configuration: Configuration) {
-            return PetApiFp.getPetById(params, configuration)(fetch, basePath);
+        getPetById(params: {  petId: number; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.getPetById(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Update an existing pet
          * 
          * @param body Pet object that needs to be added to the store
          */
-        updatePet(params: {  body: Pet; }, configuration: Configuration) {
-            return PetApiFp.updatePet(params, configuration)(fetch, basePath);
+        updatePet(params: {  body: Pet; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.updatePet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Updates a pet in the store with form data
@@ -684,8 +684,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param name Updated name of the pet
          * @param status Updated status of the pet
          */
-        updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration) {
-            return PetApiFp.updatePetWithForm(params, configuration)(fetch, basePath);
+        updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.updatePetWithForm(params, configuration, options)(fetch, basePath);
         },
         /** 
          * uploads an image
@@ -694,8 +694,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param additionalMetadata Additional data to pass to server
          * @param file file to upload
          */
-        uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration) {
-            return PetApiFp.uploadFile(params, configuration)(fetch, basePath);
+        uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.uploadFile(params, configuration, options)(fetch, basePath);
         },
     };
 };
@@ -710,7 +710,7 @@ export const StoreApiFetchParamCreator = {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: {  orderId: string; }, options?: any): FetchArgs {
+    deleteOrder(params: {  orderId: string; }, options: any = {}): FetchArgs {
         // verify required parameter "orderId" is set
         if (params["orderId"] == null) {
             throw new Error("Missing required parameter orderId when calling deleteOrder");
@@ -734,7 +734,7 @@ export const StoreApiFetchParamCreator = {
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory(configuration: Configuration, options?: any): FetchArgs {
+    getInventory(configuration: Configuration, options: any = {}): FetchArgs {
         const baseUrl = `/store/inventory`;
         let urlObj = url.parse(baseUrl, true);
         let fetchOptions: RequestInit = Object.assign({}, { method: "GET" }, options);
@@ -760,7 +760,7 @@ export const StoreApiFetchParamCreator = {
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: {  orderId: number; }, options?: any): FetchArgs {
+    getOrderById(params: {  orderId: number; }, options: any = {}): FetchArgs {
         // verify required parameter "orderId" is set
         if (params["orderId"] == null) {
             throw new Error("Missing required parameter orderId when calling getOrderById");
@@ -785,7 +785,7 @@ export const StoreApiFetchParamCreator = {
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: {  body: Order; }, options?: any): FetchArgs {
+    placeOrder(params: {  body: Order; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling placeOrder");
@@ -819,8 +819,8 @@ export const StoreApiFp = {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: { orderId: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = StoreApiFetchParamCreator.deleteOrder(params);
+    deleteOrder(params: { orderId: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = StoreApiFetchParamCreator.deleteOrder(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -835,8 +835,8 @@ export const StoreApiFp = {
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory(configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<{ [key: string]: number; }> {
-        const fetchArgs = StoreApiFetchParamCreator.getInventory(configuration);
+    getInventory(configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<{ [key: string]: number; }> {
+        const fetchArgs = StoreApiFetchParamCreator.getInventory(configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -852,8 +852,8 @@ export const StoreApiFp = {
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: { orderId: number;  }): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
-        const fetchArgs = StoreApiFetchParamCreator.getOrderById(params);
+    getOrderById(params: { orderId: number;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
+        const fetchArgs = StoreApiFetchParamCreator.getOrderById(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -869,8 +869,8 @@ export const StoreApiFp = {
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: { body: Order;  }): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
-        const fetchArgs = StoreApiFetchParamCreator.placeOrder(params);
+    placeOrder(params: { body: Order;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
+        const fetchArgs = StoreApiFetchParamCreator.placeOrder(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -892,31 +892,31 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: {  orderId: string; }) {
-        return StoreApiFp.deleteOrder(params)(this.fetch, this.basePath);
+    deleteOrder(params: {  orderId: string; }, options: any = {}) {
+        return StoreApiFp.deleteOrder(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory() {
-        return StoreApiFp.getInventory(this.configuration)(this.fetch, this.basePath);
+    getInventory(options: any = {}) {
+        return StoreApiFp.getInventory(this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: {  orderId: number; }) {
-        return StoreApiFp.getOrderById(params)(this.fetch, this.basePath);
+    getOrderById(params: {  orderId: number; }, options: any = {}) {
+        return StoreApiFp.getOrderById(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: {  body: Order; }) {
-        return StoreApiFp.placeOrder(params)(this.fetch, this.basePath);
+    placeOrder(params: {  body: Order; }, options: any = {}) {
+        return StoreApiFp.placeOrder(params, options)(this.fetch, this.basePath);
     }
 };
 
@@ -930,31 +930,31 @@ export const StoreApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
          * @param orderId ID of the order that needs to be deleted
          */
-        deleteOrder(params: {  orderId: string; }) {
-            return StoreApiFp.deleteOrder(params)(fetch, basePath);
+        deleteOrder(params: {  orderId: string; }, options: any = {}) {
+            return StoreApiFp.deleteOrder(params, options)(fetch, basePath);
         },
         /** 
          * Returns pet inventories by status
          * Returns a map of status codes to quantities
          */
-        getInventory(configuration: Configuration) {
-            return StoreApiFp.getInventory(configuration)(fetch, basePath);
+        getInventory(configuration: Configuration, options: any = {}) {
+            return StoreApiFp.getInventory(configuration, options)(fetch, basePath);
         },
         /** 
          * Find purchase order by ID
          * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
          * @param orderId ID of pet that needs to be fetched
          */
-        getOrderById(params: {  orderId: number; }) {
-            return StoreApiFp.getOrderById(params)(fetch, basePath);
+        getOrderById(params: {  orderId: number; }, options: any = {}) {
+            return StoreApiFp.getOrderById(params, options)(fetch, basePath);
         },
         /** 
          * Place an order for a pet
          * 
          * @param body order placed for purchasing the pet
          */
-        placeOrder(params: {  body: Order; }) {
-            return StoreApiFp.placeOrder(params)(fetch, basePath);
+        placeOrder(params: {  body: Order; }, options: any = {}) {
+            return StoreApiFp.placeOrder(params, options)(fetch, basePath);
         },
     };
 };
@@ -969,7 +969,7 @@ export const UserApiFetchParamCreator = {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: {  body: User; }, options?: any): FetchArgs {
+    createUser(params: {  body: User; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUser");
@@ -997,7 +997,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: {  body: Array<User>; }, options?: any): FetchArgs {
+    createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUsersWithArrayInput");
@@ -1025,7 +1025,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: {  body: Array<User>; }, options?: any): FetchArgs {
+    createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUsersWithListInput");
@@ -1053,7 +1053,7 @@ export const UserApiFetchParamCreator = {
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: {  username: string; }, options?: any): FetchArgs {
+    deleteUser(params: {  username: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling deleteUser");
@@ -1078,7 +1078,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: {  username: string; }, options?: any): FetchArgs {
+    getUserByName(params: {  username: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling getUserByName");
@@ -1104,7 +1104,7 @@ export const UserApiFetchParamCreator = {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: {  username: string; password: string; }, options?: any): FetchArgs {
+    loginUser(params: {  username: string; password: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling loginUser");
@@ -1135,7 +1135,7 @@ export const UserApiFetchParamCreator = {
      * Logs out current logged in user session
      * 
      */
-    logoutUser(options?: any): FetchArgs {
+    logoutUser(options: any = {}): FetchArgs {
         const baseUrl = `/user/logout`;
         let urlObj = url.parse(baseUrl, true);
         let fetchOptions: RequestInit = Object.assign({}, { method: "GET" }, options);
@@ -1156,7 +1156,7 @@ export const UserApiFetchParamCreator = {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: {  username: string; body: User; }, options?: any): FetchArgs {
+    updateUser(params: {  username: string; body: User; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling updateUser");
@@ -1195,8 +1195,8 @@ export const UserApiFp = {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: { body: User;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUser(params);
+    createUser(params: { body: User;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1212,8 +1212,8 @@ export const UserApiFp = {
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: { body: Array<User>;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUsersWithArrayInput(params);
+    createUsersWithArrayInput(params: { body: Array<User>;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUsersWithArrayInput(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1229,8 +1229,8 @@ export const UserApiFp = {
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: { body: Array<User>;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUsersWithListInput(params);
+    createUsersWithListInput(params: { body: Array<User>;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUsersWithListInput(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1246,8 +1246,8 @@ export const UserApiFp = {
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: { username: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.deleteUser(params);
+    deleteUser(params: { username: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.deleteUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1263,8 +1263,8 @@ export const UserApiFp = {
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: { username: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<User> {
-        const fetchArgs = UserApiFetchParamCreator.getUserByName(params);
+    getUserByName(params: { username: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<User> {
+        const fetchArgs = UserApiFetchParamCreator.getUserByName(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1281,8 +1281,8 @@ export const UserApiFp = {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: { username: string; password: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<string> {
-        const fetchArgs = UserApiFetchParamCreator.loginUser(params);
+    loginUser(params: { username: string; password: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<string> {
+        const fetchArgs = UserApiFetchParamCreator.loginUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1297,8 +1297,8 @@ export const UserApiFp = {
      * Logs out current logged in user session
      * 
      */
-    logoutUser(): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.logoutUser();
+    logoutUser(options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.logoutUser(options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1315,8 +1315,8 @@ export const UserApiFp = {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: { username: string; body: User;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.updateUser(params);
+    updateUser(params: { username: string; body: User;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.updateUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1338,40 +1338,40 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: {  body: User; }) {
-        return UserApiFp.createUser(params)(this.fetch, this.basePath);
+    createUser(params: {  body: User; }, options: any = {}) {
+        return UserApiFp.createUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Creates list of users with given input array
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: {  body: Array<User>; }) {
-        return UserApiFp.createUsersWithArrayInput(params)(this.fetch, this.basePath);
+    createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}) {
+        return UserApiFp.createUsersWithArrayInput(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Creates list of users with given input array
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: {  body: Array<User>; }) {
-        return UserApiFp.createUsersWithListInput(params)(this.fetch, this.basePath);
+    createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}) {
+        return UserApiFp.createUsersWithListInput(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: {  username: string; }) {
-        return UserApiFp.deleteUser(params)(this.fetch, this.basePath);
+    deleteUser(params: {  username: string; }, options: any = {}) {
+        return UserApiFp.deleteUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: {  username: string; }) {
-        return UserApiFp.getUserByName(params)(this.fetch, this.basePath);
+    getUserByName(params: {  username: string; }, options: any = {}) {
+        return UserApiFp.getUserByName(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Logs user into the system
@@ -1379,15 +1379,15 @@ export class UserApi extends BaseAPI {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: {  username: string; password: string; }) {
-        return UserApiFp.loginUser(params)(this.fetch, this.basePath);
+    loginUser(params: {  username: string; password: string; }, options: any = {}) {
+        return UserApiFp.loginUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Logs out current logged in user session
      * 
      */
-    logoutUser() {
-        return UserApiFp.logoutUser()(this.fetch, this.basePath);
+    logoutUser(options: any = {}) {
+        return UserApiFp.logoutUser(options)(this.fetch, this.basePath);
     }
     /** 
      * Updated user
@@ -1395,8 +1395,8 @@ export class UserApi extends BaseAPI {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: {  username: string; body: User; }) {
-        return UserApiFp.updateUser(params)(this.fetch, this.basePath);
+    updateUser(params: {  username: string; body: User; }, options: any = {}) {
+        return UserApiFp.updateUser(params, options)(this.fetch, this.basePath);
     }
 };
 
@@ -1410,40 +1410,40 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * This can only be done by the logged in user.
          * @param body Created user object
          */
-        createUser(params: {  body: User; }) {
-            return UserApiFp.createUser(params)(fetch, basePath);
+        createUser(params: {  body: User; }, options: any = {}) {
+            return UserApiFp.createUser(params, options)(fetch, basePath);
         },
         /** 
          * Creates list of users with given input array
          * 
          * @param body List of user object
          */
-        createUsersWithArrayInput(params: {  body: Array<User>; }) {
-            return UserApiFp.createUsersWithArrayInput(params)(fetch, basePath);
+        createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}) {
+            return UserApiFp.createUsersWithArrayInput(params, options)(fetch, basePath);
         },
         /** 
          * Creates list of users with given input array
          * 
          * @param body List of user object
          */
-        createUsersWithListInput(params: {  body: Array<User>; }) {
-            return UserApiFp.createUsersWithListInput(params)(fetch, basePath);
+        createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}) {
+            return UserApiFp.createUsersWithListInput(params, options)(fetch, basePath);
         },
         /** 
          * Delete user
          * This can only be done by the logged in user.
          * @param username The name that needs to be deleted
          */
-        deleteUser(params: {  username: string; }) {
-            return UserApiFp.deleteUser(params)(fetch, basePath);
+        deleteUser(params: {  username: string; }, options: any = {}) {
+            return UserApiFp.deleteUser(params, options)(fetch, basePath);
         },
         /** 
          * Get user by user name
          * 
          * @param username The name that needs to be fetched. Use user1 for testing. 
          */
-        getUserByName(params: {  username: string; }) {
-            return UserApiFp.getUserByName(params)(fetch, basePath);
+        getUserByName(params: {  username: string; }, options: any = {}) {
+            return UserApiFp.getUserByName(params, options)(fetch, basePath);
         },
         /** 
          * Logs user into the system
@@ -1451,15 +1451,15 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param username The user name for login
          * @param password The password for login in clear text
          */
-        loginUser(params: {  username: string; password: string; }) {
-            return UserApiFp.loginUser(params)(fetch, basePath);
+        loginUser(params: {  username: string; password: string; }, options: any = {}) {
+            return UserApiFp.loginUser(params, options)(fetch, basePath);
         },
         /** 
          * Logs out current logged in user session
          * 
          */
-        logoutUser() {
-            return UserApiFp.logoutUser()(fetch, basePath);
+        logoutUser(options: any = {}) {
+            return UserApiFp.logoutUser(options)(fetch, basePath);
         },
         /** 
          * Updated user
@@ -1467,8 +1467,8 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param username name that need to be deleted
          * @param body Updated user object
          */
-        updateUser(params: {  username: string; body: User; }) {
-            return UserApiFp.updateUser(params)(fetch, basePath);
+        updateUser(params: {  username: string; body: User; }, options: any = {}) {
+            return UserApiFp.updateUser(params, options)(fetch, basePath);
         },
     };
 };

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/api.ts
@@ -125,7 +125,7 @@ export const PetApiFetchParamCreator = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: {  body: Pet; }, configuration: Configuration, options?: any): FetchArgs {
+    addPet(params: {  body: Pet; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling addPet");
@@ -161,7 +161,7 @@ export const PetApiFetchParamCreator = {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options?: any): FetchArgs {
+    deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling deletePet");
@@ -193,7 +193,7 @@ export const PetApiFetchParamCreator = {
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options?: any): FetchArgs {
+    findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "status" is set
         if (params["status"] == null) {
             throw new Error("Missing required parameter status when calling findPetsByStatus");
@@ -227,7 +227,7 @@ export const PetApiFetchParamCreator = {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options?: any): FetchArgs {
+    findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "tags" is set
         if (params["tags"] == null) {
             throw new Error("Missing required parameter tags when calling findPetsByTags");
@@ -261,7 +261,7 @@ export const PetApiFetchParamCreator = {
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: {  petId: number; }, configuration: Configuration, options?: any): FetchArgs {
+    getPetById(params: {  petId: number; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling getPetById");
@@ -292,7 +292,7 @@ export const PetApiFetchParamCreator = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: {  body: Pet; }, configuration: Configuration, options?: any): FetchArgs {
+    updatePet(params: {  body: Pet; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling updatePet");
@@ -329,7 +329,7 @@ export const PetApiFetchParamCreator = {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options?: any): FetchArgs {
+    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling updatePetWithForm");
@@ -368,7 +368,7 @@ export const PetApiFetchParamCreator = {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options?: any): FetchArgs {
+    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options: any = {}): FetchArgs {
         // verify required parameter "petId" is set
         if (params["petId"] == null) {
             throw new Error("Missing required parameter petId when calling uploadFile");
@@ -411,8 +411,8 @@ export const PetApiFp = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: { body: Pet;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.addPet(params, configuration);
+    addPet(params: { body: Pet;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.addPet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -429,8 +429,8 @@ export const PetApiFp = {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: { petId: number; apiKey?: string;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.deletePet(params, configuration);
+    deletePet(params: { petId: number; apiKey?: string;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.deletePet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -446,8 +446,8 @@ export const PetApiFp = {
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: { status: Array<string>;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
-        const fetchArgs = PetApiFetchParamCreator.findPetsByStatus(params, configuration);
+    findPetsByStatus(params: { status: Array<string>;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
+        const fetchArgs = PetApiFetchParamCreator.findPetsByStatus(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -463,8 +463,8 @@ export const PetApiFp = {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: { tags: Array<string>;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
-        const fetchArgs = PetApiFetchParamCreator.findPetsByTags(params, configuration);
+    findPetsByTags(params: { tags: Array<string>;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Array<Pet>> {
+        const fetchArgs = PetApiFetchParamCreator.findPetsByTags(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -480,8 +480,8 @@ export const PetApiFp = {
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: { petId: number;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<Pet> {
-        const fetchArgs = PetApiFetchParamCreator.getPetById(params, configuration);
+    getPetById(params: { petId: number;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Pet> {
+        const fetchArgs = PetApiFetchParamCreator.getPetById(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -497,8 +497,8 @@ export const PetApiFp = {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: { body: Pet;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.updatePet(params, configuration);
+    updatePet(params: { body: Pet;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.updatePet(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -516,8 +516,8 @@ export const PetApiFp = {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: { petId: number; name?: string; status?: string;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = PetApiFetchParamCreator.updatePetWithForm(params, configuration);
+    updatePetWithForm(params: { petId: number; name?: string; status?: string;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = PetApiFetchParamCreator.updatePetWithForm(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -535,8 +535,8 @@ export const PetApiFp = {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: { petId: number; additionalMetadata?: string; file?: any;  }, configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<ApiResponse> {
-        const fetchArgs = PetApiFetchParamCreator.uploadFile(params, configuration);
+    uploadFile(params: { petId: number; additionalMetadata?: string; file?: any;  }, configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<ApiResponse> {
+        const fetchArgs = PetApiFetchParamCreator.uploadFile(params, configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -558,8 +558,8 @@ export class PetApi extends BaseAPI {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    addPet(params: {  body: Pet; }) {
-        return PetApiFp.addPet(params, this.configuration)(this.fetch, this.basePath);
+    addPet(params: {  body: Pet; }, options: any = {}) {
+        return PetApiFp.addPet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Deletes a pet
@@ -567,40 +567,40 @@ export class PetApi extends BaseAPI {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    deletePet(params: {  petId: number; apiKey?: string; }) {
-        return PetApiFp.deletePet(params, this.configuration)(this.fetch, this.basePath);
+    deletePet(params: {  petId: number; apiKey?: string; }, options: any = {}) {
+        return PetApiFp.deletePet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    findPetsByStatus(params: {  status: Array<string>; }) {
-        return PetApiFp.findPetsByStatus(params, this.configuration)(this.fetch, this.basePath);
+    findPetsByStatus(params: {  status: Array<string>; }, options: any = {}) {
+        return PetApiFp.findPetsByStatus(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    findPetsByTags(params: {  tags: Array<string>; }) {
-        return PetApiFp.findPetsByTags(params, this.configuration)(this.fetch, this.basePath);
+    findPetsByTags(params: {  tags: Array<string>; }, options: any = {}) {
+        return PetApiFp.findPetsByTags(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
      */
-    getPetById(params: {  petId: number; }) {
-        return PetApiFp.getPetById(params, this.configuration)(this.fetch, this.basePath);
+    getPetById(params: {  petId: number; }, options: any = {}) {
+        return PetApiFp.getPetById(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
      */
-    updatePet(params: {  body: Pet; }) {
-        return PetApiFp.updatePet(params, this.configuration)(this.fetch, this.basePath);
+    updatePet(params: {  body: Pet; }, options: any = {}) {
+        return PetApiFp.updatePet(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Updates a pet in the store with form data
@@ -609,8 +609,8 @@ export class PetApi extends BaseAPI {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }) {
-        return PetApiFp.updatePetWithForm(params, this.configuration)(this.fetch, this.basePath);
+    updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, options: any = {}) {
+        return PetApiFp.updatePetWithForm(params, this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * uploads an image
@@ -619,8 +619,8 @@ export class PetApi extends BaseAPI {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }) {
-        return PetApiFp.uploadFile(params, this.configuration)(this.fetch, this.basePath);
+    uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, options: any = {}) {
+        return PetApiFp.uploadFile(params, this.configuration, options)(this.fetch, this.basePath);
     }
 };
 
@@ -634,8 +634,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * 
          * @param body Pet object that needs to be added to the store
          */
-        addPet(params: {  body: Pet; }, configuration: Configuration) {
-            return PetApiFp.addPet(params, configuration)(fetch, basePath);
+        addPet(params: {  body: Pet; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.addPet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Deletes a pet
@@ -643,40 +643,40 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param petId Pet id to delete
          * @param apiKey 
          */
-        deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration) {
-            return PetApiFp.deletePet(params, configuration)(fetch, basePath);
+        deletePet(params: {  petId: number; apiKey?: string; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.deletePet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Finds Pets by status
          * Multiple status values can be provided with comma separated strings
          * @param status Status values that need to be considered for filter
          */
-        findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration) {
-            return PetApiFp.findPetsByStatus(params, configuration)(fetch, basePath);
+        findPetsByStatus(params: {  status: Array<string>; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.findPetsByStatus(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Finds Pets by tags
          * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @param tags Tags to filter by
          */
-        findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration) {
-            return PetApiFp.findPetsByTags(params, configuration)(fetch, basePath);
+        findPetsByTags(params: {  tags: Array<string>; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.findPetsByTags(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Find pet by ID
          * Returns a single pet
          * @param petId ID of pet to return
          */
-        getPetById(params: {  petId: number; }, configuration: Configuration) {
-            return PetApiFp.getPetById(params, configuration)(fetch, basePath);
+        getPetById(params: {  petId: number; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.getPetById(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Update an existing pet
          * 
          * @param body Pet object that needs to be added to the store
          */
-        updatePet(params: {  body: Pet; }, configuration: Configuration) {
-            return PetApiFp.updatePet(params, configuration)(fetch, basePath);
+        updatePet(params: {  body: Pet; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.updatePet(params, configuration, options)(fetch, basePath);
         },
         /** 
          * Updates a pet in the store with form data
@@ -685,8 +685,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param name Updated name of the pet
          * @param status Updated status of the pet
          */
-        updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration) {
-            return PetApiFp.updatePetWithForm(params, configuration)(fetch, basePath);
+        updatePetWithForm(params: {  petId: number; name?: string; status?: string; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.updatePetWithForm(params, configuration, options)(fetch, basePath);
         },
         /** 
          * uploads an image
@@ -695,8 +695,8 @@ export const PetApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param additionalMetadata Additional data to pass to server
          * @param file file to upload
          */
-        uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration) {
-            return PetApiFp.uploadFile(params, configuration)(fetch, basePath);
+        uploadFile(params: {  petId: number; additionalMetadata?: string; file?: any; }, configuration: Configuration, options: any = {}) {
+            return PetApiFp.uploadFile(params, configuration, options)(fetch, basePath);
         },
     };
 };
@@ -711,7 +711,7 @@ export const StoreApiFetchParamCreator = {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: {  orderId: string; }, options?: any): FetchArgs {
+    deleteOrder(params: {  orderId: string; }, options: any = {}): FetchArgs {
         // verify required parameter "orderId" is set
         if (params["orderId"] == null) {
             throw new Error("Missing required parameter orderId when calling deleteOrder");
@@ -735,7 +735,7 @@ export const StoreApiFetchParamCreator = {
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory(configuration: Configuration, options?: any): FetchArgs {
+    getInventory(configuration: Configuration, options: any = {}): FetchArgs {
         const baseUrl = `/store/inventory`;
         let urlObj = url.parse(baseUrl, true);
         let fetchOptions: RequestInit = assign({}, { method: "GET" }, options);
@@ -761,7 +761,7 @@ export const StoreApiFetchParamCreator = {
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: {  orderId: number; }, options?: any): FetchArgs {
+    getOrderById(params: {  orderId: number; }, options: any = {}): FetchArgs {
         // verify required parameter "orderId" is set
         if (params["orderId"] == null) {
             throw new Error("Missing required parameter orderId when calling getOrderById");
@@ -786,7 +786,7 @@ export const StoreApiFetchParamCreator = {
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: {  body: Order; }, options?: any): FetchArgs {
+    placeOrder(params: {  body: Order; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling placeOrder");
@@ -820,8 +820,8 @@ export const StoreApiFp = {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: { orderId: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = StoreApiFetchParamCreator.deleteOrder(params);
+    deleteOrder(params: { orderId: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = StoreApiFetchParamCreator.deleteOrder(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -836,8 +836,8 @@ export const StoreApiFp = {
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory(configuration: Configuration): (fetch: FetchAPI, basePath?: string) => Promise<{ [key: string]: number; }> {
-        const fetchArgs = StoreApiFetchParamCreator.getInventory(configuration);
+    getInventory(configuration: Configuration, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<{ [key: string]: number; }> {
+        const fetchArgs = StoreApiFetchParamCreator.getInventory(configuration, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -853,8 +853,8 @@ export const StoreApiFp = {
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: { orderId: number;  }): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
-        const fetchArgs = StoreApiFetchParamCreator.getOrderById(params);
+    getOrderById(params: { orderId: number;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
+        const fetchArgs = StoreApiFetchParamCreator.getOrderById(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -870,8 +870,8 @@ export const StoreApiFp = {
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: { body: Order;  }): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
-        const fetchArgs = StoreApiFetchParamCreator.placeOrder(params);
+    placeOrder(params: { body: Order;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<Order> {
+        const fetchArgs = StoreApiFetchParamCreator.placeOrder(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -893,31 +893,31 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
      */
-    deleteOrder(params: {  orderId: string; }) {
-        return StoreApiFp.deleteOrder(params)(this.fetch, this.basePath);
+    deleteOrder(params: {  orderId: string; }, options: any = {}) {
+        return StoreApiFp.deleteOrder(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      */
-    getInventory() {
-        return StoreApiFp.getInventory(this.configuration)(this.fetch, this.basePath);
+    getInventory(options: any = {}) {
+        return StoreApiFp.getInventory(this.configuration, options)(this.fetch, this.basePath);
     }
     /** 
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    getOrderById(params: {  orderId: number; }) {
-        return StoreApiFp.getOrderById(params)(this.fetch, this.basePath);
+    getOrderById(params: {  orderId: number; }, options: any = {}) {
+        return StoreApiFp.getOrderById(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
      */
-    placeOrder(params: {  body: Order; }) {
-        return StoreApiFp.placeOrder(params)(this.fetch, this.basePath);
+    placeOrder(params: {  body: Order; }, options: any = {}) {
+        return StoreApiFp.placeOrder(params, options)(this.fetch, this.basePath);
     }
 };
 
@@ -931,31 +931,31 @@ export const StoreApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
          * @param orderId ID of the order that needs to be deleted
          */
-        deleteOrder(params: {  orderId: string; }) {
-            return StoreApiFp.deleteOrder(params)(fetch, basePath);
+        deleteOrder(params: {  orderId: string; }, options: any = {}) {
+            return StoreApiFp.deleteOrder(params, options)(fetch, basePath);
         },
         /** 
          * Returns pet inventories by status
          * Returns a map of status codes to quantities
          */
-        getInventory(configuration: Configuration) {
-            return StoreApiFp.getInventory(configuration)(fetch, basePath);
+        getInventory(configuration: Configuration, options: any = {}) {
+            return StoreApiFp.getInventory(configuration, options)(fetch, basePath);
         },
         /** 
          * Find purchase order by ID
          * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
          * @param orderId ID of pet that needs to be fetched
          */
-        getOrderById(params: {  orderId: number; }) {
-            return StoreApiFp.getOrderById(params)(fetch, basePath);
+        getOrderById(params: {  orderId: number; }, options: any = {}) {
+            return StoreApiFp.getOrderById(params, options)(fetch, basePath);
         },
         /** 
          * Place an order for a pet
          * 
          * @param body order placed for purchasing the pet
          */
-        placeOrder(params: {  body: Order; }) {
-            return StoreApiFp.placeOrder(params)(fetch, basePath);
+        placeOrder(params: {  body: Order; }, options: any = {}) {
+            return StoreApiFp.placeOrder(params, options)(fetch, basePath);
         },
     };
 };
@@ -970,7 +970,7 @@ export const UserApiFetchParamCreator = {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: {  body: User; }, options?: any): FetchArgs {
+    createUser(params: {  body: User; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUser");
@@ -998,7 +998,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: {  body: Array<User>; }, options?: any): FetchArgs {
+    createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUsersWithArrayInput");
@@ -1026,7 +1026,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: {  body: Array<User>; }, options?: any): FetchArgs {
+    createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}): FetchArgs {
         // verify required parameter "body" is set
         if (params["body"] == null) {
             throw new Error("Missing required parameter body when calling createUsersWithListInput");
@@ -1054,7 +1054,7 @@ export const UserApiFetchParamCreator = {
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: {  username: string; }, options?: any): FetchArgs {
+    deleteUser(params: {  username: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling deleteUser");
@@ -1079,7 +1079,7 @@ export const UserApiFetchParamCreator = {
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: {  username: string; }, options?: any): FetchArgs {
+    getUserByName(params: {  username: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling getUserByName");
@@ -1105,7 +1105,7 @@ export const UserApiFetchParamCreator = {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: {  username: string; password: string; }, options?: any): FetchArgs {
+    loginUser(params: {  username: string; password: string; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling loginUser");
@@ -1136,7 +1136,7 @@ export const UserApiFetchParamCreator = {
      * Logs out current logged in user session
      * 
      */
-    logoutUser(options?: any): FetchArgs {
+    logoutUser(options: any = {}): FetchArgs {
         const baseUrl = `/user/logout`;
         let urlObj = url.parse(baseUrl, true);
         let fetchOptions: RequestInit = assign({}, { method: "GET" }, options);
@@ -1157,7 +1157,7 @@ export const UserApiFetchParamCreator = {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: {  username: string; body: User; }, options?: any): FetchArgs {
+    updateUser(params: {  username: string; body: User; }, options: any = {}): FetchArgs {
         // verify required parameter "username" is set
         if (params["username"] == null) {
             throw new Error("Missing required parameter username when calling updateUser");
@@ -1196,8 +1196,8 @@ export const UserApiFp = {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: { body: User;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUser(params);
+    createUser(params: { body: User;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1213,8 +1213,8 @@ export const UserApiFp = {
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: { body: Array<User>;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUsersWithArrayInput(params);
+    createUsersWithArrayInput(params: { body: Array<User>;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUsersWithArrayInput(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1230,8 +1230,8 @@ export const UserApiFp = {
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: { body: Array<User>;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.createUsersWithListInput(params);
+    createUsersWithListInput(params: { body: Array<User>;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.createUsersWithListInput(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1247,8 +1247,8 @@ export const UserApiFp = {
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: { username: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.deleteUser(params);
+    deleteUser(params: { username: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.deleteUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1264,8 +1264,8 @@ export const UserApiFp = {
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: { username: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<User> {
-        const fetchArgs = UserApiFetchParamCreator.getUserByName(params);
+    getUserByName(params: { username: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<User> {
+        const fetchArgs = UserApiFetchParamCreator.getUserByName(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1282,8 +1282,8 @@ export const UserApiFp = {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: { username: string; password: string;  }): (fetch: FetchAPI, basePath?: string) => Promise<string> {
-        const fetchArgs = UserApiFetchParamCreator.loginUser(params);
+    loginUser(params: { username: string; password: string;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<string> {
+        const fetchArgs = UserApiFetchParamCreator.loginUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1298,8 +1298,8 @@ export const UserApiFp = {
      * Logs out current logged in user session
      * 
      */
-    logoutUser(): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.logoutUser();
+    logoutUser(options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.logoutUser(options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1316,8 +1316,8 @@ export const UserApiFp = {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: { username: string; body: User;  }): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = UserApiFetchParamCreator.updateUser(params);
+    updateUser(params: { username: string; body: User;  }, options: any = {}): (fetch: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = UserApiFetchParamCreator.updateUser(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {
@@ -1339,40 +1339,40 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    createUser(params: {  body: User; }) {
-        return UserApiFp.createUser(params)(this.fetch, this.basePath);
+    createUser(params: {  body: User; }, options: any = {}) {
+        return UserApiFp.createUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Creates list of users with given input array
      * 
      * @param body List of user object
      */
-    createUsersWithArrayInput(params: {  body: Array<User>; }) {
-        return UserApiFp.createUsersWithArrayInput(params)(this.fetch, this.basePath);
+    createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}) {
+        return UserApiFp.createUsersWithArrayInput(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Creates list of users with given input array
      * 
      * @param body List of user object
      */
-    createUsersWithListInput(params: {  body: Array<User>; }) {
-        return UserApiFp.createUsersWithListInput(params)(this.fetch, this.basePath);
+    createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}) {
+        return UserApiFp.createUsersWithListInput(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
      */
-    deleteUser(params: {  username: string; }) {
-        return UserApiFp.deleteUser(params)(this.fetch, this.basePath);
+    deleteUser(params: {  username: string; }, options: any = {}) {
+        return UserApiFp.deleteUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    getUserByName(params: {  username: string; }) {
-        return UserApiFp.getUserByName(params)(this.fetch, this.basePath);
+    getUserByName(params: {  username: string; }, options: any = {}) {
+        return UserApiFp.getUserByName(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Logs user into the system
@@ -1380,15 +1380,15 @@ export class UserApi extends BaseAPI {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    loginUser(params: {  username: string; password: string; }) {
-        return UserApiFp.loginUser(params)(this.fetch, this.basePath);
+    loginUser(params: {  username: string; password: string; }, options: any = {}) {
+        return UserApiFp.loginUser(params, options)(this.fetch, this.basePath);
     }
     /** 
      * Logs out current logged in user session
      * 
      */
-    logoutUser() {
-        return UserApiFp.logoutUser()(this.fetch, this.basePath);
+    logoutUser(options: any = {}) {
+        return UserApiFp.logoutUser(options)(this.fetch, this.basePath);
     }
     /** 
      * Updated user
@@ -1396,8 +1396,8 @@ export class UserApi extends BaseAPI {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    updateUser(params: {  username: string; body: User; }) {
-        return UserApiFp.updateUser(params)(this.fetch, this.basePath);
+    updateUser(params: {  username: string; body: User; }, options: any = {}) {
+        return UserApiFp.updateUser(params, options)(this.fetch, this.basePath);
     }
 };
 
@@ -1411,40 +1411,40 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * This can only be done by the logged in user.
          * @param body Created user object
          */
-        createUser(params: {  body: User; }) {
-            return UserApiFp.createUser(params)(fetch, basePath);
+        createUser(params: {  body: User; }, options: any = {}) {
+            return UserApiFp.createUser(params, options)(fetch, basePath);
         },
         /** 
          * Creates list of users with given input array
          * 
          * @param body List of user object
          */
-        createUsersWithArrayInput(params: {  body: Array<User>; }) {
-            return UserApiFp.createUsersWithArrayInput(params)(fetch, basePath);
+        createUsersWithArrayInput(params: {  body: Array<User>; }, options: any = {}) {
+            return UserApiFp.createUsersWithArrayInput(params, options)(fetch, basePath);
         },
         /** 
          * Creates list of users with given input array
          * 
          * @param body List of user object
          */
-        createUsersWithListInput(params: {  body: Array<User>; }) {
-            return UserApiFp.createUsersWithListInput(params)(fetch, basePath);
+        createUsersWithListInput(params: {  body: Array<User>; }, options: any = {}) {
+            return UserApiFp.createUsersWithListInput(params, options)(fetch, basePath);
         },
         /** 
          * Delete user
          * This can only be done by the logged in user.
          * @param username The name that needs to be deleted
          */
-        deleteUser(params: {  username: string; }) {
-            return UserApiFp.deleteUser(params)(fetch, basePath);
+        deleteUser(params: {  username: string; }, options: any = {}) {
+            return UserApiFp.deleteUser(params, options)(fetch, basePath);
         },
         /** 
          * Get user by user name
          * 
          * @param username The name that needs to be fetched. Use user1 for testing. 
          */
-        getUserByName(params: {  username: string; }) {
-            return UserApiFp.getUserByName(params)(fetch, basePath);
+        getUserByName(params: {  username: string; }, options: any = {}) {
+            return UserApiFp.getUserByName(params, options)(fetch, basePath);
         },
         /** 
          * Logs user into the system
@@ -1452,15 +1452,15 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param username The user name for login
          * @param password The password for login in clear text
          */
-        loginUser(params: {  username: string; password: string; }) {
-            return UserApiFp.loginUser(params)(fetch, basePath);
+        loginUser(params: {  username: string; password: string; }, options: any = {}) {
+            return UserApiFp.loginUser(params, options)(fetch, basePath);
         },
         /** 
          * Logs out current logged in user session
          * 
          */
-        logoutUser() {
-            return UserApiFp.logoutUser()(fetch, basePath);
+        logoutUser(options: any = {}) {
+            return UserApiFp.logoutUser(options)(fetch, basePath);
         },
         /** 
          * Updated user
@@ -1468,8 +1468,8 @@ export const UserApiFactory = function (fetch?: FetchAPI, basePath?: string) {
          * @param username name that need to be deleted
          * @param body Updated user object
          */
-        updateUser(params: {  username: string; body: User; }) {
-            return UserApiFp.updateUser(params)(fetch, basePath);
+        updateUser(params: {  username: string; body: User; }, options: any = {}) {
+            return UserApiFp.updateUser(params, options)(fetch, basePath);
         },
     };
 };

--- a/samples/client/petstore/typescript-fetch/tests/default/test/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/tests/default/test/PetApi.ts
@@ -20,16 +20,16 @@ describe('PetApi', () => {
       });
 
       it('should get Pet by ID', () => {
-          return api.getPetById({ petId: fixture.id }, requestOptions).then((result) => {
+          return api.getPetById({ petId: fixture.id }, requestOptions).then((result: Pet) => {
               return expect(result).to.deep.equal(fixture);
           });
       });
 
       it('should update Pet by ID', () => {
-        return api.getPetById({ petId: fixture.id }, requestOptions).then( (result) => {
+        return api.getPetById({ petId: fixture.id }, requestOptions).then( (result: Pet) => {
           result.name = 'newname';
           return api.updatePet({ body: result }, requestOptions).then(() => {
-            return api.getPetById({ petId: fixture.id }, requestOptions).then( (result) => {
+            return api.getPetById({ petId: fixture.id }, requestOptions).then( (result: Pet) => {
               return expect(result.name).to.deep.equal('newname');
             });
           });
@@ -41,9 +41,9 @@ describe('PetApi', () => {
       });
 
       it('should not contain deleted Pet', () => {
-          return api.getPetById({ petId: fixture.id }, requestOptions).then((result) => {
+          return api.getPetById({ petId: fixture.id }, requestOptions).then((result: Pet) => {
               return expect(result).to.not.exist;
-          }, (err) => {
+          }, (err: any) => {
             return expect(err).to.exist;
           });
       });

--- a/samples/client/petstore/typescript-fetch/tests/default/test/PetApiFactory.ts
+++ b/samples/client/petstore/typescript-fetch/tests/default/test/PetApiFactory.ts
@@ -24,21 +24,21 @@ describe('PetApiFactory', () => {
       const fixture: Pet = createTestFixture();
 
       it('should add and delete Pet', () => {
-        return PetApiFactory().addPet({ body: fixture }, requestOptions).then(() => {
+        return PetApiFactory().addPet({ body: fixture }, config, requestOptions).then(() => {
         });
       });
 
       it('should get Pet by ID', () => {
-          return PetApiFactory().getPetById({ petId: fixture.id }, requestOptions).then((result) => {
+          return PetApiFactory().getPetById({ petId: fixture.id }, config, requestOptions).then((result: Pet) => {
               return expect(result).to.deep.equal(fixture);
           });
       });
 
       it('should update Pet by ID', () => {
-        return PetApiFactory().getPetById({ petId: fixture.id }, requestOptions).then( (result) => {
+        return PetApiFactory().getPetById({ petId: fixture.id }, config, requestOptions).then( (result: Pet) => {
           result.name = 'newname';
-          return PetApiFactory().updatePet({ body: result }, requestOptions).then(() => {
-            return PetApiFactory().getPetById({ petId: fixture.id }, requestOptions).then( (result) => {
+          return PetApiFactory().updatePet({ body: result }, config, requestOptions).then(() => {
+            return PetApiFactory().getPetById({ petId: fixture.id }, config, requestOptions).then( (result: Pet) => {
               return expect(result.name).to.deep.equal('newname');
             });
           });
@@ -46,13 +46,13 @@ describe('PetApiFactory', () => {
       });
 
       it('should delete Pet', () => {
-        return PetApiFactory().deletePet({ petId: fixture.id }, requestOptions);
+        return PetApiFactory().deletePet({ petId: fixture.id }, config, requestOptions);
       });
 
       it('should not contain deleted Pet', () => {
-        return PetApiFactory().getPetById({ petId: fixture.id }, requestOptions).then((result) => {
+        return PetApiFactory().getPetById({ petId: fixture.id }, config, requestOptions).then((result: Pet) => {
           return expect(result).to.not.exist;
-        }, (err) => {
+        }, (err: any) => {
           return expect(err).to.exist;
         });
       });

--- a/samples/client/petstore/typescript-fetch/tests/default/test/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/tests/default/test/StoreApi.ts
@@ -7,14 +7,13 @@ describe('StoreApi', function() {
 
     describe(description, () => {
       let api: StoreApi;
-      const requestOptions: any = {credentials: 'include', mode: 'cors'}
 
       beforeEach(function() {
         api = new StoreApi();
       });
 
       it('should get inventory', function() {
-        return api.getInventory(requestOptions).then((result) => {
+        return api.getInventory(requestOptions).then((result: { [key: string]: number }) => {
           expect(Object.keys(result)).to.not.be.empty;
         });
       });

--- a/samples/client/petstore/typescript-fetch/tests/default/test/StoreApiFactory.ts
+++ b/samples/client/petstore/typescript-fetch/tests/default/test/StoreApiFactory.ts
@@ -19,10 +19,8 @@ describe('StoreApiFactory', function() {
 
     describe(description, () => {
 
-      const requestOptions: any = {credentials: 'include', mode: 'cors'};
-
       it('should get inventory', function() {
-        return StoreApiFactory().getInventory(requestOptions).then((result) => {
+        return StoreApiFactory().getInventory(config, requestOptions).then((result: { [key: string]: number }) => {
           expect(Object.keys(result)).to.not.be.empty;
         });
       });


### PR DESCRIPTION
…tions and auth config. Both now play nicely together, and tests are fixed.

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixes https://github.com/swagger-api/swagger-codegen/issues/4498

There were a couple of problems causing this that have been fixed...

- The tests were missing some typing in the fulfilled promise assertions, these are now typed correctly
- This masked a bigger problem, that the signatures were incorrect - hence the tests actually caught that something worse was going on at API generation time. On investigation, found that there had been a bad merge between the addition of request options, and the auth config, with the auth config having won in the merge and accidentally having overwritten the request options.

I have fixed the template to support both the request options and auth config, also fixed the tests. All tests regenerated and everything is working fine again now