### PR TITLE
Copy dataformat if property field is an array.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1759,6 +1759,7 @@ public class DefaultCodegen {
             LOGGER.warn("skipping invalid array property " + Json.pretty(property));
             return;
         }
+        property.dataFormat = innerProperty.dataFormat;
         if (!languageSpecificPrimitives.contains(innerProperty.baseType)) {
             property.complexType = innerProperty.baseType;
         } else {
@@ -1795,6 +1796,7 @@ public class DefaultCodegen {
             property.isPrimitiveType = true;
         }
         property.items = innerProperty;
+        property.dataFormat = innerProperty.dataFormat;
         // inner item is Enum
         if (isPropertyInnerMostEnum(property)) {
             // isEnum is set to true when the type is an enum


### PR DESCRIPTION
If a type's field is an array or map, dataFormat of the innerProperty was not copied
into encapsulating property. This change fixes it.

### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

