### PR TITLE
Fix (partially) #4898 for swift3

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/api.mustache
@@ -105,7 +105,7 @@ open class {{classname}}: APIBase {
      */
     open class func {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{^secondaryParam}}var{{/secondaryParam}}{{/pathParams}} path = "{{path}}"{{#pathParams}}
-        path = path.replacingOccurrences(of: "{{=<% %>=}}{<%paramName%>}<%={{ }}=%>", with: "\({{paramName}}{{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}})", options: .literal, range: nil){{/pathParams}}
+        path = path.replacingOccurrences(of: "{{=<% %>=}}{<%baseName%>}<%={{ }}=%>", with: "\({{paramName}}{{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}})", options: .literal, range: nil){{/pathParams}}
         let URLString = {{projectName}}API.basePath + path
         {{#bodyParam}}
         let parameters = {{paramName}}{{^required}}?{{/required}}.encodeToJSON() as? [String:AnyObject]

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -134,14 +134,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 4,
+  "id" : 7,
   "category" : {
     "name" : "aeiou",
-    "id" : 5
+    "id" : 4
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 6
+    "id" : 5
   } ],
   "status" : "available"
 } ]}]
@@ -157,14 +157,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 4,
+  "id" : 7,
   "category" : {
     "name" : "aeiou",
-    "id" : 5
+    "id" : 4
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 6
+    "id" : 5
   } ],
   "status" : "available"
 } ]}]
@@ -221,14 +221,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 2,
+  "id" : 3,
   "category" : {
     "name" : "aeiou",
-    "id" : 5
+    "id" : 2
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 6
+    "id" : 9
   } ],
   "status" : "available"
 } ]}]
@@ -244,14 +244,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 2,
+  "id" : 3,
   "category" : {
     "name" : "aeiou",
-    "id" : 5
+    "id" : 2
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 6
+    "id" : 9
   } ],
   "status" : "available"
 } ]}]
@@ -308,14 +308,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example={
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 0,
+  "id" : 8,
   "category" : {
     "name" : "aeiou",
-    "id" : 5
+    "id" : 2
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 3
+    "id" : 8
   } ],
   "status" : "available"
 }}]
@@ -331,14 +331,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example={
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 0,
+  "id" : 8,
   "category" : {
     "name" : "aeiou",
-    "id" : 5
+    "id" : 2
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 3
+    "id" : 8
   } ],
   "status" : "available"
 }}]
@@ -471,7 +471,7 @@ open class PetAPI: APIBase {
        - type: oauth2
        - name: petstore_auth
      - examples: [{contentType=application/json, example={
-  "code" : 4,
+  "code" : 9,
   "type" : "aeiou",
   "message" : "aeiou"
 }}]

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -66,7 +66,7 @@ open class StoreAPI: APIBase {
        - type: apiKey api_key 
        - name: api_key
      - examples: [{contentType=application/json, example={
-  "key" : 7
+  "key" : 5
 }}]
 
      - returns: RequestBuilder<[String:Int32]> 
@@ -109,9 +109,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 1,
-  "quantity" : 7,
-  "id" : 5,
+  "petId" : 8,
+  "quantity" : 9,
+  "id" : 0,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -124,9 +124,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 1,
-  "quantity" : 7,
-  "id" : 5,
+  "petId" : 8,
+  "quantity" : 9,
+  "id" : 0,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -175,9 +175,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 3,
-  "quantity" : 1,
-  "id" : 9,
+  "petId" : 6,
+  "quantity" : 6,
+  "id" : 7,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -190,9 +190,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 3,
-  "quantity" : 1,
-  "id" : 9,
+  "petId" : 6,
+  "quantity" : 6,
+  "id" : 7,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -181,9 +181,9 @@ open class UserAPI: APIBase {
   "firstName" : "aeiou",
   "lastName" : "aeiou",
   "password" : "aeiou",
-  "userStatus" : 0,
+  "userStatus" : 8,
   "phone" : "aeiou",
-  "id" : 7,
+  "id" : 6,
   "email" : "aeiou",
   "username" : "aeiou"
 }}]
