### PR TITLE
[Java-Feign] Fixed String comparison using equals instead of == operator

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -47,7 +47,7 @@ public class ApiClient {
     this();
     for(String authName : authNames) { {{#hasAuthMethods}}
       RequestInterceptor auth;
-      {{#authMethods}}if (authName == "{{name}}") { {{#isBasic}}
+      {{#authMethods}}if ("{{name}}".equals(authName)) { {{#isBasic}}
         auth = new HttpBasicAuth();{{/isBasic}}{{#isApiKey}}
         auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}{{#isOAuth}}
         auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");{{/isOAuth}}

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
@@ -42,11 +42,11 @@ public class ApiClient {
     this();
     for(String authName : authNames) { 
       RequestInterceptor auth;
-      if (authName == "api_key") { 
+      if ("api_key".equals(authName)) { 
         auth = new ApiKeyAuth("header", "api_key");
-      } else if (authName == "http_basic_test") { 
+      } else if ("http_basic_test".equals(authName)) { 
         auth = new HttpBasicAuth();
-      } else if (authName == "petstore_auth") { 
+      } else if ("petstore_auth".equals(authName)) { 
         auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");


### PR DESCRIPTION
String comparison with equals, to avoid object reference comparison.
Run manually mvn clean package successfully.