### PR TITLE
Provide sample of Java based generator + compare results #4087

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/ComparePathUtil.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/ComparePathUtil.java
@@ -101,7 +101,13 @@ public class ComparePathUtil {
 
                     } else {
                         LOGGER.info("going into recursion with directory " + directoryFilePath);
-                        return isEverythingInCompareDirectory(directoryFilePath, compareFilePath, checkFileContent, false);
+                        boolean result = isEverythingInCompareDirectory(directoryFilePath, compareFilePath,
+                                checkFileContent, false);
+
+                        // if not equal, then cancel compare
+                        if (!result) {
+                            return false;
+                        }
                     }
                 } else {
                     LOGGER.info(directoryFilePath.toString() + ": compareFilepath not found");

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/ComparePathUtil.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/ComparePathUtil.java
@@ -1,0 +1,46 @@
+package io.swagger.codegen.generators;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ComparePathUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JaxrsSpec_Generator_Petstore.class);
+
+    public static void assertThatAllFilesAreEqual(Path expectedDirectory, Path actualDirectory)
+            throws Exception {
+
+        try {
+            try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(expectedDirectory)) {
+                for (Path expectedFilePath : directoryStream) {
+
+                    // search for expectedFile in the actualDirectory
+                    LOGGER.info("checking file " + expectedFilePath);
+
+                    Path actualFilePath = actualDirectory.resolve(expectedFilePath.getFileName());
+
+                    File expectedFile = expectedFilePath.toFile();
+                    if (expectedFile.isFile()) {
+                        if (!FileUtils.contentEquals(actualFilePath.toFile(), expectedFile)) {
+                            throw new Exception("files not equal: actual: " + actualFilePath.toFile() + ", expected: " + expectedFilePath.getFileName() + "!");
+                        };
+                      
+                    } else {
+                        LOGGER.info("going into recursion with directory " + expectedFilePath);
+                        assertThatAllFilesAreEqual(expectedFilePath, actualFilePath);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to assert that all files are equal", e);
+        }
+    }
+
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/EclipseFilenameFilter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/EclipseFilenameFilter.java
@@ -1,0 +1,18 @@
+package io.swagger.codegen.generators;
+
+import java.io.File;
+
+public class EclipseFilenameFilter implements java.io.FilenameFilter {
+
+    @Override
+    public boolean accept(File dir, String name) {
+
+        if ("target".equals(name) || ".classpath".equals(name) || ".project".equals(name)) {
+            return false;
+        } else {
+            return true;
+        }
+
+    }
+
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/JaxrsSpec_Generator_Petstore.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/JaxrsSpec_Generator_Petstore.java
@@ -34,8 +34,7 @@ public class JaxrsSpec_Generator_Petstore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JaxrsSpec_Generator_Petstore.class);
 
-    public static boolean generate() {
-        boolean equal = false;
+    public static TemporaryFolder generate() {
         try {
             TemporaryFolder folder = new TemporaryFolder();
             folder.create();
@@ -55,30 +54,13 @@ public class JaxrsSpec_Generator_Petstore {
 
             gen.generate();
 
-            java.nio.file.Path actualPath = FileSystems.getDefault().getPath(output.getAbsolutePath());
-
-            java.nio.file.Path samplePath = FileSystems.getDefault().getPath("../../samples/server/petstore/jaxrs-spec");
-            LOGGER.info("path: " + samplePath.toFile().getAbsolutePath());
-
-            try {
-                ComparePathUtil.assertThatAllFilesAreEqual(actualPath, samplePath);
-
-                // cleanup temporary folder if everything is OK
-                folder.delete();
-
-                equal = true;
-            } catch (Exception e) {
-                LOGGER.info("generated to path " + output.getAbsolutePath());
-
-                e.printStackTrace();
-            }
+            return folder;
 
         } catch (IOException e) {
             LOGGER.info("unable to create temporary folder");
             e.printStackTrace();
+            return null;
         }
-        
-        return equal;
 
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/JaxrsSpec_Generator_Petstore.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/generators/JaxrsSpec_Generator_Petstore.java
@@ -1,0 +1,85 @@
+package io.swagger.codegen.generators;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.codegen.ClientOptInput;
+import io.swagger.codegen.ClientOpts;
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.DefaultGenerator;
+import io.swagger.codegen.languages.JavaJAXRSSpecServerCodegen;
+import io.swagger.models.Swagger;
+import io.swagger.parser.SwaggerParser;
+
+/**
+ * commandline of jaxrs-spec-petstore-server.sh
+ * 
+ * # if you've executed sbt assembly previously it will use that instead. export
+ * JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M
+ * -DloggerPath=conf/log4j.properties" ags="$@ generate -t
+ * modules/swagger-codegen/src/main/resources/JavaJaxRS -i
+ * modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+ * -l jaxrs-spec -o samples/server/petstore/jaxrs-spec
+ * -DhideGenerationTimestamp=true"
+ *
+ * 
+ */
+public class JaxrsSpec_Generator_Petstore {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JaxrsSpec_Generator_Petstore.class);
+
+    public static boolean generate() {
+        boolean equal = false;
+        try {
+            TemporaryFolder folder = new TemporaryFolder();
+            folder.create();
+            File output = folder.getRoot();
+
+            final Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+
+            CodegenConfig codegenConfig = new JavaJAXRSSpecServerCodegen();
+            codegenConfig.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, true);
+
+            codegenConfig.setOutputDir(output.getAbsolutePath());
+
+            ClientOptInput clientOptInput = new ClientOptInput().opts(new ClientOpts()).swagger(swagger).config(codegenConfig);
+
+            DefaultGenerator gen = new DefaultGenerator();
+            gen.opts(clientOptInput);
+
+            gen.generate();
+
+            java.nio.file.Path actualPath = FileSystems.getDefault().getPath(output.getAbsolutePath());
+
+            java.nio.file.Path samplePath = FileSystems.getDefault().getPath("../../samples/server/petstore/jaxrs-spec");
+            LOGGER.info("path: " + samplePath.toFile().getAbsolutePath());
+
+            try {
+                ComparePathUtil.assertThatAllFilesAreEqual(actualPath, samplePath);
+
+                // cleanup temporary folder if everything is OK
+                folder.delete();
+
+                equal = true;
+            } catch (Exception e) {
+                LOGGER.info("generated to path " + output.getAbsolutePath());
+
+                e.printStackTrace();
+            }
+
+        } catch (IOException e) {
+            LOGGER.info("unable to create temporary folder");
+            e.printStackTrace();
+        }
+        
+        return equal;
+
+    }
+
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/generators/Jaxrs_Spec_Generator_Petstore_Test.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/generators/Jaxrs_Spec_Generator_Petstore_Test.java
@@ -1,0 +1,17 @@
+package io.swagger.generators;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.swagger.codegen.generators.JaxrsSpec_Generator_Petstore;
+
+public class Jaxrs_Spec_Generator_Petstore_Test {
+
+
+    @Test
+    public void test() {
+        assertTrue(JaxrsSpec_Generator_Petstore.generate());
+    }
+
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/generators/Jaxrs_Spec_Generator_Petstore_Test.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/generators/Jaxrs_Spec_Generator_Petstore_Test.java
@@ -2,16 +2,52 @@ package io.swagger.generators;
 
 import static org.junit.Assert.*;
 
-import org.junit.Test;
+import java.io.File;
+import java.nio.file.FileSystems;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.codegen.generators.ComparePathUtil;
 import io.swagger.codegen.generators.JaxrsSpec_Generator_Petstore;
 
 public class Jaxrs_Spec_Generator_Petstore_Test {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Jaxrs_Spec_Generator_Petstore_Test.class);
+
+    TemporaryFolder folder;
+
+    @Before
+    public void setup() {
+        folder = JaxrsSpec_Generator_Petstore.generate();
+        assertNotNull(folder);
+    }
 
     @Test
     public void test() {
-        assertTrue(JaxrsSpec_Generator_Petstore.generate());
+        File output = folder.getRoot();
+        java.nio.file.Path actualPath = FileSystems.getDefault().getPath(output.getAbsolutePath());
+
+        java.nio.file.Path samplePath = FileSystems.getDefault().getPath("../../samples/server/petstore/jaxrs-spec");
+        LOGGER.info("path: " + samplePath.toFile().getAbsolutePath());
+
+        try {
+            assertTrue(ComparePathUtil.isEqualDirectories(actualPath, samplePath, true));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+    }
+
+    @After
+    public void teardown() {
+        // cleanup temporary folder if everything is OK
+        folder.delete();
     }
 
 }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/FakeApi.java
@@ -2,6 +2,7 @@ package io.swagger.api;
 
 import java.math.BigDecimal;
 import io.swagger.model.Client;
+import java.util.Date;
 import org.joda.time.LocalDate;
 
 import javax.ws.rs.*;
@@ -42,7 +43,7 @@ public class FakeApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid username supplied", response = void.class),
         @ApiResponse(code = 404, message = "User not found", response = void.class) })
-    public Response testEndpointParameters(@FormParam(value = "number")  BigDecimal number,@FormParam(value = "_double")  Double _double,@FormParam(value = "patternWithoutDelimiter")  String patternWithoutDelimiter,@FormParam(value = "_byte")  byte[] _byte,@FormParam(value = "integer")  Integer integer,@FormParam(value = "int32")  Integer int32,@FormParam(value = "int64")  Long int64,@FormParam(value = "_float")  Float _float,@FormParam(value = "string")  String string,@FormParam(value = "binary")  byte[] binary,@FormParam(value = "date")  LocalDate date,@FormParam(value = "dateTime")  javax.xml.datatype.XMLGregorianCalendar dateTime,@FormParam(value = "password")  String password,@FormParam(value = "paramCallback")  String paramCallback) {
+    public Response testEndpointParameters(@FormParam(value = "number")  BigDecimal number,@FormParam(value = "double")  Double _double,@FormParam(value = "pattern_without_delimiter")  String patternWithoutDelimiter,@FormParam(value = "byte")  byte[] _byte,@FormParam(value = "integer")  Integer integer,@FormParam(value = "int32")  Integer int32,@FormParam(value = "int64")  Long int64,@FormParam(value = "float")  Float _float,@FormParam(value = "string")  String string,@FormParam(value = "binary")  byte[] binary,@FormParam(value = "date")  LocalDate date,@FormParam(value = "dateTime")  Date dateTime,@FormParam(value = "password")  String password,@FormParam(value = "callback")  String paramCallback) {
     	return Response.ok().entity("magic!").build();
     }
 
@@ -54,7 +55,7 @@ public class FakeApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid request", response = void.class),
         @ApiResponse(code = 404, message = "Not found", response = void.class) })
-    public Response testEnumParameters(@FormParam(value = "enumFormStringArray")  List<String> enumFormStringArray,@FormParam(value = "enumFormString")  String enumFormString,@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray,@HeaderParam("enum_header_string") String enumHeaderString,@QueryParam("enum_query_string_array")  List<String> enumQueryStringArray,@QueryParam("enum_query_string")  String enumQueryString,@QueryParam("enum_query_integer")  Integer enumQueryInteger,@FormParam(value = "enumQueryDouble")  Double enumQueryDouble) {
+    public Response testEnumParameters(@FormParam(value = "enum_form_string_array")  List<String> enumFormStringArray,@FormParam(value = "enum_form_string")  String enumFormString,@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray,@HeaderParam("enum_header_string") String enumHeaderString,@QueryParam("enum_query_string_array")  List<String> enumQueryStringArray,@QueryParam("enum_query_string")  String enumQueryString,@QueryParam("enum_query_integer")  Integer enumQueryInteger,@FormParam(value = "enum_query_double")  Double enumQueryDouble) {
     	return Response.ok().entity("magic!").build();
     }
 }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
@@ -49,7 +49,7 @@ public class AdditionalPropertiesClass   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class AdditionalPropertiesClass   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Animal.java
@@ -49,7 +49,7 @@ public class Animal   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class Animal   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AnimalFarm.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AnimalFarm.java
@@ -15,7 +15,7 @@ public class AnimalFarm extends ArrayList<Animal>  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -44,7 +44,7 @@ public class AnimalFarm extends ArrayList<Animal>  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
@@ -32,7 +32,7 @@ public class ArrayOfArrayOfNumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -62,7 +62,7 @@ public class ArrayOfArrayOfNumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
@@ -32,7 +32,7 @@ public class ArrayOfNumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -62,7 +62,7 @@ public class ArrayOfNumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayTest.java
@@ -66,7 +66,7 @@ public class ArrayTest   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -100,7 +100,7 @@ public class ArrayTest   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Capitalization.java
@@ -115,7 +115,7 @@ public class Capitalization   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -155,7 +155,7 @@ public class Capitalization   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Cat.java
@@ -30,7 +30,7 @@ public class Cat extends Animal  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class Cat extends Animal  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Category.java
@@ -46,7 +46,7 @@ public class Category   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class Category   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ClassModel.java
@@ -33,7 +33,7 @@ public class ClassModel   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -63,7 +63,7 @@ public class ClassModel   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Client.java
@@ -29,7 +29,7 @@ public class Client   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -59,7 +59,7 @@ public class Client   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Dog.java
@@ -30,7 +30,7 @@ public class Dog extends Animal  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class Dog extends Animal  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumArrays.java
@@ -110,7 +110,7 @@ public enum ArrayEnumEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -142,7 +142,7 @@ public enum ArrayEnumEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumTest.java
@@ -174,7 +174,7 @@ public enum EnumNumberEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -210,7 +210,7 @@ public enum EnumNumberEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/FormatTest.java
@@ -217,7 +217,11 @@ public class FormatTest   {
 
   /**
    **/
+<<<<<<< HEAD
   public FormatTest uuid(UUID uuid) {
+=======
+  public FormatTest uuid(String uuid) {
+>>>>>>> provide sample how to generate using java + compare results #4087
     this.uuid = uuid;
     return this;
   }
@@ -227,7 +231,11 @@ public class FormatTest   {
   public UUID getUuid() {
     return uuid;
   }
+<<<<<<< HEAD
   public void setUuid(UUID uuid) {
+=======
+  public void setUuid(String uuid) {
+>>>>>>> provide sample how to generate using java + compare results #4087
     this.uuid = uuid;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/FormatTest.java
@@ -1,6 +1,7 @@
 package io.swagger.model;
 
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.UUID;
 import org.joda.time.LocalDate;
 import javax.validation.constraints.*;
@@ -22,7 +23,7 @@ public class FormatTest   {
   private byte[] _byte = null;
   private byte[] binary = null;
   private LocalDate date = null;
-  private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+  private Date dateTime = null;
   private UUID uuid = null;
   private String password = null;
 
@@ -201,27 +202,23 @@ public class FormatTest   {
 
   /**
    **/
-  public FormatTest dateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public FormatTest dateTime(Date dateTime) {
     this.dateTime = dateTime;
     return this;
   }
 
   
   @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getDateTime() {
+  public Date getDateTime() {
     return dateTime;
   }
-  public void setDateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public void setDateTime(Date dateTime) {
     this.dateTime = dateTime;
   }
 
   /**
    **/
-<<<<<<< HEAD
   public FormatTest uuid(UUID uuid) {
-=======
-  public FormatTest uuid(String uuid) {
->>>>>>> provide sample how to generate using java + compare results #4087
     this.uuid = uuid;
     return this;
   }
@@ -231,11 +228,7 @@ public class FormatTest   {
   public UUID getUuid() {
     return uuid;
   }
-<<<<<<< HEAD
   public void setUuid(UUID uuid) {
-=======
-  public void setUuid(String uuid) {
->>>>>>> provide sample how to generate using java + compare results #4087
     this.uuid = uuid;
   }
 
@@ -258,7 +251,7 @@ public class FormatTest   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -312,7 +305,7 @@ public class FormatTest   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
@@ -46,7 +46,7 @@ public class HasOnlyReadOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class HasOnlyReadOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MapTest.java
@@ -80,7 +80,7 @@ public enum InnerEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -112,7 +112,7 @@ public enum InnerEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -1,11 +1,13 @@
 package io.swagger.model;
 
 import io.swagger.model.Animal;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.validation.constraints.*;
+
 
 import io.swagger.annotations.*;
 import java.util.Objects;
@@ -14,17 +16,12 @@ import java.util.Objects;
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   
   private UUID uuid = null;
-
-  private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+  private Date dateTime = null;
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   /**
    **/
-<<<<<<< HEAD
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
-=======
-  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
->>>>>>> provide sample how to generate using java + compare results #4087
     this.uuid = uuid;
     return this;
   }
@@ -34,27 +31,23 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   public UUID getUuid() {
     return uuid;
   }
-<<<<<<< HEAD
   public void setUuid(UUID uuid) {
-=======
-  public void setUuid(String uuid) {
->>>>>>> provide sample how to generate using java + compare results #4087
     this.uuid = uuid;
   }
 
   /**
    **/
-  public MixedPropertiesAndAdditionalPropertiesClass dateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public MixedPropertiesAndAdditionalPropertiesClass dateTime(Date dateTime) {
     this.dateTime = dateTime;
     return this;
   }
 
   
   @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getDateTime() {
+  public Date getDateTime() {
     return dateTime;
   }
-  public void setDateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public void setDateTime(Date dateTime) {
     this.dateTime = dateTime;
   }
 
@@ -76,7 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -110,7 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.UUID;
 import javax.validation.constraints.*;
 
-
 import io.swagger.annotations.*;
 import java.util.Objects;
 
@@ -15,12 +14,17 @@ import java.util.Objects;
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   
   private UUID uuid = null;
+
   private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   /**
    **/
+<<<<<<< HEAD
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+=======
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(String uuid) {
+>>>>>>> provide sample how to generate using java + compare results #4087
     this.uuid = uuid;
     return this;
   }
@@ -30,7 +34,11 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   public UUID getUuid() {
     return uuid;
   }
+<<<<<<< HEAD
   public void setUuid(UUID uuid) {
+=======
+  public void setUuid(String uuid) {
+>>>>>>> provide sample how to generate using java + compare results #4087
     this.uuid = uuid;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Model200Response.java
@@ -50,7 +50,7 @@ public class Model200Response   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -82,7 +82,7 @@ public class Model200Response   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -63,7 +63,7 @@ public class ModelApiResponse   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -97,7 +97,7 @@ public class ModelApiResponse   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelReturn.java
@@ -33,7 +33,7 @@ public class ModelReturn   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -63,7 +63,7 @@ public class ModelReturn   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Name.java
@@ -85,7 +85,7 @@ public class Name   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -121,7 +121,7 @@ public class Name   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/NumberOnly.java
@@ -30,7 +30,7 @@ public class NumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class NumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Order.java
@@ -1,5 +1,6 @@
 package io.swagger.model;
 
+import java.util.Date;
 import javax.validation.constraints.*;
 
 
@@ -12,7 +13,7 @@ public class Order   {
   private Long id = null;
   private Long petId = null;
   private Integer quantity = null;
-  private javax.xml.datatype.XMLGregorianCalendar shipDate = null;
+  private Date shipDate = null;
 
 public enum StatusEnum {
 
@@ -97,17 +98,17 @@ public enum StatusEnum {
 
   /**
    **/
-  public Order shipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public Order shipDate(Date shipDate) {
     this.shipDate = shipDate;
     return this;
   }
 
   
   @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getShipDate() {
+  public Date getShipDate() {
     return shipDate;
   }
-  public void setShipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public void setShipDate(Date shipDate) {
     this.shipDate = shipDate;
   }
 
@@ -146,7 +147,7 @@ public enum StatusEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -186,7 +187,7 @@ public enum StatusEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Pet.java
@@ -152,7 +152,7 @@ public enum StatusEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -192,7 +192,7 @@ public enum StatusEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ReadOnlyFirst.java
@@ -46,7 +46,7 @@ public class ReadOnlyFirst   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class ReadOnlyFirst   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/SpecialModelName.java
@@ -29,7 +29,7 @@ public class SpecialModelName   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -59,7 +59,7 @@ public class SpecialModelName   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Tag.java
@@ -46,7 +46,7 @@ public class Tag   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class Tag   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/User.java
@@ -149,7 +149,7 @@ public class User   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -193,7 +193,7 @@ public class User   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/swagger.json
+++ b/samples/server/petstore/jaxrs-spec/swagger.json
@@ -108,8 +108,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -650,8 +650,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_form_string",
@@ -669,8 +669,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_header_string",
@@ -688,8 +688,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_query_string",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
> in fact, the shellscript for jaxrs-spec is broken, see #4720 
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

For details see #4087 

This is the first draft:
1. Instead of using the shellscripts, define a Java class to generate the ouput with all the desired options.
first example: JaxrsSpec_Generator_Petstore.java

2. add a check for equality of all files 
(missing: compare directory structures)
example: Jaxrs_Spec_Generator_Petstore_Test.java

3. Setup a unittest to verify if the samples are equal with the generated output automatically 
This means no more outdated samples, otherwise the build will fail!

The basic idea has been taken from the swagger2markup project.

### Releated issues
#4087 

