### PR TITLE
Fix the `rm` to remove the correct file in two spring generation bash scripts

### DIFF
--- a/bin/spring-delegate-j8.sh
+++ b/bin/spring-delegate-j8.sh
@@ -29,6 +29,6 @@ export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/
 ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaSpring -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/springboot-delegate-j8 -DdelegatePattern=true,hideGenerationTimestamp=true,java8=true"
 
 echo "Removing files and folders under samples/server/petstore/springboot-delegate-j8/src/main"
-rm -rf samples/server/petstore/springboot/src/main
+rm -rf samples/server/petstore/springboot-delegate-j8/src/main
 find samples/server/petstore/springboot -maxdepth 1 -type f ! -name "README.md" -exec rm {} +
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-delegate.sh
+++ b/bin/spring-delegate.sh
@@ -29,6 +29,6 @@ export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/
 ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaSpring -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/springboot-delegate -DdelegatePattern=true,hideGenerationTimestamp=true"
 
 echo "Removing files and folders under samples/server/petstore/springboot-delegate/src/main"
-rm -rf samples/server/petstore/springboot/src/main
+rm -rf samples/server/petstore/springboot-delegate/src/main
 find samples/server/petstore/springboot -maxdepth 1 -type f ! -name "README.md" -exec rm {} +
 java $JAVA_OPTS -jar $executable $ags


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

In a previous PR I forgot to change the `rm` line to reflect the file that needs to be removed before running the generator.

Related #4439