@@ -200,9 +200,9 @@ open class UserAPI: APIBase {
   "firstName" : "aeiou",
   "lastName" : "aeiou",
   "password" : "aeiou",
-  "userStatus" : 0,
+  "userStatus" : 8,
   "phone" : "aeiou",
-  "id" : 7,
+  "id" : 6,
   "email" : "aeiou",
   "username" : "aeiou"
 }}]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -187,14 +187,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 1,
+  "id" : 5,
   "category" : {
     "name" : "aeiou",
-    "id" : 0
+    "id" : 5
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 2
+    "id" : 4
   } ],
   "status" : "available"
 } ]}]
@@ -210,14 +210,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 1,
+  "id" : 5,
   "category" : {
     "name" : "aeiou",
-    "id" : 0
+    "id" : 5
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 2
+    "id" : 4
   } ],
   "status" : "available"
 } ]}]
@@ -291,14 +291,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 4,
+  "id" : 0,
   "category" : {
     "name" : "aeiou",
-    "id" : 9
+    "id" : 3
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 3
+    "id" : 8
   } ],
   "status" : "available"
 } ]}]
@@ -314,14 +314,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 4,
+  "id" : 0,
   "category" : {
     "name" : "aeiou",
-    "id" : 9
+    "id" : 3
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 3
+    "id" : 8
   } ],
   "status" : "available"
 } ]}]
@@ -395,14 +395,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example={
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 8,
+  "id" : 0,
   "category" : {
     "name" : "aeiou",
-    "id" : 5
+    "id" : 8
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 4
+    "id" : 7
   } ],
   "status" : "available"
 }}]
@@ -418,14 +418,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example={
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 8,
+  "id" : 0,
   "category" : {
     "name" : "aeiou",
-    "id" : 5
+    "id" : 8
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 4
+    "id" : 7
   } ],
   "status" : "available"
 }}]
@@ -613,7 +613,7 @@ open class PetAPI: APIBase {
        - type: oauth2
        - name: petstore_auth
      - examples: [{contentType=application/json, example={
-  "code" : 0,
+  "code" : 7,
   "type" : "aeiou",
   "message" : "aeiou"
 }}]

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -160,9 +160,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 2,
-  "quantity" : 9,
-  "id" : 4,
+  "petId" : 6,
+  "quantity" : 5,
+  "id" : 0,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -175,9 +175,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 2,
-  "quantity" : 9,
-  "id" : 4,
+  "petId" : 6,
+  "quantity" : 5,
+  "id" : 0,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -243,9 +243,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 8,
-  "quantity" : 2,
-  "id" : 0,
+  "petId" : 9,
+  "quantity" : 9,
+  "id" : 3,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -258,9 +258,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 8,
-  "quantity" : 2,
-  "id" : 0,
+  "petId" : 9,
+  "quantity" : 9,
+  "id" : 3,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -267,9 +267,9 @@ open class UserAPI: APIBase {
   "firstName" : "aeiou",
   "lastName" : "aeiou",
   "password" : "aeiou",
-  "userStatus" : 9,
+  "userStatus" : 5,
   "phone" : "aeiou",
-  "id" : 9,
+  "id" : 0,
   "email" : "aeiou",
   "username" : "aeiou"
 }}]
@@ -286,9 +286,9 @@ open class UserAPI: APIBase {
   "firstName" : "aeiou",
   "lastName" : "aeiou",
   "password" : "aeiou",
-  "userStatus" : 9,
+  "userStatus" : 5,
   "phone" : "aeiou",
-  "id" : 9,
+  "id" : 0,
   "email" : "aeiou",
   "username" : "aeiou"
 }}]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -193,14 +193,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 2,
+  "id" : 6,
   "category" : {
     "name" : "aeiou",
-    "id" : 2
+    "id" : 6
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 0
+    "id" : 1
   } ],
   "status" : "available"
 } ]}]
@@ -216,14 +216,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 2,
+  "id" : 6,
   "category" : {
     "name" : "aeiou",
-    "id" : 2
+    "id" : 6
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 0
+    "id" : 1
   } ],
   "status" : "available"
 } ]}]
