### PR TITLE
[Swift] add batch files for swift 2,3 to generate petstore samples

### DIFF
--- a/bin/windows/swift-petstore-all.bat
+++ b/bin/windows/swift-petstore-all.bat
@@ -1,0 +1,3 @@
+call .\bin\windows\swift-petstore.bat
+call .\bin\windows\swift-petstore-promisekit.bat
+call .\bin\windows\swift-petstore-rxswift.bat

--- a/bin/windows/swift-petstore-promisekit.bat
+++ b/bin/windows/swift-petstore-promisekit.bat
@@ -1,0 +1,10 @@
+set executable=.\modules\swagger-codegen-cli\target\swagger-codegen-cli.jar
+
+If Not Exist %executable% (
+  mvn clean package
+)
+
+REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
+set ags=generate -t modules\swagger-codegne\src\main\resources\swift -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -c bin\swift3-petstore-promisekit.json -o samples\client\petstore\swift\promisekit
+
+java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift-petstore-promisekit.bat
+++ b/bin/windows/swift-petstore-promisekit.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -t modules\swagger-codegne\src\main\resources\swift -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -c bin\swift3-petstore-promisekit.json -o samples\client\petstore\swift\promisekit
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -c bin\swift-petstore-promisekit.json -o samples\client\petstore\swift\promisekit
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift-petstore-rxswift.bat
+++ b/bin/windows/swift-petstore-rxswift.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -t modules\swagger-codegne\src\main\resources\swift -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -c bin\swift3-petstore-rxswift.json -o samples\client\petstore\swift\rxswift
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -c bin\swift-petstore-rxswift.json -o samples\client\petstore\swift\rxswift
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift-petstore-rxswift.bat
+++ b/bin/windows/swift-petstore-rxswift.bat
@@ -1,0 +1,10 @@
+set executable=.\modules\swagger-codegen-cli\target\swagger-codegen-cli.jar
+
+If Not Exist %executable% (
+  mvn clean package
+)
+
+REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
+set ags=generate -t modules\swagger-codegne\src\main\resources\swift -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -c bin\swift3-petstore-rxswift.json -o samples\client\petstore\swift\rxswift
+
+java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift-petstore.bat
+++ b/bin/windows/swift-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -o samples\client\petstore\swift
+set ags=generate -t modules\swagger-codegne\src\main\resources\swift -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -o samples\client\petstore\swift\default
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift-petstore.bat
+++ b/bin/windows/swift-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -t modules\swagger-codegne\src\main\resources\swift -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -o samples\client\petstore\swift\default
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l swift -o samples\client\petstore\swift\default
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift3-petstore-all.bat
+++ b/bin/windows/swift3-petstore-all.bat
@@ -1,0 +1,3 @@
+call .\bin\windows\swift3-petstore.bat
+call .\bin\windows\swift3-petstore-promisekit.bat
+call .\bin\windows\swift3-petstore-rxswift.bat

--- a/bin/windows/swift3-petstore-promisekit.bat
+++ b/bin/windows/swift3-petstore-promisekit.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -t modules\swagger-codegne\src\main\resources\swift3 -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c bin\swift3-petstore-promisekit.json -o samples\client\petstore\swift3\promisekit
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c bin\swift3-petstore-promisekit.json -o samples\client\petstore\swift3\promisekit
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift3-petstore-promisekit.bat
+++ b/bin/windows/swift3-petstore-promisekit.bat
@@ -1,0 +1,10 @@
+set executable=.\modules\swagger-codegen-cli\target\swagger-codegen-cli.jar
+
+If Not Exist %executable% (
+  mvn clean package
+)
+
+REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
+set ags=generate -t modules\swagger-codegne\src\main\resources\swift3 -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c bin\swift3-petstore-promisekit.json -o samples\client\petstore\swift3\promisekit
+
+java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift3-petstore-rxswift.bat
+++ b/bin/windows/swift3-petstore-rxswift.bat
@@ -1,0 +1,10 @@
+set executable=.\modules\swagger-codegen-cli\target\swagger-codegen-cli.jar
+
+If Not Exist %executable% (
+  mvn clean package
+)
+
+REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
+set ags=generate -t modules\swagger-codegne\src\main\resources\swift3 -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c bin\swift3-petstore-rxswift.json -o samples\client\petstore\swift3\rxswift
+
+java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift3-petstore-rxswift.bat
+++ b/bin/windows/swift3-petstore-rxswift.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -t modules\swagger-codegne\src\main\resources\swift3 -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c bin\swift3-petstore-rxswift.json -o samples\client\petstore\swift3\rxswift
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c bin\swift3-petstore-rxswift.json -o samples\client\petstore\swift3\rxswift
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift3-petstore.bat
+++ b/bin/windows/swift3-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -t modules\swagger-codegne\src\main\resources\swift3 -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -o samples\client\petstore\swift3\default
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -o samples\client\petstore\swift3\default
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/swift3-petstore.bat
+++ b/bin/windows/swift3-petstore.bat
@@ -1,0 +1,10 @@
+set executable=.\modules\swagger-codegen-cli\target\swagger-codegen-cli.jar
+
+If Not Exist %executable% (
+  mvn clean package
+)
+
+REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
+set ags=generate -t modules\swagger-codegne\src\main\resources\swift3 -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -o samples\client\petstore\swift3\default
+
+java %JAVA_OPTS% -jar %executable% %ags%


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add Windows batch files for swift 2,3 API client generator to generate Petstore samples (for CI tests)
