### PR TITLE
[Swift3] null enumerations should not cause failure

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
@@ -36,7 +36,7 @@ open class RequestBuilder<T> {
     let isBody: Bool
     let method: String
     let URLString: String
-    
+
     /// Optional block to obtain a reference to the request's progress instance when available.
     public var onProgressReady: ((Progress) -> ())?
 
@@ -45,16 +45,16 @@ open class RequestBuilder<T> {
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody
-        
+
         addHeaders({{projectName}}API.customHeaders)
     }
-    
+
     open func addHeaders(_ aHeaders:[String:String]) {
         for (header, value) in aHeaders {
             headers[header] = value
         }
     }
-    
+
     open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: ErrorResponse?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
@@ -63,7 +63,7 @@ open class RequestBuilder<T> {
         }
         return self
     }
-    
+
     open func addCredential() -> Self {
         self.credential = {{projectName}}API.credential
         return self

--- a/modules/swagger-codegen/src/main/resources/swift3/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/AlamofireImplementations.mustache
@@ -189,7 +189,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 // NSNull would crash decoders
                 if response.response?.statusCode == 204 && response.result.value is NSNull{
                     completion(nil, nil)
-                    return;
+                    return
                 }
 
                 if () is T {

--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -112,6 +112,7 @@ class Decoders {
     }
 
     static func decodeOptional<T: RawRepresentable>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
+        guard !(source is NSNull), source != nil else { return .success(nil) }
         if let value = source as? T.RawValue {
             if let enumValue = T.init(rawValue: value) {
                 return .success(enumValue)
@@ -119,7 +120,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "A value from the enumeration \(T.self)", actual: "\(value)"))
             }
         } else {
-            return .success(nil)
+            return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
         }
     }
 

--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -46,10 +46,8 @@ public extension Decoded {
         switch self {
         case let .success(value):
             return value
-            break
         case .failure:
             return nil
-            break
         }
     }
 }
@@ -71,7 +69,7 @@ class Decoders {
     }
 
     static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> Decoded<T> {
-        let key = discriminator;
+        let key = discriminator
         if let decoder = decoders[key], let value = decoder(source) as? Decoded<T> {
             return value
         } else {
@@ -88,7 +86,6 @@ class Decoders {
                     values.append(value)
                 case let .failure(error):
                     return .failure(error)
-                    break
                 }
             }
             return .success(values)
@@ -104,7 +101,6 @@ class Decoders {
                 switch Decoders.decode(clazz: T.self, source: value) {
                 case let .success(value):
                     dictionary[key] = value
-                    break
                 case let .failure(error):
                     return .failure(error)
                 }
@@ -114,7 +110,7 @@ class Decoders {
             return .failure(.typeMismatch(expected: String(describing: clazz), actual: String(describing: source)))
         }
     }
-    
+
     static func decodeOptional<T: RawRepresentable>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let value = source as? T.RawValue {
             if let enumValue = T.init(rawValue: value) {
@@ -126,7 +122,7 @@ class Decoders {
             return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
         }
     }
-        
+
     static func decode<T>(clazz: T.Type, source: AnyObject) -> Decoded<T> {
         initialize()
         if let value = source.int32Value as? T, source is NSNumber, T.self is Int32.Type {
@@ -157,7 +153,7 @@ class Decoders {
     static func toOptional<T>(decoded: Decoded<T>) -> Decoded<T?> {
         return .success(decoded.value)
     }
-    
+
     static func decodeOptional<T>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let source = source, !(source is NSNull) {
             switch Decoders.decode(clazz: clazz, source: source) {
@@ -198,7 +194,7 @@ class Decoders {
             return .success(nil)
         }
     }
-    
+
     static func decodeOptional<T: RawRepresentable, U: AnyObject where T.RawValue == U>(clazz: T, source: AnyObject) -> Decoded<T?> {
         if let value = source as? U {
             if let enumValue = T.init(rawValue: value) {
@@ -244,7 +240,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "String or Int", actual: "\(source)"))
             }
         }
-        
+
         // Decoder for ISOFullDate
         Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> Decoded<ISOFullDate> in
             if let string = source as? String,

--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -119,7 +119,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "A value from the enumeration \(T.self)", actual: "\(value)"))
             }
         } else {
-            return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
+            return .success(nil)
         }
     }
 

