### PR TITLE
[aspnetcore] use default in model constructors, supports enums

### DIFF
--- a/modules/swagger-codegen/src/main/resources/aspnetcore/enumClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/enumClass.mustache
@@ -1,0 +1,14 @@
+        /// <summary>
+        /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
+        /// </summary>{{#description}}
+        /// <value>{{{description}}}</value>{{/description}}
+        public enum {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
+        {
+            {{#allowableValues}}{{#enumVars}}
+            /// <summary>
+            /// Enum {{name}} for {{{value}}}
+            /// </summary>
+            [EnumMember(Value = {{#isLong}}"{{/isLong}}{{#isInteger}}"{{/isInteger}}{{#isFloat}}"{{/isFloat}}{{#isDouble}}"{{/isDouble}}{{{value}}}{{#isLong}}"{{/isLong}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isFloat}}"{{/isFloat}})]
+            {{name}}{{#isLong}} = {{{value}}}{{/isLong}}{{#isInteger}} = {{{value}}}{{/isInteger}}{{^-last}},
+            {{/-last}}{{/enumVars}}{{/allowableValues}}
+        }

--- a/modules/swagger-codegen/src/main/resources/aspnetcore/global.json
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/global.json
@@ -1,5 +1,5 @@
 {
-  "projects": [ "src", "test" ],
+  "projects": [ "src" ],
   "sdk": {
     "version": "1.0.0-preview2-003121",
     "runtime": "coreclr"

--- a/modules/swagger-codegen/src/main/resources/aspnetcore/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/model.mustache
@@ -24,7 +24,7 @@ namespace {{packageName}}.Models
         /// </summary>
 {{#vars}}        /// <param name="{{name}}">{{#description}}{{description}}{{/description}}{{^description}}{{name}}{{/description}}{{#required}} (required){{/required}}{{#defaultValue}} (default to {{defaultValue}}){{/defaultValue}}.</param>
 {{/vars}}
-        public {{classname}}({{#vars}}{{{datatype}}} {{name}} = null{{#hasMore}}, {{/hasMore}}{{/vars}})
+        public {{classname}}({{#readWriteVars}}{{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} = {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}default({{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}}){{/defaultValue}}{{^-last}}, {{/-last}}{{/readWriteVars}})
         {
             {{#vars}}{{#required}}// to ensure "{{name}}" is required (not null)
             if ({{name}} == null)

--- a/modules/swagger-codegen/src/main/resources/aspnetcore/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/model.mustache
@@ -13,12 +13,34 @@ using Newtonsoft.Json;
 {{#model}}
 namespace {{packageName}}.Models
 {
+{{#isEnum}}{{>enumClass}}{{/isEnum}}{{^isEnum}}
     /// <summary>
     /// {{description}}
     /// </summary>
     [DataContract]
     public partial class {{classname}} : {{#parent}}{{{parent}}}, {{/parent}} IEquatable<{{classname}}>
     {
+        {{#vars}}
+        {{#isEnum}}
+        {{>enumClass}}
+        {{/isEnum}}
+        {{#items.isEnum}}
+        {{#items}}
+        {{>enumClass}}
+        {{/items}}
+        {{/items.isEnum}}
+        {{/vars}}
+        {{#vars}}
+        {{#isEnum}}
+        /// <summary>
+        /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
+        /// </summary>{{#description}}
+        /// <value>{{{description}}}</value>{{/description}}
+        [DataMember(Name="{{baseName}}")]
+        public {{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} { get; set; }
+        {{/isEnum}}
+        {{/vars}}
+
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class.
         /// </summary>
@@ -49,13 +71,14 @@ namespace {{packageName}}.Models
         }
 
         {{#vars}}
+        {{^isEnum}}
         /// <summary>
-        /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
+        /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
         /// </summary>{{#description}}
-        /// <value>{{{description}}}</value>{{/description}}
+        /// <value>{{description}}</value>{{/description}}
         [DataMember(Name="{{baseName}}")]
-        public {{{datatype}}} {{name}} { get; set; }
-
+        public {{{datatype}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
+        {{/isEnum}}
         {{/vars}}
 
         /// <summary>
@@ -153,6 +176,7 @@ namespace {{packageName}}.Models
         #endregion Operators
 
     }
+{{/isEnum}}
 {{/model}}
 {{/models}}
 }

--- a/modules/swagger-codegen/src/main/resources/aspnetcore/project.json.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/project.json.mustache
@@ -22,7 +22,8 @@
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
     "Microsoft.EntityFrameworkCore": "1.0.0",
     "Swashbuckle.SwaggerGen": "6.0.0-beta901",
-    "Swashbuckle.SwaggerUi": "6.0.0-beta901"
+    "Swashbuckle.SwaggerUi": "6.0.0-beta901",
+    "Newtonsoft.Json": "9.0.1"
   },
 
   "tools": {

--- a/samples/server/petstore/aspnetcore/IO.Swagger.sln
+++ b/samples/server/petstore/aspnetcore/IO.Swagger.sln
@@ -7,7 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
                 global.json = global.json
         EndProjectSection
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.xproj", "{85CF9021-4522-4D1B-871B-D4C1C6483FA1}"
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.xproj", "{795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}"
 EndProject
 Global
         GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,10 +15,10 @@ Global
                 Release|Any CPU = Release|Any CPU
         EndGlobalSection
         GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                {85CF9021-4522-4D1B-871B-D4C1C6483FA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {85CF9021-4522-4D1B-871B-D4C1C6483FA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {85CF9021-4522-4D1B-871B-D4C1C6483FA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {85CF9021-4522-4D1B-871B-D4C1C6483FA1}.Release|Any CPU.Build.0 = Release|Any CPU
+                {795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
         GlobalSection(SolutionProperties) = preSolution
                 HideSolutionNode = FALSE

--- a/samples/server/petstore/aspnetcore/global.json
+++ b/samples/server/petstore/aspnetcore/global.json
@@ -1,7 +1,7 @@
 {
-  "projects": [ "src", "test" ],
+  "projects": [ "src" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121",
+    "version": "1.0.0-preview3-003171",
     "runtime": "coreclr"
   }
 }

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/IO.Swagger.xproj
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/IO.Swagger.xproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
     <PropertyGroup Label="Globals">
-        <ProjectGuid>{85CF9021-4522-4D1B-871B-D4C1C6483FA1}</ProjectGuid>
+        <ProjectGuid>{795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}</ProjectGuid>
         <RootNamespace>IO.Swagger</RootNamespace>
         <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
         <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/ApiResponse.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/ApiResponse.cs
@@ -20,19 +20,21 @@ using Newtonsoft.Json;
 
 namespace IO.Swagger.Models
 {
+
     /// <summary>
     /// Describes the result of uploading an image resource
     /// </summary>
     [DataContract]
     public partial class ApiResponse :  IEquatable<ApiResponse>
     {
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
         /// </summary>
         /// <param name="Code">Code.</param>
         /// <param name="Type">Type.</param>
         /// <param name="Message">Message.</param>
-        public ApiResponse(int? Code = null, string Type = null, string Message = null)
+        public ApiResponse(int? Code = default(int?), string Type = default(string), string Message = default(string))
         {
             this.Code = Code;
             this.Type = Type;
@@ -45,19 +47,16 @@ namespace IO.Swagger.Models
         /// </summary>
         [DataMember(Name="code")]
         public int? Code { get; set; }
-
         /// <summary>
         /// Gets or Sets Type
         /// </summary>
         [DataMember(Name="type")]
         public string Type { get; set; }
-
         /// <summary>
         /// Gets or Sets Message
         /// </summary>
         [DataMember(Name="message")]
         public string Message { get; set; }
-
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/Category.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/Category.cs
@@ -20,18 +20,20 @@ using Newtonsoft.Json;
 
 namespace IO.Swagger.Models
 {
+
     /// <summary>
     /// A category for a pet
     /// </summary>
     [DataContract]
     public partial class Category :  IEquatable<Category>
     {
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
         /// </summary>
         /// <param name="Id">Id.</param>
         /// <param name="Name">Name.</param>
-        public Category(long? Id = null, string Name = null)
+        public Category(long? Id = default(long?), string Name = default(string))
         {
             this.Id = Id;
             this.Name = Name;
@@ -43,13 +45,11 @@ namespace IO.Swagger.Models
         /// </summary>
         [DataMember(Name="id")]
         public long? Id { get; set; }
-
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name="name")]
         public string Name { get; set; }
-
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/Order.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/Order.cs
@@ -20,12 +20,45 @@ using Newtonsoft.Json;
 
 namespace IO.Swagger.Models
 {
+
     /// <summary>
     /// An order for a pets from the pet store
     /// </summary>
     [DataContract]
     public partial class Order :  IEquatable<Order>
     {
+                /// <summary>
+        /// Order Status
+        /// </summary>
+        /// <value>Order Status</value>
+        public enum StatusEnum
+        {
+            
+            /// <summary>
+            /// Enum PlacedEnum for "placed"
+            /// </summary>
+            [EnumMember(Value = "placed")]
+            PlacedEnum,
+            
+            /// <summary>
+            /// Enum ApprovedEnum for "approved"
+            /// </summary>
+            [EnumMember(Value = "approved")]
+            ApprovedEnum,
+            
+            /// <summary>
+            /// Enum DeliveredEnum for "delivered"
+            /// </summary>
+            [EnumMember(Value = "delivered")]
+            DeliveredEnum
+        }
+        /// <summary>
+        /// Order Status
+        /// </summary>
+        /// <value>Order Status</value>
+        [DataMember(Name="status")]
+        public StatusEnum? Status { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
         /// </summary>
@@ -35,7 +68,7 @@ namespace IO.Swagger.Models
         /// <param name="ShipDate">ShipDate.</param>
         /// <param name="Status">Order Status.</param>
         /// <param name="Complete">Complete (default to false).</param>
-        public Order(long? Id = null, long? PetId = null, int? Quantity = null, DateTime? ShipDate = null, string Status = null, bool? Complete = null)
+        public Order(long? Id = default(long?), long? PetId = default(long?), int? Quantity = default(int?), DateTime? ShipDate = default(DateTime?), StatusEnum? Status = default(StatusEnum?), bool? Complete = false)
         {
             this.Id = Id;
             this.PetId = PetId;
@@ -59,38 +92,26 @@ namespace IO.Swagger.Models
         /// </summary>
         [DataMember(Name="id")]
         public long? Id { get; set; }
-
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name="petId")]
         public long? PetId { get; set; }
-
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name="quantity")]
         public int? Quantity { get; set; }
-
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         [DataMember(Name="shipDate")]
         public DateTime? ShipDate { get; set; }
-
-        /// <summary>
-        /// Order Status
-        /// </summary>
-        /// <value>Order Status</value>
-        [DataMember(Name="status")]
-        public string Status { get; set; }
-
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name="complete")]
         public bool? Complete { get; set; }
-
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/Pet.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/Pet.cs
@@ -20,12 +20,45 @@ using Newtonsoft.Json;
 
 namespace IO.Swagger.Models
 {
+
     /// <summary>
     /// A pet for sale in the pet store
     /// </summary>
     [DataContract]
     public partial class Pet :  IEquatable<Pet>
     {
+                /// <summary>
+        /// pet status in the store
+        /// </summary>
+        /// <value>pet status in the store</value>
+        public enum StatusEnum
+        {
+            
+            /// <summary>
+            /// Enum AvailableEnum for "available"
+            /// </summary>
+            [EnumMember(Value = "available")]
+            AvailableEnum,
+            
+            /// <summary>
+            /// Enum PendingEnum for "pending"
+            /// </summary>
+            [EnumMember(Value = "pending")]
+            PendingEnum,
+            
+            /// <summary>
+            /// Enum SoldEnum for "sold"
+            /// </summary>
+            [EnumMember(Value = "sold")]
+            SoldEnum
+        }
+        /// <summary>
+        /// pet status in the store
+        /// </summary>
+        /// <value>pet status in the store</value>
+        [DataMember(Name="status")]
+        public StatusEnum? Status { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
         /// </summary>
@@ -35,7 +68,7 @@ namespace IO.Swagger.Models
         /// <param name="PhotoUrls">PhotoUrls (required).</param>
         /// <param name="Tags">Tags.</param>
         /// <param name="Status">pet status in the store.</param>
-        public Pet(long? Id = null, Category Category = null, string Name = null, List<string> PhotoUrls = null, List<Tag> Tags = null, string Status = null)
+        public Pet(long? Id = default(long?), Category Category = default(Category), string Name = default(string), List<string> PhotoUrls = default(List<string>), List<Tag> Tags = default(List<Tag>), StatusEnum? Status = default(StatusEnum?))
         {
             // to ensure "Name" is required (not null)
             if (Name == null)
@@ -67,38 +100,26 @@ namespace IO.Swagger.Models
         /// </summary>
         [DataMember(Name="id")]
         public long? Id { get; set; }
-
         /// <summary>
         /// Gets or Sets Category
         /// </summary>
         [DataMember(Name="category")]
         public Category Category { get; set; }
-
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name="name")]
         public string Name { get; set; }
-
         /// <summary>
         /// Gets or Sets PhotoUrls
         /// </summary>
         [DataMember(Name="photoUrls")]
         public List<string> PhotoUrls { get; set; }
-
         /// <summary>
         /// Gets or Sets Tags
         /// </summary>
         [DataMember(Name="tags")]
         public List<Tag> Tags { get; set; }
-
-        /// <summary>
-        /// pet status in the store
-        /// </summary>
-        /// <value>pet status in the store</value>
-        [DataMember(Name="status")]
-        public string Status { get; set; }
-
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/Tag.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/Tag.cs
@@ -20,18 +20,20 @@ using Newtonsoft.Json;
 
 namespace IO.Swagger.Models
 {
+
     /// <summary>
     /// A tag for a pet
     /// </summary>
     [DataContract]
     public partial class Tag :  IEquatable<Tag>
     {
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
         /// </summary>
         /// <param name="Id">Id.</param>
         /// <param name="Name">Name.</param>
-        public Tag(long? Id = null, string Name = null)
+        public Tag(long? Id = default(long?), string Name = default(string))
         {
             this.Id = Id;
             this.Name = Name;
@@ -43,13 +45,11 @@ namespace IO.Swagger.Models
         /// </summary>
         [DataMember(Name="id")]
         public long? Id { get; set; }
-
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name="name")]
         public string Name { get; set; }
-
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/User.cs
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Models/User.cs
@@ -20,12 +20,14 @@ using Newtonsoft.Json;
 
 namespace IO.Swagger.Models
 {
+
     /// <summary>
     /// A User who is purchasing from the pet store
     /// </summary>
     [DataContract]
     public partial class User :  IEquatable<User>
     {
+
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
         /// </summary>
@@ -37,7 +39,7 @@ namespace IO.Swagger.Models
         /// <param name="Password">Password.</param>
         /// <param name="Phone">Phone.</param>
         /// <param name="UserStatus">User Status.</param>
-        public User(long? Id = null, string Username = null, string FirstName = null, string LastName = null, string Email = null, string Password = null, string Phone = null, int? UserStatus = null)
+        public User(long? Id = default(long?), string Username = default(string), string FirstName = default(string), string LastName = default(string), string Email = default(string), string Password = default(string), string Phone = default(string), int? UserStatus = default(int?))
         {
             this.Id = Id;
             this.Username = Username;
@@ -55,50 +57,42 @@ namespace IO.Swagger.Models
         /// </summary>
         [DataMember(Name="id")]
         public long? Id { get; set; }
-
         /// <summary>
         /// Gets or Sets Username
         /// </summary>
         [DataMember(Name="username")]
         public string Username { get; set; }
-
         /// <summary>
         /// Gets or Sets FirstName
         /// </summary>
         [DataMember(Name="firstName")]
         public string FirstName { get; set; }
-
         /// <summary>
         /// Gets or Sets LastName
         /// </summary>
         [DataMember(Name="lastName")]
         public string LastName { get; set; }
-
         /// <summary>
         /// Gets or Sets Email
         /// </summary>
         [DataMember(Name="email")]
         public string Email { get; set; }
-
         /// <summary>
         /// Gets or Sets Password
         /// </summary>
         [DataMember(Name="password")]
         public string Password { get; set; }
-
         /// <summary>
         /// Gets or Sets Phone
         /// </summary>
         [DataMember(Name="phone")]
         public string Phone { get; set; }
-
         /// <summary>
         /// User Status
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name="userStatus")]
         public int? UserStatus { get; set; }
-
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/project.json
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/project.json
@@ -22,7 +22,8 @@
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
     "Microsoft.EntityFrameworkCore": "1.0.0",
     "Swashbuckle.SwaggerGen": "6.0.0-beta901",
-    "Swashbuckle.SwaggerUi": "6.0.0-beta901"
+    "Swashbuckle.SwaggerUi": "6.0.0-beta901",
+    "Newtonsoft.Json": "9.0.1"
   },
 
   "tools": {


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This addresses a couple of issues.  As originally reported in #3608 and added to the C# client generator in #4145, this updates model constructors to use `default()` rather than attempting to initialize parameters to nulls. I didn't modify the NancyFX generator here, because it relies on object initialization and doesn't perform the same types of constructor validations or DataAnnotations/JSON validation.

The `petstore.yaml` has inner enums, so to get the sample code working against this yaml I've also added support for enums and inner enums, and regenerated the sample.

Please note if you're having issues with newer versions of `dotnet` CLI, there's a known issue (https://github.com/dotnet/corefx/issues/9171) with OS X/macOS support which requires linking openssl manually:

```
$ ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
$ ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
```

To test:

```
cd samples/server/petstore/aspnetcore
sh build.sh
```

NOTE:

If you receive the following error on build, you'll need to perform the openssl symlinks mentioned above:

```
Unhandled Exception: System.TypeInitializationException: The type initializer for 'Crypto' threw an exception. ---> System.TypeInitializationException: The type initializer for 'CryptoInitializer' threw an exception. ---> System.DllNotFoundException: Unable to load DLL 'System.Security.Cryptography.Native': The specified module could not be found.
 (Exception from HRESULT: 0x8007007E)
   at Interop.CryptoInitializer.EnsureOpenSslInitialized()
   at Interop.CryptoInitializer..cctor()
   --- End of inner exception stack trace ---
   at Interop.Crypto..cctor()
   --- End of inner exception stack trace ---
   at Interop.Crypto.GetRandomBytes(Byte* buf, Int32 num)
   at System.IO.Path.GetCryptoRandomBytes(Byte* bytes, Int32 byteCount)
   at System.IO.Path.GetRandomFileName()
   at Microsoft.DotNet.InternalAbstractions.TemporaryDirectory..ctor()
   at Microsoft.Extensions.EnvironmentAbstractions.DirectoryWrapper.CreateTemporaryDirectory()
   at Microsoft.DotNet.Configurer.NuGetPackagesArchiver..ctor()
   at Microsoft.DotNet.Cli.Program.ConfigureDotNetForFirstTimeUse(INuGetCacheSentinel nugetCacheSentinel)
   at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, ITelemetry telemetryClient)
   at Microsoft.DotNet.Cli.Program.Main(String[] args)
build.sh: line 8: 45627 Abort trap: 6           dotnet restore src/IO.Swagger/
```