### PR TITLE
[PHP] fixed ApiException's methods return types

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ApiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiException.mustache
@@ -55,12 +55,12 @@ class ApiException extends Exception
     /**
      * Constructor
      *
-     * @param string $message         Error message
-     * @param int    $code            HTTP status code
-     * @param string $responseHeaders HTTP response header
-     * @param mixed  $responseBody    HTTP body of the server response either as Json or string
+     * @param string   $message         Error message
+     * @param int      $code            HTTP status code
+     * @param string[] $responseHeaders HTTP response header
+     * @param mixed    $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = null, $responseBody = null)
+    public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -70,7 +70,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string HTTP response header
+     * @return string[] HTTP response headers
      */
     public function getResponseHeaders()
     {
@@ -80,7 +80,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP body of the server response either as Json or string
      *
-     * @return mixed HTTP body of the server response either as Json or string
+     * @return mixed HTTP body of the server response either as \stdClass or string
      */
     public function getResponseBody()
     {

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/lib/ApiException.php
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/lib/ApiException.php
@@ -65,12 +65,12 @@ class ApiException extends Exception
     /**
      * Constructor
      *
-     * @param string $message         Error message
-     * @param int    $code            HTTP status code
-     * @param string $responseHeaders HTTP response header
-     * @param mixed  $responseBody    HTTP body of the server response either as Json or string
+     * @param string   $message         Error message
+     * @param int      $code            HTTP status code
+     * @param string[] $responseHeaders HTTP response header
+     * @param mixed    $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = null, $responseBody = null)
+    public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -80,7 +80,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string HTTP response header
+     * @return string[] HTTP response headers
      */
     public function getResponseHeaders()
     {
@@ -90,7 +90,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP body of the server response either as Json or string
      *
-     * @return mixed HTTP body of the server response either as Json or string
+     * @return mixed HTTP body of the server response either as \stdClass or string
      */
     public function getResponseBody()
     {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ApiException.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ApiException.php
@@ -65,12 +65,12 @@ class ApiException extends Exception
     /**
      * Constructor
      *
-     * @param string $message         Error message
-     * @param int    $code            HTTP status code
-     * @param string $responseHeaders HTTP response header
-     * @param mixed  $responseBody    HTTP body of the server response either as Json or string
+     * @param string   $message         Error message
+     * @param int      $code            HTTP status code
+     * @param string[] $responseHeaders HTTP response header
+     * @param mixed    $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = null, $responseBody = null)
+    public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -80,7 +80,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP response header
      *
-     * @return string HTTP response header
+     * @return string[] HTTP response headers
      */
     public function getResponseHeaders()
     {
@@ -90,7 +90,7 @@ class ApiException extends Exception
     /**
      * Gets the HTTP body of the server response either as Json or string
      *
-     * @return mixed HTTP body of the server response either as Json or string
+     * @return mixed HTTP body of the server response either as \stdClass or string
      */
     public function getResponseBody()
     {

--- a/samples/client/petstore/php/test.php
+++ b/samples/client/petstore/php/test.php
@@ -55,7 +55,7 @@ try {
 
 } catch (Swagger\Client\ApiException $e) {
     echo 'Caught exception: ', $e->getMessage(), "\n";
-    echo 'HTTP response headers: ', $e->getResponseHeaders(), "\n";
-    echo 'HTTP response body: ', $e->getResponseBody(), "\n";
+    echo 'HTTP response headers: ', print_r($e->getResponseHeaders(), true), "\n";
+    echo 'HTTP response body: ', print_r($e->getResponseBody(), true), "\n";
     echo 'HTTP status code: ', $e->getCode(), "\n";
 }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Hi. This PR fixes minor errors in `test.php` file which where caused by different types returned than expected. Preview:
```
/usr/bin/php /home/bbialek/projects/swagger-codegen/samples/client/petstore/php/test.php
PHP SDK (Swagger\Client) Debug Report:
    OS: Linux bbialek-HP-EliteDesk-800-G1-SFF 4.4.0-62-generic #83-Ubuntu SMP Wed Jan 18 14:10:15 UTC 2017 x86_64
    PHP Version: 7.0.13-0ubuntu0.16.04.1
    OpenAPI Spec Version: 1.0.0
    Temp Folder Path: /tmp
PHP Notice:  Array to string conversion in /home/bbialek/projects/swagger-codegen/samples/client/petstore/php/test.php on line 58
PHP Stack trace:
PHP   1. {main}() /home/bbialek/projects/swagger-codegen/samples/client/petstore/php/test.php:0
PHP Catchable fatal error:  Object of class stdClass could not be converted to string in /home/bbialek/projects/swagger-codegen/samples/client/petstore/php/test.php on line 59
PHP Stack trace:
PHP   1. {main}() /home/bbialek/projects/swagger-codegen/samples/client/petstore/php/test.php:0
Caught exception: [404] Error connecting to the API (http://petstore.swagger.io/v2/pet/10005)
HTTP response headers: Array
HTTP response body: 
Process finished with exit code 255
```

After fix: 
```
/usr/bin/php /home/bbialek/projects/swagger-codegen/samples/client/petstore/php/test.php
PHP SDK (Swagger\Client) Debug Report:
    OS: Linux bbialek-HP-EliteDesk-800-G1-SFF 4.4.0-62-generic #83-Ubuntu SMP Wed Jan 18 14:10:15 UTC 2017 x86_64
    PHP Version: 7.0.13-0ubuntu0.16.04.1
    OpenAPI Spec Version: 1.0.0
    Temp Folder Path: /tmp
Caught exception: [404] Error connecting to the API (http://petstore.swagger.io/v2/pet/10005)
HTTP response headers: Array
(
    [0] => HTTP/1.1 404 Not Found
    [Date] => Thu, 23 Feb 2017 09:38:59 GMT
    [Access-Control-Allow-Origin] => *
    [Access-Control-Allow-Methods] => GET, POST, DELETE, PUT
    [Access-Control-Allow-Headers] => Content-Type, api_key, Authorization
    [Content-Type] => application/json
    [Connection] => close
    [Server] => Jetty(9.2.9.v20150224)
)

HTTP response body: stdClass Object
(
    [code] => 1
    [type] => error
    [message] => Pet not found
)

HTTP status code: 404

Process finished with exit code 0
```


I also updated return types in ApiException template to match what is really passed there in generated `ApiClient` class: https://github.com/swagger-api/swagger-codegen/blob/master/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php#L283