### PR TITLE
[Bash] Bugfix default curl options fix

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/BashClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/BashClientCodegen.java
@@ -194,11 +194,10 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
   @Override
   public void processOpts() {
       super.processOpts();
-      String curlopts = "";
 
       if (additionalProperties.containsKey(CURL_OPTIONS)) {
           setCurlOptions(additionalProperties.get(CURL_OPTIONS).toString());
-          additionalProperties.put("x-codegen-curl-options", curlopts);
+          additionalProperties.put("x-codegen-curl-options", this.curlOptions);
       }
 
       if (additionalProperties.containsKey(PROCESS_MARKDOWN)) {

--- a/modules/swagger-codegen/src/main/resources/bash/Dockerfile.mustache
+++ b/modules/swagger-codegen/src/main/resources/bash/Dockerfile.mustache
@@ -6,7 +6,7 @@ RUN apt-get install -y bash-completion zsh curl cowsay git vim bsdmainutils
 ADD {{scriptName}} /usr/bin/{{scriptName}}
 ADD _{{scriptName}} /usr/local/share/zsh/site-functions/_{{scriptName}}
 ADD {{scriptName}}.bash-completion /etc/bash-completion.d/{{scriptName}}
-
+RUN chmod 755 /usr/bin/{{scriptName}}
 
 #
 # Install oh-my-zsh

--- a/modules/swagger-codegen/src/main/resources/bash/README.md
+++ b/modules/swagger-codegen/src/main/resources/bash/README.md
@@ -28,7 +28,7 @@ $ git clone https://github.com/swagger-api/swagger-codegen
 
 Build the codegen:
 ```shell
-$ mvn assembly:assembly -DdescriptorId=jar-with-dependencies
+$ mvn package
 ```
 
 Define custom codegen properties in a Json file, e.g.:
@@ -47,14 +47,15 @@ Define custom codegen properties in a Json file, e.g.:
 
 Generate the client:
 ```shell
-$ java -cp target/bash-swagger-codegen-1.0.0.jar io.swagger.codegen.SwaggerCodegen generate -l bash -i http://petstore.swagger.io/v2/swagger.json -o output -c resources/example-config.json
+$ java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i http://petstore.swagger.io/v2/swagger.json -l bash -o generated/bash/petstore -c modules/swagger-codegen/src/test/resources/2_0/bash-config.json
 
-$ chmod +x output/petstore-cli
+$ chmod +x generated/bash/petstore/petstore-cli
 ```
 
 Enjoy:
 ```shell
-$ output/petstore-cli -h
+$ cd generated/bash/petstore
+$ ./petstore-cli -h
 
 Swagger Petstore command line client (API version 1.0.0)
 

--- a/modules/swagger-codegen/src/main/resources/bash/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/bash/client.mustache
@@ -292,7 +292,7 @@ body_parameters_to_json() {
         if [[ $count -lt $body_parameter_count-1 ]]; then
             body_json+=", "
         fi
-        count+=1
+        ((count+=1))
     done
     body_json+="}'"
 
@@ -362,7 +362,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+="&"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         elif [[ "${operation_parameters_collection_type["${operation}:::${qparam}"]}" == "multi" ]]; then
             local vcount=0
@@ -372,7 +372,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+="&"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         elif [[ "${operation_parameters_collection_type["${operation}:::${qparam}"]}" == "csv" ]]; then
             path_template+="${qparam}="
@@ -383,7 +383,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+=","
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         elif [[ "${operation_parameters_collection_type["${operation}:::${qparam}"]}" == "ssv" ]]; then
             path_template+="${qparam}="
@@ -393,7 +393,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+=" "
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         elif [[ "${operation_parameters_collection_type["${operation}:::${qparam}"]}" == "tsv" ]]; then
             path_template+="${qparam}="
@@ -403,7 +403,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+="\t"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         else
             echo -e ""
@@ -416,7 +416,7 @@ validate_request_parameters() {
         if [[ $count -lt $query_parameter_count-1 ]]; then
             path_template+="&"
         fi
-        count+=1
+        ((count+=1))
     done
 
 }
@@ -484,7 +484,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+="&"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         #
         # Append parameters specified as 'mutli' collections i.e. param=value1&param=value2&...
@@ -497,7 +497,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+="&"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         #
         # Append parameters specified as 'csv' collections i.e. param=value1,value2,...
@@ -511,7 +511,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+=","
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         #
         # Append parameters specified as 'ssv' collections i.e. param="value1 value2 ..."
@@ -525,7 +525,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+=" "
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         #
         # Append parameters specified as 'tsv' collections i.e. param="value1\tvalue2\t..."
@@ -539,7 +539,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+="\t"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         fi
 
@@ -551,8 +551,7 @@ build_request_path() {
             query_request_part+="&"
         fi
 
-        count+=1
-
+        ((count+=1))
     done
 
 

--- a/samples/client/petstore/bash/Dockerfile
+++ b/samples/client/petstore/bash/Dockerfile
@@ -1,0 +1,61 @@
+FROM ubuntu:16.10
+
+RUN apt-get update -y && apt-get full-upgrade -y
+RUN apt-get install -y bash-completion zsh curl cowsay git vim bsdmainutils
+
+ADD petstore-cli /usr/bin/petstore-cli
+ADD _petstore-cli /usr/local/share/zsh/site-functions/_petstore-cli
+ADD petstore-cli.bash-completion /etc/bash-completion.d/petstore-cli
+RUN chmod 755 /usr/bin/petstore-cli
+
+#
+# Install oh-my-zsh
+#
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" || true
+
+#
+# Enable bash completion
+#
+RUN echo '\n\
+. /etc/bash_completion\n\
+source /etc/bash-completion.d/petstore-cli\n\
+' >> ~/.bashrc
+
+#
+# Setup prompt
+#
+RUN echo 'export PS1="[Swagger Petstore] \$ "' >> ~/.bashrc
+RUN echo 'export PROMPT="[Swagger Petstore] \$ "' >> ~/.zshrc
+
+#
+# Setup a welcome message with basic instruction
+#
+RUN echo 'cat << EOF\n\
+\n\
+This Docker provides preconfigured environment for running the command\n\
+line REST client for $(tput setaf 6)Swagger Petstore$(tput sgr0).\n\
+\n\
+For convenience, you can export the following environment variables:\n\
+\n\
+$(tput setaf 3)PETSTORE_HOST$(tput sgr0) - server URL, e.g. https://example.com:8080\n\
+$(tput setaf 3)PETSTORE_API_KEY$(tput sgr0) - access token, e.g. "ASDASHJDG63456asdASSD"\n\
+$(tput setaf 3)PETSTORE_BASIC_AUTH$(tput sgr0) - basic authentication credentials, e.g.: "username:password"\n\
+\n\
+$(tput setaf 7)Basic usage:$(tput sgr0)\n\
+\n\
+$(tput setaf 3)Print the list of operations available on the service$(tput sgr0)\n\
+$ petstore-cli -h\n\
+\n\
+$(tput setaf 3)Print the service description$(tput sgr0)\n\
+$ petstore-cli --about\n\
+\n\
+$(tput setaf 3)Print detailed information about specific operation$(tput sgr0)\n\
+$ petstore-cli <operationId> -h\n\
+\n\
+By default you are logged into Zsh with full autocompletion for your REST API,\n\
+but you can switch to Bash, where basic autocompletion is also supported.\n\
+\n\
+EOF\n\
+' | tee -a ~/.bashrc ~/.zshrc
+
+ENTRYPOINT ["zsh"]

--- a/samples/client/petstore/bash/_petstore-cli
+++ b/samples/client/petstore/bash/_petstore-cli
@@ -10,7 +10,7 @@
 # !
 # ! Based on: https://github.com/Valodim/zsh-curl-completion/blob/master/_curl
 # !
-# ! Generated on: 2017-02-06T21:48:13.013+01:00
+# ! Generated on: 2017-02-22T08:48:10.130+01:00
 # !
 # !
 # ! Installation:

--- a/samples/client/petstore/bash/petstore-cli
+++ b/samples/client/petstore/bash/petstore-cli
@@ -8,7 +8,7 @@
 # ! swagger-codegen (https://github.com/swagger-api/swagger-codegen)
 # ! FROM SWAGGER SPECIFICATION IN JSON.
 # !
-# ! Generated on: 2017-02-06T21:48:13.013+01:00
+# ! Generated on: 2017-02-22T08:48:10.130+01:00
 # !
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -234,7 +234,7 @@ declare -A body_parameters
 
 ##
 # These arguments will be directly passed to cURL
-curl_arguments=""
+curl_arguments="-sS --tlsv1.2"
 
 ##
 # The host for making the request
@@ -387,7 +387,7 @@ body_parameters_to_json() {
         if [[ $count -lt $body_parameter_count-1 ]]; then
             body_json+=", "
         fi
-        count+=1
+        ((count+=1))
     done
     body_json+="}'"
 
@@ -457,7 +457,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+="&"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         elif [[ "${operation_parameters_collection_type["${operation}:::${qparam}"]}" == "multi" ]]; then
             local vcount=0
@@ -467,7 +467,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+="&"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         elif [[ "${operation_parameters_collection_type["${operation}:::${qparam}"]}" == "csv" ]]; then
             path_template+="${qparam}="
@@ -478,7 +478,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+=","
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         elif [[ "${operation_parameters_collection_type["${operation}:::${qparam}"]}" == "ssv" ]]; then
             path_template+="${qparam}="
@@ -488,7 +488,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+=" "
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         elif [[ "${operation_parameters_collection_type["${operation}:::${qparam}"]}" == "tsv" ]]; then
             path_template+="${qparam}="
@@ -498,7 +498,7 @@ validate_request_parameters() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     path_template+="\t"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         else
             echo -e ""
@@ -511,7 +511,7 @@ validate_request_parameters() {
         if [[ $count -lt $query_parameter_count-1 ]]; then
             path_template+="&"
         fi
-        count+=1
+        ((count+=1))
     done
 
 }
@@ -579,7 +579,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+="&"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         #
         # Append parameters specified as 'mutli' collections i.e. param=value1&param=value2&...
@@ -592,7 +592,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+="&"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         #
         # Append parameters specified as 'csv' collections i.e. param=value1,value2,...
@@ -606,7 +606,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+=","
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         #
         # Append parameters specified as 'ssv' collections i.e. param="value1 value2 ..."
@@ -620,7 +620,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+=" "
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         #
         # Append parameters specified as 'tsv' collections i.e. param="value1\tvalue2\t..."
@@ -634,7 +634,7 @@ build_request_path() {
                 if [[ $vcount -lt ${#parameter_values[@]}-1 ]]; then
                     parameter_value+="\t"
                 fi
-                vcount+=1
+                ((vcount+=1))
             done
         fi
 
@@ -646,8 +646,7 @@ build_request_path() {
             query_request_part+="&"
         fi
 
-        count+=1
-
+        ((count+=1))
     done
 
 

--- a/samples/client/petstore/bash/petstore-cli.bash-completion
+++ b/samples/client/petstore/bash/petstore-cli.bash-completion
@@ -8,7 +8,7 @@
 # ! swagger-codegen (https://github.com/swagger-api/swagger-codegen)
 # ! FROM SWAGGER SPECIFICATION IN JSON.
 # !
-# ! Generated on: 2017-02-06T21:48:13.013+01:00
+# ! Generated on: 2017-02-22T08:48:10.130+01:00
 # !
 # !
 # ! System wide installation:

--- a/samples/client/petstore/bash/tests/petstore_test.sh
+++ b/samples/client/petstore/bash/tests/petstore_test.sh
@@ -22,6 +22,18 @@ export PETSTORE_HOST="http://petstore.swagger.io"
     [[ "$output" =~ "Error: Request's content-type not specified!" ]]
 }
 
+@test "addPet abbreviated content type" {
+    run bash $PETSTORE_CLI -ct json -ac xml --host $PETSTORE_HOST \
+        addPet id:=123321 name==lucky status==available --dry-run
+    [[ "$output" =~ "Content-type: application/json" ]]
+}
+
+@test "addPet unabbreviated content type" {
+    run bash $PETSTORE_CLI -ct userdefined/custom -ac xml --host $PETSTORE_HOST \
+        addPet id:=123321 name==lucky status==available --dry-run
+    [[ "$output" =~ "Content-type: userdefined/custom" ]]
+}
+
 @test "fakeOperation invalid operation name" {
     run bash \
         -c "bash $PETSTORE_CLI --host http://petstore.swagger.io fakeOperation"
@@ -46,8 +58,11 @@ export PETSTORE_HOST="http://petstore.swagger.io"
     [[ ! "$output" =~ "-H \"api_key:" ]]
 }
 
-
-
+@test "findPetsByStatus has default cURL parameters" {
+    run bash \
+        -c "bash $PETSTORE_CLI --host http://petstore.swagger.io findPetsByStatus status=s1 --dry-run"
+    [[ ! "$output" =~ " -Ss " ]]
+}
 
 @test "findPetsByStatus too few values" {
     run bash \
@@ -97,6 +112,3 @@ export PETSTORE_HOST="http://petstore.swagger.io"
             bash $PETSTORE_CLI -ct json -ac xml addPet -"
     [[ "$output" =~ "<id>37567</id>" ]]
 }
-
-
-


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

@wing328 

I've added some further minor bugfixes to the Bash generator:

* Fixed passing of default cURL options from config options to generated Bash client
* Fixed generation of JSON body from command line arguments
* Added some more Bats test cases
* Updated README file in the Bash codegen module to use swagger-api default build instructions
* Fixed generated Dockerfile with proper access rights to client Bash script