### PR TITLE
Fixed issue #4664

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api.mustache
@@ -82,8 +82,8 @@ func (a {{{classname}}}) {{{nickname}}}({{#allParams}}{{paramName}} {{{dataType}
 	{{#hasQueryParams}}
 	{{#queryParams}}
 	{{#isListContainer}}
-	var collectionFormat = "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"
-	localVarQueryParams.Add("{{baseName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, collectionFormat))
+	var {{paramName}}CollectionFormat = "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"
+	localVarQueryParams.Add("{{baseName}}", a.Configuration.APIClient.ParameterToString({{paramName}}, {{paramName}}CollectionFormat))
 
 	{{/isListContainer}}
 	{{^isListContainer}}


### PR DESCRIPTION
Fixed issue #4664: [go] incorrect code generated, if there are more than 1 array parameters

Took the suggestion by wing328 and reworked the fix. This patch also applied to the latest master, while the original issue was about 2.2.1 code.
