### PR TITLE
[Jaxrs-cxf] Fix compile errors after update of swagger-core / add jackson dependencies to pom #4924

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -160,6 +160,18 @@
         <version>${cxf-version}</version>
         <scope>compile</scope>
     </dependency>
+    <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson-jaxrs-version}</version>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+       <groupId>com.fasterxml.jackson.datatype</groupId>
+       <artifactId>jackson-datatype-joda</artifactId>
+       <version>${jackson-jaxrs-version}</version>
+       <scope>compile</scope>
+    </dependency>
 {{#generateSpringApplication}}    
     <!-- Spring -->
     <dependency>
@@ -233,6 +245,7 @@
     <spring.boot-version>1.3.3.RELEASE</spring.boot-version>
 {{/generateSpringBootApplication}}    
     <cxf-version>3.1.8</cxf-version>
+    <jackson-jaxrs-version>2.4.5</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -245,7 +245,7 @@
     <spring.boot-version>1.3.3.RELEASE</spring.boot-version>
 {{/generateSpringBootApplication}}    
     <cxf-version>3.1.8</cxf-version>
-    <jackson-jaxrs-version>2.4.5</jackson-jaxrs-version>
+    <jackson-jaxrs-version>2.8.4</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -112,6 +112,13 @@
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Bean Validation API support -->
+    <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>${beanvalidation-version}</version>
+        <scope>provided</scope>
+    </dependency>
     <!-- CXF Client -->
     <dependency>
         <groupId>org.apache.cxf</groupId>
@@ -151,6 +158,18 @@
         <version>${cxf-version}</version>
         <scope>compile</scope>
     </dependency>
+    <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson-jaxrs-version}</version>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+       <groupId>com.fasterxml.jackson.datatype</groupId>
+       <artifactId>jackson-datatype-joda</artifactId>
+       <version>${jackson-jaxrs-version}</version>
+       <scope>compile</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>
@@ -165,13 +184,15 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.10</swagger-core-version>
+    <swagger-core-version>1.5.12</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>
+    <beanvalidation-version>1.1.0.Final</beanvalidation-version>
     <cxf-version>3.1.8</cxf-version>
+    <jackson-jaxrs-version>2.4.5</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -192,7 +192,7 @@
     <servlet-api-version>2.5</servlet-api-version>
     <beanvalidation-version>1.1.0.Final</beanvalidation-version>
     <cxf-version>3.1.8</cxf-version>
-    <jackson-jaxrs-version>2.4.5</jackson-jaxrs-version>
+    <jackson-jaxrs-version>2.8.4</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

fix dependencies for swagger-core 1.5.12 for CXF server see #4924

