### PR TITLE
Add import of all model classes to java library api.mustache.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
@@ -5,6 +5,7 @@ import {{invokerPackage}}.ApiClient;
 import {{invokerPackage}}.ParamExpander;
 {{/legacyDates}}
 
+import {{modelPackage}}.*;
 {{#imports}}import {{import}};
 {{/imports}}
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -7,6 +7,7 @@ import {{invokerPackage}}.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import {{modelPackage}}.*;
 {{#imports}}import {{import}};
 {{/imports}}
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -31,6 +31,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 {{/performBeanValidation}}
 
+import {{modelPackage}}.*;
 {{#imports}}import {{import}};
 {{/imports}}
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/api.mustache
@@ -6,6 +6,7 @@ import retrofit.Callback;
 import retrofit.http.*;
 import retrofit.mime.*;
 
+import {{modelPackage}}.*;
 {{#imports}}import {{import}};
 {{/imports}}
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
@@ -8,6 +8,7 @@ import retrofit2.http.*;
 
 import okhttp3.RequestBody;
 
+import {{modelPackage}}.*;
 {{#imports}}import {{import}};
 {{/imports}}
 

--- a/samples/client/petstore-security-test/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore-security-test/java/okhttp-gson/pom.xml
@@ -6,8 +6,10 @@
   <packaging>jar</packaging>
   <name>swagger-petstore-okhttp-gson</name>
   <version>1.0.0</version>
+  <url>https://github.com/swagger-api/swagger-codegen</url>
+  <description>Swagger Java</description>
   <scm>
-    <connection>scm:git:git@github.com:swagger-api/swagger-mustache.git</connection>
+    <connection>scm:git:git@github.com:swagger-api/swagger-codegen.git</connection>
     <developerConnection>scm:git:git@github.com:swagger-api/swagger-codegen.git</developerConnection>
     <url>https://github.com/swagger-api/swagger-codegen</url>
   </scm>
@@ -22,7 +24,16 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  
+
+  <developers>
+    <developer>
+      <name>Swagger</name>
+      <email>apiteam@swagger.io</email>
+      <organization>Swagger</organization>
+      <organizationUrl>http://swagger.io</organizationUrl>
+    </developer>
+  </developers>
+
   <build>
     <plugins>
       <plugin>
@@ -108,9 +119,55 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.10.4</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>sign-artifacts</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/samples/client/petstore-security-test/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore-security-test/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import io.swagger.client.model.*;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
@@ -2,6 +2,7 @@ package io.swagger.client.api;
 
 import io.swagger.client.ApiClient;
 
+import io.swagger.client.model.*;
 import java.math.BigDecimal;
 import io.swagger.client.model.Client;
 import org.joda.time.DateTime;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
@@ -2,6 +2,7 @@ package io.swagger.client.api;
 
 import io.swagger.client.ApiClient;
 
+import io.swagger.client.model.*;
 import java.io.File;
 import io.swagger.client.model.ModelApiResponse;
 import io.swagger.client.model.Pet;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/StoreApi.java
@@ -2,6 +2,7 @@ package io.swagger.client.api;
 
 import io.swagger.client.ApiClient;
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.Order;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/UserApi.java
@@ -2,6 +2,7 @@ package io.swagger.client.api;
 
 import io.swagger.client.ApiClient;
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/FakeApi.java
@@ -7,6 +7,7 @@ import io.swagger.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import io.swagger.client.model.*;
 import java.math.BigDecimal;
 import io.swagger.client.model.Client;
 import org.joda.time.DateTime;

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
@@ -7,6 +7,7 @@ import io.swagger.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import io.swagger.client.model.*;
 import java.io.File;
 import io.swagger.client.model.ModelApiResponse;
 import io.swagger.client.model.Pet;

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/StoreApi.java
@@ -7,6 +7,7 @@ import io.swagger.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.Order;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/UserApi.java
@@ -7,6 +7,7 @@ import io.swagger.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import io.swagger.client.model.*;
 import java.math.BigDecimal;
 import io.swagger.client.model.Client;
 import org.joda.time.DateTime;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import io.swagger.client.model.*;
 import java.io.File;
 import io.swagger.client.model.ModelApiResponse;
 import io.swagger.client.model.Pet;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.Order;
 
 import java.lang.reflect.Type;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.User;
 
 import java.lang.reflect.Type;

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/FakeApi.java
@@ -6,6 +6,7 @@ import retrofit.Callback;
 import retrofit.http.*;
 import retrofit.mime.*;
 
+import io.swagger.client.model.*;
 import java.math.BigDecimal;
 import io.swagger.client.model.Client;
 import org.joda.time.DateTime;

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/PetApi.java
@@ -6,6 +6,7 @@ import retrofit.Callback;
 import retrofit.http.*;
 import retrofit.mime.*;
 
+import io.swagger.client.model.*;
 import java.io.File;
 import io.swagger.client.model.ModelApiResponse;
 import io.swagger.client.model.Pet;

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/StoreApi.java
@@ -6,6 +6,7 @@ import retrofit.Callback;
 import retrofit.http.*;
 import retrofit.mime.*;
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.Order;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/api/UserApi.java
@@ -6,6 +6,7 @@ import retrofit.Callback;
 import retrofit.http.*;
 import retrofit.mime.*;
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.User;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/FakeApi.java
@@ -8,6 +8,7 @@ import retrofit2.http.*;
 
 import okhttp3.RequestBody;
 
+import io.swagger.client.model.*;
 import java.math.BigDecimal;
 import io.swagger.client.model.Client;
 import org.joda.time.DateTime;

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/PetApi.java
@@ -8,6 +8,7 @@ import retrofit2.http.*;
 
 import okhttp3.RequestBody;
 
+import io.swagger.client.model.*;
 import java.io.File;
 import io.swagger.client.model.ModelApiResponse;
 import io.swagger.client.model.Pet;

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/StoreApi.java
@@ -8,6 +8,7 @@ import retrofit2.http.*;
 
 import okhttp3.RequestBody;
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.Order;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/UserApi.java
@@ -8,6 +8,7 @@ import retrofit2.http.*;
 
 import okhttp3.RequestBody;
 
+import io.swagger.client.model.*;
 import io.swagger.client.model.User;
 
 import java.util.ArrayList;


### PR DESCRIPTION
This is a quick fix for https://github.com/swagger-api/swagger-codegen/issues/4651
which reports that under some circumstances imports of model classes my be omitted.

### PR checklist

Done and the results of running the various test scripts added.

### Description of the PR

This change imports all model classes in the Java library specific api.mustache template files. This is needed because the code generator fails to generate an import for model classes in response types like List&lt;List&lt;Model&gt;&gt;.
