### PR TITLE
Add back embeddedTemplateDir to some generators

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/BashClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/BashClientCodegen.java
@@ -106,7 +106,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
     /**
      * Templates location for client script and bash completion template.
      */
-    templateDir = "bash";
+    embeddedTemplateDir = templateDir = "bash";
 
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -62,7 +62,7 @@ public class CppRestClientCodegen extends DefaultCodegen implements CodegenConfi
         apiTemplateFiles.put("api-header.mustache", ".h");
         apiTemplateFiles.put("api-source.mustache", ".cpp");
 
-        templateDir = "cpprest";
+        embeddedTemplateDir = templateDir = "cpprest";
 
         cliOptions.clear();
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
@@ -43,7 +43,7 @@ public class GoClientCodegen extends DefaultCodegen implements CodegenConfig {
         modelDocTemplateFiles.put("model_doc.mustache", ".md");
         apiDocTemplateFiles.put("api_doc.mustache", ".md");
 
-        templateDir = "go";
+        embeddedTemplateDir = templateDir = "go";
 
         setReservedWordsLowerCase(
             Arrays.asList(

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JMeterCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JMeterCodegen.java
@@ -68,7 +68,7 @@ public class JMeterCodegen extends DefaultCodegen implements CodegenConfig {
      * Template Location.  This is the location which templates will be read from.  The generator
      * will use the resource stream to attempt to read the templates.
      */
-    templateDir = "JMeter";
+    embeddedTemplateDir = templateDir = "JMeter";
 
     /*
      * Api Package.  Optional, if needed, this can be used in templates


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

For https://github.com/swagger-api/swagger-codegen/issues/4595
