### PR TITLE
tests, fix for #4647.  Proper escaping project name per npmjs

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -310,7 +310,12 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
             if (info.getTitle() != null) {
                 // when info.title is defined, use it for projectName
                 // used in package.json
-                projectName = dashize(info.getTitle());
+                projectName = info.getTitle()
+                        .replaceAll("[^a-zA-Z0-9]", "-")
+                        .replaceAll("^[-]*", "")
+                        .replaceAll("[-]*$", "")
+                        .replaceAll("[-]{2,}", "-")
+                        .toLowerCase();
                 this.additionalProperties.put("projectName", projectName);
             }
         }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/nodejs/NodeJSServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/nodejs/NodeJSServerOptionsTest.java
@@ -7,6 +7,9 @@ import io.swagger.codegen.options.NodeJSServerOptionsProvider;
 
 import mockit.Expectations;
 import mockit.Tested;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 public class NodeJSServerOptionsTest extends AbstractOptionsTest {
 
@@ -31,5 +34,28 @@ public class NodeJSServerOptionsTest extends AbstractOptionsTest {
             clientCodegen.setExportedName(NodeJSServerOptionsProvider.EXPORTED_NAME);
             times = 1;
         }};
+    }
+
+
+    @Test
+    public void testCleanTitle() {
+        String dirtyTitle = "safe-title";
+        String clean = dirtyTitle.replaceAll("[^a-zA-Z0-9]", "-")
+                .replaceAll("^[-]*", "")
+                .replaceAll("[-]*$", "")
+                .replaceAll("[-]{2,}", "-");
+
+        assertEquals(clean, "safe-title");
+    }
+
+    @Test
+    public void testDirtyTitleCleansing() {
+        String dirtyTitle = "_it's-$ooo//////////---_//dirty!!!!";
+        String clean = dirtyTitle.replaceAll("[^a-zA-Z0-9]", "-")
+                .replaceAll("^[-]*", "")
+                .replaceAll("[-]*$", "")
+                .replaceAll("[-]{2,}", "-");
+
+        assertEquals(clean, "it-s-ooo-dirty");
     }
 }

--- a/samples/server/petstore/nodejs/api/swagger.yaml
+++ b/samples/server/petstore/nodejs/api/swagger.yaml
@@ -356,8 +356,8 @@ paths:
         description: "ID of pet that needs to be fetched"
         required: true
         type: "integer"
-        maximum: 5
-        minimum: 1
+        maximum: 5.0
+        minimum: 1.0
         format: "int64"
       responses:
         200:
@@ -385,7 +385,6 @@ paths:
         description: "ID of the order that needs to be deleted"
         required: true
         type: "string"
-        minimum: 1
       responses:
         400:
           description: "Invalid ID supplied"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Properly escape project name

