### PR TITLE
Fix Issue #4611 by using {{unescapedDescription}}

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
@@ -90,6 +90,7 @@ public class CodegenParameter {
         output.collectionFormat = this.collectionFormat;
         output.isCollectionFormatMulti = this.isCollectionFormatMulti;
         output.description = this.description;
+        output.unescapedDescription = this.unescapedDescription;
         output.baseType = this.baseType;
         output.isFormParam = this.isFormParam;
         output.isQueryParam = this.isQueryParam;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -11,6 +11,7 @@ public class CodegenProperty implements Cloneable {
           datatypeWithEnum, dataFormat, name, min, max, defaultValue, defaultValueWithParam,
           baseType, containerType, title;
 
+    /** The 'description' string without escape charcters needed by some programming languages/targets */
     public String unescapedDescription;
 
     /**
@@ -323,6 +324,6 @@ public class CodegenProperty implements Cloneable {
             throw new IllegalStateException(e);
         }
     }
-    
-    
+
+
 }

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/bodyParam.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/bodyParam.mustache
@@ -1,3 +1,3 @@
 {{#isBodyParam}}<div class="param">{{baseName}} {{#baseType}}<a href="#{{baseType}}">{{baseType}}</a>{{/baseType}} {{^required}}(optional){{/required}}{{#required}}(required){{/required}}</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; {{description}} {{#defaultValue}}default: {{{defaultValue}}}{{/defaultValue}}</div>{{/isBodyParam}}
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; {{unescapedDescription}} {{#defaultValue}}default: {{{defaultValue}}}{{/defaultValue}}</div>{{/isBodyParam}}

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/formParam.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/formParam.mustache
@@ -1,3 +1,3 @@
 {{#isFormParam}}<div class="param">{{baseName}} {{^required}}(optional){{/required}}{{#required}}(required){{/required}}</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; {{description}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/isFormParam}}
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; {{unescapedDescription}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/isFormParam}}

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/headerParam.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/headerParam.mustache
@@ -1,3 +1,3 @@
 {{#isHeaderParam}}<div class="param">{{baseName}} {{^required}}(optional){{/required}}{{#required}}(required){{/required}}</div>
 
-      <div class="param-desc"><span class="param-type">Header Parameter</span> &mdash; {{description}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/isHeaderParam}}
+      <div class="param-desc"><span class="param-type">Header Parameter</span> &mdash; {{unescapedDescription}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/isHeaderParam}}

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/index.mustache
@@ -165,9 +165,9 @@
   {{#model}}
   <div class="model">
     <h3 class="field-label"><a name="{{name}}">{{name}} - {{title}}</a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'>{{description}}</div>
+    <div class='model-description'>{{unescapedDescription}}</div>
     <div class="field-items">
-      {{#vars}}<div class="param">{{name}} {{^required}}(optional){{/required}}</div><div class="param-desc"><span class="param-type">{{^isPrimitiveType}}<a href="#{{complexType}}">{{datatype}}</a>{{/isPrimitiveType}}</span> {{description}} {{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>
+      {{#vars}}<div class="param">{{name}} {{^required}}(optional){{/required}}</div><div class="param-desc"><span class="param-type">{{^isPrimitiveType}}<a href="#{{complexType}}">{{datatype}}</a>{{/isPrimitiveType}}</span> {{unescapedDescription}} {{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>
       {{#isEnum}}
         <div class="param-enum-header">Enum:</div>
         {{#_enum}}<div class="param-enum">{{this}}</div>{{/_enum}}

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/pathParam.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/pathParam.mustache
@@ -1,3 +1,3 @@
 {{#isPathParam}}<div class="param">{{baseName}} {{^required}}(optional){{/required}}{{#required}}(required){{/required}}</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; {{description}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/isPathParam}}
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; {{unescapedDescription}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/isPathParam}}

--- a/modules/swagger-codegen/src/main/resources/htmlDocs/queryParam.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs/queryParam.mustache
@@ -1,3 +1,3 @@
 {{#isQueryParam}}<div class="param">{{baseName}} {{^required}}(optional){{/required}}{{#required}}(required){{/required}}</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; {{description}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/isQueryParam}}
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; {{unescapedDescription}} {{#defaultValue}}default: {{{defaultValue}}} {{/defaultValue}}{{#dataFormat}}format: {{{dataFormat}}}{{/dataFormat}}</div>{{/isQueryParam}}

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_android.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_android.mustache
@@ -5,7 +5,7 @@ public class {{{classname}}}Example {
     public static void main(String[] args) {
         {{{classname}}} apiInstance = new {{{classname}}}();
         {{#allParams}}
-        {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
+        {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{unescapedDescription}}}
         {{/allParams}}
         try {
             {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_csharp.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_csharp.mustache
@@ -25,10 +25,10 @@ namespace Example
             var apiInstance = new {{classname}}();
             {{#allParams}}
             {{#isPrimitiveType}}
-            var {{paramName}} = {{example}};  // {{{dataType}}} | {{{description}}}{{^required}} (optional) {{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+            var {{paramName}} = {{example}};  // {{{dataType}}} | {{{unescapedDescription}}}{{^required}} (optional) {{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
             {{/isPrimitiveType}}
             {{^isPrimitiveType}}
-            var {{paramName}} = new {{{dataType}}}(); // {{{dataType}}} | {{{description}}}{{^required}} (optional) {{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+            var {{paramName}} = new {{{dataType}}}(); // {{{dataType}}} | {{{unescapedDescription}}}{{^required}} (optional) {{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
             {{/isPrimitiveType}}
             {{/allParams}}
 

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_java.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_java.mustache
@@ -28,7 +28,7 @@ public class {{{classname}}}Example {
 
         {{{classname}}} apiInstance = new {{{classname}}}();
         {{#allParams}}
-        {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
+        {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{unescapedDescription}}}
         {{/allParams}}
         try {
             {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_js.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_js.mustache
@@ -19,10 +19,10 @@ var {{{name}}} = defaultClient.authentications['{{{name}}}'];
 
 var api = new {{{jsModuleName}}}.{{{classname}}}(){{#hasParams}}
 {{#vendorExtensions.x-codegen-hasRequiredParams}}{{#allParams}}{{#required}}
-var {{{paramName}}} = {{{example}}}; // {{=< >=}}{<&dataType>}<={{ }}=> {{{description}}}
+var {{{paramName}}} = {{{example}}}; // {{=< >=}}{<&dataType>}<={{ }}=> {{{unescapedDescription}}}
 {{/required}}{{/allParams}}{{/vendorExtensions.x-codegen-hasRequiredParams}}{{#hasOptionalParams}}
 var opts = { {{#allParams}}{{^required}}
-  '{{{paramName}}}': {{{example}}}{{#vendorExtensions.x-codegen-hasMoreOptional}},{{/vendorExtensions.x-codegen-hasMoreOptional}} // {{=< >=}}{<&dataType>}<={{ }}=> {{{description}}}{{/required}}{{/allParams}}
+  '{{{paramName}}}': {{{example}}}{{#vendorExtensions.x-codegen-hasMoreOptional}},{{/vendorExtensions.x-codegen-hasMoreOptional}} // {{=< >=}}{<&dataType>}<={{ }}=> {{{unescapedDescription}}}{{/required}}{{/allParams}}
 };{{/hasOptionalParams}}{{/hasParams}}
 {{#usePromises}}
 api.{{{operationId}}}({{#allParams}}{{#required}}{{{paramName}}}{{#vendorExtensions.x-codegen-hasMoreRequired}}, {{/vendorExtensions.x-codegen-hasMoreRequired}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{{#vendorExtensions.x-codegen-hasRequiredParams}}, {{/vendorExtensions.x-codegen-hasRequiredParams}}opts{{/hasOptionalParams}}).then(function({{#returnType}}data{{/returnType}}) {

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_objc.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_objc.mustache
@@ -13,7 +13,7 @@
 [apiConfig setAccessToken:@"YOUR_ACCESS_TOKEN"];
 {{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}
-{{#allParams}}{{{dataType}}} *{{paramName}} = {{{example}}}; // {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+{{#allParams}}{{{dataType}}} *{{paramName}} = {{{example}}}; // {{{unescapedDescription}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
 {{/allParams}}
 
 {{classname}} *apiInstance = [[{{classname}} alloc] init];

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_perl.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_perl.mustache
@@ -14,7 +14,7 @@ ${{{perlModuleName}}}::Configuration::access_token = 'YOUR_ACCESS_TOKEN';{{/isOA
 {{/hasAuthMethods}}
 
 my $api_instance = {{perlModuleName}}::{{classname}}->new();
-{{#allParams}}my ${{paramName}} = {{#isListContainer}}[{{/isListContainer}}{{#isBodyParam}}{{{perlModuleName}}}::Object::{{dataType}}->new(){{/isBodyParam}}{{^isBodyParam}}{{{example}}}{{/isBodyParam}}{{#isListContainer}}]{{/isListContainer}}; # {{{dataType}}} | {{{description}}}
+{{#allParams}}my ${{paramName}} = {{#isListContainer}}[{{/isListContainer}}{{#isBodyParam}}{{{perlModuleName}}}::Object::{{dataType}}->new(){{/isBodyParam}}{{^isBodyParam}}{{{example}}}{{/isBodyParam}}{{#isListContainer}}]{{/isListContainer}}; # {{{dataType}}} | {{{unescapedDescription}}}
 {{/allParams}}
 
 eval { 

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_php.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_php.mustache
@@ -13,7 +13,7 @@ require_once(__DIR__ . '/vendor/autoload.php');
 {{/hasAuthMethods}}
 
 $api_instance = new Swagger\Client\Api\{{classname}}();
-{{#allParams}}${{paramName}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
+{{#allParams}}${{paramName}} = {{{example}}}; // {{{dataType}}} | {{{unescapedDescription}}}
 {{/allParams}}
 
 try {

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_python.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_python.mustache
@@ -17,7 +17,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = {{{pythonPackageName}}}.{{{classname}}}()
-{{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+{{#allParams}}{{paramName}} = {{{example}}} # {{{dataType}}} | {{{unescapedDescription}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
 {{/allParams}}
 
 try: 

--- a/samples/html/index.html
+++ b/samples/html/index.html
@@ -248,7 +248,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#Pet">Pet</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Pet object that needs to be added to the store </div>
 
     </div>  <!-- field-items -->
 
@@ -284,7 +284,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">petId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; Pet id to delete format: int64</div>
     </div>  <!-- field-items -->
 
 
@@ -329,7 +329,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">status (required)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; Status values that need to be considered for filter </div>
     </div>  <!-- field-items -->
 
 
@@ -402,7 +402,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">tags (required)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; Tags to filter by </div>
     </div>  <!-- field-items -->
 
 
@@ -471,7 +471,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">petId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of pet to return format: int64</div>
     </div>  <!-- field-items -->
 
 
@@ -555,7 +555,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#Pet">Pet</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Pet object that needs to be added to the store </div>
 
     </div>  <!-- field-items -->
 
@@ -597,7 +597,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">petId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of pet that needs to be updated format: int64</div>
     </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
@@ -613,9 +613,9 @@ font-style: italic;
     <div class="field-items">
       <div class="param">name (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash;  </div><div class="param">status (optional)</div>
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; Updated name of the pet </div><div class="param">status (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; Updated status of the pet </div>
     </div>  <!-- field-items -->
 
 
@@ -647,7 +647,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">petId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of pet to update format: int64</div>
     </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
@@ -663,9 +663,9 @@ font-style: italic;
     <div class="field-items">
       <div class="param">additionalMetadata (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash;  </div><div class="param">file (optional)</div>
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; Additional data to pass to server </div><div class="param">file (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; file to upload </div>
     </div>  <!-- field-items -->
 
     <h3 class="field-label">Return type</h3>
@@ -709,7 +709,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">orderId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of the order that needs to be deleted </div>
     </div>  <!-- field-items -->
 
 
@@ -789,7 +789,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">orderId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of pet that needs to be fetched format: int64</div>
     </div>  <!-- field-items -->
 
 
@@ -859,7 +859,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#Order">Order</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; order placed for purchasing the pet </div>
 
     </div>  <!-- field-items -->
 
@@ -926,7 +926,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#User">User</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Created user object </div>
 
     </div>  <!-- field-items -->
 
@@ -964,7 +964,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#User">User</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; List of user object </div>
 
     </div>  <!-- field-items -->
 
@@ -1002,7 +1002,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#User">User</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; List of user object </div>
 
     </div>  <!-- field-items -->
 
@@ -1038,7 +1038,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">username (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; The name that needs to be deleted </div>
     </div>  <!-- field-items -->
 
 
@@ -1078,7 +1078,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">username (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; The name that needs to be fetched. Use user1 for testing.  </div>
     </div>  <!-- field-items -->
 
 
@@ -1154,9 +1154,9 @@ font-style: italic;
     <div class="field-items">
       <div class="param">username (required)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  </div><div class="param">password (required)</div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The user name for login </div><div class="param">password (required)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The password for login in clear text </div>
     </div>  <!-- field-items -->
 
 
@@ -1234,7 +1234,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">username (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; name that need to be deleted </div>
     </div>  <!-- field-items -->
 
 
@@ -1242,7 +1242,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#User">User</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Updated user object </div>
 
     </div>  <!-- field-items -->
 

--- a/samples/html/index.html
+++ b/samples/html/index.html
@@ -248,7 +248,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#Pet">Pet</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Pet object that needs to be added to the store </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
     </div>  <!-- field-items -->
 
@@ -284,7 +284,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">petId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; Pet id to delete format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
     </div>  <!-- field-items -->
 
 
@@ -329,7 +329,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">status (required)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; Status values that need to be considered for filter </div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
 
@@ -356,18 +356,18 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
 } ]</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -402,7 +402,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">tags (required)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; Tags to filter by </div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
 
@@ -429,18 +429,18 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>[ {
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
 } ]</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -471,7 +471,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">petId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of pet to return format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
     </div>  <!-- field-items -->
 
 
@@ -502,18 +502,18 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "tags" : [ {
-    "id" : 123456789,
-    "name" : "aeiou"
-  } ],
+  "photoUrls" : [ "aeiou" ],
+  "name" : "doggie",
   "id" : 123456789,
   "category" : {
-    "id" : 123456789,
-    "name" : "aeiou"
+    "name" : "aeiou",
+    "id" : 123456789
   },
-  "status" : "aeiou",
-  "name" : "doggie",
-  "photoUrls" : [ "aeiou" ]
+  "tags" : [ {
+    "name" : "aeiou",
+    "id" : 123456789
+  } ],
+  "status" : "aeiou"
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -555,7 +555,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#Pet">Pet</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Pet object that needs to be added to the store </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
     </div>  <!-- field-items -->
 
@@ -597,7 +597,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">petId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of pet that needs to be updated format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
     </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
@@ -613,9 +613,9 @@ font-style: italic;
     <div class="field-items">
       <div class="param">name (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; Updated name of the pet </div><div class="param">status (optional)</div>
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash;  </div><div class="param">status (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; Updated status of the pet </div>
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
 
@@ -647,7 +647,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">petId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of pet to update format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
     </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
@@ -663,9 +663,9 @@ font-style: italic;
     <div class="field-items">
       <div class="param">additionalMetadata (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; Additional data to pass to server </div><div class="param">file (optional)</div>
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash;  </div><div class="param">file (optional)</div>
 
-      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash; file to upload </div>
+      <div class="param-desc"><span class="param-type">Form Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
     <h3 class="field-label">Return type</h3>
@@ -679,9 +679,9 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "message" : "aeiou",
   "code" : 123,
-  "type" : "aeiou"
+  "type" : "aeiou",
+  "message" : "aeiou"
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -709,7 +709,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">orderId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of the order that needs to be deleted </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
 
@@ -789,7 +789,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">orderId (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; ID of pet that needs to be fetched format: int64</div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  format: int64</div>
     </div>  <!-- field-items -->
 
 
@@ -818,12 +818,12 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "id" : 123456789,
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -859,7 +859,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#Order">Order</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; order placed for purchasing the pet </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
     </div>  <!-- field-items -->
 
@@ -887,12 +887,12 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "id" : 123456789,
   "petId" : 123456789,
-  "complete" : true,
-  "status" : "aeiou",
   "quantity" : 123,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+  "id" : 123456789,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "complete" : true,
+  "status" : "aeiou"
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -926,7 +926,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#User">User</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Created user object </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
     </div>  <!-- field-items -->
 
@@ -964,7 +964,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#User">User</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; List of user object </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
     </div>  <!-- field-items -->
 
@@ -1002,7 +1002,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#User">User</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; List of user object </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
     </div>  <!-- field-items -->
 
@@ -1038,7 +1038,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">username (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; The name that needs to be deleted </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
 
@@ -1078,7 +1078,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">username (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; The name that needs to be fetched. Use user1 for testing.  </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
 
@@ -1109,14 +1109,14 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "id" : 123456789,
-  "lastName" : "aeiou",
-  "phone" : "aeiou",
-  "username" : "aeiou",
-  "email" : "aeiou",
-  "userStatus" : 123,
   "firstName" : "aeiou",
-  "password" : "aeiou"
+  "lastName" : "aeiou",
+  "password" : "aeiou",
+  "userStatus" : 123,
+  "phone" : "aeiou",
+  "id" : 123456789,
+  "email" : "aeiou",
+  "username" : "aeiou"
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -1154,9 +1154,9 @@ font-style: italic;
     <div class="field-items">
       <div class="param">username (required)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The user name for login </div><div class="param">password (required)</div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  </div><div class="param">password (required)</div>
 
-      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The password for login in clear text </div>
+      <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
 
@@ -1234,7 +1234,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">username (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash; name that need to be deleted </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
     </div>  <!-- field-items -->
 
 
@@ -1242,7 +1242,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">body <a href="#User">User</a> (required)</div>
 
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Updated user object </div>
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
 
     </div>  <!-- field-items -->
 

--- a/samples/html2/index.html
+++ b/samples/html2/index.html
@@ -7112,7 +7112,7 @@ except ApiException as e:
           </div>
           <div id="generator">
             <div class="content">
-              Generated 2017-01-23T12:54:14.547-05:00
+              Generated 2017-01-24T11:58:21.560-05:00
             </div>
           </div>
       </div>

--- a/samples/html2/index.html
+++ b/samples/html2/index.html
@@ -1858,8 +1858,8 @@ except ApiException as e:
   "type" : "array",
   "items" : {
     "type" : "string",
-    "default" : "available",
-    "enum" : [ "available", "pending", "sold" ]
+    "enum" : [ "available", "pending", "sold" ],
+    "default" : "available"
   },
   "collectionFormat" : "csv"
 };
@@ -3924,8 +3924,7 @@ except ApiException as e:
   "in" : "path",
   "description" : "ID of the order that needs to be deleted",
   "required" : true,
-  "type" : "string",
-  "minimum" : 1.0
+  "type" : "string"
 };
 													var schema = schemaWrapper;
 
@@ -7113,7 +7112,7 @@ except ApiException as e:
           </div>
           <div id="generator">
             <div class="content">
-              Generated 2017-01-16T09:17:32.398-08:00
+              Generated 2017-01-23T12:54:14.547-05:00
             </div>
           </div>
       </div>


### PR DESCRIPTION
Fix #4611 : Use `{{unescapedDescription}}` instead of `{{description}}` in `html` and `html2` language output (mustache) templates, so that Java escaping (such as replacing `"` with `\"` does not occur for API, parameter, operation description strings.