### PR TITLE
Encode form paramerers properly

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -2,18 +2,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['superagent'], factory);
+    define(['superagent', 'querystring'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('superagent'));
+    module.exports = factory(require('superagent'), require('querystring'));
   } else {
     // Browser globals (root is window)
     if (!root.{{moduleName}}) {
       root.{{moduleName}} = {};
     }
-    root.{{moduleName}}.ApiClient = factory(root.superagent);
+    root.{{moduleName}}.ApiClient = factory(root.superagent, root.querystring);
   }
-}(this, function(superagent) {
+}(this, function(superagent, querystring) {
   'use strict';
 
 {{#emitJSDoc}}  /**
@@ -383,7 +383,7 @@
     }
 
     if (contentType === 'application/x-www-form-urlencoded') {
-      request.send(this.normalizeParams(formParams));
+      request.send(querystring.stringify(this.normalizeParams(formParams)));
     } else if (contentType == 'multipart/form-data') {
       var _formParams = this.normalizeParams(formParams);
       for (var key in _formParams) {

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -14,18 +14,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['superagent'], factory);
+    define(['superagent', 'querystring'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('superagent'));
+    module.exports = factory(require('superagent'), require('querystring'));
   } else {
     // Browser globals (root is window)
     if (!root.SwaggerPetstore) {
       root.SwaggerPetstore = {};
     }
-    root.SwaggerPetstore.ApiClient = factory(root.superagent);
+    root.SwaggerPetstore.ApiClient = factory(root.superagent, root.querystring);
   }
-}(this, function(superagent) {
+}(this, function(superagent, querystring) {
   'use strict';
 
   /**
@@ -386,7 +386,7 @@
     }
 
     if (contentType === 'application/x-www-form-urlencoded') {
-      request.send(this.normalizeParams(formParams));
+      request.send(querystring.stringify(this.normalizeParams(formParams)));
     } else if (contentType == 'multipart/form-data') {
       var _formParams = this.normalizeParams(formParams);
       for (var key in _formParams) {


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Superagent doesn't encode form parameters properly. For example it doesn't encode objects which contain array. The following is a failed test case:
```
var my_opts = {
  'storyId': 65441,
  'id': [56, 352]
};
```

