### PR TITLE
Added csharp Configuration = {{packageName}}.Client.Configuration using clause

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/README.mustache
@@ -49,6 +49,7 @@ Then include the DLL (under the `bin` folder) in the C# project, and use the nam
 ```csharp
 using {{packageName}}.{{apiPackage}};
 using {{packageName}}.Client;
+using Configuration = {{packageName}}.Configuration;
 using {{packageName}}.{{modelPackage}};
 ```
 

--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using RestSharp;
 using {{packageName}}.Client;
+using Configuration = {{packageName}}.Client.Configuration;
 {{#hasImport}}using {{packageName}}.{{modelPackage}};
 {{/hasImport}}
 

--- a/modules/swagger-codegen/src/main/resources/csharp/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api_doc.mustache
@@ -25,6 +25,7 @@ using System.Diagnostics;
 using {{packageName}}.{{apiPackage}};
 using {{packageName}}.Client;
 using {{packageName}}.{{modelPackage}};
+using Configuration = {{packageName}}.Client.Configuration;
 
 namespace Example
 {

--- a/modules/swagger-codegen/src/main/resources/csharp/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api_test.mustache
@@ -10,6 +10,7 @@ using NUnit.Framework;
 
 using {{packageName}}.Client;
 using {{packageName}}.{{apiPackage}};
+using Configuration = {{packageName}}.Configuration;
 {{#hasImport}}using {{packageName}}.{{modelPackage}};
 {{/hasImport}}
 

--- a/modules/swagger-codegen/src/main/resources/csharp/model_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/model_test.mustache
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using {{packageName}}.{{apiPackage}};
 using {{packageName}}.{{modelPackage}};
 using {{packageName}}.Client;
+using Configuration = {{packageName}}.Client.Configuration;
 using System.Reflection;
 
 {{#models}}


### PR DESCRIPTION
Added csharp Configuration = {{packageName}}.Client.Configuration using clause. This allows the models to include a class called Configuration. This change could be done by fully specifying the location of the Configuration class each time its referenced, however this would mean a number of updates through out the mustache files, and for developers to remember each subsequent update. 

Tested against the petstore example. Generation works and resulting client compiles. 