### PR TITLE
[Javascript] Fix for 'Uncaught Reference Error' when calling certain functions

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/api_test.mustache
@@ -41,7 +41,7 @@
     describe('{{operationId}}', function() {
       it('should call {{operationId}} successfully', function(done) {
         //uncomment below and update the code to test {{operationId}}
-        //instance.{{operationId}}(pet, function(error) {
+        //instance.{{operationId}}(function(error) {
         //  if (error) throw error;
         //expect().to.be();
         //});

--- a/modules/swagger-codegen/src/main/resources/Javascript/partial_model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/partial_model_generic.mustache
@@ -39,7 +39,7 @@
   exports.constructFromObject = function(data, obj) {
     if (data){{! TODO: support polymorphism: discriminator property on data determines class to instantiate.}} {
       obj = obj || new exports();
-{{#parent}}{{^parentModel}}      ApiClient.constructFromObject(data, obj, {{vendorExtensions.x-itemType}});
+{{#parent}}{{^parentModel}}      ApiClient.constructFromObject(data, obj, '{{vendorExtensions.x-itemType}}');
 {{/parentModel}}{{/parent}}{{#useInheritance}}{{#parentModel}}      {{classname}}.constructFromObject(data, obj);{{/parentModel}}
 {{#interfaces}}      {{.}}.constructFromObject(data, obj);
 {{/interfaces}}{{/useInheritance}}{{#vars}}      if (data.hasOwnProperty('{{baseName}}')) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Added single quotes -- fixes bug where generated client throws an 'Uncaught Reference Error' when calling a function.

