### PR TITLE
fix for allowable values, #4645

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
@@ -128,7 +128,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}imple
         {{^isContainer}}
         $allowed_values = [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}];
         if (!in_array($this->container['{{name}}'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for '{{name}}', must be one of #{allowed_values}.";
+            $invalid_properties[] = "invalid value for '{{name}}', must be one of #{allowableValues}.";
         }
 
         {{/isContainer}}

--- a/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
@@ -128,7 +128,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}imple
         {{^isContainer}}
         $allowed_values = [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}];
         if (!in_array($this->container['{{name}}'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for '{{name}}', must be one of #{allowableValues}.";
+            $invalid_properties[] = "invalid value for '{{name}}', must be one of {{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}.";
         }
 
         {{/isContainer}}

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
@@ -165,7 +165,7 @@ class EnumArrays implements ArrayAccess
         $invalid_properties = [];
         $allowed_values = [">=", "$"];
         if (!in_array($this->container['just_symbol'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'just_symbol', must be one of #{allowed_values}.";
+            $invalid_properties[] = "invalid value for 'just_symbol', must be one of '>=', '$'.";
         }
 
         return $invalid_properties;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
@@ -191,17 +191,17 @@ class EnumTest implements ArrayAccess
         $invalid_properties = [];
         $allowed_values = ["UPPER", "lower", ""];
         if (!in_array($this->container['enum_string'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'enum_string', must be one of #{allowed_values}.";
+            $invalid_properties[] = "invalid value for 'enum_string', must be one of 'UPPER', 'lower', ''.";
         }
 
         $allowed_values = ["1", "-1"];
         if (!in_array($this->container['enum_integer'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'enum_integer', must be one of #{allowed_values}.";
+            $invalid_properties[] = "invalid value for 'enum_integer', must be one of '1', '-1'.";
         }
 
         $allowed_values = ["1.1", "-1.2"];
         if (!in_array($this->container['enum_number'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'enum_number', must be one of #{allowed_values}.";
+            $invalid_properties[] = "invalid value for 'enum_number', must be one of '1.1', '-1.2'.";
         }
 
         return $invalid_properties;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
@@ -173,7 +173,7 @@ class Order implements ArrayAccess
         $invalid_properties = [];
         $allowed_values = ["placed", "approved", "delivered"];
         if (!in_array($this->container['status'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'status', must be one of #{allowed_values}.";
+            $invalid_properties[] = "invalid value for 'status', must be one of 'placed', 'approved', 'delivered'.";
         }
 
         return $invalid_properties;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
@@ -179,7 +179,7 @@ class Pet implements ArrayAccess
         }
         $allowed_values = ["available", "pending", "sold"];
         if (!in_array($this->container['status'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'status', must be one of #{allowed_values}.";
+            $invalid_properties[] = "invalid value for 'status', must be one of 'available', 'pending', 'sold'.";
         }
 
         return $invalid_properties;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Changed template substitution value to be a valid mustache variable
