### PR TITLE
Remove default format (JSON) from API operations

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -62,7 +62,7 @@ public class {{classname}} {
     }
     {{/required}}{{/allParams}}
     // create path and map variables
-    String {{localVariablePrefix}}localVarPath = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
+    String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
       .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     // query params

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -59,7 +59,7 @@ public class {{classname}} {
     }
     {{/required}}{{/allParams}}
     // create path and map variables
-    String {{localVariablePrefix}}localVarPath = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
+    String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
       .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     // query params

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -69,7 +69,7 @@ public class {{classname}} {
         
         // create path and map variables
         String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
-                .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+            .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
         {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();{{#queryParams}}
         if ({{paramName}} != null)

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -68,8 +68,8 @@ public class {{classname}} {
         Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
         
         // create path and map variables
-        String {{localVariablePrefix}}localVarPath = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
-        .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+        String {{localVariablePrefix}}localVarPath = "{{{path}}}"{{#pathParams}}
+                .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
         {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();{{#queryParams}}
         if ({{paramName}} != null)

--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/api.mustache
@@ -66,7 +66,7 @@ public class {{classname}} {
     {{/allParams}}
 
     // create path and map variables
-    String path = "{{path}}".replaceAll("\\{format\\}","json"){{#pathParams}}.replaceAll("\\{" + "{{baseName}}" + "\\}", apiInvoker.escapeString({{{paramName}}}.toString())){{/pathParams}};
+    String path = "{{path}}"{{#pathParams}}.replaceAll("\\{" + "{{baseName}}" + "\\}", apiInvoker.escapeString({{{paramName}}}.toString())){{/pathParams}};
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -79,9 +79,6 @@ NSInteger k{{classname}}MissingParamErrorCode = 234513;
     {{/allParams}}
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"{{path}}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     {{#pathParams}}
     if ({{paramName}} != nil) {

--- a/modules/swagger-codegen/src/main/resources/perl/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/api.mustache
@@ -79,7 +79,6 @@ sub {{operationId}} {
     {{/allParams}}
     # parse inputs
     my $_resource_path = '{{path}}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = '{{httpMethod}}';
     my $query_params = {};

--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -211,9 +211,6 @@ use \{{invokerPackage}}\ObjectSerializer;
             );
         }
         {{/pathParams}}
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         {{#formParams}}
         // form params
         if (${{paramName}} !== null) {

--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -161,7 +161,6 @@ class {{classname}}(object):
 {{/allParams}}
         collection_formats = {}
 
-        resource_path = '{{path}}'.replace('{format}', 'json')
         path_params = {}
 {{#pathParams}}
         if '{{paramName}}' in params:
@@ -211,7 +210,7 @@ class {{classname}}(object):
         # Authentication setting
         auth_settings = [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
 
-        return self.api_client.call_api(resource_path, '{{httpMethod}}',
+        return self.api_client.call_api('{{path}}', '{{httpMethod}}',
                                         path_params,
                                         query_params,
                                         header_params,

--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -108,7 +108,7 @@ module {{moduleName}}
       {{/hasValidation}}
       {{/allParams}}
       # resource path
-      local_var_path = "{{{path}}}".sub('{format}','json'){{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
+      local_var_path = "{{{path}}}"{{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
 
       # query parameters
       query_params = {}

--- a/samples/client/petstore/android/httpclient/docs/PetApi.md
+++ b/samples/client/petstore/android/httpclient/docs/PetApi.md
@@ -222,7 +222,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api_key](../README.md#api_key), [petstore_auth](../README.md#petstore_auth)
+[petstore_auth](../README.md#petstore_auth), [api_key](../README.md#api_key)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/android/httpclient/pom.xml
+++ b/samples/client/petstore/android/httpclient/pom.xml
@@ -145,7 +145,7 @@
     </repository>
   </repositories>
   <properties>
-    <swagger-core-version>1.5.9</swagger-core-version>
+    <swagger-core-version>1.5.12</swagger-core-version>
     <gson-version>2.3.1</gson-version>
     <junit-version>4.8.1</junit-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/android/volley/docs/PetApi.md
+++ b/samples/client/petstore/android/volley/docs/PetApi.md
@@ -222,7 +222,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[api_key](../README.md#api_key), [petstore_auth](../README.md#petstore_auth)
+[petstore_auth](../README.md#petstore_auth), [api_key](../README.md#api_key)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/PetApi.java
@@ -66,7 +66,7 @@ public class PetApi {
     Object postBody = body;
 
     // create path and map variables
-    String path = "/pet".replaceAll("\\{format\\}","json");
+    String path = "/pet";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -188,7 +188,7 @@ public class PetApi {
     }
 
     // create path and map variables
-    String path = "/pet/{petId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "petId" + "\\}", apiInvoker.escapeString(petId.toString()));
+    String path = "/pet/{petId}".replaceAll("\\{" + "petId" + "\\}", apiInvoker.escapeString(petId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -310,7 +310,7 @@ public class PetApi {
     Object postBody = null;
 
     // create path and map variables
-    String path = "/pet/findByStatus".replaceAll("\\{format\\}","json");
+    String path = "/pet/findByStatus";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -430,7 +430,7 @@ public class PetApi {
     Object postBody = null;
 
     // create path and map variables
-    String path = "/pet/findByTags".replaceAll("\\{format\\}","json");
+    String path = "/pet/findByTags";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -555,7 +555,7 @@ public class PetApi {
     }
 
     // create path and map variables
-    String path = "/pet/{petId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "petId" + "\\}", apiInvoker.escapeString(petId.toString()));
+    String path = "/pet/{petId}".replaceAll("\\{" + "petId" + "\\}", apiInvoker.escapeString(petId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -576,7 +576,7 @@ public class PetApi {
       // normal form params
     }
 
-    String[] authNames = new String[] { "api_key", "petstore_auth" };
+    String[] authNames = new String[] { "petstore_auth", "api_key" };
 
     try {
       String localVarResponse = apiInvoker.invokeAPI (basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames);
@@ -646,7 +646,7 @@ public class PetApi {
       // normal form params
           }
 
-      String[] authNames = new String[] { "api_key", "petstore_auth" };
+      String[] authNames = new String[] { "petstore_auth", "api_key" };
 
     try {
       apiInvoker.invokeAPI(basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames,
@@ -679,7 +679,7 @@ public class PetApi {
     Object postBody = body;
 
     // create path and map variables
-    String path = "/pet".replaceAll("\\{format\\}","json");
+    String path = "/pet";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -802,7 +802,7 @@ public class PetApi {
     }
 
     // create path and map variables
-    String path = "/pet/{petId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "petId" + "\\}", apiInvoker.escapeString(petId.toString()));
+    String path = "/pet/{petId}".replaceAll("\\{" + "petId" + "\\}", apiInvoker.escapeString(petId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -948,7 +948,7 @@ formParams.put("status", ApiInvoker.parameterToString(status));
     }
 
     // create path and map variables
-    String path = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json").replaceAll("\\{" + "petId" + "\\}", apiInvoker.escapeString(petId.toString()));
+    String path = "/pet/{petId}/uploadImage".replaceAll("\\{" + "petId" + "\\}", apiInvoker.escapeString(petId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/StoreApi.java
@@ -71,7 +71,7 @@ public class StoreApi {
     }
 
     // create path and map variables
-    String path = "/store/order/{orderId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "orderId" + "\\}", apiInvoker.escapeString(orderId.toString()));
+    String path = "/store/order/{orderId}".replaceAll("\\{" + "orderId" + "\\}", apiInvoker.escapeString(orderId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -190,7 +190,7 @@ public class StoreApi {
     Object postBody = null;
 
     // create path and map variables
-    String path = "/store/inventory".replaceAll("\\{format\\}","json");
+    String path = "/store/inventory";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -313,7 +313,7 @@ public class StoreApi {
     }
 
     // create path and map variables
-    String path = "/store/order/{orderId}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "orderId" + "\\}", apiInvoker.escapeString(orderId.toString()));
+    String path = "/store/order/{orderId}".replaceAll("\\{" + "orderId" + "\\}", apiInvoker.escapeString(orderId.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -437,7 +437,7 @@ public class StoreApi {
     Object postBody = body;
 
     // create path and map variables
-    String path = "/store/order".replaceAll("\\{format\\}","json");
+    String path = "/store/order";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/UserApi.java
@@ -66,7 +66,7 @@ public class UserApi {
     Object postBody = body;
 
     // create path and map variables
-    String path = "/user".replaceAll("\\{format\\}","json");
+    String path = "/user";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -180,7 +180,7 @@ public class UserApi {
     Object postBody = body;
 
     // create path and map variables
-    String path = "/user/createWithArray".replaceAll("\\{format\\}","json");
+    String path = "/user/createWithArray";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -294,7 +294,7 @@ public class UserApi {
     Object postBody = body;
 
     // create path and map variables
-    String path = "/user/createWithList".replaceAll("\\{format\\}","json");
+    String path = "/user/createWithList";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -413,7 +413,7 @@ public class UserApi {
     }
 
     // create path and map variables
-    String path = "/user/{username}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "username" + "\\}", apiInvoker.escapeString(username.toString()));
+    String path = "/user/{username}".replaceAll("\\{" + "username" + "\\}", apiInvoker.escapeString(username.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -538,7 +538,7 @@ public class UserApi {
     }
 
     // create path and map variables
-    String path = "/user/{username}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "username" + "\\}", apiInvoker.escapeString(username.toString()));
+    String path = "/user/{username}".replaceAll("\\{" + "username" + "\\}", apiInvoker.escapeString(username.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -663,7 +663,7 @@ public class UserApi {
     Object postBody = null;
 
     // create path and map variables
-    String path = "/user/login".replaceAll("\\{format\\}","json");
+    String path = "/user/login";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -784,7 +784,7 @@ public class UserApi {
     Object postBody = null;
 
     // create path and map variables
-    String path = "/user/logout".replaceAll("\\{format\\}","json");
+    String path = "/user/logout";
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();
@@ -904,7 +904,7 @@ public class UserApi {
     }
 
     // create path and map variables
-    String path = "/user/{username}".replaceAll("\\{format\\}","json").replaceAll("\\{" + "username" + "\\}", apiInvoker.escapeString(username.toString()));
+    String path = "/user/{username}".replaceAll("\\{" + "username" + "\\}", apiInvoker.escapeString(username.toString()));
 
     // query params
     List<Pair> queryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/FakeApi.java
@@ -67,7 +67,7 @@ public class FakeApi {
     }
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -135,7 +135,7 @@ public class FakeApi {
     }
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -205,7 +205,7 @@ if (paramCallback != null)
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/PetApi.java
@@ -65,7 +65,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -106,7 +106,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -150,7 +150,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/findByStatus".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet/findByStatus";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -192,7 +192,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/findByTags".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet/findByTags";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -234,7 +234,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -275,7 +275,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -317,7 +317,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -365,7 +365,7 @@ if (status != null)
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}/uploadImage"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/StoreApi.java
@@ -63,7 +63,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/store/order/{orderId}"
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
@@ -99,7 +99,7 @@ public class StoreApi {
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/store/inventory".replaceAll("\\{format\\}","json");
+    String localVarPath = "/store/inventory";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -140,7 +140,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/store/order/{orderId}"
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
@@ -182,7 +182,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order".replaceAll("\\{format\\}","json");
+    String localVarPath = "/store/order";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/api/UserApi.java
@@ -63,7 +63,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -103,7 +103,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/createWithArray".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/createWithArray";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -143,7 +143,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/createWithList".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/createWithList";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -183,7 +183,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
@@ -225,7 +225,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
@@ -273,7 +273,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/login".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/login";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -309,7 +309,7 @@ public class UserApi {
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/user/logout".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/logout";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -355,7 +355,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/FakeApi.java
@@ -53,7 +53,7 @@ public class FakeApi {
     }
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -121,7 +121,7 @@ public class FakeApi {
     }
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -191,7 +191,7 @@ if (paramCallback != null)
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/PetApi.java
@@ -51,7 +51,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -92,7 +92,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -136,7 +136,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/findByStatus".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet/findByStatus";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -178,7 +178,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/findByTags".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet/findByTags";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -220,7 +220,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -261,7 +261,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -303,7 +303,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -351,7 +351,7 @@ if (status != null)
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}/uploadImage"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/StoreApi.java
@@ -49,7 +49,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/store/order/{orderId}"
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
@@ -85,7 +85,7 @@ public class StoreApi {
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/store/inventory".replaceAll("\\{format\\}","json");
+    String localVarPath = "/store/inventory";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -126,7 +126,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/store/order/{orderId}"
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
@@ -168,7 +168,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order".replaceAll("\\{format\\}","json");
+    String localVarPath = "/store/order";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/api/UserApi.java
@@ -49,7 +49,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -89,7 +89,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/createWithArray".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/createWithArray";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -129,7 +129,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/createWithList".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/createWithList";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -169,7 +169,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
@@ -211,7 +211,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
@@ -259,7 +259,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/login".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/login";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -295,7 +295,7 @@ public class UserApi {
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/user/logout".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/logout";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -341,7 +341,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params

--- a/samples/client/petstore/java/jersey2/git_push.sh
+++ b/samples/client/petstore/java/jersey2/git_push.sh
@@ -8,17 +8,17 @@ git_repo_id=$2
 release_note=$3
 
 if [ "$git_user_id" = "" ]; then
-    git_user_id=""
+    git_user_id="GIT_USER_ID"
     echo "[INFO] No command line input provided. Set \$git_user_id to $git_user_id"
 fi
 
 if [ "$git_repo_id" = "" ]; then
-    git_repo_id=""
+    git_repo_id="GIT_REPO_ID"
     echo "[INFO] No command line input provided. Set \$git_repo_id to $git_repo_id"
 fi
 
 if [ "$release_note" = "" ]; then
-    release_note=""
+    release_note="Minor update"
     echo "[INFO] No command line input provided. Set \$release_note to $release_note"
 fi
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/FakeApi.java
@@ -53,7 +53,7 @@ public class FakeApi {
     }
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -121,7 +121,7 @@ public class FakeApi {
     }
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -191,7 +191,7 @@ if (paramCallback != null)
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+    String localVarPath = "/fake";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/PetApi.java
@@ -51,7 +51,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -92,7 +92,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -136,7 +136,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/findByStatus".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet/findByStatus";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -178,7 +178,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/findByTags".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet/findByTags";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -220,7 +220,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -261,7 +261,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet".replaceAll("\\{format\\}","json");
+    String localVarPath = "/pet";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -303,7 +303,7 @@ public class PetApi {
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params
@@ -351,7 +351,7 @@ if (status != null)
     }
     
     // create path and map variables
-    String localVarPath = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
+    String localVarPath = "/pet/{petId}/uploadImage"
       .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
     // query params

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/StoreApi.java
@@ -49,7 +49,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/store/order/{orderId}"
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
@@ -85,7 +85,7 @@ public class StoreApi {
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/store/inventory".replaceAll("\\{format\\}","json");
+    String localVarPath = "/store/inventory";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -126,7 +126,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/store/order/{orderId}"
       .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
     // query params
@@ -168,7 +168,7 @@ public class StoreApi {
     }
     
     // create path and map variables
-    String localVarPath = "/store/order".replaceAll("\\{format\\}","json");
+    String localVarPath = "/store/order";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/api/UserApi.java
@@ -49,7 +49,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -89,7 +89,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/createWithArray".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/createWithArray";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -129,7 +129,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/createWithList".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/createWithList";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -169,7 +169,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
@@ -211,7 +211,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params
@@ -259,7 +259,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/login".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/login";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -295,7 +295,7 @@ public class UserApi {
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/user/logout".replaceAll("\\{format\\}","json");
+    String localVarPath = "/user/logout";
 
     // query params
     List<Pair> localVarQueryParams = new ArrayList<Pair>();
@@ -341,7 +341,7 @@ public class UserApi {
     }
     
     // create path and map variables
-    String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
+    String localVarPath = "/user/{username}"
       .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
     // query params

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/FakeApi.java
@@ -62,7 +62,7 @@ public class FakeApi {
         Object localVarPostBody = body;
         
         // create path and map variables
-        String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+        String localVarPath = "/fake";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -180,7 +180,7 @@ public class FakeApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+        String localVarPath = "/fake";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -376,7 +376,7 @@ public class FakeApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/fake".replaceAll("\\{format\\}","json");
+        String localVarPath = "/fake";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         if (enumQueryStringArray != null)

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/PetApi.java
@@ -61,7 +61,7 @@ public class PetApi {
         Object localVarPostBody = body;
         
         // create path and map variables
-        String localVarPath = "/pet".replaceAll("\\{format\\}","json");
+        String localVarPath = "/pet";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -175,8 +175,8 @@ public class PetApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+        String localVarPath = "/pet/{petId}"
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -295,7 +295,7 @@ public class PetApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/pet/findByStatus".replaceAll("\\{format\\}","json");
+        String localVarPath = "/pet/findByStatus";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         if (status != null)
@@ -415,7 +415,7 @@ public class PetApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/pet/findByTags".replaceAll("\\{format\\}","json");
+        String localVarPath = "/pet/findByTags";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         if (tags != null)
@@ -535,8 +535,8 @@ public class PetApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+        String localVarPath = "/pet/{petId}"
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -654,7 +654,7 @@ public class PetApi {
         Object localVarPostBody = body;
         
         // create path and map variables
-        String localVarPath = "/pet".replaceAll("\\{format\\}","json");
+        String localVarPath = "/pet";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -768,8 +768,8 @@ public class PetApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/pet/{petId}".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+        String localVarPath = "/pet/{petId}"
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -893,8 +893,8 @@ public class PetApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/pet/{petId}/uploadImage".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
+        String localVarPath = "/pet/{petId}/uploadImage"
+            .replaceAll("\\{" + "petId" + "\\}", apiClient.escapeString(petId.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/StoreApi.java
@@ -59,8 +59,8 @@ public class StoreApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
+        String localVarPath = "/store/order/{orderId}"
+            .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -174,7 +174,7 @@ public class StoreApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/store/inventory".replaceAll("\\{format\\}","json");
+        String localVarPath = "/store/inventory";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -284,8 +284,8 @@ public class StoreApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/store/order/{orderId}".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
+        String localVarPath = "/store/order/{orderId}"
+            .replaceAll("\\{" + "orderId" + "\\}", apiClient.escapeString(orderId.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -403,7 +403,7 @@ public class StoreApi {
         Object localVarPostBody = body;
         
         // create path and map variables
-        String localVarPath = "/store/order".replaceAll("\\{format\\}","json");
+        String localVarPath = "/store/order";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/api/UserApi.java
@@ -59,7 +59,7 @@ public class UserApi {
         Object localVarPostBody = body;
         
         // create path and map variables
-        String localVarPath = "/user".replaceAll("\\{format\\}","json");
+        String localVarPath = "/user";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -173,7 +173,7 @@ public class UserApi {
         Object localVarPostBody = body;
         
         // create path and map variables
-        String localVarPath = "/user/createWithArray".replaceAll("\\{format\\}","json");
+        String localVarPath = "/user/createWithArray";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -287,7 +287,7 @@ public class UserApi {
         Object localVarPostBody = body;
         
         // create path and map variables
-        String localVarPath = "/user/createWithList".replaceAll("\\{format\\}","json");
+        String localVarPath = "/user/createWithList";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -401,8 +401,8 @@ public class UserApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+        String localVarPath = "/user/{username}"
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -516,8 +516,8 @@ public class UserApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+        String localVarPath = "/user/{username}"
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -635,7 +635,7 @@ public class UserApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/user/login".replaceAll("\\{format\\}","json");
+        String localVarPath = "/user/login";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         if (username != null)
@@ -765,7 +765,7 @@ public class UserApi {
         Object localVarPostBody = null;
         
         // create path and map variables
-        String localVarPath = "/user/logout".replaceAll("\\{format\\}","json");
+        String localVarPath = "/user/logout";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 
@@ -871,8 +871,8 @@ public class UserApi {
         Object localVarPostBody = body;
         
         // create path and map variables
-        String localVarPath = "/user/{username}".replaceAll("\\{format\\}","json")
-        .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
+        String localVarPath = "/user/{username}"
+            .replaceAll("\\{" + "username" + "\\}", apiClient.escapeString(username.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/FakeApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.CollectionFormats.*;
 
 
+
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/PetApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.CollectionFormats.*;
 
 
+
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/StoreApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.CollectionFormats.*;
 
 
+
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/UserApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.CollectionFormats.*;
 
 
+
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/FormatTest.java
@@ -79,9 +79,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
-  @Min(10)
-  @Max(100)
-  @ApiModelProperty(example = "null", value = "")
+ @Min(10) @Max(100)  @ApiModelProperty(example = "null", value = "")
   public Integer getInteger() {
     return integer;
   }
@@ -101,9 +99,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
-  @Min(20)
-  @Max(200)
-  @ApiModelProperty(example = "null", value = "")
+ @Min(20) @Max(200)  @ApiModelProperty(example = "null", value = "")
   public Integer getInt32() {
     return int32;
   }
@@ -142,9 +138,7 @@ public class FormatTest {
    * @return number
   **/
   @NotNull
-  @DecimalMin("32.1")
-  @DecimalMax("543.2")
-  @ApiModelProperty(example = "null", required = true, value = "")
+ @DecimalMin("32.1") @DecimalMax("543.2")  @ApiModelProperty(example = "null", required = true, value = "")
   public BigDecimal getNumber() {
     return number;
   }
@@ -164,9 +158,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
-  @DecimalMin("54.3")
-  @DecimalMax("987.6")
-  @ApiModelProperty(example = "null", value = "")
+ @DecimalMin("54.3") @DecimalMax("987.6")  @ApiModelProperty(example = "null", value = "")
   public Float getFloat() {
     return _float;
   }
@@ -186,9 +178,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
-  @DecimalMin("67.8")
-  @DecimalMax("123.4")
-  @ApiModelProperty(example = "null", value = "")
+ @DecimalMin("67.8") @DecimalMax("123.4")  @ApiModelProperty(example = "null", value = "")
   public Double getDouble() {
     return _double;
   }
@@ -206,8 +196,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
-  @Pattern(regexp="/[a-z]/i")
-  @ApiModelProperty(example = "null", value = "")
+ @Pattern(regexp="/[a-z]/i")  @ApiModelProperty(example = "null", value = "")
   public String getString() {
     return string;
   }
@@ -318,8 +307,7 @@ public class FormatTest {
    * @return password
   **/
   @NotNull
-  @Size(min=10,max=64)
-  @ApiModelProperty(example = "null", required = true, value = "")
+ @Size(min=10,max=64)  @ApiModelProperty(example = "null", required = true, value = "")
   public String getPassword() {
     return password;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/ApiClient.java
@@ -16,6 +16,7 @@ import org.joda.time.format.ISODateTimeFormat;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 
+
 import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 
@@ -128,6 +129,7 @@ public class ApiClient {
         adapterBuilder = new Retrofit
                 .Builder()
                 .baseUrl(baseUrl)
+                
                 
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .addConverterFactory(GsonCustomConverterFactory.create(gson));

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/FakeApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.CollectionFormats.*;
 
 
+
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/PetApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.CollectionFormats.*;
 
 
+
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/StoreApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.CollectionFormats.*;
 
 
+
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/UserApi.java
@@ -3,6 +3,7 @@ package io.swagger.client.api;
 import io.swagger.client.CollectionFormats.*;
 
 
+
 import retrofit2.Call;
 import retrofit2.http.*;
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/ApiClient.java
@@ -16,6 +16,7 @@ import org.joda.time.format.ISODateTimeFormat;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+
 import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 
@@ -129,6 +130,7 @@ public class ApiClient {
                 .Builder()
                 .baseUrl(baseUrl)
                 .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+                
                 .addConverterFactory(ScalarsConverterFactory.create())
                 .addConverterFactory(GsonCustomConverterFactory.create(gson));
     }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/FakeApi.java
@@ -4,6 +4,7 @@ import io.swagger.client.CollectionFormats.*;
 
 import rx.Observable;
 
+
 import retrofit2.http.*;
 
 import okhttp3.RequestBody;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/PetApi.java
@@ -4,6 +4,7 @@ import io.swagger.client.CollectionFormats.*;
 
 import rx.Observable;
 
+
 import retrofit2.http.*;
 
 import okhttp3.RequestBody;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/StoreApi.java
@@ -4,6 +4,7 @@ import io.swagger.client.CollectionFormats.*;
 
 import rx.Observable;
 
+
 import retrofit2.http.*;
 
 import okhttp3.RequestBody;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/UserApi.java
@@ -4,6 +4,7 @@ import io.swagger.client.CollectionFormats.*;
 
 import rx.Observable;
 
+
 import retrofit2.http.*;
 
 import okhttp3.RequestBody;

--- a/samples/client/petstore/objc/default/SwaggerClient/Api/SWGPetApi.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Api/SWGPetApi.m
@@ -60,9 +60,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -132,9 +129,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/{petId}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (petId != nil) {
         pathParams[@"petId"] = petId;
@@ -195,9 +189,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/findByStatus"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -255,9 +246,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) findPetsByTagsWithTags: (NSArray<NSString*>*) tags
     completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/findByTags"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -328,9 +316,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/{petId}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (petId != nil) {
         pathParams[@"petId"] = petId;
@@ -387,9 +372,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) updatePetWithBody: (SWGPet*) body
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -462,9 +444,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
     }
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/{petId}"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (petId != nil) {
@@ -545,9 +524,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
     }
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/{petId}/uploadImage"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (petId != nil) {

--- a/samples/client/petstore/objc/default/SwaggerClient/Api/SWGStoreApi.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Api/SWGStoreApi.m
@@ -71,9 +71,6 @@ NSInteger kSWGStoreApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/store/order/{orderId}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (orderId != nil) {
         pathParams[@"orderId"] = orderId;
@@ -128,9 +125,6 @@ NSInteger kSWGStoreApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) getInventoryWithCompletionHandler: 
     (void (^)(NSDictionary<NSString*, NSNumber*>* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/store/inventory"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -197,9 +191,6 @@ NSInteger kSWGStoreApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/store/order/{orderId}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (orderId != nil) {
         pathParams[@"orderId"] = orderId;
@@ -256,9 +247,6 @@ NSInteger kSWGStoreApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) placeOrderWithBody: (SWGOrder*) body
     completionHandler: (void (^)(SWGOrder* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/store/order"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 

--- a/samples/client/petstore/objc/default/SwaggerClient/Api/SWGUserApi.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Api/SWGUserApi.m
@@ -60,9 +60,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -118,9 +115,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/createWithArray"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -175,9 +169,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) createUsersWithListInputWithBody: (NSArray<SWGUser>*) body
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/createWithList"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -244,9 +235,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     }
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/{username}"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (username != nil) {
@@ -316,9 +304,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/{username}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (username != nil) {
         pathParams[@"username"] = username;
@@ -379,9 +364,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSString* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/login"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -439,9 +421,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) logoutUserWithCompletionHandler: 
     (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/logout"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -510,9 +489,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     }
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/{username}"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (username != nil) {

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/FakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/FakeApi.pm
@@ -83,7 +83,6 @@ sub test_client_model {
 
     # parse inputs
     my $_resource_path = '/fake';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'PATCH';
     my $query_params = {};
@@ -242,7 +241,6 @@ sub test_endpoint_parameters {
 
     # parse inputs
     my $_resource_path = '/fake';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'POST';
     my $query_params = {};
@@ -406,7 +404,6 @@ sub test_enum_parameters {
 
     # parse inputs
     my $_resource_path = '/fake';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/PetApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/PetApi.pm
@@ -83,7 +83,6 @@ sub add_pet {
 
     # parse inputs
     my $_resource_path = '/pet';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'POST';
     my $query_params = {};
@@ -151,7 +150,6 @@ sub delete_pet {
 
     # parse inputs
     my $_resource_path = '/pet/{petId}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'DELETE';
     my $query_params = {};
@@ -220,7 +218,6 @@ sub find_pets_by_status {
 
     # parse inputs
     my $_resource_path = '/pet/findByStatus';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};
@@ -286,7 +283,6 @@ sub find_pets_by_tags {
 
     # parse inputs
     my $_resource_path = '/pet/findByTags';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};
@@ -352,7 +348,6 @@ sub get_pet_by_id {
 
     # parse inputs
     my $_resource_path = '/pet/{petId}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};
@@ -420,7 +415,6 @@ sub update_pet {
 
     # parse inputs
     my $_resource_path = '/pet';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'PUT';
     my $query_params = {};
@@ -494,7 +488,6 @@ sub update_pet_with_form {
 
     # parse inputs
     my $_resource_path = '/pet/{petId}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'POST';
     my $query_params = {};
@@ -580,7 +573,6 @@ sub upload_file {
 
     # parse inputs
     my $_resource_path = '/pet/{petId}/uploadImage';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'POST';
     my $query_params = {};

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/StoreApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/StoreApi.pm
@@ -83,7 +83,6 @@ sub delete_order {
 
     # parse inputs
     my $_resource_path = '/store/order/{orderId}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'DELETE';
     my $query_params = {};
@@ -136,7 +135,6 @@ sub get_inventory {
 
     # parse inputs
     my $_resource_path = '/store/inventory';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};
@@ -197,7 +195,6 @@ sub get_order_by_id {
 
     # parse inputs
     my $_resource_path = '/store/order/{orderId}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};
@@ -265,7 +262,6 @@ sub place_order {
 
     # parse inputs
     my $_resource_path = '/store/order';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'POST';
     my $query_params = {};

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/UserApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/UserApi.pm
@@ -83,7 +83,6 @@ sub create_user {
 
     # parse inputs
     my $_resource_path = '/user';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'POST';
     my $query_params = {};
@@ -145,7 +144,6 @@ sub create_users_with_array_input {
 
     # parse inputs
     my $_resource_path = '/user/createWithArray';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'POST';
     my $query_params = {};
@@ -207,7 +205,6 @@ sub create_users_with_list_input {
 
     # parse inputs
     my $_resource_path = '/user/createWithList';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'POST';
     my $query_params = {};
@@ -269,7 +266,6 @@ sub delete_user {
 
     # parse inputs
     my $_resource_path = '/user/{username}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'DELETE';
     my $query_params = {};
@@ -333,7 +329,6 @@ sub get_user_by_name {
 
     # parse inputs
     my $_resource_path = '/user/{username}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};
@@ -412,7 +407,6 @@ sub login_user {
 
     # parse inputs
     my $_resource_path = '/user/login';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};
@@ -472,7 +466,6 @@ sub logout_user {
 
     # parse inputs
     my $_resource_path = '/user/logout';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'GET';
     my $query_params = {};
@@ -540,7 +533,6 @@ sub update_user {
 
     # parse inputs
     my $_resource_path = '/user/{username}';
-    $_resource_path =~ s/{format}/json/; # default format to json
 
     my $_method = 'PUT';
     my $query_params = {};

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -129,9 +129,6 @@ class FakeApi
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json']);
 
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -295,9 +292,6 @@ class FakeApi
             $headerParams['Accept'] = $_header_accept;
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/xml; charset=utf-8', 'application/json; charset=utf-8']);
-
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
 
         // form params
         if ($integer !== null) {
@@ -465,9 +459,6 @@ class FakeApi
         if ($enum_header_string !== null) {
             $headerParams['enum_header_string'] = $this->apiClient->getSerializer()->toHeaderValue($enum_header_string);
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         // form params
         if ($enum_form_string_array !== null) {
             $formParams['enum_form_string_array'] = $this->apiClient->getSerializer()->toFormValue($enum_form_string_array);

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -129,9 +129,6 @@ class PetApi
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json', 'application/xml']);
 
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -225,9 +222,6 @@ class PetApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -309,9 +303,6 @@ class PetApi
         if ($status !== null) {
             $queryParams['status'] = $this->apiClient->getSerializer()->toQueryValue($status);
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -397,9 +388,6 @@ class PetApi
         if ($tags !== null) {
             $queryParams['tags'] = $this->apiClient->getSerializer()->toQueryValue($tags);
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -486,9 +474,6 @@ class PetApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -567,9 +552,6 @@ class PetApi
             $headerParams['Accept'] = $_header_accept;
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType(['application/json', 'application/xml']);
-
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
 
         // body params
         $_tempBody = null;
@@ -662,9 +644,6 @@ class PetApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         // form params
         if ($name !== null) {
             $formParams['name'] = $this->apiClient->getSerializer()->toFormValue($name);
@@ -759,9 +738,6 @@ class PetApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         // form params
         if ($additional_metadata !== null) {
             $formParams['additionalMetadata'] = $this->apiClient->getSerializer()->toFormValue($additional_metadata);

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -137,9 +137,6 @@ class StoreApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -203,9 +200,6 @@ class StoreApi
             $headerParams['Accept'] = $_header_accept;
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType([]);
-
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
 
         
         // for model (json/xml)
@@ -301,9 +295,6 @@ class StoreApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -377,9 +368,6 @@ class StoreApi
             $headerParams['Accept'] = $_header_accept;
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType([]);
-
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
 
         // body params
         $_tempBody = null;

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -129,9 +129,6 @@ class UserApi
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType([]);
 
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -207,9 +204,6 @@ class UserApi
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType([]);
 
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -284,9 +278,6 @@ class UserApi
             $headerParams['Accept'] = $_header_accept;
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType([]);
-
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
 
         // body params
         $_tempBody = null;
@@ -371,9 +362,6 @@ class UserApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -452,9 +440,6 @@ class UserApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -543,9 +528,6 @@ class UserApi
         if ($password !== null) {
             $queryParams['password'] = $this->apiClient->getSerializer()->toQueryValue($password);
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         
         // for model (json/xml)
         if (isset($_tempBody)) {
@@ -613,9 +595,6 @@ class UserApi
             $headerParams['Accept'] = $_header_accept;
         }
         $headerParams['Content-Type'] = $this->apiClient->selectHeaderContentType([]);
-
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
 
         
         // for model (json/xml)
@@ -701,9 +680,6 @@ class UserApi
                 $resourcePath
             );
         }
-        // default format to json
-        $resourcePath = str_replace("{format}", "json", $resourcePath);
-
         // body params
         $_tempBody = null;
         if (isset($body)) {

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -108,7 +108,6 @@ class FakeApi(object):
 
         collection_formats = {}
 
-        resource_path = '/fake'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -132,7 +131,7 @@ class FakeApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'PATCH',
+        return self.api_client.call_api('/fake', 'PATCH',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -276,7 +275,6 @@ class FakeApi(object):
 
         collection_formats = {}
 
-        resource_path = '/fake'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -326,7 +324,7 @@ class FakeApi(object):
         # Authentication setting
         auth_settings = ['http_basic_test']
 
-        return self.api_client.call_api(resource_path, 'POST',
+        return self.api_client.call_api('/fake', 'POST',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -420,7 +418,6 @@ class FakeApi(object):
 
         collection_formats = {}
 
-        resource_path = '/fake'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -461,7 +458,7 @@ class FakeApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/fake', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,

--- a/samples/client/petstore/python/petstore_api/apis/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/pet_api.py
@@ -108,7 +108,6 @@ class PetApi(object):
 
         collection_formats = {}
 
-        resource_path = '/pet'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -132,7 +131,7 @@ class PetApi(object):
         # Authentication setting
         auth_settings = ['petstore_auth']
 
-        return self.api_client.call_api(resource_path, 'POST',
+        return self.api_client.call_api('/pet', 'POST',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -217,7 +216,6 @@ class PetApi(object):
 
         collection_formats = {}
 
-        resource_path = '/pet/{petId}'.replace('{format}', 'json')
         path_params = {}
         if 'pet_id' in params:
             path_params['petId'] = params['pet_id']
@@ -239,7 +237,7 @@ class PetApi(object):
         # Authentication setting
         auth_settings = ['petstore_auth']
 
-        return self.api_client.call_api(resource_path, 'DELETE',
+        return self.api_client.call_api('/pet/{petId}', 'DELETE',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -322,7 +320,6 @@ class PetApi(object):
 
         collection_formats = {}
 
-        resource_path = '/pet/findByStatus'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -343,7 +340,7 @@ class PetApi(object):
         # Authentication setting
         auth_settings = ['petstore_auth']
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/pet/findByStatus', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -426,7 +423,6 @@ class PetApi(object):
 
         collection_formats = {}
 
-        resource_path = '/pet/findByTags'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -447,7 +443,7 @@ class PetApi(object):
         # Authentication setting
         auth_settings = ['petstore_auth']
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/pet/findByTags', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -530,7 +526,6 @@ class PetApi(object):
 
         collection_formats = {}
 
-        resource_path = '/pet/{petId}'.replace('{format}', 'json')
         path_params = {}
         if 'pet_id' in params:
             path_params['petId'] = params['pet_id']
@@ -550,7 +545,7 @@ class PetApi(object):
         # Authentication setting
         auth_settings = ['api_key']
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/pet/{petId}', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -633,7 +628,6 @@ class PetApi(object):
 
         collection_formats = {}
 
-        resource_path = '/pet'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -657,7 +651,7 @@ class PetApi(object):
         # Authentication setting
         auth_settings = ['petstore_auth']
 
-        return self.api_client.call_api(resource_path, 'PUT',
+        return self.api_client.call_api('/pet', 'PUT',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -744,7 +738,6 @@ class PetApi(object):
 
         collection_formats = {}
 
-        resource_path = '/pet/{petId}'.replace('{format}', 'json')
         path_params = {}
         if 'pet_id' in params:
             path_params['petId'] = params['pet_id']
@@ -772,7 +765,7 @@ class PetApi(object):
         # Authentication setting
         auth_settings = ['petstore_auth']
 
-        return self.api_client.call_api(resource_path, 'POST',
+        return self.api_client.call_api('/pet/{petId}', 'POST',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -859,7 +852,6 @@ class PetApi(object):
 
         collection_formats = {}
 
-        resource_path = '/pet/{petId}/uploadImage'.replace('{format}', 'json')
         path_params = {}
         if 'pet_id' in params:
             path_params['petId'] = params['pet_id']
@@ -887,7 +879,7 @@ class PetApi(object):
         # Authentication setting
         auth_settings = ['petstore_auth']
 
-        return self.api_client.call_api(resource_path, 'POST',
+        return self.api_client.call_api('/pet/{petId}/uploadImage', 'POST',
                                         path_params,
                                         query_params,
                                         header_params,

--- a/samples/client/petstore/python/petstore_api/apis/store_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/store_api.py
@@ -108,7 +108,6 @@ class StoreApi(object):
 
         collection_formats = {}
 
-        resource_path = '/store/order/{orderId}'.replace('{format}', 'json')
         path_params = {}
         if 'order_id' in params:
             path_params['orderId'] = params['order_id']
@@ -128,7 +127,7 @@ class StoreApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'DELETE',
+        return self.api_client.call_api('/store/order/{orderId}', 'DELETE',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -205,7 +204,6 @@ class StoreApi(object):
 
         collection_formats = {}
 
-        resource_path = '/store/inventory'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -223,7 +221,7 @@ class StoreApi(object):
         # Authentication setting
         auth_settings = ['api_key']
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/store/inventory', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -310,7 +308,6 @@ class StoreApi(object):
 
         collection_formats = {}
 
-        resource_path = '/store/order/{orderId}'.replace('{format}', 'json')
         path_params = {}
         if 'order_id' in params:
             path_params['orderId'] = params['order_id']
@@ -330,7 +327,7 @@ class StoreApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/store/order/{orderId}', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -413,7 +410,6 @@ class StoreApi(object):
 
         collection_formats = {}
 
-        resource_path = '/store/order'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -433,7 +429,7 @@ class StoreApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'POST',
+        return self.api_client.call_api('/store/order', 'POST',
                                         path_params,
                                         query_params,
                                         header_params,

--- a/samples/client/petstore/python/petstore_api/apis/user_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/user_api.py
@@ -108,7 +108,6 @@ class UserApi(object):
 
         collection_formats = {}
 
-        resource_path = '/user'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -128,7 +127,7 @@ class UserApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'POST',
+        return self.api_client.call_api('/user', 'POST',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -211,7 +210,6 @@ class UserApi(object):
 
         collection_formats = {}
 
-        resource_path = '/user/createWithArray'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -231,7 +229,7 @@ class UserApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'POST',
+        return self.api_client.call_api('/user/createWithArray', 'POST',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -314,7 +312,6 @@ class UserApi(object):
 
         collection_formats = {}
 
-        resource_path = '/user/createWithList'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -334,7 +331,7 @@ class UserApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'POST',
+        return self.api_client.call_api('/user/createWithList', 'POST',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -417,7 +414,6 @@ class UserApi(object):
 
         collection_formats = {}
 
-        resource_path = '/user/{username}'.replace('{format}', 'json')
         path_params = {}
         if 'username' in params:
             path_params['username'] = params['username']
@@ -437,7 +433,7 @@ class UserApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'DELETE',
+        return self.api_client.call_api('/user/{username}', 'DELETE',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -520,7 +516,6 @@ class UserApi(object):
 
         collection_formats = {}
 
-        resource_path = '/user/{username}'.replace('{format}', 'json')
         path_params = {}
         if 'username' in params:
             path_params['username'] = params['username']
@@ -540,7 +535,7 @@ class UserApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/user/{username}', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -628,7 +623,6 @@ class UserApi(object):
 
         collection_formats = {}
 
-        resource_path = '/user/login'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -650,7 +644,7 @@ class UserApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/user/login', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -727,7 +721,6 @@ class UserApi(object):
 
         collection_formats = {}
 
-        resource_path = '/user/logout'.replace('{format}', 'json')
         path_params = {}
 
         query_params = {}
@@ -745,7 +738,7 @@ class UserApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'GET',
+        return self.api_client.call_api('/user/logout', 'GET',
                                         path_params,
                                         query_params,
                                         header_params,
@@ -833,7 +826,6 @@ class UserApi(object):
 
         collection_formats = {}
 
-        resource_path = '/user/{username}'.replace('{format}', 'json')
         path_params = {}
         if 'username' in params:
             path_params['username'] = params['username']
@@ -855,7 +847,7 @@ class UserApi(object):
         # Authentication setting
         auth_settings = []
 
-        return self.api_client.call_api(resource_path, 'PUT',
+        return self.api_client.call_api('/user/{username}', 'PUT',
                                         path_params,
                                         query_params,
                                         header_params,

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -41,7 +41,7 @@ module Petstore
       # verify the required parameter 'body' is set
       fail ArgumentError, "Missing the required parameter 'body' when calling FakeApi.test_client_model" if body.nil?
       # resource path
-      local_var_path = "/fake".sub('{format}','json')
+      local_var_path = "/fake"
 
       # query parameters
       query_params = {}
@@ -178,7 +178,7 @@ module Petstore
       end
 
       # resource path
-      local_var_path = "/fake".sub('{format}','json')
+      local_var_path = "/fake"
 
       # query parameters
       query_params = {}
@@ -274,7 +274,7 @@ module Petstore
         fail ArgumentError, 'invalid value for "enum_query_string", must be one of _abc, -efg, (xyz)'
       end
       # resource path
-      local_var_path = "/fake".sub('{format}','json')
+      local_var_path = "/fake"
 
       # query parameters
       query_params = {}

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -41,7 +41,7 @@ module Petstore
       # verify the required parameter 'body' is set
       fail ArgumentError, "Missing the required parameter 'body' when calling PetApi.add_pet" if body.nil?
       # resource path
-      local_var_path = "/pet".sub('{format}','json')
+      local_var_path = "/pet"
 
       # query parameters
       query_params = {}
@@ -95,7 +95,7 @@ module Petstore
       # verify the required parameter 'pet_id' is set
       fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.delete_pet" if pet_id.nil?
       # resource path
-      local_var_path = "/pet/{petId}".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = "/pet/{petId}".sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
       query_params = {}
@@ -146,7 +146,7 @@ module Petstore
       # verify the required parameter 'status' is set
       fail ArgumentError, "Missing the required parameter 'status' when calling PetApi.find_pets_by_status" if status.nil?
       # resource path
-      local_var_path = "/pet/findByStatus".sub('{format}','json')
+      local_var_path = "/pet/findByStatus"
 
       # query parameters
       query_params = {}
@@ -198,7 +198,7 @@ module Petstore
       # verify the required parameter 'tags' is set
       fail ArgumentError, "Missing the required parameter 'tags' when calling PetApi.find_pets_by_tags" if tags.nil?
       # resource path
-      local_var_path = "/pet/findByTags".sub('{format}','json')
+      local_var_path = "/pet/findByTags"
 
       # query parameters
       query_params = {}
@@ -250,7 +250,7 @@ module Petstore
       # verify the required parameter 'pet_id' is set
       fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.get_pet_by_id" if pet_id.nil?
       # resource path
-      local_var_path = "/pet/{petId}".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = "/pet/{petId}".sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
       query_params = {}
@@ -301,7 +301,7 @@ module Petstore
       # verify the required parameter 'body' is set
       fail ArgumentError, "Missing the required parameter 'body' when calling PetApi.update_pet" if body.nil?
       # resource path
-      local_var_path = "/pet".sub('{format}','json')
+      local_var_path = "/pet"
 
       # query parameters
       query_params = {}
@@ -357,7 +357,7 @@ module Petstore
       # verify the required parameter 'pet_id' is set
       fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.update_pet_with_form" if pet_id.nil?
       # resource path
-      local_var_path = "/pet/{petId}".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = "/pet/{petId}".sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
       query_params = {}
@@ -415,7 +415,7 @@ module Petstore
       # verify the required parameter 'pet_id' is set
       fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.upload_file" if pet_id.nil?
       # resource path
-      local_var_path = "/pet/{petId}/uploadImage".sub('{format}','json').sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = "/pet/{petId}/uploadImage".sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
       query_params = {}

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -41,7 +41,7 @@ module Petstore
       # verify the required parameter 'order_id' is set
       fail ArgumentError, "Missing the required parameter 'order_id' when calling StoreApi.delete_order" if order_id.nil?
       # resource path
-      local_var_path = "/store/order/{orderId}".sub('{format}','json').sub('{' + 'orderId' + '}', order_id.to_s)
+      local_var_path = "/store/order/{orderId}".sub('{' + 'orderId' + '}', order_id.to_s)
 
       # query parameters
       query_params = {}
@@ -87,7 +87,7 @@ module Petstore
         @api_client.config.logger.debug "Calling API: StoreApi.get_inventory ..."
       end
       # resource path
-      local_var_path = "/store/inventory".sub('{format}','json')
+      local_var_path = "/store/inventory"
 
       # query parameters
       query_params = {}
@@ -146,7 +146,7 @@ module Petstore
       end
 
       # resource path
-      local_var_path = "/store/order/{orderId}".sub('{format}','json').sub('{' + 'orderId' + '}', order_id.to_s)
+      local_var_path = "/store/order/{orderId}".sub('{' + 'orderId' + '}', order_id.to_s)
 
       # query parameters
       query_params = {}
@@ -197,7 +197,7 @@ module Petstore
       # verify the required parameter 'body' is set
       fail ArgumentError, "Missing the required parameter 'body' when calling StoreApi.place_order" if body.nil?
       # resource path
-      local_var_path = "/store/order".sub('{format}','json')
+      local_var_path = "/store/order"
 
       # query parameters
       query_params = {}

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -41,7 +41,7 @@ module Petstore
       # verify the required parameter 'body' is set
       fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_user" if body.nil?
       # resource path
-      local_var_path = "/user".sub('{format}','json')
+      local_var_path = "/user"
 
       # query parameters
       query_params = {}
@@ -91,7 +91,7 @@ module Petstore
       # verify the required parameter 'body' is set
       fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_users_with_array_input" if body.nil?
       # resource path
-      local_var_path = "/user/createWithArray".sub('{format}','json')
+      local_var_path = "/user/createWithArray"
 
       # query parameters
       query_params = {}
@@ -141,7 +141,7 @@ module Petstore
       # verify the required parameter 'body' is set
       fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_users_with_list_input" if body.nil?
       # resource path
-      local_var_path = "/user/createWithList".sub('{format}','json')
+      local_var_path = "/user/createWithList"
 
       # query parameters
       query_params = {}
@@ -191,7 +191,7 @@ module Petstore
       # verify the required parameter 'username' is set
       fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.delete_user" if username.nil?
       # resource path
-      local_var_path = "/user/{username}".sub('{format}','json').sub('{' + 'username' + '}', username.to_s)
+      local_var_path = "/user/{username}".sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
       query_params = {}
@@ -241,7 +241,7 @@ module Petstore
       # verify the required parameter 'username' is set
       fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.get_user_by_name" if username.nil?
       # resource path
-      local_var_path = "/user/{username}".sub('{format}','json').sub('{' + 'username' + '}', username.to_s)
+      local_var_path = "/user/{username}".sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
       query_params = {}
@@ -296,7 +296,7 @@ module Petstore
       # verify the required parameter 'password' is set
       fail ArgumentError, "Missing the required parameter 'password' when calling UserApi.login_user" if password.nil?
       # resource path
-      local_var_path = "/user/login".sub('{format}','json')
+      local_var_path = "/user/login"
 
       # query parameters
       query_params = {}
@@ -345,7 +345,7 @@ module Petstore
         @api_client.config.logger.debug "Calling API: UserApi.logout_user ..."
       end
       # resource path
-      local_var_path = "/user/logout".sub('{format}','json')
+      local_var_path = "/user/logout"
 
       # query parameters
       query_params = {}
@@ -399,7 +399,7 @@ module Petstore
       # verify the required parameter 'body' is set
       fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.update_user" if body.nil?
       # resource path
-      local_var_path = "/user/{username}".sub('{format}','json').sub('{' + 'username' + '}', username.to_s)
+      local_var_path = "/user/{username}".sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
       query_params = {}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Remove default format (JSON) from API operations from all remaining generators (C# generator was fixed via https://github.com/swagger-api/swagger-codegen/pull/4980)