--- a/modules/swagger-codegen/src/main/resources/swift3/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/api.mustache
@@ -35,9 +35,9 @@ open class {{classname}}: APIBase {
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}completion: @escaping ((_ {{#returnType}}data: {{{returnType}}}?,_ {{/returnType}}error: ErrorResponse?) -> Void)) {
+    open class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}completion: @escaping ((_ {{#returnType}}data: {{{returnType}}}?, _ {{/returnType}}error: ErrorResponse?) -> Void)) {
         {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute { (response, error) -> Void in
-            completion({{#returnType}}response?.body, {{/returnType}}error);
+            completion({{#returnType}}response?.body, {{/returnType}}error)
         }
     }
 
@@ -114,11 +114,11 @@ open class {{classname}}: APIBase {
         ]{{/hasMore}}{{/formParams}}{{/queryParams}}{{#queryParams}}{{^secondaryParam}}[{{/secondaryParam}}
             {{> _param}}{{#hasMore}},{{/hasMore}}{{^hasMore}}
         ]{{/hasMore}}{{/queryParams}}
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters){{/bodyParam}}
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.Type = {{projectName}}API.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "{{httpMethod}}", URLString: URLString, parameters: convertedParameters, isBody: {{^queryParams}}{{^formParams}}true{{/formParams}}{{/queryParams}}{{#queryParams}}{{^formParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/formParams}}{{/queryParams}}{{#formParams}}{{^secondaryParam}}false{{/secondaryParam}}{{/formParams}})

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -36,7 +36,7 @@ open class RequestBuilder<T> {
     let isBody: Bool
     let method: String
     let URLString: String
-    
+
     /// Optional block to obtain a reference to the request's progress instance when available.
     public var onProgressReady: ((Progress) -> ())?
 
@@ -45,16 +45,16 @@ open class RequestBuilder<T> {
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody
-        
+
         addHeaders(PetstoreClientAPI.customHeaders)
     }
-    
+
     open func addHeaders(_ aHeaders:[String:String]) {
         for (header, value) in aHeaders {
             headers[header] = value
         }
     }
-    
+
     open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: ErrorResponse?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
@@ -63,7 +63,7 @@ open class RequestBuilder<T> {
         }
         return self
     }
-    
+
     open func addCredential() -> Self {
         self.credential = PetstoreClientAPI.credential
         return self

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -16,9 +16,9 @@ open class FakeAPI: APIBase {
      - parameter body: (body) client model 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClientModel(body: Client, completion: @escaping ((_ data: Client?,_ error: ErrorResponse?) -> Void)) {
+    open class func testClientModel(body: Client, completion: @escaping ((_ data: Client?, _ error: ErrorResponse?) -> Void)) {
         testClientModelWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -27,9 +27,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 
@@ -39,9 +39,9 @@ open class FakeAPI: APIBase {
         let path = "/fake"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Client>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PATCH", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -68,7 +68,7 @@ open class FakeAPI: APIBase {
      */
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int32? = nil, int32: Int32? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: Data? = nil, date: ISOFullDate? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -118,11 +118,11 @@ open class FakeAPI: APIBase {
             "password": password,
             "callback": callback
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -175,7 +175,7 @@ open class FakeAPI: APIBase {
      */
     open class func testEnumParameters(enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: Int32? = nil, enumQueryDouble: Double? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         testEnumParametersWithRequestBuilder(enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -203,11 +203,11 @@ open class FakeAPI: APIBase {
             "enum_query_string": enumQueryString?.rawValue,
             "enum_query_integer": enumQueryInteger?.encodeToJSON()
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
@@ -16,9 +16,9 @@ open class Fake_classname_tags123API: APIBase {
      - parameter body: (body) client model 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClassname(body: Client, completion: @escaping ((_ data: Client?,_ error: ErrorResponse?) -> Void)) {
+    open class func testClassname(body: Client, completion: @escaping ((_ data: Client?, _ error: ErrorResponse?) -> Void)) {
         testClassnameWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -26,9 +26,9 @@ open class Fake_classname_tags123API: APIBase {
     /**
      To test class name in snake case
      - PATCH /fake_classname_test
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 
@@ -38,9 +38,9 @@ open class Fake_classname_tags123API: APIBase {
         let path = "/fake_classname_test"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Client>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PATCH", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -18,7 +18,7 @@ open class PetAPI: APIBase {
      */
     open class func addPet(body: Pet, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         addPetWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -39,9 +39,9 @@ open class PetAPI: APIBase {
         let path = "/pet"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -55,7 +55,7 @@ open class PetAPI: APIBase {
      */
     open class func deletePet(petId: Int64, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deletePetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -78,11 +78,11 @@ open class PetAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -103,9 +103,9 @@ open class PetAPI: APIBase {
      - parameter status: (query) Status values that need to be considered for filter 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?,_ error: ErrorResponse?) -> Void)) {
+    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?, _ error: ErrorResponse?) -> Void)) {
         findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -117,7 +117,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -126,21 +126,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -149,20 +149,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -175,11 +175,11 @@ open class PetAPI: APIBase {
         let nillableParameters: [String:Any?] = [
             "status": status
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -191,9 +191,9 @@ open class PetAPI: APIBase {
      - parameter tags: (query) Tags to filter by 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?,_ error: ErrorResponse?) -> Void)) {
+    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?, _ error: ErrorResponse?) -> Void)) {
         findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -205,7 +205,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -214,21 +214,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -237,20 +237,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -263,11 +263,11 @@ open class PetAPI: APIBase {
         let nillableParameters: [String:Any?] = [
             "tags": tags
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -279,9 +279,9 @@ open class PetAPI: APIBase {
      - parameter petId: (path) ID of pet to return 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?,_ error: ErrorResponse?) -> Void)) {
+    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?, _ error: ErrorResponse?) -> Void)) {
         getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -293,7 +293,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -302,21 +302,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -325,20 +325,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -350,11 +350,11 @@ open class PetAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Pet>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -368,7 +368,7 @@ open class PetAPI: APIBase {
      */
     open class func updatePet(body: Pet, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updatePetWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -389,9 +389,9 @@ open class PetAPI: APIBase {
         let path = "/pet"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PUT", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -407,7 +407,7 @@ open class PetAPI: APIBase {
      */
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -435,11 +435,11 @@ open class PetAPI: APIBase {
             "name": name,
             "status": status
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -453,9 +453,9 @@ open class PetAPI: APIBase {
      - parameter file: (form) file to upload (optional)
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: ErrorResponse?) -> Void)) {
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?, _ error: ErrorResponse?) -> Void)) {
         uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -467,11 +467,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 123,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
@@ -488,11 +488,11 @@ open class PetAPI: APIBase {
             "additionalMetadata": additionalMetadata,
             "file": file
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<ApiResponse>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -18,7 +18,7 @@ open class StoreAPI: APIBase {
      */
     open class func deleteOrder(orderId: String, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -38,11 +38,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -53,9 +53,9 @@ open class StoreAPI: APIBase {
      
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getInventory(completion: @escaping ((_ data: [String:Int32]?,_ error: ErrorResponse?) -> Void)) {
+    open class func getInventory(completion: @escaping ((_ data: [String:Int32]?, _ error: ErrorResponse?) -> Void)) {
         getInventoryWithRequestBuilder().execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -67,9 +67,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 123
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -78,11 +78,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[String:Int32]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -94,9 +94,9 @@ open class StoreAPI: APIBase {
      - parameter orderId: (path) ID of pet that needs to be fetched 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?,_ error: ErrorResponse?) -> Void)) {
+    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?, _ error: ErrorResponse?) -> Void)) {
         getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -105,36 +105,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{orderId}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -146,11 +146,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -162,9 +162,9 @@ open class StoreAPI: APIBase {
      - parameter body: (body) order placed for purchasing the pet 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func placeOrder(body: Order, completion: @escaping ((_ data: Order?,_ error: ErrorResponse?) -> Void)) {
+    open class func placeOrder(body: Order, completion: @escaping ((_ data: Order?, _ error: ErrorResponse?) -> Void)) {
         placeOrderWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -173,36 +173,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 
@@ -212,9 +212,9 @@ open class StoreAPI: APIBase {
         let path = "/store/order"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -18,7 +18,7 @@ open class UserAPI: APIBase {
      */
     open class func createUser(body: User, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUserWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -36,9 +36,9 @@ open class UserAPI: APIBase {
         let path = "/user"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -52,7 +52,7 @@ open class UserAPI: APIBase {
      */
     open class func createUsersWithArrayInput(body: [User], completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUsersWithArrayInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -70,9 +70,9 @@ open class UserAPI: APIBase {
         let path = "/user/createWithArray"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -86,7 +86,7 @@ open class UserAPI: APIBase {
      */
     open class func createUsersWithListInput(body: [User], completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUsersWithListInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -104,9 +104,9 @@ open class UserAPI: APIBase {
         let path = "/user/createWithList"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -120,7 +120,7 @@ open class UserAPI: APIBase {
      */
     open class func deleteUser(username: String, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -140,11 +140,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -156,9 +156,9 @@ open class UserAPI: APIBase {
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: ErrorResponse?) -> Void)) {
+    open class func getUserByName(username: String, completion: @escaping ((_ data: User?, _ error: ErrorResponse?) -> Void)) {
         getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -167,7 +167,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -176,17 +176,17 @@ open class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 123,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 123456789,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 123,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -195,16 +195,16 @@ open class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 123,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 123456789,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 123,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -216,11 +216,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<User>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -233,9 +233,9 @@ open class UserAPI: APIBase {
      - parameter password: (query) The password for login in clear text 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?,_ error: ErrorResponse?) -> Void)) {
+    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?, _ error: ErrorResponse?) -> Void)) {
         loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -246,8 +246,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=string}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=string}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=string, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=string, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
@@ -262,11 +262,11 @@ open class UserAPI: APIBase {
             "username": username,
             "password": password
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -279,7 +279,7 @@ open class UserAPI: APIBase {
      */
     open class func logoutUser(completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         logoutUserWithRequestBuilder().execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -296,11 +296,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -315,7 +315,7 @@ open class UserAPI: APIBase {
      */
     open class func updateUser(username: String, body: User, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updateUserWithRequestBuilder(username: username, body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -335,9 +335,9 @@ open class UserAPI: APIBase {
         path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PUT", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -189,7 +189,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 // NSNull would crash decoders
                 if response.response?.statusCode == 204 && response.result.value is NSNull{
                     completion(nil, nil)
-                    return;
+                    return
                 }
 
                 if () is T {

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -46,10 +46,8 @@ public extension Decoded {
         switch self {
         case let .success(value):
             return value
-            break
         case .failure:
             return nil
-            break
         }
     }
 }
@@ -71,7 +69,7 @@ class Decoders {
     }
 
     static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> Decoded<T> {
-        let key = discriminator;
+        let key = discriminator
         if let decoder = decoders[key], let value = decoder(source) as? Decoded<T> {
             return value
         } else {
@@ -88,7 +86,6 @@ class Decoders {
                     values.append(value)
                 case let .failure(error):
                     return .failure(error)
-                    break
                 }
             }
             return .success(values)
@@ -104,7 +101,6 @@ class Decoders {
                 switch Decoders.decode(clazz: T.self, source: value) {
                 case let .success(value):
                     dictionary[key] = value
-                    break
                 case let .failure(error):
                     return .failure(error)
                 }
@@ -114,7 +110,7 @@ class Decoders {
             return .failure(.typeMismatch(expected: String(describing: clazz), actual: String(describing: source)))
         }
     }
-    
+
     static func decodeOptional<T: RawRepresentable>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let value = source as? T.RawValue {
             if let enumValue = T.init(rawValue: value) {
@@ -123,10 +119,10 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "A value from the enumeration \(T.self)", actual: "\(value)"))
             }
         } else {
-            return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
+            return .success(nil)
         }
     }
-        
+
     static func decode<T>(clazz: T.Type, source: AnyObject) -> Decoded<T> {
         initialize()
         if let value = source.int32Value as? T, source is NSNumber, T.self is Int32.Type {
@@ -141,8 +137,7 @@ class Decoders {
         if let value = source as? T {
             return .success(value)
         }
-        //The last two expressions in this condition must be unnecessary, but it would be good to test this.
-        if let intermediate = source as? String, let value = Data(base64Encoded: intermediate) as? T, T.self is Data.Type, source is String {
+        if let intermediate = source as? String, let value = Data(base64Encoded: intermediate) as? T {
             return .success(value)
         }
 
@@ -158,7 +153,7 @@ class Decoders {
     static func toOptional<T>(decoded: Decoded<T>) -> Decoded<T?> {
         return .success(decoded.value)
     }
-    
+
     static func decodeOptional<T>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let source = source, !(source is NSNull) {
             switch Decoders.decode(clazz: clazz, source: source) {
@@ -199,7 +194,7 @@ class Decoders {
             return .success(nil)
         }
     }
-    
+
     static func decodeOptional<T: RawRepresentable, U: AnyObject where T.RawValue == U>(clazz: T, source: AnyObject) -> Decoded<T?> {
         if let value = source as? U {
             if let enumValue = T.init(rawValue: value) {
@@ -245,7 +240,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "String or Int", actual: "\(source)"))
             }
         }
-        
+
         // Decoder for ISOFullDate
         Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> Decoded<ISOFullDate> in
             if let string = source as? String,

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -112,6 +112,7 @@ class Decoders {
     }
 
     static func decodeOptional<T: RawRepresentable>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
+        guard !(source is NSNull), source != nil else { return .success(nil) }
         if let value = source as? T.RawValue {
             if let enumValue = T.init(rawValue: value) {
                 return .success(enumValue)
@@ -119,7 +120,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "A value from the enumeration \(T.self)", actual: "\(value)"))
             }
         } else {
-            return .success(nil)
+            return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
         }
     }
 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -36,7 +36,7 @@ open class RequestBuilder<T> {
     let isBody: Bool
     let method: String
     let URLString: String
-    
+
     /// Optional block to obtain a reference to the request's progress instance when available.
     public var onProgressReady: ((Progress) -> ())?
 
@@ -45,16 +45,16 @@ open class RequestBuilder<T> {
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody
-        
+
         addHeaders(PetstoreClientAPI.customHeaders)
     }
-    
+
     open func addHeaders(_ aHeaders:[String:String]) {
         for (header, value) in aHeaders {
             headers[header] = value
         }
     }
-    
+
     open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: ErrorResponse?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
@@ -63,7 +63,7 @@ open class RequestBuilder<T> {
         }
         return self
     }
-    
+
     open func addCredential() -> Self {
         self.credential = PetstoreClientAPI.credential
         return self

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -17,9 +17,9 @@ open class FakeAPI: APIBase {
      - parameter body: (body) client model 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClientModel(body: Client, completion: @escaping ((_ data: Client?,_ error: ErrorResponse?) -> Void)) {
+    open class func testClientModel(body: Client, completion: @escaping ((_ data: Client?, _ error: ErrorResponse?) -> Void)) {
         testClientModelWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -45,9 +45,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 
@@ -57,9 +57,9 @@ open class FakeAPI: APIBase {
         let path = "/fake"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Client>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PATCH", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -86,7 +86,7 @@ open class FakeAPI: APIBase {
      */
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int32? = nil, int32: Int32? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: Data? = nil, date: ISOFullDate? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -166,11 +166,11 @@ open class FakeAPI: APIBase {
             "password": password,
             "callback": callback
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -223,7 +223,7 @@ open class FakeAPI: APIBase {
      */
     open class func testEnumParameters(enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: Int32? = nil, enumQueryDouble: Double? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         testEnumParametersWithRequestBuilder(enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -273,11 +273,11 @@ open class FakeAPI: APIBase {
             "enum_query_string": enumQueryString?.rawValue,
             "enum_query_integer": enumQueryInteger?.encodeToJSON()
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
@@ -17,9 +17,9 @@ open class Fake_classname_tags123API: APIBase {
      - parameter body: (body) client model 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClassname(body: Client, completion: @escaping ((_ data: Client?,_ error: ErrorResponse?) -> Void)) {
+    open class func testClassname(body: Client, completion: @escaping ((_ data: Client?, _ error: ErrorResponse?) -> Void)) {
         testClassnameWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -44,9 +44,9 @@ open class Fake_classname_tags123API: APIBase {
     /**
      To test class name in snake case
      - PATCH /fake_classname_test
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 
@@ -56,9 +56,9 @@ open class Fake_classname_tags123API: APIBase {
         let path = "/fake_classname_test"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Client>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PATCH", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -19,7 +19,7 @@ open class PetAPI: APIBase {
      */
     open class func addPet(body: Pet, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         addPetWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -57,9 +57,9 @@ open class PetAPI: APIBase {
         let path = "/pet"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -73,7 +73,7 @@ open class PetAPI: APIBase {
      */
     open class func deletePet(petId: Int64, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deletePetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -113,11 +113,11 @@ open class PetAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -138,9 +138,9 @@ open class PetAPI: APIBase {
      - parameter status: (query) Status values that need to be considered for filter 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?,_ error: ErrorResponse?) -> Void)) {
+    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?, _ error: ErrorResponse?) -> Void)) {
         findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -169,7 +169,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -178,21 +178,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -201,20 +201,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -227,11 +227,11 @@ open class PetAPI: APIBase {
         let nillableParameters: [String:Any?] = [
             "status": status
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -243,9 +243,9 @@ open class PetAPI: APIBase {
      - parameter tags: (query) Tags to filter by 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?,_ error: ErrorResponse?) -> Void)) {
+    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?, _ error: ErrorResponse?) -> Void)) {
         findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -274,7 +274,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -283,21 +283,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -306,20 +306,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -332,11 +332,11 @@ open class PetAPI: APIBase {
         let nillableParameters: [String:Any?] = [
             "tags": tags
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -348,9 +348,9 @@ open class PetAPI: APIBase {
      - parameter petId: (path) ID of pet to return 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?,_ error: ErrorResponse?) -> Void)) {
+    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?, _ error: ErrorResponse?) -> Void)) {
         getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -379,7 +379,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -388,21 +388,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -411,20 +411,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -436,11 +436,11 @@ open class PetAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Pet>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -454,7 +454,7 @@ open class PetAPI: APIBase {
      */
     open class func updatePet(body: Pet, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updatePetWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -492,9 +492,9 @@ open class PetAPI: APIBase {
         let path = "/pet"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PUT", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -510,7 +510,7 @@ open class PetAPI: APIBase {
      */
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -557,11 +557,11 @@ open class PetAPI: APIBase {
             "name": name,
             "status": status
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -575,9 +575,9 @@ open class PetAPI: APIBase {
      - parameter file: (form) file to upload (optional)
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: ErrorResponse?) -> Void)) {
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?, _ error: ErrorResponse?) -> Void)) {
         uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -608,11 +608,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 123,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
@@ -629,11 +629,11 @@ open class PetAPI: APIBase {
             "additionalMetadata": additionalMetadata,
             "file": file
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<ApiResponse>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -19,7 +19,7 @@ open class StoreAPI: APIBase {
      */
     open class func deleteOrder(orderId: String, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -56,11 +56,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -71,9 +71,9 @@ open class StoreAPI: APIBase {
      
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getInventory(completion: @escaping ((_ data: [String:Int32]?,_ error: ErrorResponse?) -> Void)) {
+    open class func getInventory(completion: @escaping ((_ data: [String:Int32]?, _ error: ErrorResponse?) -> Void)) {
         getInventoryWithRequestBuilder().execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -101,9 +101,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 123
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -112,11 +112,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[String:Int32]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -128,9 +128,9 @@ open class StoreAPI: APIBase {
      - parameter orderId: (path) ID of pet that needs to be fetched 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?,_ error: ErrorResponse?) -> Void)) {
+    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?, _ error: ErrorResponse?) -> Void)) {
         getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -156,36 +156,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{orderId}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -197,11 +197,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -213,9 +213,9 @@ open class StoreAPI: APIBase {
      - parameter body: (body) order placed for purchasing the pet 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func placeOrder(body: Order, completion: @escaping ((_ data: Order?,_ error: ErrorResponse?) -> Void)) {
+    open class func placeOrder(body: Order, completion: @escaping ((_ data: Order?, _ error: ErrorResponse?) -> Void)) {
         placeOrderWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -241,36 +241,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 
@@ -280,9 +280,9 @@ open class StoreAPI: APIBase {
         let path = "/store/order"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -19,7 +19,7 @@ open class UserAPI: APIBase {
      */
     open class func createUser(body: User, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUserWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -54,9 +54,9 @@ open class UserAPI: APIBase {
         let path = "/user"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -70,7 +70,7 @@ open class UserAPI: APIBase {
      */
     open class func createUsersWithArrayInput(body: [User], completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUsersWithArrayInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -105,9 +105,9 @@ open class UserAPI: APIBase {
         let path = "/user/createWithArray"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -121,7 +121,7 @@ open class UserAPI: APIBase {
      */
     open class func createUsersWithListInput(body: [User], completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUsersWithListInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -156,9 +156,9 @@ open class UserAPI: APIBase {
         let path = "/user/createWithList"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -172,7 +172,7 @@ open class UserAPI: APIBase {
      */
     open class func deleteUser(username: String, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -209,11 +209,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -225,9 +225,9 @@ open class UserAPI: APIBase {
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: ErrorResponse?) -> Void)) {
+    open class func getUserByName(username: String, completion: @escaping ((_ data: User?, _ error: ErrorResponse?) -> Void)) {
         getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -253,7 +253,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -262,17 +262,17 @@ open class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 123,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 123456789,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 123,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -281,16 +281,16 @@ open class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 123,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 123456789,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 123,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -302,11 +302,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<User>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -319,9 +319,9 @@ open class UserAPI: APIBase {
      - parameter password: (query) The password for login in clear text 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?,_ error: ErrorResponse?) -> Void)) {
+    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?, _ error: ErrorResponse?) -> Void)) {
         loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -350,8 +350,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=string}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=string}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=string, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=string, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
@@ -366,11 +366,11 @@ open class UserAPI: APIBase {
             "username": username,
             "password": password
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -383,7 +383,7 @@ open class UserAPI: APIBase {
      */
     open class func logoutUser(completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         logoutUserWithRequestBuilder().execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -416,11 +416,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -435,7 +435,7 @@ open class UserAPI: APIBase {
      */
     open class func updateUser(username: String, body: User, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updateUserWithRequestBuilder(username: username, body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -473,9 +473,9 @@ open class UserAPI: APIBase {
         path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PUT", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -189,7 +189,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 // NSNull would crash decoders
                 if response.response?.statusCode == 204 && response.result.value is NSNull{
                     completion(nil, nil)
-                    return;
+                    return
                 }
 
                 if () is T {

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -46,10 +46,8 @@ public extension Decoded {
         switch self {
         case let .success(value):
             return value
-            break
         case .failure:
             return nil
-            break
         }
     }
 }
@@ -71,7 +69,7 @@ class Decoders {
     }
 
     static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> Decoded<T> {
-        let key = discriminator;
+        let key = discriminator
         if let decoder = decoders[key], let value = decoder(source) as? Decoded<T> {
             return value
         } else {
@@ -88,7 +86,6 @@ class Decoders {
                     values.append(value)
                 case let .failure(error):
                     return .failure(error)
-                    break
                 }
             }
             return .success(values)
@@ -104,7 +101,6 @@ class Decoders {
                 switch Decoders.decode(clazz: T.self, source: value) {
                 case let .success(value):
                     dictionary[key] = value
-                    break
                 case let .failure(error):
                     return .failure(error)
                 }
@@ -114,7 +110,7 @@ class Decoders {
             return .failure(.typeMismatch(expected: String(describing: clazz), actual: String(describing: source)))
         }
     }
-    
+
     static func decodeOptional<T: RawRepresentable>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let value = source as? T.RawValue {
             if let enumValue = T.init(rawValue: value) {
@@ -123,10 +119,10 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "A value from the enumeration \(T.self)", actual: "\(value)"))
             }
         } else {
-            return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
+            return .success(nil)
         }
     }
-        
+
     static func decode<T>(clazz: T.Type, source: AnyObject) -> Decoded<T> {
         initialize()
         if let value = source.int32Value as? T, source is NSNumber, T.self is Int32.Type {
@@ -141,8 +137,7 @@ class Decoders {
         if let value = source as? T {
             return .success(value)
         }
-        //The last two expressions in this condition must be unnecessary, but it would be good to test this.
-        if let intermediate = source as? String, let value = Data(base64Encoded: intermediate) as? T, T.self is Data.Type, source is String {
+        if let intermediate = source as? String, let value = Data(base64Encoded: intermediate) as? T {
             return .success(value)
         }
 
@@ -158,7 +153,7 @@ class Decoders {
     static func toOptional<T>(decoded: Decoded<T>) -> Decoded<T?> {
         return .success(decoded.value)
     }
-    
+
     static func decodeOptional<T>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let source = source, !(source is NSNull) {
             switch Decoders.decode(clazz: clazz, source: source) {
@@ -199,7 +194,7 @@ class Decoders {
             return .success(nil)
         }
     }
-    
+
     static func decodeOptional<T: RawRepresentable, U: AnyObject where T.RawValue == U>(clazz: T, source: AnyObject) -> Decoded<T?> {
         if let value = source as? U {
             if let enumValue = T.init(rawValue: value) {
@@ -245,7 +240,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "String or Int", actual: "\(source)"))
             }
         }
-        
+
         // Decoder for ISOFullDate
         Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> Decoded<ISOFullDate> in
             if let string = source as? String,

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -112,6 +112,7 @@ class Decoders {
     }
 
     static func decodeOptional<T: RawRepresentable>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
+        guard !(source is NSNull), source != nil else { return .success(nil) }
         if let value = source as? T.RawValue {
             if let enumValue = T.init(rawValue: value) {
                 return .success(enumValue)
@@ -119,7 +120,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "A value from the enumeration \(T.self)", actual: "\(value)"))
             }
         } else {
-            return .success(nil)
+            return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
         }
     }
 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -36,7 +36,7 @@ open class RequestBuilder<T> {
     let isBody: Bool
     let method: String
     let URLString: String
-    
+
     /// Optional block to obtain a reference to the request's progress instance when available.
     public var onProgressReady: ((Progress) -> ())?
 
@@ -45,16 +45,16 @@ open class RequestBuilder<T> {
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody
-        
+
         addHeaders(PetstoreClientAPI.customHeaders)
     }
-    
+
     open func addHeaders(_ aHeaders:[String:String]) {
         for (header, value) in aHeaders {
             headers[header] = value
         }
     }
-    
+
     open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: ErrorResponse?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
@@ -63,7 +63,7 @@ open class RequestBuilder<T> {
         }
         return self
     }
-    
+
     open func addCredential() -> Self {
         self.credential = PetstoreClientAPI.credential
         return self

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -17,9 +17,9 @@ open class FakeAPI: APIBase {
      - parameter body: (body) client model 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClientModel(body: Client, completion: @escaping ((_ data: Client?,_ error: ErrorResponse?) -> Void)) {
+    open class func testClientModel(body: Client, completion: @escaping ((_ data: Client?, _ error: ErrorResponse?) -> Void)) {
         testClientModelWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -47,9 +47,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 
@@ -59,9 +59,9 @@ open class FakeAPI: APIBase {
         let path = "/fake"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Client>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PATCH", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -88,7 +88,7 @@ open class FakeAPI: APIBase {
      */
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int32? = nil, int32: Int32? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: Data? = nil, date: ISOFullDate? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -170,11 +170,11 @@ open class FakeAPI: APIBase {
             "password": password,
             "callback": callback
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -227,7 +227,7 @@ open class FakeAPI: APIBase {
      */
     open class func testEnumParameters(enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: Int32? = nil, enumQueryDouble: Double? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         testEnumParametersWithRequestBuilder(enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -279,11 +279,11 @@ open class FakeAPI: APIBase {
             "enum_query_string": enumQueryString?.rawValue,
             "enum_query_integer": enumQueryInteger?.encodeToJSON()
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
@@ -17,9 +17,9 @@ open class Fake_classname_tags123API: APIBase {
      - parameter body: (body) client model 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClassname(body: Client, completion: @escaping ((_ data: Client?,_ error: ErrorResponse?) -> Void)) {
+    open class func testClassname(body: Client, completion: @escaping ((_ data: Client?, _ error: ErrorResponse?) -> Void)) {
         testClassnameWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -46,9 +46,9 @@ open class Fake_classname_tags123API: APIBase {
     /**
      To test class name in snake case
      - PATCH /fake_classname_test
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 
@@ -58,9 +58,9 @@ open class Fake_classname_tags123API: APIBase {
         let path = "/fake_classname_test"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Client>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PATCH", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -19,7 +19,7 @@ open class PetAPI: APIBase {
      */
     open class func addPet(body: Pet, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         addPetWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -59,9 +59,9 @@ open class PetAPI: APIBase {
         let path = "/pet"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -75,7 +75,7 @@ open class PetAPI: APIBase {
      */
     open class func deletePet(petId: Int64, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deletePetWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -117,11 +117,11 @@ open class PetAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -142,9 +142,9 @@ open class PetAPI: APIBase {
      - parameter status: (query) Status values that need to be considered for filter 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?,_ error: ErrorResponse?) -> Void)) {
+    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?, _ error: ErrorResponse?) -> Void)) {
         findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -175,7 +175,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -184,21 +184,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -207,20 +207,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -233,11 +233,11 @@ open class PetAPI: APIBase {
         let nillableParameters: [String:Any?] = [
             "status": status
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -249,9 +249,9 @@ open class PetAPI: APIBase {
      - parameter tags: (query) Tags to filter by 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?,_ error: ErrorResponse?) -> Void)) {
+    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?, _ error: ErrorResponse?) -> Void)) {
         findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -282,7 +282,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -291,21 +291,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -314,20 +314,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-} ]}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -340,11 +340,11 @@ open class PetAPI: APIBase {
         let nillableParameters: [String:Any?] = [
             "tags": tags
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[Pet]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -356,9 +356,9 @@ open class PetAPI: APIBase {
      - parameter petId: (path) ID of pet to return 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?,_ error: ErrorResponse?) -> Void)) {
+    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?, _ error: ErrorResponse?) -> Void)) {
         getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -389,7 +389,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -398,21 +398,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456</id>
   <name>doggie</name>
   <photoUrls>
@@ -421,20 +421,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>string</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 123456789,
+    "name" : "aeiou"
+  } ],
   "id" : 123456789,
   "category" : {
-    "name" : "aeiou",
-    "id" : 123456789
+    "id" : 123456789,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 123456789
-  } ],
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -446,11 +446,11 @@ open class PetAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Pet>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -464,7 +464,7 @@ open class PetAPI: APIBase {
      */
     open class func updatePet(body: Pet, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updatePetWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -504,9 +504,9 @@ open class PetAPI: APIBase {
         let path = "/pet"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PUT", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -522,7 +522,7 @@ open class PetAPI: APIBase {
      */
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -571,11 +571,11 @@ open class PetAPI: APIBase {
             "name": name,
             "status": status
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -589,9 +589,9 @@ open class PetAPI: APIBase {
      - parameter file: (form) file to upload (optional)
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: ErrorResponse?) -> Void)) {
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?, _ error: ErrorResponse?) -> Void)) {
         uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -624,11 +624,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 123,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
@@ -645,11 +645,11 @@ open class PetAPI: APIBase {
             "additionalMetadata": additionalMetadata,
             "file": file
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<ApiResponse>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: false)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -19,7 +19,7 @@ open class StoreAPI: APIBase {
      */
     open class func deleteOrder(orderId: String, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -58,11 +58,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -73,9 +73,9 @@ open class StoreAPI: APIBase {
      
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getInventory(completion: @escaping ((_ data: [String:Int32]?,_ error: ErrorResponse?) -> Void)) {
+    open class func getInventory(completion: @escaping ((_ data: [String:Int32]?, _ error: ErrorResponse?) -> Void)) {
         getInventoryWithRequestBuilder().execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -105,9 +105,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 123
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -116,11 +116,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<[String:Int32]>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -132,9 +132,9 @@ open class StoreAPI: APIBase {
      - parameter orderId: (path) ID of pet that needs to be fetched 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?,_ error: ErrorResponse?) -> Void)) {
+    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?, _ error: ErrorResponse?) -> Void)) {
         getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -162,36 +162,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{orderId}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -203,11 +203,11 @@ open class StoreAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -219,9 +219,9 @@ open class StoreAPI: APIBase {
      - parameter body: (body) order placed for purchasing the pet 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func placeOrder(body: Order, completion: @escaping ((_ data: Order?,_ error: ErrorResponse?) -> Void)) {
+    open class func placeOrder(body: Order, completion: @escaping ((_ data: Order?, _ error: ErrorResponse?) -> Void)) {
         placeOrderWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -249,36 +249,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456</id>
   <petId>123456</petId>
   <quantity>0</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>string</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 123456789,
-  "quantity" : 123,
+</Order>, contentType=application/xml}, {example={
   "id" : 123456789,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 123456789,
   "complete" : true,
-  "status" : "aeiou"
-}}]
+  "status" : "aeiou",
+  "quantity" : 123,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 
@@ -288,9 +288,9 @@ open class StoreAPI: APIBase {
         let path = "/store/order"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Order>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -19,7 +19,7 @@ open class UserAPI: APIBase {
      */
     open class func createUser(body: User, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUserWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -56,9 +56,9 @@ open class UserAPI: APIBase {
         let path = "/user"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -72,7 +72,7 @@ open class UserAPI: APIBase {
      */
     open class func createUsersWithArrayInput(body: [User], completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUsersWithArrayInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -109,9 +109,9 @@ open class UserAPI: APIBase {
         let path = "/user/createWithArray"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -125,7 +125,7 @@ open class UserAPI: APIBase {
      */
     open class func createUsersWithListInput(body: [User], completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         createUsersWithListInputWithRequestBuilder(body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -162,9 +162,9 @@ open class UserAPI: APIBase {
         let path = "/user/createWithList"
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "POST", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -178,7 +178,7 @@ open class UserAPI: APIBase {
      */
     open class func deleteUser(username: String, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -217,11 +217,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "DELETE", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -233,9 +233,9 @@ open class UserAPI: APIBase {
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: ErrorResponse?) -> Void)) {
+    open class func getUserByName(username: String, completion: @escaping ((_ data: User?, _ error: ErrorResponse?) -> Void)) {
         getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -263,7 +263,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -272,17 +272,17 @@ open class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 123,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 123456789,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 123,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456</id>
   <username>string</username>
   <firstName>string</firstName>
@@ -291,16 +291,16 @@ open class UserAPI: APIBase {
   <password>string</password>
   <phone>string</phone>
   <userStatus>0</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 123,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 123456789,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 123,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -312,11 +312,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<User>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -329,9 +329,9 @@ open class UserAPI: APIBase {
      - parameter password: (query) The password for login in clear text 
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?,_ error: ErrorResponse?) -> Void)) {
+    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?, _ error: ErrorResponse?) -> Void)) {
         loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
-            completion(response?.body, error);
+            completion(response?.body, error)
         }
     }
 
@@ -362,8 +362,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=string}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=string}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=string, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=string, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
@@ -378,11 +378,11 @@ open class UserAPI: APIBase {
             "username": username,
             "password": password
         ]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: false)
@@ -395,7 +395,7 @@ open class UserAPI: APIBase {
      */
     open class func logoutUser(completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         logoutUserWithRequestBuilder().execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -430,11 +430,11 @@ open class UserAPI: APIBase {
         let URLString = PetstoreClientAPI.basePath + path
 
         let nillableParameters: [String:Any?] = [:]
- 
+
         let parameters = APIHelper.rejectNil(nillableParameters)
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "GET", URLString: URLString, parameters: convertedParameters, isBody: true)
@@ -449,7 +449,7 @@ open class UserAPI: APIBase {
      */
     open class func updateUser(username: String, body: User, completion: @escaping ((_ error: ErrorResponse?) -> Void)) {
         updateUserWithRequestBuilder(username: username, body: body).execute { (response, error) -> Void in
-            completion(error);
+            completion(error)
         }
     }
 
@@ -489,9 +489,9 @@ open class UserAPI: APIBase {
         path = path.replacingOccurrences(of: "{username}", with: "\(username)", options: .literal, range: nil)
         let URLString = PetstoreClientAPI.basePath + path
         let parameters = body.encodeToJSON() as? [String:AnyObject]
- 
+
         let convertedParameters = APIHelper.convertBoolToString(parameters)
- 
+
         let requestBuilder: RequestBuilder<Void>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()
 
         return requestBuilder.init(method: "PUT", URLString: URLString, parameters: convertedParameters, isBody: true)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -189,7 +189,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                 // NSNull would crash decoders
                 if response.response?.statusCode == 204 && response.result.value is NSNull{
                     completion(nil, nil)
-                    return;
+                    return
                 }
 
                 if () is T {

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -46,10 +46,8 @@ public extension Decoded {
         switch self {
         case let .success(value):
             return value
-            break
         case .failure:
             return nil
-            break
         }
     }
 }
@@ -71,7 +69,7 @@ class Decoders {
     }
 
     static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> Decoded<T> {
-        let key = discriminator;
+        let key = discriminator
         if let decoder = decoders[key], let value = decoder(source) as? Decoded<T> {
             return value
         } else {
@@ -88,7 +86,6 @@ class Decoders {
                     values.append(value)
                 case let .failure(error):
                     return .failure(error)
-                    break
                 }
             }
             return .success(values)
@@ -104,7 +101,6 @@ class Decoders {
                 switch Decoders.decode(clazz: T.self, source: value) {
                 case let .success(value):
                     dictionary[key] = value
-                    break
                 case let .failure(error):
                     return .failure(error)
                 }
@@ -114,7 +110,7 @@ class Decoders {
             return .failure(.typeMismatch(expected: String(describing: clazz), actual: String(describing: source)))
         }
     }
-    
+
     static func decodeOptional<T: RawRepresentable>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let value = source as? T.RawValue {
             if let enumValue = T.init(rawValue: value) {
@@ -123,10 +119,10 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "A value from the enumeration \(T.self)", actual: "\(value)"))
             }
         } else {
-            return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
+            return .success(nil)
         }
     }
-        
+
     static func decode<T>(clazz: T.Type, source: AnyObject) -> Decoded<T> {
         initialize()
         if let value = source.int32Value as? T, source is NSNumber, T.self is Int32.Type {
@@ -141,8 +137,7 @@ class Decoders {
         if let value = source as? T {
             return .success(value)
         }
-        //The last two expressions in this condition must be unnecessary, but it would be good to test this.
-        if let intermediate = source as? String, let value = Data(base64Encoded: intermediate) as? T, T.self is Data.Type, source is String {
+        if let intermediate = source as? String, let value = Data(base64Encoded: intermediate) as? T {
             return .success(value)
         }
 
@@ -158,7 +153,7 @@ class Decoders {
     static func toOptional<T>(decoded: Decoded<T>) -> Decoded<T?> {
         return .success(decoded.value)
     }
-    
+
     static func decodeOptional<T>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let source = source, !(source is NSNull) {
             switch Decoders.decode(clazz: clazz, source: source) {
@@ -199,7 +194,7 @@ class Decoders {
             return .success(nil)
         }
     }
-    
+
     static func decodeOptional<T: RawRepresentable, U: AnyObject where T.RawValue == U>(clazz: T, source: AnyObject) -> Decoded<T?> {
         if let value = source as? U {
             if let enumValue = T.init(rawValue: value) {
@@ -245,7 +240,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "String or Int", actual: "\(source)"))
             }
         }
-        
+
         // Decoder for ISOFullDate
         Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> Decoded<ISOFullDate> in
             if let string = source as? String,

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -112,6 +112,7 @@ class Decoders {
     }
 
     static func decodeOptional<T: RawRepresentable>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
+        guard !(source is NSNull), source != nil else { return .success(nil) }
         if let value = source as? T.RawValue {
             if let enumValue = T.init(rawValue: value) {
                 return .success(enumValue)
@@ -119,7 +120,7 @@ class Decoders {
                 return .failure(.typeMismatch(expected: "A value from the enumeration \(T.self)", actual: "\(value)"))
             }
         } else {
-            return .success(nil)
+            return .failure(.typeMismatch(expected: "\(T.RawValue.self) matching a case from the enumeration \(T.self)", actual: String(describing: type(of: source))))
         }
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

As all other the fields can be null, I think an enumeration field can also be null. The users can decide whether that's a problem. This is to be consistent with previous behaviors.
This was introduced in #4547 (@philippelatulippe)

The real change is only [one line](https://github.com/swagger-api/swagger-codegen/pull/4762/files#diff-940535e66d162a893df844fd9b6b45ffR122), but I cannot help but fix format issues.