### PR TITLE
Ensure that `ApiInvoker.scala` can support `UUID` types

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
@@ -13,6 +13,7 @@ import com.sun.jersey.multipart.file.FileDataBodyPart
 
 import java.io.File
 import java.net.URLEncoder
+import java.util.UUID
 import javax.ws.rs.core.MediaType
 
 import scala.collection.JavaConverters._
@@ -55,6 +56,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
   def escape(value: Long): String = value.toString
   def escape(value: Double): String = value.toString
   def escape(value: Float): String = value.toString
+  def escape(value: UUID): String = value.toString
 
   def deserialize(json: String, containerType: String, cls: Class[_]) = {
     if (cls == classOf[String]) {

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/ApiInvoker.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/ApiInvoker.scala
@@ -24,6 +24,7 @@ import com.sun.jersey.multipart.file.FileDataBodyPart
 
 import java.io.File
 import java.net.URLEncoder
+import java.util.UUID
 import javax.ws.rs.core.MediaType
 
 import scala.collection.JavaConverters._
@@ -66,6 +67,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
   def escape(value: Long): String = value.toString
   def escape(value: Double): String = value.toString
   def escape(value: Float): String = value.toString
+  def escape(value: UUID): String = value.toString
 
   def deserialize(json: String, containerType: String, cls: Class[_]) = {
     if (cls == classOf[String]) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add an escape method for handling UUIDs in generated scala client code.
