### PR TITLE
Add support for read-only  annotation generation on values in spring model

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
@@ -64,7 +64,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
  {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
   {{/vendorExtensions.extraAnnotation}}
-  @ApiModelProperty({{#example}}example = "{{example}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+  @ApiModelProperty({{#example}}example = "{{example}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/HasOnlyReadOnly.java
@@ -26,7 +26,7 @@ public class HasOnlyReadOnly   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }
@@ -44,7 +44,7 @@ public class HasOnlyReadOnly   {
    * Get foo
    * @return foo
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/Name.java
@@ -51,7 +51,7 @@ public class Name   {
    * Get snakeCase
    * @return snakeCase
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -87,7 +87,7 @@ public class Name   {
    * Get _123Number
    * @return _123Number
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer get123Number() {
     return _123Number;
   }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/model/ReadOnlyFirst.java
@@ -26,7 +26,7 @@ public class ReadOnlyFirst   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/HasOnlyReadOnly.java
@@ -26,7 +26,7 @@ public class HasOnlyReadOnly   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }
@@ -44,7 +44,7 @@ public class HasOnlyReadOnly   {
    * Get foo
    * @return foo
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/Name.java
@@ -51,7 +51,7 @@ public class Name   {
    * Get snakeCase
    * @return snakeCase
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -87,7 +87,7 @@ public class Name   {
    * Get _123Number
    * @return _123Number
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer get123Number() {
     return _123Number;
   }

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/model/ReadOnlyFirst.java
@@ -26,7 +26,7 @@ public class ReadOnlyFirst   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/model/HasOnlyReadOnly.java
@@ -26,7 +26,7 @@ public class HasOnlyReadOnly   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }
@@ -44,7 +44,7 @@ public class HasOnlyReadOnly   {
    * Get foo
    * @return foo
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/model/Name.java
@@ -51,7 +51,7 @@ public class Name   {
    * Get snakeCase
    * @return snakeCase
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -87,7 +87,7 @@ public class Name   {
    * Get _123Number
    * @return _123Number
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer get123Number() {
     return _123Number;
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/model/ReadOnlyFirst.java
@@ -26,7 +26,7 @@ public class ReadOnlyFirst   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/model/HasOnlyReadOnly.java
@@ -26,7 +26,7 @@ public class HasOnlyReadOnly   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }
@@ -44,7 +44,7 @@ public class HasOnlyReadOnly   {
    * Get foo
    * @return foo
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/model/Name.java
@@ -51,7 +51,7 @@ public class Name   {
    * Get snakeCase
    * @return snakeCase
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -87,7 +87,7 @@ public class Name   {
    * Get _123Number
    * @return _123Number
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer get123Number() {
     return _123Number;
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/model/ReadOnlyFirst.java
@@ -26,7 +26,7 @@ public class ReadOnlyFirst   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/model/HasOnlyReadOnly.java
@@ -26,7 +26,7 @@ public class HasOnlyReadOnly   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }
@@ -44,7 +44,7 @@ public class HasOnlyReadOnly   {
    * Get foo
    * @return foo
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/model/Name.java
@@ -51,7 +51,7 @@ public class Name   {
    * Get snakeCase
    * @return snakeCase
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -87,7 +87,7 @@ public class Name   {
    * Get _123Number
    * @return _123Number
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public Integer get123Number() {
     return _123Number;
   }

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/model/ReadOnlyFirst.java
@@ -26,7 +26,7 @@ public class ReadOnlyFirst   {
    * Get bar
    * @return bar
   **/
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(readOnly = true, value = "")
   public String getBar() {
     return bar;
   }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Adds the generation of the `isReadOnly` value in the model for spring.
