### PR TITLE
Default directory for generated sources is "src/gen/java" and not "src/main/java"

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -346,7 +346,7 @@ public class CodeGenMojo extends AbstractMojo {
 
         if (addCompileSourceRoot) {
             final Object sourceFolderObject = configOptions == null ? null : configOptions.get(CodegenConstants.SOURCE_FOLDER);
-            final String sourceFolder =  sourceFolderObject == null ? "src/main/java" : sourceFolderObject.toString();
+            final String sourceFolder =  sourceFolderObject == null ? "src/gen/java" : sourceFolderObject.toString();
 
             String sourceJavaFolder = output.toString() + "/" + sourceFolder;
             project.addCompileSourceRoot(sourceJavaFolder);


### PR DESCRIPTION
Default directory for generated sources is "src/gen/java" and not "src/main/java"

### Description of the PR

If i use this configuration : 
``` xml
<executions>
	<execution>
		<goals>
			<goal>generate</goal>
		</goals>
		<configuration>
		    <inputSpec>src/main/resources/contextPortalPanoramix-swagger.json</inputSpec>
		     <language>jaxrs-cxf-client</language>
                     <addCompileSourceRoot>true</addCompileSourceRoot>
		</configuration>
	</execution>
</executions>
```

The generated sources are in "generated-sources/swagger/src/gen/java" directory, but maven pulgin add "generated-sources/swagger/src/main/java" on the maven build directory.