### PR TITLE
[Java][Issue #1806] generate using java.util.UUID for UUIDs

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -120,7 +120,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         instantiationTypes.put("map", "HashMap");
         typeMapping.put("date", "Date");
         typeMapping.put("file", "File");
-        typeMapping.put("UUID", "String");
 
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
@@ -400,7 +399,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public String escapeReservedWord(String name) {           
+    public String escapeReservedWord(String name) {
         if(this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
         }
@@ -1126,7 +1125,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public String toRegularExpression(String pattern) {
         return escapeText(pattern);
     }
-    
+
     public boolean convertPropertyToBoolean(String propertyKey) {
         boolean booleanValue = false;
         if (additionalProperties.containsKey(propertyKey)) {
@@ -1135,7 +1134,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
        return booleanValue;
     }
-    
+
     public void writePropertyBack(String propertyKey, boolean value) {
         additionalProperties.put(propertyKey, value);
     }
@@ -1143,6 +1142,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     @Override
     public String sanitizeTag(String tag) {
         return camelize(sanitizeName(tag));
-    } 
+    }
 
 }


### PR DESCRIPTION
Before this change if a model had a property of type=string and
format=uuid, it would be generated as a Java String.
Now, it generates the property as java.util.UUID.
