### PR TITLE
[PHP][Silex] use original path name for path variable naming

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SilexServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SilexServerCodegen.java
@@ -3,6 +3,7 @@ package io.swagger.codegen.languages;
 import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenType;
+import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.DefaultCodegen;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.models.properties.ArrayProperty;
@@ -13,6 +14,10 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class SilexServerCodegen extends DefaultCodegen implements CodegenConfig {
     protected String invokerPackage;
@@ -213,4 +218,28 @@ public class SilexServerCodegen extends DefaultCodegen implements CodegenConfig 
     public String escapeUnsafeCharacters(String input) {
         return input.replace("*/", "*_/").replace("/*", "/_*");
     }
+
+    @Override
+    public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
+        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+        List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
+        for (CodegenOperation op : operationList) {
+            String path = new String(op.path);
+            String[] items = path.split("/", -1);
+            String opsPath = "";
+            int pathParamIndex = 0;
+
+            for (int i = 0; i < items.length; ++i) {
+                if (items[i].matches("^\\{(.*)\\}$")) { // wrap in {}
+                    // camelize path variable
+                    items[i] = "{" + camelize(items[i].substring(1, items[i].length()-1), true) + "}";
+                }
+            }
+
+            op.path = StringUtils.join(items, "/");
+        }
+
+        return objs;
+    }
+
 }

