### PR TITLE
[JAXRS-CXF] [bug #4422] use java.util.Date when selecting dateLibrary=legacy

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaCXFClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaCXFClientCodegen.java
@@ -21,30 +21,30 @@ import io.swagger.codegen.languages.features.LoggingTestFeatures;
 import io.swagger.models.Operation;
 
 public class JavaCXFClientCodegen extends AbstractJavaCodegen
-        implements BeanValidationFeatures, JaxbFeatures, GzipTestFeatures, LoggingTestFeatures 
-{   
+        implements BeanValidationFeatures, JaxbFeatures, GzipTestFeatures, LoggingTestFeatures
+{
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaCXFClientCodegen.class);
-    
+
     /**
      * Name of the sub-directory in "src/main/resource" where to find the
      * Mustache template for the JAX-RS Codegen.
      */
     protected static final String JAXRS_TEMPLATE_DIRECTORY_NAME = "JavaJaxRS";
-    
+
     protected boolean useJaxbAnnotations = true;
 
     protected boolean useBeanValidation = false;
-    
+
     protected boolean useGzipFeatureForTests = false;
-    
+
     protected boolean useLoggingFeatureForTests = false;
-    
+
     public JavaCXFClientCodegen()
     {
         super();
 
         supportsInheritance = true;
-        
+
         sourceFolder = "src/gen/java";
         invokerPackage = "io.swagger.api";
         artifactId = "swagger-jaxrs-client";
@@ -52,9 +52,9 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
 
         apiPackage = "io.swagger.api";
         modelPackage = "io.swagger.model";
-        
+
         outputFolder = "generated-code/JavaJaxRS-CXF";
-        
+
         // clear model and api doc template as this codegen
         // does not support auto-generated markdown doc at the moment
         //TODO: add doc templates
@@ -63,7 +63,6 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
 
 
         typeMapping.put("date", "LocalDate");
-        typeMapping.put("DateTime", "javax.xml.datatype.XMLGregorianCalendar"); // Map DateTime fields to Java standart class 'XMLGregorianCalendar'
 
         importMapping.put("LocalDate", "org.joda.time.LocalDate");
 
@@ -72,11 +71,11 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_JAXB_ANNOTATIONS, "Use JAXB annotations for XML"));
 
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
-        
+
         cliOptions.add(CliOption.newBoolean(USE_GZIP_FEATURE_FOR_TESTS, "Use Gzip Feature for tests"));
         cliOptions.add(CliOption.newBoolean(USE_LOGGING_FEATURE_FOR_TESTS, "Use Logging Feature for tests"));
-        
-        
+
+
     }
 
 
@@ -84,7 +83,7 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
     public void processOpts()
     {
         super.processOpts();
-        
+
         if (additionalProperties.containsKey(USE_JAXB_ANNOTATIONS)) {
             boolean useJaxbAnnotationsProp = convertPropertyToBooleanAndWriteBack(USE_JAXB_ANNOTATIONS);
             this.setUseJaxbAnnotations(useJaxbAnnotationsProp);
@@ -94,15 +93,15 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
             boolean useBeanValidationProp = convertPropertyToBooleanAndWriteBack(USE_BEANVALIDATION);
             this.setUseBeanValidation(useBeanValidationProp);
         }
-        
+
         this.setUseGzipFeatureForTests(convertPropertyToBooleanAndWriteBack(USE_GZIP_FEATURE_FOR_TESTS));
         this.setUseLoggingFeatureForTests(convertPropertyToBooleanAndWriteBack(USE_LOGGING_FEATURE_FOR_TESTS));
-            
-       
+
+
         supportingFiles.clear(); // Don't need extra files provided by AbstractJAX-RS & Java Codegen
-        
+
         writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
-        
+
     }
 
     @Override
@@ -117,13 +116,13 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
     {
         return CodegenType.CLIENT;
     }
-    
+
     @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
-        super.addOperationToGroup(tag, resourcePath, operation, co, operations);        
+        super.addOperationToGroup(tag, resourcePath, operation, co, operations);
         co.subresourceOperation = !co.path.isEmpty();
     }
-    
+
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         super.postProcessModelProperty(model, property);
@@ -132,17 +131,17 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
         model.imports.remove("JsonSerialize");
         model.imports.remove("ToStringSerializer");
     }
-    
+
     @Override
     public String getHelp()
     {
         return "Generates a Java JAXRS Client based on Apache CXF framework.";
     }
-    
+
     public void setUseBeanValidation(boolean useBeanValidation) {
         this.useBeanValidation = useBeanValidation;
     }
-    
+
 
     public void setUseJaxbAnnotations(boolean useJaxbAnnotations) {
         this.useJaxbAnnotations = useJaxbAnnotations;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaCXFServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaCXFServerCodegen.java
@@ -78,7 +78,6 @@ public class JavaCXFServerCodegen extends AbstractJavaJAXRSServerCodegen
 
 
         typeMapping.put("date", "LocalDate");
-        typeMapping.put("DateTime", "javax.xml.datatype.XMLGregorianCalendar"); // Map DateTime fields to Java standart class 'XMLGregorianCalendar'
 
         importMapping.put("LocalDate", "org.joda.time.LocalDate");
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -21,9 +21,9 @@ import io.swagger.models.Swagger;
 import io.swagger.models.properties.Property;
 import io.swagger.util.Json;
 
-public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen 
-{    
-    
+public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen
+{
+
     public JavaJAXRSSpecServerCodegen()
     {
         super();
@@ -48,7 +48,6 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen
         additionalProperties.put("title", title);
 
         typeMapping.put("date", "LocalDate");
-        typeMapping.put("DateTime", "javax.xml.datatype.XMLGregorianCalendar"); // Map DateTime fields to Java standart class 'XMLGregorianCalendar'
 
         importMapping.put("LocalDate", "org.joda.time.LocalDate");
 
@@ -60,7 +59,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen
                 break;
             }
         }
-                
+
         CliOption library = new CliOption(CodegenConstants.LIBRARY, "library template (sub-template) to use");
         library.setDefault(DEFAULT_LIBRARY);
 
@@ -71,20 +70,20 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen
 
         cliOptions.add(library);
     }
-    
+
     @Override
     public void processOpts()
     {
         super.processOpts();
-        
+
         supportingFiles.clear(); // Don't need extra files provided by AbstractJAX-RS & Java Codegen
         writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
-        
+
         writeOptional(outputFolder, new SupportingFile("RestApplication.mustache",
                 (sourceFolder + '/' + invokerPackage).replace(".", "/"), "RestApplication.java"));
-        
-    } 
-    
+
+    }
+
 
     @Override
     public String getName()
@@ -119,7 +118,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen
         opList.add(co);
         co.baseName = basePath;
     }
-    
+
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         super.postProcessModelProperty(model, property);
@@ -130,10 +129,10 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen
         model.imports.remove("JsonValue");
         model.imports.remove("JsonProperty");
     }
-    
+
     @Override
     public void preprocessSwagger(Swagger swagger) {
-        //copy input swagger to output folder 
+        //copy input swagger to output folder
         try {
             String swaggerJson = Json.pretty(swagger);
             FileUtils.writeStringToFile(new File(outputFolder + File.separator + "swagger.json"), swaggerJson);


### PR DESCRIPTION
according to the help message setting dateLibrary to 'legacy' should
make the code generator use java.util.Date.
before this change, when setting dateLibrary to 'legacy' made the
generator use javax.xml.datatype.XMLGregorianCalendar.
now, the generator uses java.util.Date such that the documentation and
behavior are consistent.