### PR TITLE
[JAX-RS] Codegen implicitly assumes first part of URI to be API name #4247

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJerseyServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaJerseyServerCodegen.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
-
+    protected static final String USE_TAGS = "useTags";
     protected static final String LIBRARY_JERSEY1 = "jersey1";
     protected static final String LIBRARY_JERSEY2 = "jersey2";
     
@@ -18,6 +18,9 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
      * Default library template to use. (Default:{@value #DEFAULT_LIBRARY})
      */
     public static final String DEFAULT_LIBRARY = LIBRARY_JERSEY2;
+
+    // Default useTags to false
+    protected boolean useTags = false;
 
     public JavaJerseyServerCodegen() {
         super();
@@ -46,6 +49,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
         cliOptions.add(library);
         cliOptions.add(CliOption.newBoolean(SUPPORT_JAVA6, "Whether to support Java6 with the Jersey1/2 library."));
+        cliOptions.add(CliOption.newBoolean(USE_TAGS, "use tags for creating service classnames"));
     }
 
     @Override
@@ -88,6 +92,10 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
         
         if ( additionalProperties.containsKey(CodegenConstants.IMPL_FOLDER)) {
             implFolder = (String) additionalProperties.get(CodegenConstants.IMPL_FOLDER);
+        }
+
+        if (additionalProperties.containsKey(USE_TAGS)) {
+            this.setUseTags(Boolean.valueOf(additionalProperties.get(USE_TAGS).toString()));
         }
 
         if ("joda".equals(dateLibrary)) {
@@ -136,30 +144,37 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
     @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
-        String basePath = resourcePath;
-        if (basePath.startsWith("/")) {
-            basePath = basePath.substring(1);
-        }
-        int pos = basePath.indexOf("/");
-        if (pos > 0) {
-            basePath = basePath.substring(0, pos);
-        }
-
-        if (basePath == "") {
-            basePath = "default";
-        } else {
-            if (co.path.startsWith("/" + basePath)) {
-                co.path = co.path.substring(("/" + basePath).length());
+        if (!useTags) {
+            String basePath = resourcePath;
+            if (basePath.startsWith("/")) {
+                basePath = basePath.substring(1);
             }
-            co.subresourceOperation = !co.path.isEmpty();
+            int pos = basePath.indexOf("/");
+            if (pos > 0) {
+                basePath = basePath.substring(0, pos);
+            }
+
+            if (basePath == "") {
+                basePath = "default";
+            } else {
+                if (co.path.startsWith("/" + basePath)) {
+                    co.path = co.path.substring(("/" + basePath).length());
+                }
+                co.subresourceOperation = !co.path.isEmpty();
+            }
+            List<CodegenOperation> opList = operations.get(basePath);
+            if (opList == null) {
+                opList = new ArrayList<CodegenOperation>();
+                operations.put(basePath, opList);
+            }
+            opList.add(co);
+            co.baseName = basePath;
+        } else {
+            super.addOperationToGroup(tag, resourcePath, operation, co, operations);
         }
-        List<CodegenOperation> opList = operations.get(basePath);
-        if (opList == null) {
-            opList = new ArrayList<CodegenOperation>();
-            operations.put(basePath, opList);
-        }
-        opList.add(co);
-        co.baseName = basePath;
     }
-    
+
+    public void setUseTags(boolean useTags) {
+        this.useTags = useTags;
+    }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/jaxrs/JaxRSServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/jaxrs/JaxRSServerOptionsTest.java
@@ -76,6 +76,7 @@ public class JaxRSServerOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setUseBeanValidation(Boolean.valueOf(JaxRSServerOptionsProvider.USE_BEANVALIDATION));
             times = 1;
+            clientCodegen.setUseTags(Boolean.valueOf(JaxRSServerOptionsProvider.USE_TAGS_DEFAULT));
         }};
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
@@ -37,6 +37,8 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
     public static final String JAXRS_DEFAULT_LIBRARY_VALUE = "jersey1";
     public static final String USE_BEANVALIDATION = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
+    public static final String USE_TAGS = "useTags";
+    public static final String USE_TAGS_DEFAULT = "false";
 
 
     @Override
@@ -84,7 +86,8 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
             //.put(JavaClientCodegen.DATE_LIBRARY, "joda")
             .put("hideGenerationTimestamp", "true")
             .put(JavaCXFServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION)
-            .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE);
+            .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
+            .put(USE_TAGS, USE_TAGS_DEFAULT);
 
         return builder.build();
     }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Added a useTags flag to allow specifying a service classname as the first tag associated with an operation. If the useTags flag is set to true, the `addOperationToGroup` method defaults to the `DefaultCodeGen` implementation.

I tested this against petstore and verified adding one tag changes the `classname` used in the four mustache files used for jaxrs (`Api`, `ApiService`, `ApiServiceFactory`, `ApiServiceImpl`). Adding two tags, results in the first tag being used for the classname. 


#### Relevant Issues
#4247
#1888
#4387


