### PR TITLE
Added include to qt5cpp to fix library compile

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -5,6 +5,7 @@
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonValue>
+#include <QDateTime>
 
 namespace Swagger {
 


### PR DESCRIPTION
While creating a static library from the generated files, compilation issues arose due to QDateTime only being forward declared. Adding the include resolves the issue.

This is my proposed fix for #4833 