### PR TITLE
[Java] remove trailing whitespaces in Java API client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -45,17 +45,27 @@ public class ApiClient {
 
   public ApiClient(String[] authNames) {
     this();
-    for(String authName : authNames) { {{#hasAuthMethods}}
+    for(String authName : authNames) {
+      {{#hasAuthMethods}}
       RequestInterceptor auth;
-      {{#authMethods}}if ("{{name}}".equals(authName)) { {{#isBasic}}
-        auth = new HttpBasicAuth();{{/isBasic}}{{#isApiKey}}
-        auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}{{#isOAuth}}
-        auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");{{/isOAuth}}
+      {{#authMethods}}if ("{{name}}".equals(authName)) {
+      {{#isBasic}}
+        auth = new HttpBasicAuth();
+      {{/isBasic}}
+      {{#isApiKey}}
+        auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");
+      {{/isApiKey}}
+      {{#isOAuth}}
+        auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");
+      {{/isOAuth}}
       } else {{/authMethods}}{
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
       }
-      addAuthorization(authName, auth);{{/hasAuthMethods}}{{^hasAuthMethods}}
-      throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");{{/hasAuthMethods}}
+      addAuthorization(authName, auth);
+      {{/hasAuthMethods}}
+      {{^hasAuthMethods}}
+      throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
+      {{/hasAuthMethods}}
     }
   }
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
@@ -52,17 +52,26 @@ public class ApiClient {
 
     public ApiClient(String[] authNames) {
         this();
-        for(String authName : authNames) { {{#hasAuthMethods}}
+        for(String authName : authNames) {
+            {{#hasAuthMethods}}
             Interceptor auth;
-            {{#authMethods}}if ("{{name}}".equals(authName)) { {{#isBasic}}
-                auth = new HttpBasicAuth();{{/isBasic}}{{#isApiKey}}
-                auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}{{#isOAuth}}
-                auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");{{/isOAuth}}
+            {{#authMethods}}if ("{{name}}".equals(authName)) {
+            {{#isBasic}}
+                auth = new HttpBasicAuth();
+            {{/isBasic}}
+            {{#isApiKey}}
+                auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}
+            {{#isOAuth}}
+                auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");
+            {{/isOAuth}}
             } else {{/authMethods}}{
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
             }
-            addAuthorization(authName, auth);{{/hasAuthMethods}}{{^hasAuthMethods}}
-            throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");{{/hasAuthMethods}}
+            addAuthorization(authName, auth);
+            {{/hasAuthMethods}}
+            {{^hasAuthMethods}}
+            throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
+            {{/hasAuthMethods}}
         }
     }
 

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -58,17 +58,27 @@ public class ApiClient {
 
     public ApiClient(String[] authNames) {
         this();
-        for(String authName : authNames) { {{#hasAuthMethods}}
+        for(String authName : authNames) {
+            {{#hasAuthMethods}}
             Interceptor auth;
-            {{#authMethods}}if ("{{name}}".equals(authName)) { {{#isBasic}}
-                auth = new HttpBasicAuth();{{/isBasic}}{{#isApiKey}}
-                auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}{{#isOAuth}}
-                auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");{{/isOAuth}}
+            {{#authMethods}}if ("{{name}}".equals(authName)) {
+            {{#isBasic}}
+                auth = new HttpBasicAuth();
+            {{/isBasic}}
+            {{#isApiKey}}
+                auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");
+            {{/isApiKey}}
+            {{#isOAuth}}
+                auth = new OAuth(OAuthFlow.{{flow}}, "{{authorizationUrl}}", "{{tokenUrl}}", "{{#scopes}}{{scope}}{{#hasMore}}, {{/hasMore}}{{/scopes}}");
+            {{/isOAuth}}
             } else {{/authMethods}}{
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
             }
-            addAuthorization(authName, auth);{{/hasAuthMethods}}{{^hasAuthMethods}}
-            throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");{{/hasAuthMethods}}
+            addAuthorization(authName, auth);
+            {{/hasAuthMethods}}
+            {{^hasAuthMethods}}
+            throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
+            {{/hasAuthMethods}}
         }
     }
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
@@ -40,13 +40,13 @@ public class ApiClient {
 
   public ApiClient(String[] authNames) {
     this();
-    for(String authName : authNames) { 
+    for(String authName : authNames) {
       RequestInterceptor auth;
-      if ("api_key".equals(authName)) { 
+      if ("api_key".equals(authName)) {
         auth = new ApiKeyAuth("header", "api_key");
-      } else if ("http_basic_test".equals(authName)) { 
+      } else if ("http_basic_test".equals(authName)) {
         auth = new HttpBasicAuth();
-      } else if ("petstore_auth".equals(authName)) { 
+      } else if ("petstore_auth".equals(authName)) {
         auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/ApiClient.java
@@ -52,13 +52,15 @@ public class ApiClient {
 
     public ApiClient(String[] authNames) {
         this();
-        for(String authName : authNames) { 
+        for(String authName : authNames) {
             Interceptor auth;
-            if ("api_key".equals(authName)) { 
+            if ("api_key".equals(authName)) {
                 auth = new ApiKeyAuth("header", "api_key");
-            } else if ("http_basic_test".equals(authName)) { 
+            } else if ("http_basic_test".equals(authName)) {
                 auth = new HttpBasicAuth();
-            } else if ("petstore_auth".equals(authName)) { 
+
+            } else if ("petstore_auth".equals(authName)) {
+
                 auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
             } else {
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/ApiClient.java
@@ -51,13 +51,13 @@ public class ApiClient {
 
     public ApiClient(String[] authNames) {
         this();
-        for(String authName : authNames) { 
+        for(String authName : authNames) {
             Interceptor auth;
-            if ("api_key".equals(authName)) { 
+            if ("api_key".equals(authName)) {
                 auth = new ApiKeyAuth("header", "api_key");
-            } else if ("http_basic_test".equals(authName)) { 
+            } else if ("http_basic_test".equals(authName)) {
                 auth = new HttpBasicAuth();
-            } else if ("petstore_auth".equals(authName)) { 
+            } else if ("petstore_auth".equals(authName)) {
                 auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
             } else {
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
@@ -51,13 +51,13 @@ public class ApiClient {
 
     public ApiClient(String[] authNames) {
         this();
-        for(String authName : authNames) { 
+        for(String authName : authNames) {
             Interceptor auth;
-            if (authName == "api_key") { 
+            if ("api_key".equals(authName)) {
                 auth = new ApiKeyAuth("header", "api_key");
-            } else if (authName == "http_basic_test") { 
+            } else if ("http_basic_test".equals(authName)) {
                 auth = new HttpBasicAuth();
-            } else if (authName == "petstore_auth") { 
+            } else if ("petstore_auth".equals(authName)) {
                 auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
             } else {
                 throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

To clean up trailing whitespace in Java API clients.
