### PR TITLE
Update samples for Scalatra after 2.2.2.

### DIFF
--- a/samples/server/petstore/scalatra/build.sbt
+++ b/samples/server/petstore/scalatra/build.sbt
@@ -23,23 +23,12 @@ scalaVersion := "2.11.2"
 scalacOptions += "-language:postfixOps"
 
 libraryDependencies ++= Seq(
-  "org.scalatest"           %% "scalatest"                      % "2.2.1"               % "test",
-  "org.scalatra"            %% "scalatra"                       % "2.3.0.RC3",
-  "org.scalatra"            %% "scalatra-scalate"               % "2.3.0.RC3",
-  "org.scalatra"            %% "scalatra-json"                  % "2.3.0.RC3",
-  "org.scalatra"            %% "scalatra-swagger"               % "2.3.0.RC3",
-  "org.scalatra"            %% "scalatra-swagger-ext"           % "2.3.0.RC3",
-  "org.scalatra"            %% "scalatra-slf4j"                 % "2.3.0.RC3",
-  "org.json4s"              %% "json4s-jackson"                 % "3.2.10",
-  "org.json4s"              %% "json4s-ext"                     % "3.2.10",
-  "commons-codec"            % "commons-codec"                  % "1.7",
-  "net.databinder.dispatch" %% "dispatch-core"                  % "0.11.2",
-  //"net.databinder.dispatch" %% "json4s-jackson"                 % "0.11.2",
-  "net.databinder.dispatch" %% "dispatch-json4s-jackson"        % "0.11.2",
-  "com.typesafe.akka"       %% "akka-actor"                     % "2.3.6",
-  "org.eclipse.jetty"        % "jetty-server"                   % "9.2.3.v20140905" % "container;compile;test",
-  "org.eclipse.jetty"        % "jetty-webapp"                   % "9.2.3.v20140905" % "container;compile;test",
-  "org.eclipse.jetty.orbit"  % "javax.servlet"                  % "3.0.0.v201112011016" % "container;compile;provided;test" artifacts (Artifact("javax.servlet", "jar", "jar"))
+  "com.github.finagle" %% "finch-core" % "0.9.2-SNAPSHOT" changing(),
+  "com.github.finagle" %% "finch-argonaut" % "0.9.2-SNAPSHOT" changing(),
+  "io.argonaut" %% "argonaut" % "6.1",
+  "com.github.finagle" %% "finch-test" % "0.9.2-SNAPSHOT" % "test,it" changing(),
+  "org.scalacheck" %% "scalacheck" % "1.12.5" % "test,it",
+  "org.scalatest" %% "scalatest" % "2.2.5" % "test,it"
 )
 
 resolvers += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository"
@@ -47,6 +36,9 @@ resolvers += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/
 resolvers += "Sonatype OSS Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
 resolvers += "Sonatype OSS Releases" at "http://oss.sonatype.org/content/repositories/releases/"
+
+resolvers += "TM" at "http://maven.twttr.com"
+
 
 ivyXML := <dependencies>
     <exclude module="slf4j-log4j12"/>

--- a/samples/server/petstore/scalatra/build.sbt
+++ b/samples/server/petstore/scalatra/build.sbt
@@ -23,12 +23,23 @@ scalaVersion := "2.11.2"
 scalacOptions += "-language:postfixOps"
 
 libraryDependencies ++= Seq(
-  "com.github.finagle" %% "finch-core" % "0.9.2-SNAPSHOT" changing(),
-  "com.github.finagle" %% "finch-argonaut" % "0.9.2-SNAPSHOT" changing(),
-  "io.argonaut" %% "argonaut" % "6.1",
-  "com.github.finagle" %% "finch-test" % "0.9.2-SNAPSHOT" % "test,it" changing(),
-  "org.scalacheck" %% "scalacheck" % "1.12.5" % "test,it",
-  "org.scalatest" %% "scalatest" % "2.2.5" % "test,it"
+  "org.scalatest"           %% "scalatest"                      % "2.2.1"               % "test",
+  "org.scalatra"            %% "scalatra"                       % "2.3.0.RC3",
+  "org.scalatra"            %% "scalatra-scalate"               % "2.3.0.RC3",
+  "org.scalatra"            %% "scalatra-json"                  % "2.3.0.RC3",
+  "org.scalatra"            %% "scalatra-swagger"               % "2.3.0.RC3",
+  "org.scalatra"            %% "scalatra-swagger-ext"           % "2.3.0.RC3",
+  "org.scalatra"            %% "scalatra-slf4j"                 % "2.3.0.RC3",
+  "org.json4s"              %% "json4s-jackson"                 % "3.2.10",
+  "org.json4s"              %% "json4s-ext"                     % "3.2.10",
+  "commons-codec"            % "commons-codec"                  % "1.7",
+  "net.databinder.dispatch" %% "dispatch-core"                  % "0.11.2",
+  //"net.databinder.dispatch" %% "json4s-jackson"                 % "0.11.2",
+  "net.databinder.dispatch" %% "dispatch-json4s-jackson"        % "0.11.2",
+  "com.typesafe.akka"       %% "akka-actor"                     % "2.3.6",
+  "org.eclipse.jetty"        % "jetty-server"                   % "9.2.3.v20140905" % "container;compile;test",
+  "org.eclipse.jetty"        % "jetty-webapp"                   % "9.2.3.v20140905" % "container;compile;test",
+  "org.eclipse.jetty.orbit"  % "javax.servlet"                  % "3.0.0.v201112011016" % "container;compile;provided;test" artifacts (Artifact("javax.servlet", "jar", "jar"))
 )
 
 resolvers += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository"
