### PR TITLE
Add proxy support to fix #4639

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/configuration.mustache
@@ -80,6 +80,9 @@ class Configuration(object):
         # client key file
         self.key_file = None
 
+        # Proxy URL
+        self.proxy = None
+
     @property
     def logger_file(self):
         """

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -76,7 +76,7 @@ class RESTClientObject(object):
         # key file
         key_file = Configuration().key_file
 
-       # proxy
+        # proxy
         proxy = Configuration().proxy
 
         # https pool manager
@@ -100,14 +100,6 @@ class RESTClientObject(object):
                 key_file=key_file
             )
 
-        # https pool manager
-        self.pool_manager = urllib3.PoolManager(
-            num_pools=pools_size,
-            cert_reqs=cert_reqs,
-            ca_certs=ca_certs,
-            cert_file=cert_file,
-            key_file=key_file
-        )
 
     def request(self, method, url, query_params=None, headers=None,
                 body=None, post_params=None, _preload_content=True, _request_timeout=None):

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -76,10 +76,33 @@ class RESTClientObject(object):
         # key file
         key_file = Configuration().key_file
 
+       # proxy
+        proxy = Configuration().proxy
+
+        # https pool manager
+        if proxy:
+            self.pool_manager = urllib3.ProxyManager(
+                num_pools=pools_size,
+                maxsize=maxsize,
+                cert_reqs=cert_reqs,
+                ca_certs=ca_certs,
+                cert_file=cert_file,
+                key_file=key_file,
+                proxy_url=proxy
+            )
+        else:
+            self.pool_manager = urllib3.PoolManager(
+                num_pools=pools_size,
+                maxsize=maxsize,
+                cert_reqs=cert_reqs,
+                ca_certs=ca_certs,
+                cert_file=cert_file,
+                key_file=key_file
+            )
+
         # https pool manager
         self.pool_manager = urllib3.PoolManager(
             num_pools=pools_size,
-            maxsize=maxsize,
             cert_reqs=cert_reqs,
             ca_certs=ca_certs,
             cert_file=cert_file,

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -116,7 +116,7 @@ class ApiClient(object):
                                                     collection_formats)
             for k, v in path_params:
                 resource_path = resource_path.replace(
-                    '{%s}' % k, quote(str(v), safe=""))
+                    '{%s}' % k, quote(str(v), safe=''))  # no safe chars, encode everything
 
         # query parameters
         if query_params:

--- a/samples/client/petstore-security-test/python/petstore_api/configuration.py
+++ b/samples/client/petstore-security-test/python/petstore_api/configuration.py
@@ -89,6 +89,9 @@ class Configuration(object):
         # client key file
         self.key_file = None
 
+        # Proxy URL
+        self.proxy = None
+
     @property
     def logger_file(self):
         """

--- a/samples/client/petstore-security-test/python/petstore_api/rest.py
+++ b/samples/client/petstore-security-test/python/petstore_api/rest.py
@@ -85,10 +85,33 @@ class RESTClientObject(object):
         # key file
         key_file = Configuration().key_file
 
+       # proxy
+        proxy = Configuration().proxy
+
+        # https pool manager
+        if proxy:
+            self.pool_manager = urllib3.ProxyManager(
+                num_pools=pools_size,
+                maxsize=maxsize,
+                cert_reqs=cert_reqs,
+                ca_certs=ca_certs,
+                cert_file=cert_file,
+                key_file=key_file,
+                proxy_url=proxy
+            )
+        else:
+            self.pool_manager = urllib3.PoolManager(
+                num_pools=pools_size,
+                maxsize=maxsize,
+                cert_reqs=cert_reqs,
+                ca_certs=ca_certs,
+                cert_file=cert_file,
+                key_file=key_file
+            )
+
         # https pool manager
         self.pool_manager = urllib3.PoolManager(
             num_pools=pools_size,
-            maxsize=maxsize,
             cert_reqs=cert_reqs,
             ca_certs=ca_certs,
             cert_file=cert_file,

--- a/samples/client/petstore-security-test/python/requirements.txt
+++ b/samples/client/petstore-security-test/python/requirements.txt
@@ -1,5 +1,5 @@
 certifi >= 14.05.14
-six == 1.8.0
+six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -89,6 +89,9 @@ class Configuration(object):
         # client key file
         self.key_file = None
 
+        # Proxy URL
+        self.proxy = None
+
     @property
     def logger_file(self):
         """

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -85,7 +85,7 @@ class RESTClientObject(object):
         # key file
         key_file = Configuration().key_file
 
-       # proxy
+        # proxy
         proxy = Configuration().proxy
 
         # https pool manager
@@ -109,14 +109,6 @@ class RESTClientObject(object):
                 key_file=key_file
             )
 
-        # https pool manager
-        self.pool_manager = urllib3.PoolManager(
-            num_pools=pools_size,
-            cert_reqs=cert_reqs,
-            ca_certs=ca_certs,
-            cert_file=cert_file,
-            key_file=key_file
-        )
 
     def request(self, method, url, query_params=None, headers=None,
                 body=None, post_params=None, _preload_content=True, _request_timeout=None):

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -85,10 +85,33 @@ class RESTClientObject(object):
         # key file
         key_file = Configuration().key_file
 
+       # proxy
+        proxy = Configuration().proxy
+
+        # https pool manager
+        if proxy:
+            self.pool_manager = urllib3.ProxyManager(
+                num_pools=pools_size,
+                maxsize=maxsize,
+                cert_reqs=cert_reqs,
+                ca_certs=ca_certs,
+                cert_file=cert_file,
+                key_file=key_file,
+                proxy_url=proxy
+            )
+        else:
+            self.pool_manager = urllib3.PoolManager(
+                num_pools=pools_size,
+                maxsize=maxsize,
+                cert_reqs=cert_reqs,
+                ca_certs=ca_certs,
+                cert_file=cert_file,
+                key_file=key_file
+            )
+
         # https pool manager
         self.pool_manager = urllib3.PoolManager(
             num_pools=pools_size,
-            maxsize=maxsize,
             cert_reqs=cert_reqs,
             ca_certs=ca_certs,
             cert_file=cert_file,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Adds support for proxies in the Python client as discussed in #4639. Simply setting the `proxy` property of the configuration object to the proper URL should be picked up and the client will use `ProxyManager` instead of `PoolManager`. Note that this does not support authenticated proxies.
