### PR TITLE
Enum constructFromObject should return value

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/partial_model_enum_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/partial_model_enum_class.mustache
@@ -26,7 +26,7 @@
    * @return {{=< >=}}{module:<#invokerPackage><invokerPackage>/</invokerPackage><#modelPackage><modelPackage>/</modelPackage><classname>}<={{ }}=> The enum <code>{{classname}}</code> value.
    */
   exports.constructFromObject = function(object) {
-    return exports[object];
+    return object;
   }
 
   return exports;

--- a/samples/client/petstore/javascript-promise/src/model/EnumClass.js
+++ b/samples/client/petstore/javascript-promise/src/model/EnumClass.js
@@ -57,7 +57,7 @@
    * @return {module:model/EnumClass} The enum <code>EnumClass</code> value.
    */
   exports.constructFromObject = function(object) {
-    return exports[object];
+    return object;
   }
 
   return exports;

--- a/samples/client/petstore/javascript-promise/src/model/OuterEnum.js
+++ b/samples/client/petstore/javascript-promise/src/model/OuterEnum.js
@@ -57,7 +57,7 @@
    * @return {module:model/OuterEnum} The enum <code>OuterEnum</code> value.
    */
   exports.constructFromObject = function(object) {
-    return exports[object];
+    return object;
   }
 
   return exports;

--- a/samples/client/petstore/javascript/src/model/EnumClass.js
+++ b/samples/client/petstore/javascript/src/model/EnumClass.js
@@ -57,7 +57,7 @@
    * @return {module:model/EnumClass} The enum <code>EnumClass</code> value.
    */
   exports.constructFromObject = function(object) {
-    return exports[object];
+    return object;
   }
 
   return exports;

--- a/samples/client/petstore/javascript/src/model/OuterEnum.js
+++ b/samples/client/petstore/javascript/src/model/OuterEnum.js
@@ -57,7 +57,7 @@
    * @return {module:model/OuterEnum} The enum <code>OuterEnum</code> value.
    */
   exports.constructFromObject = function(object) {
-    return exports[object];
+    return object;
   }
 
   return exports;


### PR DESCRIPTION
When constructing an enum through constructFromObject the original value provided by the API response should be returned rather than extracting the value from the enum name. This resolves an issue where the constructed value is undefined when the name and value are not equivalent.
