### PR TITLE
[TypeScript][Fetch] Make configuration properties optional

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/configuration.mustache
@@ -6,7 +6,7 @@ export class Configuration {
 {{/isApiKey}}
 {{/authMethods}}
     };
-    usernam?: string;
+    username?: string;
     password?: string;
     accessToken?: string;
 }

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/configuration.mustache
@@ -1,12 +1,12 @@
 export class Configuration {
-    apiKey: {
+    apiKey?: {
 {{#authMethods}}
 {{#isApiKey}}
         {{keyParamName}}: string;
 {{/isApiKey}}
 {{/authMethods}}
     };
-    username: string;
-    password: string;
-    accessToken: string;
+    usernam?: string;
+    password?: string;
+    accessToken?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/configuration.ts
@@ -1,8 +1,8 @@
 export class Configuration {
-    apiKey: {
+    apiKey?: {
         api_key: string;
     };
-    username: string;
-    password: string;
-    accessToken: string;
+    username?: string;
+    password?: string;
+    accessToken?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/configuration.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/configuration.ts
@@ -1,8 +1,8 @@
 export class Configuration {
-    apiKey: {
+    apiKey?: {
         api_key: string;
     };
-    username: string;
-    password: string;
-    accessToken: string;
+    username?: string;
+    password?: string;
+    accessToken?: string;
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/configuration.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/configuration.ts
@@ -1,8 +1,8 @@
 export class Configuration {
-    apiKey: {
+    apiKey?: {
         api_key: string;
     };
-    username: string;
-    password: string;
-    accessToken: string;
+    username?: string;
+    password?: string;
+    accessToken?: string;
 }


### PR DESCRIPTION
Right now all properties are required despite the enabled authentication schemes

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Made configuration properties optional in typescript-fetch
(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

