### PR TITLE
[JavaScript] Fix for issue #4654: do not encode commas in CSV collection query parameters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -369,8 +369,10 @@
           // SuperAgent normally percent-encodes all reserved characters in a query parameter. However,
           // commas are used as delimiters for the 'csv' collectionFormat so they must not be encoded. We
           // must therefore construct and encode 'csv' collection query parameters manually.
-          var value = param.value.map(this.paramToString).map(encodeURIComponent).join(',');
-          request.query(encodeURIComponent(key) + "=" + value);
+          if (param.value != null) {
+            var value = param.value.map(this.paramToString).map(encodeURIComponent).join(',');
+            request.query(encodeURIComponent(key) + "=" + value);
+          }
         } else {
           // All other collection query parameters should be treated as ordinary query parameters.
           queryParams[key] = this.apiClient.buildCollectionParam(param.value, param.collectionFormat);

--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -338,6 +338,7 @@
    * @param {String} httpMethod The HTTP method to use.
    * @param {Object.<String, String>} pathParams A map of path parameters and their values.
    * @param {Object.<String, Object>} queryParams A map of query parameters and their values.
+   * @param {Object.<String, Object>} collectionQueryParams A map of collection query parameters and their values.
    * @param {Object.<String, Object>} headerParams A map of header parameters and their values.
    * @param {Object.<String, Object>} formParams A map of form parameters and their values.
    * @param {Object} bodyParam The value to pass as the request body.
@@ -350,7 +351,7 @@
    * @returns {{#usePromises}}{Promise} A {@link https://www.promisejs.org/|Promise} object{{/usePromises}}{{^usePromises}}{Object} The SuperAgent request object{{/usePromises}}.
    */
 {{/emitJSDoc}}  exports.prototype.callApi = function callApi(path, httpMethod, pathParams,
-      queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
+      queryParams, collectionQueryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
       returnType{{^usePromises}}, callback{{/usePromises}}) {
 
     var _this = this;
@@ -359,6 +360,23 @@
 
     // apply authentications
     this.applyAuthToRequest(request, authNames);
+
+    // set collection query parameters
+    for (var key in collectionQueryParams) {
+      if (collectionQueryParams.hasOwnProperty(key)) {
+        var param = collectionQueryParams[key];
+        if (param.collectionFormat === 'csv') {
+          // SuperAgent normally percent-encodes all reserved characters in a query parameter. However,
+          // commas are used as delimiters for the 'csv' collectionFormat so they must not be encoded. We
+          // must therefore construct and encode 'csv' collection query parameters manually.
+          var value = param.value.map(this.paramToString).map(encodeURIComponent).join(',');
+          request.query(encodeURIComponent(key) + "=" + value);
+        } else {
+          // All other collection query parameters should be treated as ordinary query parameters.
+          queryParams[key] = this.apiClient.buildCollectionParam(param.value, param.collectionFormat);
+        }
+      }
+    }
 
     // set query parameters
     if (httpMethod.toUpperCase() === 'GET' && this.cache === false) {

--- a/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
@@ -65,8 +65,14 @@
       var pathParams = {<#pathParams>
         '<baseName>': <#required><paramName></required><^required>opts['<paramName>']</required><#hasMore>,</hasMore></pathParams>
       };
-      var queryParams = {<#queryParams>
-        '<baseName>': <#collectionFormat>this.apiClient.buildCollectionParam(<#required><paramName></required><^required>opts['<paramName>']</required>, '<collectionFormat>')</collectionFormat><^collectionFormat><#required><paramName></required><^required>opts['<paramName>']</required></collectionFormat><#hasMore>,</hasMore></queryParams>
+      var queryParams = {<#queryParams><^collectionFormat>
+        '<baseName>': <#required><paramName></required><^required>opts['<paramName>']</required>,</collectionFormat></queryParams>
+      };
+      var collectionQueryParams = {<#queryParams><#collectionFormat>
+        '<baseName>': {
+          value: <#required><paramName></required><^required>opts['<paramName>']</required>,
+          collectionFormat: '<collectionFormat>'
+        },</collectionFormat></queryParams>
       };
       var headerParams = {<#headerParams>
         '<baseName>': <#required><paramName></required><^required>opts['<paramName>']</required><#hasMore>,</hasMore></headerParams>
@@ -82,7 +88,7 @@
 
       return this.apiClient.callApi(
         '<&path>', '<httpMethod>',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType<^usePromises>, callback</usePromises>
       );
     }

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -333,6 +333,7 @@
    * @param {String} httpMethod The HTTP method to use.
    * @param {Object.<String, String>} pathParams A map of path parameters and their values.
    * @param {Object.<String, Object>} queryParams A map of query parameters and their values.
+   * @param {Object.<String, Object>} collectionQueryParams A map of collection query parameters and their values.
    * @param {Object.<String, Object>} headerParams A map of header parameters and their values.
    * @param {Object.<String, Object>} formParams A map of form parameters and their values.
    * @param {Object} bodyParam The value to pass as the request body.
@@ -344,7 +345,7 @@
    * @returns {Promise} A {@link https://www.promisejs.org/|Promise} object.
    */
   exports.prototype.callApi = function callApi(path, httpMethod, pathParams,
-      queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
+      queryParams, collectionQueryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
       returnType) {
 
     var _this = this;
@@ -353,6 +354,23 @@
 
     // apply authentications
     this.applyAuthToRequest(request, authNames);
+
+    // set collection query parameters
+    for (var key in collectionQueryParams) {
+      if (collectionQueryParams.hasOwnProperty(key)) {
+        var param = collectionQueryParams[key];
+        if (param.collectionFormat === 'csv') {
+          // SuperAgent normally percent-encodes all reserved characters in a query parameter. However,
+          // commas are used as delimiters for the 'csv' collectionFormat so they must not be encoded. We
+          // must therefore construct and encode 'csv' collection query parameters manually.
+          var value = param.value.map(this.paramToString).map(encodeURIComponent).join(',');
+          request.query(encodeURIComponent(key) + "=" + value);
+        } else {
+          // All other collection query parameters should be treated as ordinary query parameters.
+          queryParams[key] = this.apiClient.buildCollectionParam(param.value, param.collectionFormat);
+        }
+      }
+    }
 
     // set query parameters
     if (httpMethod.toUpperCase() === 'GET' && this.cache === false) {

--- a/samples/client/petstore/javascript-promise/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/FakeApi.js
@@ -65,6 +65,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -77,7 +79,7 @@
 
       return this.apiClient.callApi(
         '/fake', 'PATCH',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -132,6 +134,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -158,7 +162,7 @@
 
       return this.apiClient.callApi(
         '/fake', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -186,9 +190,14 @@
       var pathParams = {
       };
       var queryParams = {
-        'enum_query_string_array': this.apiClient.buildCollectionParam(opts['enumQueryStringArray'], 'csv'),
         'enum_query_string': opts['enumQueryString'],
-        'enum_query_integer': opts['enumQueryInteger']
+        'enum_query_integer': opts['enumQueryInteger'],
+      };
+      var collectionQueryParams = {
+        'enum_query_string_array': {
+          value: opts['enumQueryStringArray'],
+          collectionFormat: 'csv'
+        },
       };
       var headerParams = {
         'enum_header_string_array': opts['enumHeaderStringArray'],
@@ -207,7 +216,7 @@
 
       return this.apiClient.callApi(
         '/fake', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }

--- a/samples/client/petstore/javascript-promise/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/PetApi.js
@@ -65,6 +65,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -77,7 +79,7 @@
 
       return this.apiClient.callApi(
         '/pet', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -106,6 +108,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
         'api_key': opts['apiKey']
       };
@@ -119,7 +123,7 @@
 
       return this.apiClient.callApi(
         '/pet/{petId}', 'DELETE',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -143,7 +147,12 @@
       var pathParams = {
       };
       var queryParams = {
-        'status': this.apiClient.buildCollectionParam(status, 'csv')
+      };
+      var collectionQueryParams = {
+        'status': {
+          value: status,
+          collectionFormat: 'csv'
+        },
       };
       var headerParams = {
       };
@@ -157,7 +166,7 @@
 
       return this.apiClient.callApi(
         '/pet/findByStatus', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -181,7 +190,12 @@
       var pathParams = {
       };
       var queryParams = {
-        'tags': this.apiClient.buildCollectionParam(tags, 'csv')
+      };
+      var collectionQueryParams = {
+        'tags': {
+          value: tags,
+          collectionFormat: 'csv'
+        },
       };
       var headerParams = {
       };
@@ -195,7 +209,7 @@
 
       return this.apiClient.callApi(
         '/pet/findByTags', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -221,6 +235,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -233,7 +249,7 @@
 
       return this.apiClient.callApi(
         '/pet/{petId}', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -258,6 +274,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -270,7 +288,7 @@
 
       return this.apiClient.callApi(
         '/pet', 'PUT',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -300,6 +318,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -314,7 +334,7 @@
 
       return this.apiClient.callApi(
         '/pet/{petId}', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -344,6 +364,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -358,7 +380,7 @@
 
       return this.apiClient.callApi(
         '/pet/{petId}/uploadImage', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }

--- a/samples/client/petstore/javascript-promise/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/StoreApi.js
@@ -66,6 +66,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -78,7 +80,7 @@
 
       return this.apiClient.callApi(
         '/store/order/{orderId}', 'DELETE',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -97,6 +99,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -109,7 +113,7 @@
 
       return this.apiClient.callApi(
         '/store/inventory', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -135,6 +139,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -147,7 +153,7 @@
 
       return this.apiClient.callApi(
         '/store/order/{orderId}', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -172,6 +178,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -184,7 +192,7 @@
 
       return this.apiClient.callApi(
         '/store/order', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }

--- a/samples/client/petstore/javascript-promise/src/api/UserApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/UserApi.js
@@ -65,6 +65,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -77,7 +79,7 @@
 
       return this.apiClient.callApi(
         '/user', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -102,6 +104,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -114,7 +118,7 @@
 
       return this.apiClient.callApi(
         '/user/createWithArray', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -139,6 +143,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -151,7 +157,7 @@
 
       return this.apiClient.callApi(
         '/user/createWithList', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -177,6 +183,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -189,7 +197,7 @@
 
       return this.apiClient.callApi(
         '/user/{username}', 'DELETE',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -215,6 +223,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -227,7 +237,7 @@
 
       return this.apiClient.callApi(
         '/user/{username}', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -258,7 +268,9 @@
       };
       var queryParams = {
         'username': username,
-        'password': password
+        'password': password,
+      };
+      var collectionQueryParams = {
       };
       var headerParams = {
       };
@@ -272,7 +284,7 @@
 
       return this.apiClient.callApi(
         '/user/login', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -291,6 +303,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -303,7 +317,7 @@
 
       return this.apiClient.callApi(
         '/user/logout', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }
@@ -335,6 +349,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -347,7 +363,7 @@
 
       return this.apiClient.callApi(
         '/user/{username}', 'PUT',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );
     }

--- a/samples/client/petstore/javascript-promise/test/ApiClientTest.js
+++ b/samples/client/petstore/javascript-promise/test/ApiClientTest.js
@@ -380,6 +380,7 @@ function makeDumbRequest(apiClient, opts) {
   var httpMethod = opts.httpMethod || 'GET';
   var pathParams = opts.pathParams || {};
   var queryParams = opts.queryParams || {};
+  var collectionQueryParams = opts.collectionQueryParams || {};
   var headerParams = opts.headerParams || {};
   var formParams = opts.formParams || {};
   var bodyParam = opts.bodyParam;
@@ -387,6 +388,6 @@ function makeDumbRequest(apiClient, opts) {
   var contentTypes = opts.contentTypes || [];
   var accepts = opts.accepts || [];
   var callback = opts.callback;
-  return apiClient.callApi(path, httpMethod, pathParams, queryParams,
+  return apiClient.callApi(path, httpMethod, pathParams, queryParams, collectionQueryParams,
     headerParams, formParams, bodyParam, authNames, contentTypes, accepts);
 }

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -341,6 +341,7 @@
    * @param {String} httpMethod The HTTP method to use.
    * @param {Object.<String, String>} pathParams A map of path parameters and their values.
    * @param {Object.<String, Object>} queryParams A map of query parameters and their values.
+   * @param {Object.<String, Object>} collectionQueryParams A map of collection query parameters and their values.
    * @param {Object.<String, Object>} headerParams A map of header parameters and their values.
    * @param {Object.<String, Object>} formParams A map of form parameters and their values.
    * @param {Object} bodyParam The value to pass as the request body.
@@ -353,7 +354,7 @@
    * @returns {Object} The SuperAgent request object.
    */
   exports.prototype.callApi = function callApi(path, httpMethod, pathParams,
-      queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
+      queryParams, collectionQueryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
       returnType, callback) {
 
     var _this = this;
@@ -362,6 +363,23 @@
 
     // apply authentications
     this.applyAuthToRequest(request, authNames);
+
+    // set collection query parameters
+    for (var key in collectionQueryParams) {
+      if (collectionQueryParams.hasOwnProperty(key)) {
+        var param = collectionQueryParams[key];
+        if (param.collectionFormat === 'csv') {
+          // SuperAgent normally percent-encodes all reserved characters in a query parameter. However,
+          // commas are used as delimiters for the 'csv' collectionFormat so they must not be encoded. We
+          // must therefore construct and encode 'csv' collection query parameters manually.
+          var value = param.value.map(this.paramToString).map(encodeURIComponent).join(',');
+          request.query(encodeURIComponent(key) + "=" + value);
+        } else {
+          // All other collection query parameters should be treated as ordinary query parameters.
+          queryParams[key] = this.apiClient.buildCollectionParam(param.value, param.collectionFormat);
+        }
+      }
+    }
 
     // set query parameters
     if (httpMethod.toUpperCase() === 'GET' && this.cache === false) {

--- a/samples/client/petstore/javascript/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript/src/api/FakeApi.js
@@ -73,6 +73,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -85,7 +87,7 @@
 
       return this.apiClient.callApi(
         '/fake', 'PATCH',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -147,6 +149,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -173,7 +177,7 @@
 
       return this.apiClient.callApi(
         '/fake', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -208,9 +212,14 @@
       var pathParams = {
       };
       var queryParams = {
-        'enum_query_string_array': this.apiClient.buildCollectionParam(opts['enumQueryStringArray'], 'csv'),
         'enum_query_string': opts['enumQueryString'],
-        'enum_query_integer': opts['enumQueryInteger']
+        'enum_query_integer': opts['enumQueryInteger'],
+      };
+      var collectionQueryParams = {
+        'enum_query_string_array': {
+          value: opts['enumQueryStringArray'],
+          collectionFormat: 'csv'
+        },
       };
       var headerParams = {
         'enum_header_string_array': opts['enumHeaderStringArray'],
@@ -229,7 +238,7 @@
 
       return this.apiClient.callApi(
         '/fake', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }

--- a/samples/client/petstore/javascript/src/api/PetApi.js
+++ b/samples/client/petstore/javascript/src/api/PetApi.js
@@ -72,6 +72,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -84,7 +86,7 @@
 
       return this.apiClient.callApi(
         '/pet', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -120,6 +122,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
         'api_key': opts['apiKey']
       };
@@ -133,7 +137,7 @@
 
       return this.apiClient.callApi(
         '/pet/{petId}', 'DELETE',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -165,7 +169,12 @@
       var pathParams = {
       };
       var queryParams = {
-        'status': this.apiClient.buildCollectionParam(status, 'csv')
+      };
+      var collectionQueryParams = {
+        'status': {
+          value: status,
+          collectionFormat: 'csv'
+        },
       };
       var headerParams = {
       };
@@ -179,7 +188,7 @@
 
       return this.apiClient.callApi(
         '/pet/findByStatus', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -211,7 +220,12 @@
       var pathParams = {
       };
       var queryParams = {
-        'tags': this.apiClient.buildCollectionParam(tags, 'csv')
+      };
+      var collectionQueryParams = {
+        'tags': {
+          value: tags,
+          collectionFormat: 'csv'
+        },
       };
       var headerParams = {
       };
@@ -225,7 +239,7 @@
 
       return this.apiClient.callApi(
         '/pet/findByTags', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -259,6 +273,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -271,7 +287,7 @@
 
       return this.apiClient.callApi(
         '/pet/{petId}', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -303,6 +319,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -315,7 +333,7 @@
 
       return this.apiClient.callApi(
         '/pet', 'PUT',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -352,6 +370,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -366,7 +386,7 @@
 
       return this.apiClient.callApi(
         '/pet/{petId}', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -404,6 +424,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -418,7 +440,7 @@
 
       return this.apiClient.callApi(
         '/pet/{petId}/uploadImage', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }

--- a/samples/client/petstore/javascript/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript/src/api/StoreApi.js
@@ -73,6 +73,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -85,7 +87,7 @@
 
       return this.apiClient.callApi(
         '/store/order/{orderId}', 'DELETE',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -112,6 +114,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -124,7 +128,7 @@
 
       return this.apiClient.callApi(
         '/store/inventory', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -158,6 +162,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -170,7 +176,7 @@
 
       return this.apiClient.callApi(
         '/store/order/{orderId}', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -203,6 +209,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -215,7 +223,7 @@
 
       return this.apiClient.callApi(
         '/store/order', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }

--- a/samples/client/petstore/javascript/src/api/UserApi.js
+++ b/samples/client/petstore/javascript/src/api/UserApi.js
@@ -72,6 +72,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -84,7 +86,7 @@
 
       return this.apiClient.callApi(
         '/user', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -116,6 +118,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -128,7 +132,7 @@
 
       return this.apiClient.callApi(
         '/user/createWithArray', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -160,6 +164,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -172,7 +178,7 @@
 
       return this.apiClient.callApi(
         '/user/createWithList', 'POST',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -205,6 +211,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -217,7 +225,7 @@
 
       return this.apiClient.callApi(
         '/user/{username}', 'DELETE',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -251,6 +259,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -263,7 +273,7 @@
 
       return this.apiClient.callApi(
         '/user/{username}', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -302,7 +312,9 @@
       };
       var queryParams = {
         'username': username,
-        'password': password
+        'password': password,
+      };
+      var collectionQueryParams = {
       };
       var headerParams = {
       };
@@ -316,7 +328,7 @@
 
       return this.apiClient.callApi(
         '/user/login', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -342,6 +354,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -354,7 +368,7 @@
 
       return this.apiClient.callApi(
         '/user/logout', 'GET',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }
@@ -393,6 +407,8 @@
       };
       var queryParams = {
       };
+      var collectionQueryParams = {
+      };
       var headerParams = {
       };
       var formParams = {
@@ -405,7 +421,7 @@
 
       return this.apiClient.callApi(
         '/user/{username}', 'PUT',
-        pathParams, queryParams, headerParams, formParams, postBody,
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType, callback
       );
     }

--- a/samples/client/petstore/javascript/test/ApiClientTest.js
+++ b/samples/client/petstore/javascript/test/ApiClientTest.js
@@ -377,6 +377,7 @@ function makeDumbRequest(apiClient, opts) {
   var httpMethod = opts.httpMethod || 'GET';
   var pathParams = opts.pathParams || {};
   var queryParams = opts.queryParams || {};
+  var collectionQueryParams = opts.collectionQueryParams || {};
   var headerParams = opts.headerParams || {};
   var formParams = opts.formParams || {};
   var bodyParam = opts.bodyParam;
@@ -384,7 +385,7 @@ function makeDumbRequest(apiClient, opts) {
   var contentTypes = opts.contentTypes || [];
   var accepts = opts.accepts || [];
   var callback = opts.callback;
-  return apiClient.callApi(path, httpMethod, pathParams, queryParams,
+  return apiClient.callApi(path, httpMethod, pathParams, queryParams, collectionQueryParams,
     headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
     callback
   );


### PR DESCRIPTION
This PR addresses issue #4654 by fixing the generated JavaScript API such that it no longer incorrectly encodes commas when used as delimiters for elements in a query parameter with a `csv` collection format.

I've committed the changes against master. I'm not sure whether this should be considered a backwards-incompatible change; it does change the behaviour of the generated JavaScript API, but the prior behaviour was erroneous, so...

I've also updated the tests so that they are compatible with this change (except for the security ones, which don't appear to be enabled anyways).