### PR TITLE
[JAVA] fixed white line in javadoc comment java pojo issue that breaks maven…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -50,22 +50,22 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     return this;
   }
   {{/isMapContainer}}
-
   {{/isReadOnly}}
-   /**
-  {{#description}}
-   * {{{description}}}
-  {{/description}}
-  {{^description}}
-   * Get {{name}}
-  {{/description}}
-  {{#minimum}}
-   * minimum: {{minimum}}
-  {{/minimum}}
-  {{#maximum}}
-   * maximum: {{maximum}}
-  {{/maximum}}
-   * @return {{name}}
+  
+  /**
+{{#description}}
+  * {{{description}}}
+{{/description}}
+{{^description}}
+  * Get {{name}}
+{{/description}}
+{{#minimum}}
+  * minimum: {{minimum}}
+{{/minimum}}
+{{#maximum}}
+  * maximum: {{maximum}}
+{{/maximum}}
+  * @return {{name}}
   **/
 {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{example}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
 {{#vendorExtensions.extraAnnotation}}


### PR DESCRIPTION
fix pojo template for javadoc generation

### PR checklist

### Description of the PR
small fix to allow maven build of generated java pojo