### PR TITLE
Remove maven-api dependencies on swagger-codegen module

### DIFF
--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -225,16 +225,6 @@
             <version>${commons-io-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-tools-api</artifactId>
-            <version>2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>maven-bundle-plugin</artifactId>
-            <version>${felix-version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
             <version>${slf4j-version}</version>

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
@@ -20,6 +20,8 @@ import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +108,7 @@ public class XmlExampleGenerator {
         for (String pName : elements.keySet()) {
             Property p = elements.get(pName);
             final String asXml = toXml(pName, p, indent + 1, selfPath);
-            if (asXml == null || "".equals(asXml)) {
+            if (StringUtils.isEmpty(asXml)) {
                 continue;
             }
             sb.append(asXml);
@@ -143,7 +145,7 @@ public class XmlExampleGenerator {
                     prefix = NEWLINE;
                 }
                 final String asXml = toXml(name, inner, indent + 1, path);
-                if (asXml != null && !"".equals(asXml)) {
+                if (StringUtils.isNotEmpty(asXml)) {
                     sb.append(prefix).append(asXml);
                 }
                 if (name != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/examples/XmlExampleGenerator.java
@@ -20,8 +20,6 @@ import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 
-import org.codehaus.plexus.util.StringUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +106,7 @@ public class XmlExampleGenerator {
         for (String pName : elements.keySet()) {
             Property p = elements.get(pName);
             final String asXml = toXml(pName, p, indent + 1, selfPath);
-            if (StringUtils.isEmpty(asXml)) {
+            if (asXml == null || "".equals(asXml)) {
                 continue;
             }
             sb.append(asXml);
@@ -145,7 +143,7 @@ public class XmlExampleGenerator {
                     prefix = NEWLINE;
                 }
                 final String asXml = toXml(name, inner, indent + 1, path);
-                if (StringUtils.isNotEmpty(asXml)) {
+                if (asXml != null && !"".equals(asXml)) {
                     sb.append(prefix).append(asXml);
                 }
                 if (name != null) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] (doesn't really apply here..) Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Reduce maven dependencies for swagger-codegen artefact, to make it easier to use it outside of a maven-plugin context.

See http://mvnrepository.com/artifact/io.swagger/swagger-codegen/2.2.1
`org.apache.felix:maven-bundle-plugin` and `org.apache.maven:maven-plugin-tools-api` should be obsolete.