### PR TITLE
Update Spring Fox dependency version to 2.6.1. This fixes a defect wh…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -9,12 +9,12 @@
         <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <springfox-version>2.5.0</springfox-version>
+        <springfox-version>2.6.1</springfox-version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.5.RELEASE</version>
+        <version>1.4.5.RELEASE</version>
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>


### PR DESCRIPTION
Fixes a defect with eureka registration on port 8080 no matter what server.port is specified in Spring Boot config. 
```@SpringBootApplication
@EnableSwagger2
@EnableDiscoveryClient
```
Fixed this by adding SpringBoot 1.4.5 dependency with Spring Fox 2.6.1. Swagger and Feign clients have a conflict when registration occurs with Eureka. SpringFox has fixed the defect in version 2.6.1 

### PR checklist

- [ ] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Tests have been done with a sample yaml file and generated pom file as expected. Runtime tests were done to ensure swagger-ui still work on spring boot.
