### PR TITLE
Minor: fix incorrect reference in Rails 5 readme from "Sinatra" to "Ruby on Rails"

### DIFF
--- a/modules/swagger-codegen/src/main/resources/rails5/README.md
+++ b/modules/swagger-codegen/src/main/resources/rails5/README.md
@@ -1,6 +1,6 @@
 # Swagger for Rails 5
 
-This is a project to provide Swagger support inside the [Sinatra](http://rubyonrails.org/) framework.
+This is a project to provide Swagger support inside the [Ruby on Rails](http://rubyonrails.org/) framework.
 
 ## Prerequisites
 You need to install ruby >= 2.2.2 and run:


### PR DESCRIPTION
### PR checklist

- [ x ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Newly generated code in Rails 5 readme wrongly says the code was generated for "Sinatra". This patch changes it to read "Ruby on Rails".

Fixes #4655

