### PR TITLE
For dateLibrary=java8, remove JODA references

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/jacksonJsonProvider.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/jacksonJsonProvider.mustache
@@ -3,7 +3,14 @@ package {{apiPackage}};
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
+
+{{#java8}}
+import com.fasterxml.jackson.datatype.jsr310.*;
+{{/java8}}
+{{^java8}}
+import com.fasterxml.jackson.datatype.joda.*;
+{{/java8}}
+
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
 import javax.ws.rs.Produces;
@@ -19,7 +26,12 @@ public class JacksonJsonProvider extends JacksonJaxbJsonProvider {
         ObjectMapper objectMapper = new ObjectMapper()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+{{#java8}}
+            .registerModule(new JavaTimeModule())
+{{/java8}}
+{{^java8}}
             .registerModule(new JodaModule())
+{{/java8}}
             .setDateFormat(new RFC3339DateFormat());
 
         setMapper(objectMapper);


### PR DESCRIPTION
This is related, at least in spirit, to this issue: https://github.com/swagger-api/swagger-codegen/issues/2874

### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

