### PR TITLE
[aspnetcore] resolve source/packageName issues

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNetCoreServerCodegen.java
@@ -14,8 +14,6 @@ import static java.util.UUID.randomUUID;
 
 public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
-    protected String sourceFolder = "src" + File.separator + packageName;
-
     private final String packageGuid = "{" + randomUUID().toString().toUpperCase() + "}";
 
     @SuppressWarnings("hiding")
@@ -24,6 +22,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public AspNetCoreServerCodegen() {
         super();
 
+        setSourceFolder("src");
         outputFolder = "generated-code" + File.separator + this.getName();
 
         modelTemplateFiles.put("model.mustache", ".cs");
@@ -91,38 +90,53 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         apiPackage = packageName + ".Controllers";
         modelPackage = packageName + ".Models";
 
+        String packageFolder = sourceFolder + File.separator + packageName;
+
         supportingFiles.add(new SupportingFile("NuGet.Config", "", "NuGet.Config"));
         supportingFiles.add(new SupportingFile("global.json", "", "global.json"));
         supportingFiles.add(new SupportingFile("build.sh.mustache", "", "build.sh"));
         supportingFiles.add(new SupportingFile("build.bat.mustache", "", "build.bat"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("Solution.mustache", "", this.packageName + ".sln"));
-        supportingFiles.add(new SupportingFile("Dockerfile.mustache", this.sourceFolder, "Dockerfile"));
-        supportingFiles.add(new SupportingFile("gitignore", this.sourceFolder, ".gitignore"));
-        supportingFiles.add(new SupportingFile("appsettings.json", this.sourceFolder, "appsettings.json"));
+        supportingFiles.add(new SupportingFile("Dockerfile.mustache", packageFolder, "Dockerfile"));
+        supportingFiles.add(new SupportingFile("gitignore", packageFolder, ".gitignore"));
+        supportingFiles.add(new SupportingFile("appsettings.json", packageFolder, "appsettings.json"));
 
-        supportingFiles.add(new SupportingFile("project.json.mustache", this.sourceFolder, "project.json"));
-        supportingFiles.add(new SupportingFile("Startup.mustache", this.sourceFolder, "Startup.cs"));
-        supportingFiles.add(new SupportingFile("Program.mustache", this.sourceFolder, "Program.cs"));
-        supportingFiles.add(new SupportingFile("web.config", this.sourceFolder, "web.config"));
+        supportingFiles.add(new SupportingFile("project.json.mustache", packageFolder, "project.json"));
+        supportingFiles.add(new SupportingFile("Startup.mustache", packageFolder, "Startup.cs"));
+        supportingFiles.add(new SupportingFile("Program.mustache", packageFolder, "Program.cs"));
+        supportingFiles.add(new SupportingFile("web.config", packageFolder, "web.config"));
 
-        supportingFiles.add(new SupportingFile("Project.xproj.mustache", this.sourceFolder, this.packageName + ".xproj"));
+        supportingFiles.add(new SupportingFile("Project.xproj.mustache", packageFolder, this.packageName + ".xproj"));
 
-        supportingFiles.add(new SupportingFile("Properties" + File.separator + "launchSettings.json", this.sourceFolder + File.separator + "Properties", "launchSettings.json"));
+        supportingFiles.add(new SupportingFile("Properties" + File.separator + "launchSettings.json", packageFolder + File.separator + "Properties", "launchSettings.json"));
 
-        supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "README.md", this.sourceFolder + File.separator + "wwwroot", "README.md"));
-        supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "index.html", this.sourceFolder + File.separator + "wwwroot", "index.html"));
-        supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "web.config", this.sourceFolder + File.separator + "wwwroot", "web.config"));
+        supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "README.md", packageFolder + File.separator + "wwwroot", "README.md"));
+        supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "index.html", packageFolder + File.separator + "wwwroot", "index.html"));
+        supportingFiles.add(new SupportingFile("wwwroot" + File.separator + "web.config", packageFolder + File.separator + "wwwroot", "web.config"));
+    }
+
+    @Override
+    public void setSourceFolder(final String sourceFolder) {
+        if(sourceFolder == null) {
+            LOGGER.warn("No sourceFolder specified, using default");
+            this.sourceFolder =  "src" + File.separator + this.packageName;
+        } else if(!sourceFolder.equals("src") && !sourceFolder.startsWith("src")) {
+            LOGGER.warn("ASP.NET Core requires source code exists under src. Adjusting.");
+            this.sourceFolder =  "src" + File.separator + sourceFolder;
+        } else {
+            this.sourceFolder = sourceFolder;
+        }
     }
 
     @Override
     public String apiFileFolder() {
-        return outputFolder + File.separator + sourceFolder + File.separator + "Controllers";
+        return outputFolder + File.separator + sourceFolder + File.separator + packageName + File.separator + "Controllers";
     }
 
     @Override
     public String modelFileFolder() {
-        return outputFolder + File.separator + sourceFolder + File.separator + "Models";
+        return outputFolder + File.separator + sourceFolder + File.separator + packageName + File.separator  + "Models";
     }
 
     @Override


### PR DESCRIPTION
Outputs warnings about ASP.NET Core's src/ requirement, and adjusts
sourceFolder if the input doesn't start with src/.

As a consequence of this change, apiFileFolder and modelFileFolder may
possibly return different values if users are setting both sourceFolder
and packageName. This could be considered a breaking change in those
sceanrios.

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

see #4690 

This fix resolves the issue with `packageName` not being respected. I've also added some log messages in a new `setSourceFolder` override. However, ASP.NET Core requires a rigid source directory structure, and it appears as though changing `sourceFolder` can cause problems. We may want to override `setSourceFolder` to prevent overwriting it from "src".