### PR TITLE
[Java] Change Boolean fields of CodegenParameter and CodegenResponse …

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
@@ -6,28 +6,29 @@ import java.util.Map;
 import java.util.List;
 
 public class CodegenParameter {
-    public Boolean isFormParam, isQueryParam, isPathParam, isHeaderParam,
+    public boolean isFormParam, isQueryParam, isPathParam, isHeaderParam,
             isCookieParam, isBodyParam, hasMore, isContainer,
             secondaryParam, isCollectionFormatMulti, isPrimitiveType;
-    public String baseName, paramName, dataType, datatypeWithEnum, dataFormat, collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName;
+    public String baseName, paramName, dataType, datatypeWithEnum, dataFormat,
+          collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName;
     public String example; // example value (x-example)
     public String jsonSchema;
-    public Boolean isString, isInteger, isLong, isFloat, isDouble, isByteArray, isBinary, isBoolean, isDate, isDateTime;
-    public Boolean isListContainer, isMapContainer;
-    public Boolean isFile, notFile;
+    public boolean isString, isInteger, isLong, isFloat, isDouble, isByteArray, isBinary, isBoolean, isDate, isDateTime;
+    public boolean isListContainer, isMapContainer;
+    public boolean isFile, notFile;
     public boolean isEnum;
     public List<String> _enum;
     public Map<String, Object> allowableValues;
     public CodegenProperty items;
     public Map<String, Object> vendorExtensions;
-    public Boolean hasValidation;
+    public boolean hasValidation;
 
     /**
      * Determines whether this parameter is mandatory. If the parameter is in "path",
      * this property is required and its value MUST be true. Otherwise, the property
      * MAY be included and its default value is false.
      */
-    public Boolean required;
+    public boolean required;
 
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
@@ -36,7 +37,7 @@ public class CodegenParameter {
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor17
 	 */
-    public Boolean exclusiveMaximum;
+    public boolean exclusiveMaximum;
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor21
 	 */
@@ -44,7 +45,7 @@ public class CodegenParameter {
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor21
 	 */
-    public Boolean exclusiveMinimum;
+    public boolean exclusiveMinimum;
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor26
 	 */
@@ -68,7 +69,7 @@ public class CodegenParameter {
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor49
 	 */
-    public Boolean uniqueItems;
+    public boolean uniqueItems;
 	/**
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor14
 	 */
@@ -156,27 +157,27 @@ public class CodegenParameter {
         CodegenParameter that = (CodegenParameter) o;
 
         if (isEnum != that.isEnum) return false;
-        if (isFormParam != null ? !isFormParam.equals(that.isFormParam) : that.isFormParam != null)
+        if (isFormParam != that.isFormParam)
             return false;
-        if (isQueryParam != null ? !isQueryParam.equals(that.isQueryParam) : that.isQueryParam != null)
+        if (isQueryParam != that.isQueryParam)
             return false;
-        if (isPathParam != null ? !isPathParam.equals(that.isPathParam) : that.isPathParam != null)
+        if (isPathParam != that.isPathParam)
             return false;
-        if (isHeaderParam != null ? !isHeaderParam.equals(that.isHeaderParam) : that.isHeaderParam != null)
+        if (isHeaderParam != that.isHeaderParam)
             return false;
-        if (isCookieParam != null ? !isCookieParam.equals(that.isCookieParam) : that.isCookieParam != null)
+        if (isCookieParam != that.isCookieParam)
             return false;
-        if (isBodyParam != null ? !isBodyParam.equals(that.isBodyParam) : that.isBodyParam != null)
+        if (isBodyParam != that.isBodyParam)
             return false;
-        if (hasMore != null ? !hasMore.equals(that.hasMore) : that.hasMore != null)
+        if (hasMore != that.hasMore)
             return false;
-        if (isContainer != null ? !isContainer.equals(that.isContainer) : that.isContainer != null)
+        if (isContainer != that.isContainer)
             return false;
-        if (secondaryParam != null ? !secondaryParam.equals(that.secondaryParam) : that.secondaryParam != null)
+        if (secondaryParam != that.secondaryParam)
             return false;
-        if (isCollectionFormatMulti != null ? !isCollectionFormatMulti.equals(that.isCollectionFormatMulti) : that.isCollectionFormatMulti != null)
+        if (isCollectionFormatMulti != that.isCollectionFormatMulti)
             return false;
-        if (isPrimitiveType != null ? !isPrimitiveType.equals(that.isPrimitiveType) : that.isPrimitiveType != null)
+        if (isPrimitiveType != that.isPrimitiveType)
             return false;
         if (baseName != null ? !baseName.equals(that.baseName) : that.baseName != null)
             return false;
@@ -204,33 +205,33 @@ public class CodegenParameter {
             return false;
         if (jsonSchema != null ? !jsonSchema.equals(that.jsonSchema) : that.jsonSchema != null)
             return false;
-        if (isString != null ? !isString.equals(that.isString) : that.isString != null)
+        if (isString != that.isString)
             return false;
-        if (isInteger != null ? !isInteger.equals(that.isInteger) : that.isInteger != null)
+        if (isInteger != that.isInteger)
             return false;
-        if (isLong != null ? !isLong.equals(that.isLong) : that.isLong != null)
+        if (isLong != that.isLong)
             return false;
-        if (isFloat != null ? !isFloat.equals(that.isFloat) : that.isFloat != null)
+        if (isFloat != that.isFloat)
             return false;
-        if (isDouble != null ? !isDouble.equals(that.isDouble) : that.isDouble != null)
+        if (isDouble != that.isDouble)
             return false;
-        if (isByteArray != null ? !isByteArray.equals(that.isByteArray) : that.isByteArray != null)
+        if (isByteArray != that.isByteArray)
             return false;
-        if (isBinary != null ? !isBinary.equals(that.isBinary) : that.isBinary != null)
+        if (isBinary != that.isBinary)
             return false;
-        if (isBoolean != null ? !isBoolean.equals(that.isBoolean) : that.isBoolean != null)
+        if (isBoolean != that.isBoolean)
             return false;
-        if (isDate != null ? !isDate.equals(that.isDate) : that.isDate != null)
+        if (isDate != that.isDate)
             return false;
-        if (isDateTime != null ? !isDateTime.equals(that.isDateTime) : that.isDateTime != null)
+        if (isDateTime != that.isDateTime)
             return false;
-        if (isListContainer != null ? !isListContainer.equals(that.isListContainer) : that.isListContainer != null)
+        if (isListContainer != that.isListContainer)
             return false;
-        if (isMapContainer != null ? !isMapContainer.equals(that.isMapContainer) : that.isMapContainer != null)
+        if (isMapContainer != that.isMapContainer)
             return false;
-        if (isFile != null ? !isFile.equals(that.isFile) : that.isFile != null)
+        if (isFile != that.isFile)
             return false;
-        if (notFile != null ? !notFile.equals(that.notFile) : that.notFile != null)
+        if (notFile != that.notFile)
             return false;
         if (_enum != null ? !_enum.equals(that._enum) : that._enum != null)
             return false;
@@ -240,17 +241,17 @@ public class CodegenParameter {
             return false;
         if (vendorExtensions != null ? !vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions != null)
             return false;
-        if (hasValidation != null ? !hasValidation.equals(that.hasValidation) : that.hasValidation != null)
+        if (hasValidation != that.hasValidation)
             return false;
-        if (required != null ? !required.equals(that.required) : that.required != null)
+        if (required != that.required)
             return false;
         if (maximum != null ? !maximum.equals(that.maximum) : that.maximum != null)
             return false;
-        if (exclusiveMaximum != null ? !exclusiveMaximum.equals(that.exclusiveMaximum) : that.exclusiveMaximum != null)
+        if (exclusiveMaximum != that.exclusiveMaximum)
             return false;
         if (minimum != null ? !minimum.equals(that.minimum) : that.minimum != null)
             return false;
-        if (exclusiveMinimum != null ? !exclusiveMinimum.equals(that.exclusiveMinimum) : that.exclusiveMinimum != null)
+        if (exclusiveMinimum != that.exclusiveMinimum)
             return false;
         if (maxLength != null ? !maxLength.equals(that.maxLength) : that.maxLength != null)
             return false;
@@ -262,7 +263,7 @@ public class CodegenParameter {
             return false;
         if (minItems != null ? !minItems.equals(that.minItems) : that.minItems != null)
             return false;
-        if (uniqueItems != null ? !uniqueItems.equals(that.uniqueItems) : that.uniqueItems != null)
+        if (uniqueItems != that.uniqueItems)
             return false;
         return multipleOf != null ? multipleOf.equals(that.multipleOf) : that.multipleOf == null;
 
@@ -270,17 +271,17 @@ public class CodegenParameter {
 
     @Override
     public int hashCode() {
-        int result = isFormParam != null ? isFormParam.hashCode() : 0;
-        result = 31 * result + (isQueryParam != null ? isQueryParam.hashCode() : 0);
-        result = 31 * result + (isPathParam != null ? isPathParam.hashCode() : 0);
-        result = 31 * result + (isHeaderParam != null ? isHeaderParam.hashCode() : 0);
-        result = 31 * result + (isCookieParam != null ? isCookieParam.hashCode() : 0);
-        result = 31 * result + (isBodyParam != null ? isBodyParam.hashCode() : 0);
-        result = 31 * result + (hasMore != null ? hasMore.hashCode() : 0);
-        result = 31 * result + (isContainer != null ? isContainer.hashCode() : 0);
-        result = 31 * result + (secondaryParam != null ? secondaryParam.hashCode() : 0);
-        result = 31 * result + (isCollectionFormatMulti != null ? isCollectionFormatMulti.hashCode() : 0);
-        result = 31 * result + (isPrimitiveType != null ? isPrimitiveType.hashCode() : 0);
+        int result = isFormParam ? 13:31;
+        result = 31 * result + (isQueryParam ? 13:31);
+        result = 31 * result + (isPathParam ? 13:31);
+        result = 31 * result + (isHeaderParam ? 13:31);
+        result = 31 * result + (isCookieParam ? 13:31);
+        result = 31 * result + (isBodyParam ? 13:31);
+        result = 31 * result + (hasMore ? 13:31);
+        result = 31 * result + (isContainer ? 13:31);
+        result = 31 * result + (secondaryParam ? 13:31);
+        result = 31 * result + (isCollectionFormatMulti ? 13:31);
+        result = 31 * result + (isPrimitiveType ? 13:31);
         result = 31 * result + (baseName != null ? baseName.hashCode() : 0);
         result = 31 * result + (paramName != null ? paramName.hashCode() : 0);
         result = 31 * result + (dataType != null ? dataType.hashCode() : 0);
@@ -294,37 +295,37 @@ public class CodegenParameter {
         result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
         result = 31 * result + (example != null ? example.hashCode() : 0);
         result = 31 * result + (jsonSchema != null ? jsonSchema.hashCode() : 0);
-        result = 31 * result + (isString != null ? isString.hashCode() : 0);
-        result = 31 * result + (isInteger != null ? isInteger.hashCode() : 0);
-        result = 31 * result + (isLong != null ? isLong.hashCode() : 0);
-        result = 31 * result + (isFloat != null ? isFloat.hashCode() : 0);
-        result = 31 * result + (isDouble != null ? isDouble.hashCode() : 0);
-        result = 31 * result + (isByteArray != null ? isByteArray.hashCode() : 0);
-        result = 31 * result + (isBinary != null ? isBinary.hashCode() : 0);
-        result = 31 * result + (isBoolean != null ? isBoolean.hashCode() : 0);
-        result = 31 * result + (isDate != null ? isDate.hashCode() : 0);
-        result = 31 * result + (isDateTime != null ? isDateTime.hashCode() : 0);
-        result = 31 * result + (isListContainer != null ? isListContainer.hashCode() : 0);
-        result = 31 * result + (isMapContainer != null ? isMapContainer.hashCode() : 0);
-        result = 31 * result + (isFile != null ? isFile.hashCode() : 0);
-        result = 31 * result + (notFile != null ? notFile.hashCode() : 0);
+        result = 31 * result + (isString ? 13:31);
+        result = 31 * result + (isInteger ? 13:31);
+        result = 31 * result + (isLong ? 13:31);
+        result = 31 * result + (isFloat ? 13:31);
+        result = 31 * result + (isDouble ? 13:31);
+        result = 31 * result + (isByteArray ? 13:31);
+        result = 31 * result + (isBinary ? 13:31);
+        result = 31 * result + (isBoolean ? 13:31);
+        result = 31 * result + (isDate ? 13:31);
+        result = 31 * result + (isDateTime ? 13:31);
+        result = 31 * result + (isListContainer ? 13:31);
+        result = 31 * result + (isMapContainer ? 13:31);
+        result = 31 * result + (isFile ? 13:31);
+        result = 31 * result + (notFile ? 13:31);
         result = 31 * result + (isEnum ? 1 : 0);
         result = 31 * result + (_enum != null ? _enum.hashCode() : 0);
         result = 31 * result + (allowableValues != null ? allowableValues.hashCode() : 0);
         result = 31 * result + (items != null ? items.hashCode() : 0);
         result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
-        result = 31 * result + (hasValidation != null ? hasValidation.hashCode() : 0);
-        result = 31 * result + (required != null ? required.hashCode() : 0);
+        result = 31 * result + (hasValidation ? 13:31);
+        result = 31 * result + (required ? 13:31);
         result = 31 * result + (maximum != null ? maximum.hashCode() : 0);
-        result = 31 * result + (exclusiveMaximum != null ? exclusiveMaximum.hashCode() : 0);
+        result = 31 * result + (exclusiveMaximum ? 13:31);
         result = 31 * result + (minimum != null ? minimum.hashCode() : 0);
-        result = 31 * result + (exclusiveMinimum != null ? exclusiveMinimum.hashCode() : 0);
+        result = 31 * result + (exclusiveMinimum ? 13:31);
         result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
         result = 31 * result + (minLength != null ? minLength.hashCode() : 0);
         result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
         result = 31 * result + (maxItems != null ? maxItems.hashCode() : 0);
         result = 31 * result + (minItems != null ? minItems.hashCode() : 0);
-        result = 31 * result + (uniqueItems != null ? uniqueItems.hashCode() : 0);
+        result = 31 * result + (uniqueItems ? 13:31);
         result = 31 * result + (multipleOf != null ? multipleOf.hashCode() : 0);
         return result;
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
@@ -7,23 +7,19 @@ import java.util.Map;
 public class CodegenResponse {
     public final List<CodegenProperty> headers = new ArrayList<CodegenProperty>();
     public String code, message;
-    public Boolean hasMore;
+    public boolean hasMore;
     public List<Map<String, Object>> examples;
     public String dataType, baseType, containerType;
-    public Boolean isDefault;
-    public Boolean simpleType;
-    public Boolean primitiveType;
-    public Boolean isMapContainer;
-    public Boolean isListContainer;
-    public Boolean isBinary = Boolean.FALSE;
-    public Boolean isFile = Boolean.FALSE;
+    public boolean isDefault;
+    public boolean simpleType;
+    public boolean primitiveType;
+    public boolean isMapContainer;
+    public boolean isListContainer;
+    public boolean isBinary = false;
+    public boolean isFile = false;
     public Object schema;
     public String jsonSchema;
     public Map<String, Object> vendorExtensions;
-
-    public boolean isWildcard() {
-        return "0".equals(code) || "default".equals(code);
-    }
 
     @Override
     public String toString() {
@@ -43,7 +39,7 @@ public class CodegenResponse {
             return false;
         if (message != null ? !message.equals(that.message) : that.message != null)
             return false;
-        if (hasMore != null ? !hasMore.equals(that.hasMore) : that.hasMore != null)
+        if (hasMore != that.hasMore)
             return false;
         if (examples != null ? !examples.equals(that.examples) : that.examples != null)
             return false;
@@ -53,19 +49,19 @@ public class CodegenResponse {
             return false;
         if (containerType != null ? !containerType.equals(that.containerType) : that.containerType != null)
             return false;
-        if (isDefault != null ? !isDefault.equals(that.isDefault) : that.isDefault != null)
+        if (isDefault != that.isDefault)
             return false;
-        if (simpleType != null ? !simpleType.equals(that.simpleType) : that.simpleType != null)
+        if (simpleType != that.simpleType)
             return false;
-        if (primitiveType != null ? !primitiveType.equals(that.primitiveType) : that.primitiveType != null)
+        if (primitiveType != that.primitiveType)
             return false;
-        if (isMapContainer != null ? !isMapContainer.equals(that.isMapContainer) : that.isMapContainer != null)
+        if (isMapContainer != that.isMapContainer)
             return false;
-        if (isListContainer != null ? !isListContainer.equals(that.isListContainer) : that.isListContainer != null)
+        if (isListContainer != that.isListContainer)
             return false;
-        if (isBinary != null ? !isBinary.equals(that.isBinary) : that.isBinary != null)
+        if (isBinary != that.isBinary)
             return false;
-        if (isFile != null ? !isFile.equals(that.isFile) : that.isFile != null)
+        if (isFile != that.isFile)
             return false;
         if (schema != null ? !schema.equals(that.schema) : that.schema != null)
             return false;
@@ -80,18 +76,18 @@ public class CodegenResponse {
         int result = headers.hashCode();
         result = 31 * result + (code != null ? code.hashCode() : 0);
         result = 31 * result + (message != null ? message.hashCode() : 0);
-        result = 31 * result + (hasMore != null ? hasMore.hashCode() : 0);
+        result = 31 * result + (hasMore ? 13:31);
         result = 31 * result + (examples != null ? examples.hashCode() : 0);
         result = 31 * result + (dataType != null ? dataType.hashCode() : 0);
         result = 31 * result + (baseType != null ? baseType.hashCode() : 0);
         result = 31 * result + (containerType != null ? containerType.hashCode() : 0);
-        result = 31 * result + (isDefault != null ? isDefault.hashCode() : 0);
-        result = 31 * result + (simpleType != null ? simpleType.hashCode() : 0);
-        result = 31 * result + (primitiveType != null ? primitiveType.hashCode() : 0);
-        result = 31 * result + (isMapContainer != null ? isMapContainer.hashCode() : 0);
-        result = 31 * result + (isListContainer != null ? isListContainer.hashCode() : 0);
-        result = 31 * result + (isBinary != null ? isBinary.hashCode() : 0);
-        result = 31 * result + (isFile != null ? isFile.hashCode() : 0);
+        result = 31 * result + (isDefault ? 13:31);
+        result = 31 * result + (simpleType ? 13:31);
+        result = 31 * result + (primitiveType ? 13:31);
+        result = 31 * result + (isMapContainer ? 13:31);
+        result = 31 * result + (isListContainer ? 13:31);
+        result = 31 * result + (isBinary ? 13:31);
+        result = 31 * result + (isFile ? 13:31);
         result = 31 * result + (schema != null ? schema.hashCode() : 0);
         result = 31 * result + (jsonSchema != null ? jsonSchema.hashCode() : 0);
         result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2161,7 +2161,7 @@ public class DefaultCodegen {
                 } else if (param instanceof FormParameter) {
                     formParams.add(p.copy());
                 }
-                if (p.required == null || !p.required) {
+                if (!p.required) {
                     op.hasOptionalParams = true;
                 }
             }
@@ -2179,10 +2179,8 @@ public class DefaultCodegen {
           Collections.sort(allParams, new Comparator<CodegenParameter>() {
               @Override
               public int compare(CodegenParameter one, CodegenParameter another) {
-                  boolean oneRequired = one.required == null ? false : one.required;
-                  boolean anotherRequired = another.required == null ? false : another.required;
-                  if (oneRequired == anotherRequired) return 0;
-                  else if (oneRequired) return -1;
+                  if (one.required == another.required) return 0;
+                  else if (one.required) return -1;
                   else return 1;
               }
           });
@@ -2410,14 +2408,14 @@ public class DefaultCodegen {
                 p.minimum = qp.getMinimum() == null ? null : String.valueOf(qp.getMinimum());
             }
 
-            p.exclusiveMaximum = qp.isExclusiveMaximum();
-            p.exclusiveMinimum = qp.isExclusiveMinimum();
+            p.exclusiveMaximum = qp.isExclusiveMaximum() == null ? false : qp.isExclusiveMaximum();
+            p.exclusiveMinimum = qp.isExclusiveMinimum() == null ? false : qp.isExclusiveMinimum();
             p.maxLength = qp.getMaxLength();
             p.minLength = qp.getMinLength();
             p.pattern = toRegularExpression(qp.getPattern());
             p.maxItems = qp.getMaxItems();
             p.minItems = qp.getMinItems();
-            p.uniqueItems = qp.isUniqueItems();
+            p.uniqueItems = qp.isUniqueItems() == null ? false : qp.isUniqueItems();
             p.multipleOf = qp.getMultipleOf();
 
             // exclusive* are noop without corresponding min/max

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
@@ -389,7 +389,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         // Query parameters appended to routes
         for (CodegenParameter param : op.queryParams) {
             String paramType = param.dataType;
-            if(param.isListContainer != null && param.isListContainer) {
+            if (param.isListContainer) {
                 paramType = makeQueryListType(paramType, param.collectionFormat);
             }
             path.add("QueryParam \"" + param.baseName + "\" " + paramType);
@@ -420,7 +420,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
             path.add("Header \"" + param.baseName + "\" " + param.dataType);
 
             String paramType = param.dataType;
-            if(param.isListContainer != null && param.isListContainer) {
+            if (param.isListContainer) {
                 paramType = makeQueryListType(paramType, param.collectionFormat);
             }
             type.add("Maybe " + paramType);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -710,7 +710,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
       CodegenParameter lastRequired = null;
       CodegenParameter lastOptional = null;
       for (CodegenParameter p : op.allParams) {
-          if (p.required != null && p.required) {
+          if (p.required) {
               lastRequired = p;
           } else {
               lastOptional = p;
@@ -866,7 +866,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
                 List<String> argList = new ArrayList<String>();
                 boolean hasOptionalParams = false;
                 for (CodegenParameter p : operation.allParams) {
-                    if (p.required != null && p.required) {
+                    if (p.required) {
                         argList.add(p.paramName);
                     } else {
                       hasOptionalParams = true;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RubyClientCodegen.java
@@ -272,7 +272,7 @@ public class RubyClientCodegen extends DefaultCodegen implements CodegenConfig {
         CodegenParameter lastRequired = null;
         CodegenParameter lastOptional = null;
         for (CodegenParameter p : op.allParams) {
-            if (p.required != null && p.required) {
+            if (p.required) {
                 lastRequired = p;
             } else {
                 lastOptional = p;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtml2Generator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtml2Generator.java
@@ -158,7 +158,7 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
         CodegenParameter lastRequired = null;
         CodegenParameter lastOptional = null;
         for (CodegenParameter p : op.allParams) {
-            if (p.required != null && p.required) {
+            if (p.required) {
                 lastRequired = p;
             } else {
                 lastOptional = p;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -58,9 +58,9 @@ public class CodegenTest {
         final CodegenParameter file = op.formParams.get(1);
         Assert.assertTrue(file.isFormParam);
         Assert.assertEquals(file.dataType, "File");
-        Assert.assertNull(file.required);
+        Assert.assertFalse(file.required);
         Assert.assertTrue(file.isFile);
-        Assert.assertNull(file.hasMore);
+        Assert.assertFalse(file.hasMore);
     }
 
     @Test(description = "read formParam values from a 2.0 spec")
@@ -87,7 +87,7 @@ public class CodegenTest {
         Assert.assertTrue(idParam.isPathParam);
         Assert.assertEquals(idParam.dataType, "String");
         Assert.assertTrue(idParam.required);
-        Assert.assertNull(idParam.hasMore);
+        Assert.assertFalse(idParam.hasMore);
 
         Assert.assertEquals(op.allParams.size(), 3);
         Assert.assertEquals(op.formParams.size(), 2);
@@ -96,15 +96,15 @@ public class CodegenTest {
         Assert.assertTrue(nameParam.isFormParam);
         Assert.assertTrue(nameParam.notFile);
         Assert.assertEquals(nameParam.dataType, "String");
-        Assert.assertNull(nameParam.required);
+        Assert.assertFalse(nameParam.required);
         Assert.assertTrue(nameParam.hasMore);
 
         final CodegenParameter statusParam = op.formParams.get(1);
         Assert.assertTrue(statusParam.isFormParam);
         Assert.assertTrue(statusParam.notFile);
         Assert.assertEquals(statusParam.dataType, "String");
-        Assert.assertNull(statusParam.required);
-        Assert.assertNull(statusParam.hasMore);
+        Assert.assertFalse(statusParam.required);
+        Assert.assertFalse(statusParam.hasMore);
     }
 
     @Test(description = "handle enum array in query parameter test")


### PR DESCRIPTION
…to boolean.

CodegenOperation and CodegenProperty classes have boolean fields instead of Boolean.
This fix changes Boolean fields of CodegenParameter and CodegenResponse to boolean as well.

Boolean fields are not necessary. Other classes interacting with them have to check for null
before interacting with them which is unnecessary and leads to ugly code.

### PR checklist

- [x ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

CodegenOperation and CodegenProperty classes have boolean fields instead of Boolean.
This fix changes Boolean fields of CodegenParameter and CodegenResponse to boolean as well.

Boolean fields are not necessary. Other classes interacting with them have to check for null
before interacting with them which is unnecessary and leads to ugly code.