--- a/modules/swagger-codegen/src/main/resources/silex/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/silex/index.mustache
@@ -8,19 +8,23 @@ use Silex\Application;
 $app = new Silex\Application();
 
 {{#apiInfo}}
-    {{#apis}}
-        {{#operations}}
-            {{#operation}}
+{{#apis}}
+{{#operations}}
+{{#operation}}
 
-$app->{{httpMethod}}('{{basePathWithoutHost}}{{path}}', function(Application $app, Request $request{{#pathParams}}, ${{paramName}}{{/pathParams}}) {
-            {{#queryParams}}${{paramName}} = $request->get('{{paramName}}');{{newline}}    {{/queryParams}}
-            {{#formParams}}${{paramName}} = $request->get('{{paramName}}');{{newline}}    {{/formParams}}
-            return new Response('How about implementing {{nickname}} as a {{httpMethod}} method ?');
+$app->{{httpMethod}}('{{basePathWithoutHost}}{{path}}', function(Application $app, Request $request{{#pathParams}}, ${{baseName}}{{/pathParams}}) {
+            {{#queryParams}}
+            ${{paramName}} = $request->get('{{paramName}}');
+            {{/queryParams}}
+            {{#formParams}}
+            ${{paramName}} = $request->get('{{paramName}}');
+            {{/formParams}}
+            return new Response('How about implementing {{operationId}} as a {{httpMethod}} method ?');
             });
 
-            {{/operation}}
-        {{/operations}}
-    {{/apis}}
+{{/operation}}
+{{/operations}}
+{{/apis}}
 {{/apiInfo}}
 
 $app->run();

--- a/samples/server/petstore/silex/SwaggerServer/index.php
+++ b/samples/server/petstore/silex/SwaggerServer/index.php
@@ -9,141 +9,109 @@ $app = new Silex\Application();
 
 
 $app->POST('/v2/pet', function(Application $app, Request $request) {
-            
-            
             return new Response('How about implementing addPet as a POST method ?');
             });
 
 
-$app->DELETE('/v2/pet/{petId}', function(Application $app, Request $request, $pet_id) {
-            
-            
+$app->DELETE('/v2/pet/{petId}', function(Application $app, Request $request, $petId) {
             return new Response('How about implementing deletePet as a DELETE method ?');
             });
 
 
 $app->GET('/v2/pet/findByStatus', function(Application $app, Request $request) {
-            $status = $request->get('status');    
-            
+            $status = $request->get('status');
             return new Response('How about implementing findPetsByStatus as a GET method ?');
             });
 
 
 $app->GET('/v2/pet/findByTags', function(Application $app, Request $request) {
-            $tags = $request->get('tags');    
-            
+            $tags = $request->get('tags');
             return new Response('How about implementing findPetsByTags as a GET method ?');
             });
 
 
-$app->GET('/v2/pet/{petId}', function(Application $app, Request $request, $pet_id) {
-            
-            
+$app->GET('/v2/pet/{petId}', function(Application $app, Request $request, $petId) {
             return new Response('How about implementing getPetById as a GET method ?');
             });
 
 
 $app->PUT('/v2/pet', function(Application $app, Request $request) {
-            
-            
             return new Response('How about implementing updatePet as a PUT method ?');
             });
 
 
-$app->POST('/v2/pet/{petId}', function(Application $app, Request $request, $pet_id) {
-            
-            $name = $request->get('name');    $status = $request->get('status');    
+$app->POST('/v2/pet/{petId}', function(Application $app, Request $request, $petId) {
+            $name = $request->get('name');
+            $status = $request->get('status');
             return new Response('How about implementing updatePetWithForm as a POST method ?');
             });
 
 
-$app->POST('/v2/pet/{petId}/uploadImage', function(Application $app, Request $request, $pet_id) {
-            
-            $additional_metadata = $request->get('additional_metadata');    $file = $request->get('file');    
+$app->POST('/v2/pet/{petId}/uploadImage', function(Application $app, Request $request, $petId) {
+            $additional_metadata = $request->get('additional_metadata');
+            $file = $request->get('file');
             return new Response('How about implementing uploadFile as a POST method ?');
             });
 
 
-$app->DELETE('/v2/store/order/{orderId}', function(Application $app, Request $request, $order_id) {
-            
-            
+$app->DELETE('/v2/store/order/{orderId}', function(Application $app, Request $request, $orderId) {
             return new Response('How about implementing deleteOrder as a DELETE method ?');
             });
 
 
 $app->GET('/v2/store/inventory', function(Application $app, Request $request) {
-            
-            
             return new Response('How about implementing getInventory as a GET method ?');
             });
 
 
-$app->GET('/v2/store/order/{orderId}', function(Application $app, Request $request, $order_id) {
-            
-            
+$app->GET('/v2/store/order/{orderId}', function(Application $app, Request $request, $orderId) {
             return new Response('How about implementing getOrderById as a GET method ?');
             });
 
 
 $app->POST('/v2/store/order', function(Application $app, Request $request) {
-            
-            
             return new Response('How about implementing placeOrder as a POST method ?');
             });
 
 
 $app->POST('/v2/user', function(Application $app, Request $request) {
-            
-            
             return new Response('How about implementing createUser as a POST method ?');
             });
 
 
 $app->POST('/v2/user/createWithArray', function(Application $app, Request $request) {
-            
-            
             return new Response('How about implementing createUsersWithArrayInput as a POST method ?');
             });
 
 
 $app->POST('/v2/user/createWithList', function(Application $app, Request $request) {
-            
-            
             return new Response('How about implementing createUsersWithListInput as a POST method ?');
             });
 
 
 $app->DELETE('/v2/user/{username}', function(Application $app, Request $request, $username) {
-            
-            
             return new Response('How about implementing deleteUser as a DELETE method ?');
             });
 
 
 $app->GET('/v2/user/{username}', function(Application $app, Request $request, $username) {
-            
-            
             return new Response('How about implementing getUserByName as a GET method ?');
             });
 
 
 $app->GET('/v2/user/login', function(Application $app, Request $request) {
-            $username = $request->get('username');    $password = $request->get('password');    
-            
+            $username = $request->get('username');
+            $password = $request->get('password');
             return new Response('How about implementing loginUser as a GET method ?');
             });
 
 
 $app->GET('/v2/user/logout', function(Application $app, Request $request) {
-            
-            
             return new Response('How about implementing logoutUser as a GET method ?');
             });
 
 
 $app->PUT('/v2/user/{username}', function(Application $app, Request $request, $username) {
-            
-            
             return new Response('How about implementing updateUser as a PUT method ?');
             });
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Use original path name for path variable naming to resolve https://github.com/swagger-api/swagger-codegen/issues/4257
