### PR TITLE
[Jaxrs-cxf] Add cascaded beanvalidation @Valid for pojos #4738

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -27,7 +27,8 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
 {{#useJaxbAnnotations}}
   @XmlElement(name="{{baseName}}"{{#required}}, required = {{required}}{{/required}})
 {{/useJaxbAnnotations}}
-  @ApiModelProperty({{#example}}example = "{{example}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+  @ApiModelProperty({{#example}}example = "{{example}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{^isPrimitiveType}}{{^isContainer}}{{#useBeanValidation}}
+  @Valid{{/useBeanValidation}}{{/isContainer}}{{/isPrimitiveType}}
   private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/vars}}
 
   {{#vars}}

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumTest.java
@@ -120,6 +120,7 @@ public enum EnumNumberEnum {
   @ApiModelProperty(example = "null", value = "")
   private EnumNumberEnum enumNumber = null;
   @ApiModelProperty(example = "null", value = "")
+  @Valid
   private OuterEnum outerEnum = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/FormatTest.java
@@ -23,6 +23,7 @@ public class FormatTest  {
   @ApiModelProperty(example = "null", value = "")
   private Long int64 = null;
   @ApiModelProperty(example = "null", required = true, value = "")
+  @Valid
   private BigDecimal number = null;
   @ApiModelProperty(example = "null", value = "")
   private Float _float = null;
@@ -35,10 +36,13 @@ public class FormatTest  {
   @ApiModelProperty(example = "null", value = "")
   private byte[] binary = null;
   @ApiModelProperty(example = "null", required = true, value = "")
+  @Valid
   private LocalDate date = null;
   @ApiModelProperty(example = "null", value = "")
+  @Valid
   private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
   @ApiModelProperty(example = "null", value = "")
+  @Valid
   private UUID uuid = null;
   @ApiModelProperty(example = "null", required = true, value = "")
   private String password = null;

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -19,8 +19,10 @@ import javax.xml.bind.annotation.XmlEnumValue;
 public class MixedPropertiesAndAdditionalPropertiesClass  {
   
   @ApiModelProperty(example = "null", value = "")
+  @Valid
   private UUID uuid = null;
   @ApiModelProperty(example = "null", value = "")
+  @Valid
   private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
   @ApiModelProperty(example = "null", value = "")
   private Map<String, Animal> map = new HashMap<String, Animal>();

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/NumberOnly.java
@@ -15,6 +15,7 @@ import javax.xml.bind.annotation.XmlEnumValue;
 public class NumberOnly  {
   
   @ApiModelProperty(example = "null", value = "")
+  @Valid
   private BigDecimal justNumber = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Order.java
@@ -20,6 +20,7 @@ public class Order  {
   @ApiModelProperty(example = "null", value = "")
   private Integer quantity = null;
   @ApiModelProperty(example = "null", value = "")
+  @Valid
   private javax.xml.datatype.XMLGregorianCalendar shipDate = null;
 
 @XmlType(name="StatusEnum")

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Pet.java
@@ -20,6 +20,7 @@ public class Pet  {
   @ApiModelProperty(example = "null", value = "")
   private Long id = null;
   @ApiModelProperty(example = "null", value = "")
+  @Valid
   private Category category = null;
   @ApiModelProperty(example = "doggie", required = true, value = "")
   private String name = null;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Implemented #4738 for CXF

Open issues: 
@Valid is currently also generated for properties of type (isPrimitiveType/^isContainer does not cover these):
* java.lang.BigDecimal
* javax.xml.datatype.XMLGregorianCalendar
* org.joda.time.LocalDate
* java.util.UUID

Please advise how we can best check for model-specific pojos?