### PR TITLE
Update gitignore to ignore dist folder

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/gitignore
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/gitignore
@@ -1,3 +1,4 @@
 wwwroot/*.js
 node_modules
 typings
+dist


### PR DESCRIPTION
ignore dist folder

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Adding the dist folder to .gitignore so that it isn't packed by `npm package`.