@@ -299,14 +299,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 4,
+  "id" : 2,
   "category" : {
     "name" : "aeiou",
-    "id" : 0
+    "id" : 1
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 3
+    "id" : 2
   } ],
   "status" : "available"
 } ]}]
@@ -322,14 +322,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example=[ {
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 4,
+  "id" : 2,
   "category" : {
     "name" : "aeiou",
-    "id" : 0
+    "id" : 1
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 3
+    "id" : 2
   } ],
   "status" : "available"
 } ]}]
@@ -405,14 +405,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example={
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 1,
+  "id" : 8,
   "category" : {
     "name" : "aeiou",
-    "id" : 1
+    "id" : 7
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 2
+    "id" : 7
   } ],
   "status" : "available"
 }}]
@@ -428,14 +428,14 @@ open class PetAPI: APIBase {
 </Pet>}, {contentType=application/json, example={
   "photoUrls" : [ "aeiou" ],
   "name" : "doggie",
-  "id" : 1,
+  "id" : 8,
   "category" : {
     "name" : "aeiou",
-    "id" : 1
+    "id" : 7
   },
   "tags" : [ {
     "name" : "aeiou",
-    "id" : 2
+    "id" : 7
   } ],
   "status" : "available"
 }}]
@@ -629,7 +629,7 @@ open class PetAPI: APIBase {
        - type: oauth2
        - name: petstore_auth
      - examples: [{contentType=application/json, example={
-  "code" : 1,
+  "code" : 9,
   "type" : "aeiou",
   "message" : "aeiou"
 }}]

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -104,7 +104,7 @@ open class StoreAPI: APIBase {
        - type: apiKey api_key 
        - name: api_key
      - examples: [{contentType=application/json, example={
-  "key" : 7
+  "key" : 9
 }}]
 
      - returns: RequestBuilder<[String:Int32]> 
@@ -166,9 +166,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 6,
+  "petId" : 0,
   "quantity" : 0,
-  "id" : 5,
+  "id" : 2,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -181,9 +181,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 6,
+  "petId" : 0,
   "quantity" : 0,
-  "id" : 5,
+  "id" : 2,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -251,9 +251,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 3,
-  "quantity" : 8,
-  "id" : 8,
+  "petId" : 4,
+  "quantity" : 3,
+  "id" : 0,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"
@@ -266,9 +266,9 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}, {contentType=application/json, example={
-  "petId" : 3,
-  "quantity" : 8,
-  "id" : 8,
+  "petId" : 4,
+  "quantity" : 3,
+  "id" : 0,
   "shipDate" : "2000-01-23T04:56:07.000+00:00",
   "complete" : false,
   "status" : "placed"

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -279,7 +279,7 @@ open class UserAPI: APIBase {
   "password" : "aeiou",
   "userStatus" : 2,
   "phone" : "aeiou",
-  "id" : 4,
+  "id" : 7,
   "email" : "aeiou",
   "username" : "aeiou"
 }}]
@@ -298,7 +298,7 @@ open class UserAPI: APIBase {
   "password" : "aeiou",
   "userStatus" : 2,
   "phone" : "aeiou",
-  "id" : 4,
+  "id" : 7,
   "email" : "aeiou",
   "username" : "aeiou"
 }}]


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. 
   → bin/swift3-petstore-all.sh (~~once before the change, see #4911, once again~~ after the change.)
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

~~This includes the changes of #4911 – after merging those, it should be clearer what actually changed. (Or just have a look at the last two commits.)~~

This fixes a wrong name-mapping of path parameters, as part of solving #4898.

It looks like there is no test case in petstore which actually makes a difference here.
It might be that there actually is no problem (i.e. if parameter names are never modified for Swift3, then `baseName` is the same as `paramName`, so it doesn't matter – though then there might be problems when hitting reserved words), or that it just is not happens with our petstore example.

I need someone who knows about the swift clients to review this – cc @jaz-ah @Edubits.

_(A side remark: Some ids in the generated samples look different each time the generator is run – see commit 8e847ab. This introduces unneeded noise when looking at the diffs. Might be worth looking into, in a separate issue/PR.)_