### PR TITLE
export top level enumeration types in typescript-fetch mode

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
@@ -34,7 +34,12 @@ export class BaseAPI {
  * {{{description}}}
  */
 {{/description}}
+{{^isEnum}}
 export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
+{{/isEnum}}
+{{#isEnum}}
+export type {{{classname}}} = {{#allowableValues}}{{#values}}"{{{.}}}"{{^-last}} | {{/-last}}{{/values}}{{/allowableValues}};
+{{/isEnum}}
 {{#vars}}
 {{#description}}
     /**
@@ -43,7 +48,9 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{/description}}
     "{{name}}"{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
 {{/vars}}
+{{^isEnum}}
 }
+{{/isEnum}}
 
 {{#hasEnums}}
 {{#vars}}


### PR DESCRIPTION
This change enables top level enumeratons to be written out as:
```
export type SortDirection = "Ascending" | "Descending";
```
vs.
```
export class SortDirection {
}
```
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

