### PR TITLE
[PHP] error when deserializing enums #4032

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -261,7 +261,8 @@ class ObjectSerializer
             return $deserialized;
         } elseif (method_exists($class, 'getAllowableEnumValues')) {
             if (!in_array($data, $class::getAllowableEnumValues())) {
-                throw new \InvalidArgumentException('invalid value provided');
+                $imploded = implode("', '", $class::getAllowableEnumValues());
+                throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'");
             }
             return $data;
         } else {

--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -49,10 +49,16 @@ class ObjectSerializer
             return $data;
         } elseif (is_object($data)) {
             $values = [];
-            foreach (array_keys($data::swaggerTypes()) as $property) {
+            foreach ($data::swaggerTypes() as $property => $swaggerType) {
                 $getter = $data::getters()[$property];
-                if ($data->$getter() !== null) {
-                    $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($data->$getter());
+                $value = $data->$getter();
+                if (method_exists($swaggerType, 'getAllowableEnumValues')
+                    && !in_array($value, $swaggerType::getAllowableEnumValues())) {
+                    $imploded = implode("', '", $swaggerType::getAllowableEnumValues());
+                    throw new \InvalidArgumentException("Invalid value for enum '$swaggerType', must be one of: '$imploded'");
+                }
+                if ($value !== null) {
+                    $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value);
                 }
             }
             return (object)$values;

--- a/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ObjectSerializer.mustache
@@ -259,6 +259,11 @@ class ObjectSerializer
             }
 
             return $deserialized;
+        } elseif (method_exists($class, 'getAllowableEnumValues')) {
+            if (!in_array($data, $class::getAllowableEnumValues())) {
+                throw new \InvalidArgumentException('invalid value provided');
+            }
+            return $data;
         } else {
             // If a discriminator is defined and points to a valid subclass, use it.
             $discriminator = $class::DISCRIMINATOR;

--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -20,8 +20,10 @@
  */
 
 namespace {{modelPackage}};
+{{^isEnum}}
 
 use \ArrayAccess;
+{{/isEnum}}
 
 /**
  * {{classname}} Class Doc Comment

--- a/modules/swagger-codegen/src/main/resources/php/model_enum.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_enum.mustache
@@ -1,18 +1,18 @@
 class {{classname}} {
+    /**
+     * Possible values of this enum
+     */
     {{#allowableValues}}{{#enumVars}}const {{{name}}} = {{{value}}};
     {{/enumVars}}{{/allowableValues}}
-
-    {{#vars}}{{#isEnum}}
     /**
      * Gets allowable values of the enum
      * @return string[]
      */
-    public function {{getter}}AllowableValues()
+    public function getAllowableEnumValues()
     {
         return [
-            {{#allowableValues}}{{#enumVars}}self::{{datatypeWithEnum}}_{{{name}}},{{^-last}}
+            {{#allowableValues}}{{#enumVars}}self::{{{name}}},{{^-last}}
             {{/-last}}{{/enumVars}}{{/allowableValues}}
         ];
     }
-    {{/isEnum}}{{/vars}}
 }

--- a/modules/swagger-codegen/src/main/resources/php/model_enum.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_enum.mustache
@@ -8,7 +8,7 @@ class {{classname}} {
      * Gets allowable values of the enum
      * @return string[]
      */
-    public function getAllowableEnumValues()
+    public static function getAllowableEnumValues()
     {
         return [
             {{#allowableValues}}{{#enumVars}}self::{{{name}}},{{^-last}}

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumClass.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumClass.php
@@ -29,8 +29,6 @@
 
 namespace Swagger\Client\Model;
 
-use \ArrayAccess;
-
 /**
  * EnumClass Class Doc Comment
  *
@@ -40,11 +38,24 @@ use \ArrayAccess;
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class EnumClass {
+    /**
+     * Possible values of this enum
+     */
     const ABC = '_abc';
     const EFG = '-efg';
     const XYZ = '(xyz)';
     
-
-    
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public function getAllowableEnumValues()
+    {
+        return [
+            self::ABC,
+            self::EFG,
+            self::XYZ,
+        ];
+    }
 }
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumClass.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumClass.php
@@ -49,7 +49,7 @@ class EnumClass {
      * Gets allowable values of the enum
      * @return string[]
      */
-    public function getAllowableEnumValues()
+    public static function getAllowableEnumValues()
     {
         return [
             self::ABC,
@@ -58,4 +58,5 @@ class EnumClass {
         ];
     }
 }
+
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterEnum.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterEnum.php
@@ -29,8 +29,6 @@
 
 namespace Swagger\Client\Model;
 
-use \ArrayAccess;
-
 /**
  * OuterEnum Class Doc Comment
  *
@@ -40,11 +38,24 @@ use \ArrayAccess;
  * @link        https://github.com/swagger-api/swagger-codegen
  */
 class OuterEnum {
+    /**
+     * Possible values of this enum
+     */
     const PLACED = 'placed';
     const APPROVED = 'approved';
     const DELIVERED = 'delivered';
     
-
-    
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public function getAllowableEnumValues()
+    {
+        return [
+            self::PLACED,
+            self::APPROVED,
+            self::DELIVERED,
+        ];
+    }
 }
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterEnum.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterEnum.php
@@ -49,7 +49,7 @@ class OuterEnum {
      * Gets allowable values of the enum
      * @return string[]
      */
-    public function getAllowableEnumValues()
+    public static function getAllowableEnumValues()
     {
         return [
             self::PLACED,
@@ -58,4 +58,5 @@ class OuterEnum {
         ];
     }
 }
+
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -59,10 +59,16 @@ class ObjectSerializer
             return $data;
         } elseif (is_object($data)) {
             $values = [];
-            foreach (array_keys($data::swaggerTypes()) as $property) {
+            foreach ($data::swaggerTypes() as $property => $swaggerType) {
                 $getter = $data::getters()[$property];
-                if ($data->$getter() !== null) {
-                    $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($data->$getter());
+                $value = $data->$getter();
+                if (method_exists($swaggerType, 'getAllowableEnumValues')
+                    && !in_array($value, $swaggerType::getAllowableEnumValues())) {
+                    $imploded = implode("', '", $swaggerType::getAllowableEnumValues());
+                    throw new \InvalidArgumentException("Invalid value for enum '$swaggerType', must be one of: '$imploded'");
+                }
+                if ($value !== null) {
+                    $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value);
                 }
             }
             return (object)$values;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -269,6 +269,11 @@ class ObjectSerializer
             }
 
             return $deserialized;
+        } elseif (method_exists($class, 'getAllowableEnumValues')) {
+            if (!in_array($data, $class::getAllowableEnumValues())) {
+                throw new \InvalidArgumentException('invalid value provided');
+            }
+            return $data;
         } else {
             // If a discriminator is defined and points to a valid subclass, use it.
             $discriminator = $class::DISCRIMINATOR;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ObjectSerializer.php
@@ -271,7 +271,8 @@ class ObjectSerializer
             return $deserialized;
         } elseif (method_exists($class, 'getAllowableEnumValues')) {
             if (!in_array($data, $class::getAllowableEnumValues())) {
-                throw new \InvalidArgumentException('invalid value provided');
+                $imploded = implode("', '", $class::getAllowableEnumValues());
+                throw new \InvalidArgumentException("Invalid value for enum '$class', must be one of: '$imploded'");
             }
             return $data;
         } else {

--- a/samples/client/petstore/php/SwaggerClient-php/tests/OuterEnumTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/OuterEnumTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Swagger\Client;
+
+use Swagger\Client\Model\EnumTest;
+use Swagger\Client\Model\OuterEnum;
+
+class OuterEnumTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDeserialize()
+    {
+        $result = ObjectSerializer::deserialize(
+            "placed",
+            OuterEnum::class
+        );
+
+        $this->assertInternalType('string', $result);
+        $this->assertEquals('placed', $result);
+    }
+
+    public function testDeserializeInvalidValue()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class, 'Invalid value for enum');
+
+        ObjectSerializer::deserialize(
+            "lkjfalgkdfjg",
+            OuterEnum::class
+        );
+    }
+
+    public function testDeserializeNested()
+    {
+        $json = '{
+            "enum_string": "UPPER",
+            "enum_integer": -1,
+            "enum_number": -1.2, 
+            "outerEnum": "approved"
+        }';
+
+        /** * @var EnumTest $result */
+        $result = ObjectSerializer::deserialize(
+            json_decode($json),
+            EnumTest::class
+        );
+
+        $this->assertInstanceOf(EnumTest::class, $result);
+        $this->assertEquals('approved', $result->getOuterEnum());
+    }
+
+    public function testSanitize()
+    {
+        $json = "placed";
+
+        $result = ObjectSerializer::sanitizeForSerialization(
+            $json
+        );
+
+        $this->assertInternalType('string', $result);
+    }
+
+    public function testSanitizeNested()
+    {
+        $input = new EnumTest([
+            'enum_string' => 'UPPER',
+            'enum_integer' => -1,
+            'enum_number' => -1.2,
+            'outer_enum' => 'approved'
+        ]);
+
+        $result = ObjectSerializer::sanitizeForSerialization(
+            $input
+        );
+
+        $this->assertInternalType('object', $result);
+        $this->assertInstanceOf(\stdClass::class, $result);
+
+        $this->assertInternalType('string', $result->outerEnum);
+        $this->assertEquals('approved', $result->outerEnum);
+    }
+
+    public function testSanitizeNestedInvalidValue()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class, 'Invalid value for enum');
+
+        $input = new EnumTest([
+            'enum_string' => 'UPPER',
+            'enum_integer' => -1,
+            'enum_number' => -1.2,
+            'outer_enum' => 'invalid_value'
+        ]);
+
+        ObjectSerializer::sanitizeForSerialization($input);
+    }
+}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fix for #4032. 
Example given in referenced ticket where Model has multiple properties is not really causing any errors on current version of SwaggerCodegen. 
This PR fixes serialization failure when we're dealing with Model containing only enum, like this one:
```
definitions:
  OuterEnum:
    type: "string"
    enum:
    - "placed"
    - "approved"
    - "delivered"
```

I added new serialization rule for this case and method `getAllowableEnumValues()` to Enum model class. Enum class is used only to validate parameters and store constants, deserialized result is just a string. Is it valid approach?

To differentiate between enum and non-enum model I am checking if model class has method `getAllowableEnumValues()`. That's dirty solution for now just to validate my idea. It would be nicer to have some EnumClassInterface instead.

Here's spec i was testing with:
```
swagger: '2.0'
info:
  version: 1.0.0
  title: Swagger TEST
host: petstore.swagger.io
basePath: /api
paths:
  /fake:
    post:
      operationId: testPostingEnum
      consumes:
        - application/json
      produces:
        - application/json
      parameters:
        - in: body
          name: body
          required: true
          schema:
            $ref: '#/definitions/Enum_Test'
      responses:
        '200':
          description: ok
    get:
      operationId: testGettingEnum
      consumes:
        - "*/*"
      produces:
        - "*/*"
      responses:
        '200':
          description: successful operation
          schema:
            $ref: '#/definitions/Enum_Test'

definitions:
  Enum_Test:
    type: object
    properties:
      enum_string:
        type: string
        enum:
          - UPPER
          - lower
          - ''
      enum_integer:
        type: integer
        format: int32
        enum:
          - 1
          - -1
      enum_number:
        type: number
        format: double
        enum:
          - 1.1
          - -1.2
      outerEnum:
        $ref: '#/definitions/OuterEnum'
  OuterEnum:
    type: "string"
    enum:
    - "placed"
    - "approved"
    - "delivered"
```

Controller class for generated silex server:
```
<?php
require_once __DIR__ . '/vendor/autoload.php';

use Symfony\Component\HttpFoundation\JsonResponse;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpFoundation\Response;
use Silex\Application;

$app = new Silex\Application();
$app->get('/api/fake', function (Application $app, Request $request) {
    return new JsonResponse([
        'enum_string' => 'UPPER',
        'enum_integer' => -1,
        'enum_number' => -1.2,
        'outerEnum' => 'placed'
    ]);
});
$app->post('/api/fake', function (Application $app, Request $request) {
    file_put_contents('/tmp/a', print_r($request->getContent(), true));
    return new Response();
});


$app->run();
```

and php code using client:
```
   $config = new \Swagger\Client\Configuration();
    $config->setHost('http://localhost/api');
    $client = new Swagger\Client\ApiClient($config);
4032
    $fakeApi = new Swagger\Client\Api\DefaultApi($client);
    $response = $fakeApi->testGettingEnum();

    var_dump($response);
    var_dump($response->getEnumInteger());
    var_dump($response->getOuterEnum());

    $fakeApi->testPostingEnum(
        new \Swagger\Client\Model\EnumTest([
            'enum_string' => 'lower',
            'enum_integer' => 'lower',
            'enum_number' => 'lower',
            'outer_enum' => \Swagger\Client\Model\OuterEnum::DELIVERED
        ])
    );
 ```
Heres what server recives through POST:
`{"enum_string":"lower","enum_integer":"lower","enum_number":"lower","outerEnum":"delivered"}`
Heres output of test php code:
```
class Swagger\Client\Model\EnumTest#8 (1) {
  protected $container =>
  array(4) {
    'enum_string' =>
    string(5) "UPPER"
    'enum_integer' =>
    int(-1)
    'enum_number' =>
    double(-1.2)
    'outer_enum' =>
    string(6) "placed"
  }
}
int(-1)
string(6) "placed"
```