@@ -36,9 +47,6 @@ resolvers += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/
 resolvers += "Sonatype OSS Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
 resolvers += "Sonatype OSS Releases" at "http://oss.sonatype.org/content/repositories/releases/"
-
-resolvers += "TM" at "http://maven.twttr.com"
-
 
 ivyXML := <dependencies>
     <exclude module="slf4j-log4j12"/>

--- a/samples/server/petstore/scalatra/src/main/scala/com/wordnik/client/api/PetApi.scala
+++ b/samples/server/petstore/scalatra/src/main/scala/com/wordnik/client/api/PetApi.scala
@@ -63,7 +63,7 @@ class PetApi (implicit val swagger: Swagger) extends ScalatraServlet
       parameters(pathParam[Long]("petId").description(""), headerParam[String]("apiKey").description("").optional)
   )
 
-  delete("/pet/{petId}",operation(deletePetOperation)) {
+  delete("/pet/:petId",operation(deletePetOperation)) {
     
     
       val petId = params.getOrElse("petId", halt(400))
@@ -131,7 +131,7 @@ class PetApi (implicit val swagger: Swagger) extends ScalatraServlet
       parameters(pathParam[Long]("petId").description(""))
   )
 
-  get("/pet/{petId}",operation(getPetByIdOperation)) {
+  get("/pet/:petId",operation(getPetByIdOperation)) {
     
     
       val petId = params.getOrElse("petId", halt(400))
@@ -161,7 +161,7 @@ class PetApi (implicit val swagger: Swagger) extends ScalatraServlet
       parameters(pathParam[Long]("petId").description(""), formParam[String]("name").description("").optional, formParam[String]("status").description("").optional)
   )
 
-  post("/pet/{petId}",operation(updatePetWithFormOperation)) {
+  post("/pet/:petId",operation(updatePetWithFormOperation)) {
     
     
       val petId = params.getOrElse("petId", halt(400))
@@ -186,7 +186,7 @@ class PetApi (implicit val swagger: Swagger) extends ScalatraServlet
       parameters(pathParam[Long]("petId").description(""), formParam[String]("additionalMetadata").description("").optional, formParam[File]("file").description("").optional)
   )
 
-  post("/pet/{petId}/uploadImage",operation(uploadFileOperation)) {
+  post("/pet/:petId/uploadImage",operation(uploadFileOperation)) {
     
     
       val petId = params.getOrElse("petId", halt(400))

--- a/samples/server/petstore/scalatra/src/main/scala/com/wordnik/client/api/StoreApi.scala
+++ b/samples/server/petstore/scalatra/src/main/scala/com/wordnik/client/api/StoreApi.scala
@@ -46,7 +46,7 @@ class StoreApi (implicit val swagger: Swagger) extends ScalatraServlet
       parameters(pathParam[String]("orderId").description(""))
   )
 
-  delete("/store/order/{orderId}",operation(deleteOrderOperation)) {
+  delete("/store/order/:orderId",operation(deleteOrderOperation)) {
     
     
       val orderId = params.getOrElse("orderId", halt(400))
@@ -71,7 +71,7 @@ class StoreApi (implicit val swagger: Swagger) extends ScalatraServlet
       parameters(pathParam[Long]("orderId").description(""))
   )
 
-  get("/store/order/{orderId}",operation(getOrderByIdOperation)) {
+  get("/store/order/:orderId",operation(getOrderByIdOperation)) {
     
     
       val orderId = params.getOrElse("orderId", halt(400))

--- a/samples/server/petstore/scalatra/src/main/scala/com/wordnik/client/api/UserApi.scala
+++ b/samples/server/petstore/scalatra/src/main/scala/com/wordnik/client/api/UserApi.scala
@@ -93,6 +93,7 @@ class UserApi (implicit val swagger: Swagger) extends ScalatraServlet
 
   delete("/user/:username",operation(deleteUserOperation)) {
     
+    
       val username = params.getOrElse("username", halt(400))
     
     println("username: " + username)
@@ -106,6 +107,7 @@ class UserApi (implicit val swagger: Swagger) extends ScalatraServlet
   )
 
   get("/user/:username",operation(getUserByNameOperation)) {
+    
     
       val username = params.getOrElse("username", halt(400))
     
@@ -150,6 +152,7 @@ class UserApi (implicit val swagger: Swagger) extends ScalatraServlet
   )
 
   put("/user/:username",operation(updateUserOperation)) {
+    
     
       val username = params.getOrElse("username", halt(400))
     


### PR DESCRIPTION
### PR checklist

- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. 
   → just bin/scalatra-petstore.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This just updates the scalatra samples without any functionality changes.
(This is a part of #4901 split out into a separate PR to see if CI likes it better than the whole thing.)

