### PR TITLE
fix(jax-rs): fix package name in generated StringUtil.java to match 

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/StringUtil.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/StringUtil.mustache
@@ -1,4 +1,4 @@
-package {{invokerPackage}};
+package {{apiPackage}};
 
 {{>generatedAnnotation}}
 public class StringUtil {


### PR DESCRIPTION
…here file is generated

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

When generating for JaxRS, the StringUtil.java file is generated under "apiPackage", but the package name IN the file was set to "invokerPackage". This fixes the mustache file to align the two, to "apiPackage"