### PR TITLE
Port the optional/enum template logic from async-scala to the regular scala client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/model.mustache
@@ -12,29 +12,9 @@ case class {{classname}} (
   {{#description}}
   /* {{{description}}} */
   {{/description}}
-  {{{name}}}: {{^required}}Option[{{/required}}{{^isEnum}}{{datatype}}{{/isEnum}}{{#isEnum}}{{classname}}Enums.{{datatypeWithEnum}}{{/isEnum}}{{^required}}]{{/required}}{{#hasMore}},{{/hasMore}}
+  {{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}]{{/required}}{{#hasMore}},{{/hasMore}}
   {{/vars}}
 )
 
-{{#hasEnums}}
-object {{classname}}Enums {
-
-  {{#vars}}
-  {{#isEnum}}
-  type {{datatypeWithEnum}} = {{datatypeWithEnum}}.Value
-  {{/isEnum}}
-  {{/vars}}
-  {{#vars}}
-  {{#isEnum}}
-  object {{datatypeWithEnum}} extends Enumeration {
-{{#_enum}}
-    val {{#fnEnumEntry}}{{.}}{{/fnEnumEntry}} = Value("{{.}}")
-{{/_enum}}
-  }
-
-  {{/isEnum}}
-  {{/vars}}
-}
-{{/hasEnums}}
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/scala/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/model.mustache
@@ -12,8 +12,29 @@ case class {{classname}} (
   {{#description}}
   /* {{{description}}} */
   {{/description}}
-  {{name}}: {{{datatype}}}{{#hasMore}},{{/hasMore}}
+  {{{name}}}: {{^required}}Option[{{/required}}{{^isEnum}}{{datatype}}{{/isEnum}}{{#isEnum}}{{classname}}Enums.{{datatypeWithEnum}}{{/isEnum}}{{^required}}]{{/required}}{{#hasMore}},{{/hasMore}}
   {{/vars}}
 )
+
+{{#hasEnums}}
+object {{classname}}Enums {
+
+  {{#vars}}
+  {{#isEnum}}
+  type {{datatypeWithEnum}} = {{datatypeWithEnum}}.Value
+  {{/isEnum}}
+  {{/vars}}
+  {{#vars}}
+  {{#isEnum}}
+  object {{datatypeWithEnum}} extends Enumeration {
+{{#_enum}}
+    val {{#fnEnumEntry}}{{.}}{{/fnEnumEntry}} = Value("{{.}}")
+{{/_enum}}
+  }
+
+  {{/isEnum}}
+  {{/vars}}
+}
+{{/hasEnums}}
 {{/model}}
 {{/models}}

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/ApiResponse.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/ApiResponse.scala
@@ -14,7 +14,8 @@ package io.swagger.client.model
 
 
 case class ApiResponse (
-  code: Integer,
-  _type: String,
-  message: String
+  code: Option[Integer],
+  _type: Option[String],
+  message: Option[String]
 )
+

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Category.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Category.scala
@@ -14,6 +14,7 @@ package io.swagger.client.model
 
 
 case class Category (
-  id: Long,
-  name: String
+  id: Option[Long],
+  name: Option[String]
 )
+

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Order.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Order.scala
@@ -20,17 +20,7 @@ case class Order (
   quantity: Option[Integer],
   shipDate: Option[DateTime],
   /* Order Status */
-  status: Option[OrderEnums.StatusEnum],
+  status: Option[String],
   complete: Option[Boolean]
 )
 
-object OrderEnums {
-
-  type StatusEnum = StatusEnum.Value
-  object StatusEnum extends Enumeration {
-    val  = Value("placed")
-    val  = Value("approved")
-    val  = Value("delivered")
-  }
-
-}

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Order.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Order.scala
@@ -15,11 +15,22 @@ package io.swagger.client.model
 import org.joda.time.DateTime
 
 case class Order (
-  id: Long,
-  petId: Long,
-  quantity: Integer,
-  shipDate: DateTime,
+  id: Option[Long],
+  petId: Option[Long],
+  quantity: Option[Integer],
+  shipDate: Option[DateTime],
   /* Order Status */
-  status: String,
-  complete: Boolean
+  status: Option[OrderEnums.StatusEnum],
+  complete: Option[Boolean]
 )
+
+object OrderEnums {
+
+  type StatusEnum = StatusEnum.Value
+  object StatusEnum extends Enumeration {
+    val  = Value("placed")
+    val  = Value("approved")
+    val  = Value("delivered")
+  }
+
+}

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala
@@ -14,11 +14,22 @@ package io.swagger.client.model
 
 
 case class Pet (
-  id: Long,
-  category: Category,
+  id: Option[Long],
+  category: Option[Category],
   name: String,
   photoUrls: List[String],
-  tags: List[Tag],
+  tags: Option[List[Tag]],
   /* pet status in the store */
-  status: String
+  status: Option[PetEnums.StatusEnum]
 )
+
+object PetEnums {
+
+  type StatusEnum = StatusEnum.Value
+  object StatusEnum extends Enumeration {
+    val  = Value("available")
+    val  = Value("pending")
+    val  = Value("sold")
+  }
+
+}

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala
@@ -20,16 +20,6 @@ case class Pet (
   photoUrls: List[String],
   tags: Option[List[Tag]],
   /* pet status in the store */
-  status: Option[PetEnums.StatusEnum]
+  status: Option[String]
 )
 
-object PetEnums {
-
-  type StatusEnum = StatusEnum.Value
-  object StatusEnum extends Enumeration {
-    val  = Value("available")
-    val  = Value("pending")
-    val  = Value("sold")
-  }
-
-}

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Tag.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Tag.scala
@@ -14,6 +14,7 @@ package io.swagger.client.model
 
 
 case class Tag (
-  id: Long,
-  name: String
+  id: Option[Long],
+  name: Option[String]
 )
+

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/User.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/User.scala
@@ -14,13 +14,14 @@ package io.swagger.client.model
 
 
 case class User (
-  id: Long,
-  username: String,
-  firstName: String,
-  lastName: String,
-  email: String,
-  password: String,
-  phone: String,
+  id: Option[Long],
+  username: Option[String],
+  firstName: Option[String],
+  lastName: Option[String],
+  email: Option[String],
+  password: Option[String],
+  phone: Option[String],
   /* User Status */
-  userStatus: Integer
+  userStatus: Option[Integer]
 )
+

--- a/samples/client/petstore/scala/src/test/scala/PetApiTest.scala
+++ b/samples/client/petstore/scala/src/test/scala/PetApiTest.scala
@@ -17,22 +17,22 @@ class PetApiTest extends FlatSpec with Matchers {
 
   it should "add and fetch a pet" in {
     val pet = Pet(
-      1000,
-      Category(1, "sold"),
+      Some(1000),
+      Some(Category(Some(1), Some("sold"))),
       "dragon",
       (for (i <- (1 to 10)) yield "http://foo.com/photo/" + i).toList,
-      (for (i <- (1 to 5)) yield io.swagger.client.model.Tag(i, "tag-" + i)).toList,
-      "lost"
+      Some((for (i <- (1 to 5)) yield io.swagger.client.model.Tag(Some(i), Some("tag-" + i))).toList),
+      Some("lost")
     )
 
     api.addPet(pet)
     api.getPetById(1000) match {
       case Some(pet) => {
-        pet.id should be(1000)
-        pet.tags.size should be(5)
-        pet.status should be("lost")
+        pet.id should be(Some(1000))
+        pet.tags.get.size should be(5)
+        pet.status should be(Some("lost"))
         pet.category should not be (null)
-        pet.category.name should be("sold")
+        pet.category.get.name should be(Some("sold"))
         pet.name should be("dragon")
         pet.photoUrls.size should be(10)
       }
@@ -42,12 +42,12 @@ class PetApiTest extends FlatSpec with Matchers {
 
   it should "update a pet" in {
     val pet = Pet(
-      1000,
-      Category(1, "sold"),
+      Some(1000),
+      Some(Category(Some(1), Some("sold"))),
       "programmer",
       (for (i <- (1 to 10)) yield "http://foo.com/photo/" + i).toList,
-      (for (i <- (1 to 5)) yield io.swagger.client.model.Tag(i, "tag-" + i)).toList,
-      "confused"
+      Some((for (i <- (1 to 5)) yield io.swagger.client.model.Tag(Some(i), Some("tag-" + i))).toList),
+      Some("confused")
     )
 
     api.addPet(pet)
@@ -55,16 +55,16 @@ class PetApiTest extends FlatSpec with Matchers {
     api.getPetById(1000) match {
       case Some(pet) => {
         pet.name should be("programmer")
-        pet.status should be("confused")
+        pet.status should be(Some("confused"))
       }
       case None => fail("didn't find pet created")
     }
-    val updatedPet = pet.copy(status = "fulfilled")
+    val updatedPet = pet.copy(status = Some("fulfilled"))
     api.updatePet(updatedPet)
     api.getPetById(1000) match {
       case Some(pet) => {
         pet.name should be("programmer")
-        pet.status should be("fulfilled")
+        pet.status should be(Some("fulfilled"))
       }
       case None => fail("didn't find pet updated")
     }
@@ -83,8 +83,8 @@ class PetApiTest extends FlatSpec with Matchers {
     api.findPetsByTags(List("tag1", "tag2")) match {
       case Some(pets) => {
         pets.foreach(pet => {
-          val tags = (for (tag <- pet.tags) yield tag.name).toSet
-          if ((tags & Set("tag1", "tag2")).size == 0)
+          val tags = (for (tag <- pet.tags.get) yield tag.name).toSet
+                       if ((tags & Set(Some("tag1"), Some("tag2"))).size == 0)
             fail("unexpected tags in " + tags)
         })
       }

--- a/samples/client/petstore/scala/src/test/scala/StoreApiTest.scala
+++ b/samples/client/petstore/scala/src/test/scala/StoreApiTest.scala
@@ -20,22 +20,22 @@ class StoreApiTest extends FlatSpec with Matchers {
   it should "place and fetch an order" in {
     val now = new org.joda.time.DateTime
     val order = Order(
-      petId = 10,
-      id = 1000,
-      quantity = 101,
-      status = "pending",
-      shipDate = now,
-      complete = true)
+      petId = Some(10),
+      id = Some(1000),
+      quantity = Some(101),
+      status = Some("pending"),
+      shipDate = Some(now),
+      complete = Some(true))
 
     api.placeOrder(order)
 
     api.getOrderById(1000) match {
       case Some(order) => {
-        order.id should be(1000)
-        order.petId should be(10)
-        order.quantity should be(101)
+        order.id should be(Some(1000))
+        order.petId should be(Some(10))
+        order.quantity should be(Some(101))
         // use `getMillis` to compare across timezones
-        order.shipDate.getMillis.equals(now.getMillis) should be(true)
+        order.shipDate.get.getMillis.equals(now.getMillis) should be(true)
       }
       case None => fail("didn't find order created")
     }
@@ -44,17 +44,17 @@ class StoreApiTest extends FlatSpec with Matchers {
   it should "delete an order" in {
     val now = new org.joda.time.DateTime
     val order = Order(
-      id = 1001,
-      petId = 10,
-      quantity = 101,
-      status = "pending",
-      shipDate = now,
-      complete = true)
+      id = Some(1001),
+      petId = Some(10),
+      quantity = Some(101),
+      status = Some("pending"),
+      shipDate = Some(now),
+      complete = Some(true))
 
     api.placeOrder(order)
 
     api.getOrderById(1001) match {
-      case Some(order) => order.id should be(1001)
+      case Some(order) => order.id should be(Some(1001))
       case None => fail("didn't find order created")
     }
 

--- a/samples/client/petstore/scala/src/test/scala/UserApiTest.scala
+++ b/samples/client/petstore/scala/src/test/scala/UserApiTest.scala
@@ -19,14 +19,14 @@ class UserApiTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   // preparation before running a test
   override def beforeAll() {
     val user = User(
-      11222,
-      "scala-test-username",
-      "scala-test-first",
-      "scala-test-last",
-      "scala_test@fail.com",
-      "SCALATEST",
-      "408-867-5309",
-      1)
+      Some(11222),
+      Some("scala-test-username"),
+      Some("scala-test-first"),
+      Some("scala-test-last"),
+      Some("scala_test@fail.com"),
+      Some("SCALATEST"),
+      Some("408-867-5309"),
+      Some(1))
 
     api.createUser(user)
   }
@@ -39,14 +39,14 @@ class UserApiTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "fetch a user" in {
     api.getUserByName("scala-test-username") match {
       case Some(user) => {
-        user.id should be(11222)
-        user.username should be("scala-test-username")
-        user.password should be("SCALATEST")
-        user.email should be("scala_test@fail.com")
-        user.firstName should be("scala-test-first")
-        user.lastName should be("scala-test-last")
-        user.phone should be("408-867-5309")
-        user.userStatus should be(1)
+        user.id should be(Some(11222))
+        user.username should be(Some("scala-test-username"))
+        user.password should be(Some("SCALATEST"))
+        user.email should be(Some("scala_test@fail.com"))
+        user.firstName should be(Some("scala-test-first"))
+        user.lastName should be(Some("scala-test-last"))
+        user.phone should be(Some("408-867-5309"))
+        user.userStatus should be(Some(1))
       }
       case None =>
     }
@@ -69,22 +69,22 @@ class UserApiTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "create 2 users" in {
     val userArray = (for (i <- (1 to 2)) yield {
       User(
-        2000 + i,
-        "johnny-" + i,
-        "Johnny",
-        "Rocket-" + i,
-        "johnny-" + i + "@fail.com",
-        "XXXXXXXXXXX",
-        "408-867-5309",
-        1)
+        Some(2000 + i),
+        Some("johnny-" + i),
+        Some("Johnny"),
+        Some("Rocket-" + i),
+        Some("johnny-" + i + "@fail.com"),
+        Some("XXXXXXXXXXX"),
+        Some("408-867-5309"),
+        Some(1))
     }).toList
     api.createUsersWithArrayInput(userArray)
 
     for (i <- (1 to 2)) {
       api.getUserByName("johnny-" + i) match {
         case Some(user) => {
-          user.id should be(2000 + i)
-          user.email should be("johnny-" + i + "@fail.com")
+          user.id should be(Some(2000 + i))
+          user.email should be(Some("johnny-" + i + "@fail.com"))
         }
         case None => fail("didn't find user " + i)
       }
@@ -94,22 +94,22 @@ class UserApiTest extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "create 3 users" in {
     val userList = (for (i <- (1 to 3)) yield {
       User(
-        3000 + i,
-        "fred-" + i,
-        "Johnny",
-        "Rocket-" + i,
-        "fred-" + i + "@fail.com",
-        "XXXXXXXXXXX",
-        "408-867-5309",
-        1)
+        Some(3000 + i),
+        Some("fred-" + i),
+        Some("Johnny"),
+        Some("Rocket-" + i),
+        Some("fred-" + i + "@fail.com"),
+        Some("XXXXXXXXXXX"),
+        Some("408-867-5309"),
+        Some(1))
     }).toList
     api.createUsersWithListInput(userList)
 
     for (i <- (1 to 3)) {
       api.getUserByName("fred-" + i) match {
         case Some(user) => {
-          user.id should be(3000 + i)
-          user.email should be("fred-" + i + "@fail.com")
+          user.id should be(Some(3000 + i))
+          user.email should be(Some("fred-" + i + "@fail.com"))
         }
         case None => fail("didn't find user " + i)
       }
@@ -118,31 +118,31 @@ class UserApiTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "update a user" in {
     val user = User(
-      4000,
-      "tony",
-      "Tony",
-      "Tiger",
-      "tony@fail.com",
-      "XXXXXXXXXXX",
-      "408-867-5309",
-      1)
+      Some(4000),
+      Some("tony"),
+      Some("Tony"),
+      Some("Tiger"),
+      Some("tony@fail.com"),
+      Some("XXXXXXXXXXX"),
+      Some("408-867-5309"),
+      Some(1))
 
     api.createUser(user)
 
     api.getUserByName("tony") match {
       case Some(user) => {
-        user.id should be(4000)
-        user.username should be("tony")
+        user.id should be(Some(4000))
+        user.username should be(Some("tony"))
       }
       case None =>
     }
 
-    val updatedUser = user.copy(email = "tony@succeed.com")
+    val updatedUser = user.copy(email = Some("tony@succeed.com"))
 
     api.updateUser("tony", updatedUser)
     api.getUserByName("tony") match {
       case Some(user) => {
-        user.email should be("tony@succeed.com")
+        user.email should be(Some("tony@succeed.com"))
       }
       case None =>
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Port the option and enum logic from the scala-async template into this one. What is considered a breaking change? This will certainly require anyone generating scala templates to update their code should they regenerate with this template, does that count as breaking? If so I'll recreate the PR onto the right branch.

I know that the plans are to merge the scala & async-scala generators, which project will be considered the main project? I initially tried using the async-scala generator and had some small issues, and switched to this generator just because it was easier to get working initially.

