### PR TITLE
Fix name mangling for JSON processing with QT5

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -57,10 +57,10 @@ void
 void
 {{classname}}::fromJsonObject(QJsonObject &pJson) {
     {{#vars}}
-    {{^isContainer}}::Swagger::setValue(&{{name}}, pJson["{{name}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}}
+    {{^isContainer}}::Swagger::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}}
     {{#isContainer}}
-    {{#complexType}}::Swagger::setValue(&{{name}}, pJson["{{name}}"], "{{baseType}}", "{{complexType}}");{{/complexType}}
-    {{^complexType}}::Swagger::setValue(&{{name}}, pJson["{{name}}"], "{{baseType}}", "{{items.baseType}}");{{/complexType}}
+    {{#complexType}}::Swagger::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/complexType}}
+    {{^complexType}}::Swagger::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{items.baseType}}");{{/complexType}}
     {{/isContainer}}
     {{/vars}}
 }
@@ -79,17 +79,17 @@ QJsonObject*
 {{classname}}::asJsonObject() {
     QJsonObject* obj = new QJsonObject();
     {{#vars}}{{#complexType}}{{^isContainer}}{{#complexType}}
-    toJsonValue(QString("{{name}}"), {{name}}, obj, QString("{{complexType}}"));{{/complexType}}{{^complexType}}
+    toJsonValue(QString("{{baseName}}"), {{name}}, obj, QString("{{complexType}}"));{{/complexType}}{{^complexType}}
     if({{name}} != nullptr && *{{name}} != nullptr) { 
         obj->insert("{{name}}", QJsonValue(*{{name}}));
     }{{/complexType}}{{/isContainer}}{{#isContainer}}
     QJsonArray {{name}}JsonArray;
     toJsonArray((QList<void*>*){{name}}, &{{name}}JsonArray, "{{name}}", "{{complexType}}");
-    obj->insert("{{name}}", {{name}}JsonArray);{{/isContainer}}{{/complexType}}{{^complexType}}{{^isContainer}}
-    obj->insert("{{name}}", QJsonValue({{name}}));{{/isContainer}}{{#isContainer}}
+    obj->insert("{{baseName}}", {{name}}JsonArray);{{/isContainer}}{{/complexType}}{{^complexType}}{{^isContainer}}
+    obj->insert("{{baseName}}", QJsonValue({{name}}));{{/isContainer}}{{#isContainer}}
     QJsonArray {{name}}JsonArray;
     toJsonArray((QList<void*>*){{name}}, &{{name}}JsonArray, "{{name}}", "{{items.baseType}}");
-    obj->insert("{{name}}", {{name}}JsonArray);{{/isContainer}}{{/complexType}}
+    obj->insert("{{baseName}}", {{name}}JsonArray);{{/isContainer}}{{/complexType}}
     {{/vars}}
 
     return obj;

--- a/samples/client/petstore/qt5cpp/client/SWGOrder.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGOrder.cpp
@@ -74,9 +74,9 @@ SWGOrder::fromJson(QString &json) {
 void
 SWGOrder::fromJsonObject(QJsonObject &pJson) {
     ::Swagger::setValue(&id, pJson["id"], "qint64", "");
-    ::Swagger::setValue(&pet_id, pJson["pet_id"], "qint64", "");
+    ::Swagger::setValue(&pet_id, pJson["petId"], "qint64", "");
     ::Swagger::setValue(&quantity, pJson["quantity"], "qint32", "");
-    ::Swagger::setValue(&ship_date, pJson["ship_date"], "QDateTime", "QDateTime");
+    ::Swagger::setValue(&ship_date, pJson["shipDate"], "QDateTime", "QDateTime");
     ::Swagger::setValue(&status, pJson["status"], "QString", "QString");
     ::Swagger::setValue(&complete, pJson["complete"], "bool", "");
 }
@@ -97,11 +97,11 @@ SWGOrder::asJsonObject() {
     
     obj->insert("id", QJsonValue(id));
 
-    obj->insert("pet_id", QJsonValue(pet_id));
+    obj->insert("petId", QJsonValue(pet_id));
 
     obj->insert("quantity", QJsonValue(quantity));
 
-    toJsonValue(QString("ship_date"), ship_date, obj, QString("QDateTime"));
+    toJsonValue(QString("shipDate"), ship_date, obj, QString("QDateTime"));
 
     toJsonValue(QString("status"), status, obj, QString("QString"));
 

--- a/samples/client/petstore/qt5cpp/client/SWGPet.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGPet.cpp
@@ -94,7 +94,7 @@ SWGPet::fromJsonObject(QJsonObject &pJson) {
     ::Swagger::setValue(&category, pJson["category"], "SWGCategory", "SWGCategory");
     ::Swagger::setValue(&name, pJson["name"], "QString", "QString");
     
-    ::Swagger::setValue(&photo_urls, pJson["photo_urls"], "QList", "QString");
+    ::Swagger::setValue(&photo_urls, pJson["photoUrls"], "QList", "QString");
     
     
     ::Swagger::setValue(&tags, pJson["tags"], "QList", "SWGTag");
@@ -124,7 +124,7 @@ SWGPet::asJsonObject() {
 
     QJsonArray photo_urlsJsonArray;
     toJsonArray((QList<void*>*)photo_urls, &photo_urlsJsonArray, "photo_urls", "QString");
-    obj->insert("photo_urls", photo_urlsJsonArray);
+    obj->insert("photoUrls", photo_urlsJsonArray);
 
     QJsonArray tagsJsonArray;
     toJsonArray((QList<void*>*)tags, &tagsJsonArray, "tags", "SWGTag");

--- a/samples/client/petstore/qt5cpp/client/SWGUser.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGUser.cpp
@@ -91,12 +91,12 @@ void
 SWGUser::fromJsonObject(QJsonObject &pJson) {
     ::Swagger::setValue(&id, pJson["id"], "qint64", "");
     ::Swagger::setValue(&username, pJson["username"], "QString", "QString");
-    ::Swagger::setValue(&first_name, pJson["first_name"], "QString", "QString");
-    ::Swagger::setValue(&last_name, pJson["last_name"], "QString", "QString");
+    ::Swagger::setValue(&first_name, pJson["firstName"], "QString", "QString");
+    ::Swagger::setValue(&last_name, pJson["lastName"], "QString", "QString");
     ::Swagger::setValue(&email, pJson["email"], "QString", "QString");
     ::Swagger::setValue(&password, pJson["password"], "QString", "QString");
     ::Swagger::setValue(&phone, pJson["phone"], "QString", "QString");
-    ::Swagger::setValue(&user_status, pJson["user_status"], "qint32", "");
+    ::Swagger::setValue(&user_status, pJson["userStatus"], "qint32", "");
 }
 
 QString
@@ -117,9 +117,9 @@ SWGUser::asJsonObject() {
 
     toJsonValue(QString("username"), username, obj, QString("QString"));
 
-    toJsonValue(QString("first_name"), first_name, obj, QString("QString"));
+    toJsonValue(QString("firstName"), first_name, obj, QString("QString"));
 
-    toJsonValue(QString("last_name"), last_name, obj, QString("QString"));
+    toJsonValue(QString("lastName"), last_name, obj, QString("QString"));
 
     toJsonValue(QString("email"), email, obj, QString("QString"));
 
@@ -127,7 +127,7 @@ SWGUser::asJsonObject() {
 
     toJsonValue(QString("phone"), phone, obj, QString("QString"));
 
-    obj->insert("user_status", QJsonValue(user_status));
+    obj->insert("userStatus", QJsonValue(user_status));
 
     return obj;
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

