### PR TITLE
[Jaxrs-cxf] Unittests: uncomment api invocations, add Multipart snippet

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -817,6 +817,23 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
               itr.remove();
             }
         }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+        if (operations != null) {
+
+            @SuppressWarnings("unchecked")
+            List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
+            for (CodegenOperation operation : ops) {
+
+                if (operation.returnType == null) {
+                    operation.returnType = "void";
+                    // set vendorExtensions.x-java-is-response-void to true as returnType is set to "void"
+                    operation.vendorExtensions.put("x-java-is-response-void", true);
+                }
+            }
+        }
+
         return objs;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -818,22 +818,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             }
         }
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
-        if (operations != null) {
-
-            @SuppressWarnings("unchecked")
-            List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
-            for (CodegenOperation operation : ops) {
-
-                if (operation.returnType == null) {
-                    operation.returnType = "void";
-                    // set vendorExtensions.x-java-is-response-void to true as returnType is set to "void"
-                    operation.vendorExtensions.put("x-java-is-response-void", true);
-                }
-            }
-        }
-
         return objs;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -21,7 +21,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
     protected String testResourcesFolder = "src/test/resources";
     protected String title = "Swagger Server";
 
-	protected boolean useBeanValidation = true;
+    protected boolean useBeanValidation = true;
 
     static Logger LOGGER = LoggerFactory.getLogger(AbstractJavaJAXRSServerCodegen.class);
 
@@ -44,7 +44,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         cliOptions.add(new CliOption(CodegenConstants.IMPL_FOLDER, CodegenConstants.IMPL_FOLDER_DESC));
         cliOptions.add(new CliOption("title", "a title describing the application"));
 
-		cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
+        cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
 
     }
 
@@ -67,13 +67,13 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
             implFolder = (String) additionalProperties.get(CodegenConstants.IMPL_FOLDER);
         }
 
-		if (additionalProperties.containsKey(USE_BEANVALIDATION)) {
-			this.setUseBeanValidation(convertPropertyToBoolean(USE_BEANVALIDATION));
-		}
+        if (additionalProperties.containsKey(USE_BEANVALIDATION)) {
+            this.setUseBeanValidation(convertPropertyToBoolean(USE_BEANVALIDATION));
+        }
 
-		if (useBeanValidation) {
-			writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
-		}
+        if (useBeanValidation) {
+            writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
+        }
 
     }
 
@@ -220,8 +220,8 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         return outputFolder + "/" + output + "/" + apiPackage().replace('.', '/');
     }
 
-	public void setUseBeanValidation(boolean useBeanValidation) {
-		this.useBeanValidation = useBeanValidation;
-	}
+    public void setUseBeanValidation(boolean useBeanValidation) {
+        this.useBeanValidation = useBeanValidation;
+    }
 
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaCXFClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaCXFClientCodegen.java
@@ -122,7 +122,30 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
         super.addOperationToGroup(tag, resourcePath, operation, co, operations);
         co.subresourceOperation = !co.path.isEmpty();
     }
-
+    
+    @Override
+    public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
+    	super.postProcessOperations(objs);
+    	
+	    @SuppressWarnings("unchecked")
+	    Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+	    if (operations != null) {
+	
+	        @SuppressWarnings("unchecked")
+	        List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
+	        for (CodegenOperation operation : ops) {
+	
+	            if (operation.returnType == null) {
+	                operation.returnType = "void";
+	                // set vendorExtensions.x-java-is-response-void to true as returnType is set to "void"
+	                operation.vendorExtensions.put("x-java-is-response-void", true);
+	            }
+	        }
+	    }
+	    
+	    return objs;
+    }
+    
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         super.postProcessModelProperty(model, property);

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api_test.mustache
@@ -103,8 +103,8 @@ public class {{classname}}Test {
         {{#allParams}}
         {{^isFile}}{{{dataType}}} {{paramName}} = null;{{/isFile}}{{#isFile}}org.apache.cxf.jaxrs.ext.multipart.Attachment {{paramName}} = null;{{/isFile}}
         {{/allParams}}
-	//{{^vendorExtensions.x-java-is-response-void}}{{>returnTypes}} response = {{/vendorExtensions.x-java-is-response-void}}api.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
-        {{^vendorExtensions.x-java-is-response-void}}//assertNotNull(response);{{/vendorExtensions.x-java-is-response-void}}
+        {{^vendorExtensions.x-java-is-response-void}}{{>returnTypes}} response = {{/vendorExtensions.x-java-is-response-void}}api.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+        {{^vendorExtensions.x-java-is-response-void}}assertNotNull(response);{{/vendorExtensions.x-java-is-response-void}}
         // TODO: test validations
         
         

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/api_test.mustache
@@ -21,6 +21,9 @@ import org.apache.cxf.transport.common.gzip.GZIPOutInterceptor;
 import org.apache.cxf.interceptor.LoggingOutInterceptor;
 {{/useLoggingFeature}}
 
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
+
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 {{^fullJavaUtil}}
@@ -101,7 +104,11 @@ public class {{classname}}Test {
     @Test
     public void {{operationId}}Test() {
         {{#allParams}}
-        {{^isFile}}{{{dataType}}} {{paramName}} = null;{{/isFile}}{{#isFile}}org.apache.cxf.jaxrs.ext.multipart.Attachment {{paramName}} = null;{{/isFile}}
+        {{^isFile}}{{{dataType}}} {{paramName}} = null;{{/isFile}}{{#isFile}}
+        String {{paramName}}Filename = "myfile.txt";
+        InputStream {{paramName}}InputStream = null; // TODO: new FileInputStream("...");
+        ContentDisposition cd = new ContentDisposition("attachment;filename=" + {{paramName}}Filename);
+        Attachment file = new Attachment("{{paramName}}", {{paramName}}InputStream, cd);{{/isFile}}
         {{/allParams}}
         {{^vendorExtensions.x-java-is-response-void}}{{>returnTypes}} response = {{/vendorExtensions.x-java-is-response-void}}api.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
         {{^vendorExtensions.x-java-is-response-void}}assertNotNull(response);{{/vendorExtensions.x-java-is-response-void}}

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/FakeApi.java
@@ -1,0 +1,45 @@
+package io.swagger.api;
+
+import java.math.BigDecimal;
+import io.swagger.model.Client;
+import org.joda.time.LocalDate;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.MediaType;
+import org.apache.cxf.jaxrs.ext.multipart.*;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.jaxrs.PATCH;
+
+@Path("/")
+@Api(value = "/", description = "")
+public interface FakeApi  {
+
+    @PATCH
+    @Path("/fake")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "To test \"client\" model", tags={  })
+    public Client testClientModel(Client body);
+
+    @POST
+    @Path("/fake")
+    @Consumes({ "application/xml; charset=utf-8", "application/json; charset=utf-8" })
+    @Produces({ "application/xml; charset=utf-8", "application/json; charset=utf-8" })
+    @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ", tags={  })
+    public void testEndpointParameters(@Multipart(value = "number")  BigDecimal number, @Multipart(value = "_double")  Double _double, @Multipart(value = "patternWithoutDelimiter")  String patternWithoutDelimiter, @Multipart(value = "_byte")  byte[] _byte, @Multipart(value = "integer", required = false)  Integer integer, @Multipart(value = "int32", required = false)  Integer int32, @Multipart(value = "int64", required = false)  Long int64, @Multipart(value = "_float", required = false)  Float _float, @Multipart(value = "string", required = false)  String string, @Multipart(value = "binary", required = false)  byte[] binary, @Multipart(value = "date", required = false)  LocalDate date, @Multipart(value = "dateTime", required = false)  javax.xml.datatype.XMLGregorianCalendar dateTime, @Multipart(value = "password", required = false)  String password, @Multipart(value = "paramCallback", required = false)  String paramCallback);
+
+    @GET
+    @Path("/fake")
+    @Consumes({ "*/*" })
+    @Produces({ "*/*" })
+    @ApiOperation(value = "To test enum parameters", tags={  })
+    public void testEnumParameters(@Multipart(value = "enumFormStringArray", required = false)  List<String> enumFormStringArray, @Multipart(value = "enumFormString", required = false)  String enumFormString, @HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray, @HeaderParam("enum_header_string") String enumHeaderString, @QueryParam("enum_query_string_array")List<String> enumQueryStringArray, @QueryParam("enum_query_string")String enumQueryString, @QueryParam("enum_query_integer")Integer enumQueryInteger, @Multipart(value = "enumQueryDouble", required = false)  Double enumQueryDouble);
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/PetApi.java
@@ -1,8 +1,8 @@
 package io.swagger.api;
 
-import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
+import io.swagger.model.Pet;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -15,11 +15,10 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.jaxrs.PATCH;
 
 @Path("/")
 @Api(value = "/", description = "")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public interface PetApi  {
 
     @POST
@@ -27,52 +26,51 @@ public interface PetApi  {
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Add a new pet to the store", tags={  })
-    public void  addPet(Pet body);
+    public void addPet(Pet body);
 
     @DELETE
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Deletes a pet", tags={  })
-    public void  deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
+    public void deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
 
     @GET
     @Path("/pet/findByStatus")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Finds Pets by status", tags={  })
-    public List<Pet>  findPetsByStatus(@QueryParam("status")List<String> status);
+    public List<List<Pet>> findPetsByStatus(@QueryParam("status")List<String> status);
 
     @GET
     @Path("/pet/findByTags")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Finds Pets by tags", tags={  })
-    public List<Pet>  findPetsByTags(@QueryParam("tags")List<String> tags);
+    public List<List<Pet>> findPetsByTags(@QueryParam("tags")List<String> tags);
 
     @GET
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Find pet by ID", tags={  })
-    public Pet  getPetById(@PathParam("petId") Long petId);
+    public Pet getPetById(@PathParam("petId") Long petId);
 
     @PUT
     @Path("/pet")
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Update an existing pet", tags={  })
-    public void  updatePet(Pet body);
+    public void updatePet(Pet body);
 
     @POST
     @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Updates a pet in the store with form data", tags={  })
-    public void  updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
+    public void updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
 
     @POST
     @Path("/pet/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
     @ApiOperation(value = "uploads an image", tags={  })
-    public ModelApiResponse  uploadFile(@PathParam("petId") Long petId, @Multipart(value = "additionalMetadata", required = false)  String additionalMetadata,  @Multipart(value = "file", required = false) InputStream fileInputStream,
-   @Multipart(value = "file" , required = false) Attachment fileDetail);
+    public ModelApiResponse uploadFile(@PathParam("petId") Long petId, @Multipart(value = "additionalMetadata", required = false)  String additionalMetadata,  @Multipart(value = "file" , required = false) Attachment fileDetail);
 }
 

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/StoreApi.java
@@ -13,35 +13,34 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.jaxrs.PATCH;
 
 @Path("/")
 @Api(value = "/", description = "")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public interface StoreApi  {
 
     @DELETE
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Delete purchase order by ID", tags={  })
-    public void  deleteOrder(@PathParam("orderId") String orderId);
+    public void deleteOrder(@PathParam("orderId") String orderId);
 
     @GET
     @Path("/store/inventory")
     @Produces({ "application/json" })
     @ApiOperation(value = "Returns pet inventories by status", tags={  })
-    public Map<String, Integer>  getInventory();
+    public Map<String, Map<String, Integer>> getInventory();
 
     @GET
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Find purchase order by ID", tags={  })
-    public Order  getOrderById(@PathParam("orderId") Long orderId);
+    public Order getOrderById(@PathParam("orderId") Long orderId);
 
     @POST
     @Path("/store/order")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Place an order for a pet", tags={  })
-    public Order  placeOrder(Order body);
+    public Order placeOrder(Order body);
 }
 

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/UserApi.java
@@ -13,59 +13,58 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.jaxrs.PATCH;
 
 @Path("/")
 @Api(value = "/", description = "")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public interface UserApi  {
 
     @POST
     @Path("/user")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Create user", tags={  })
-    public void  createUser(User body);
+    public void createUser(User body);
 
     @POST
     @Path("/user/createWithArray")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Creates list of users with given input array", tags={  })
-    public void  createUsersWithArrayInput(List<User> body);
+    public void createUsersWithArrayInput(List<User> body);
 
     @POST
     @Path("/user/createWithList")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Creates list of users with given input array", tags={  })
-    public void  createUsersWithListInput(List<User> body);
+    public void createUsersWithListInput(List<User> body);
 
     @DELETE
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Delete user", tags={  })
-    public void  deleteUser(@PathParam("username") String username);
+    public void deleteUser(@PathParam("username") String username);
 
     @GET
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Get user by user name", tags={  })
-    public User  getUserByName(@PathParam("username") String username);
+    public User getUserByName(@PathParam("username") String username);
 
     @GET
     @Path("/user/login")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Logs user into the system", tags={  })
-    public String  loginUser(@QueryParam("username")String username, @QueryParam("password")String password);
+    public String loginUser(@QueryParam("username")String username, @QueryParam("password")String password);
 
     @GET
     @Path("/user/logout")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Logs out current logged in user session", tags={  })
-    public void  logoutUser();
+    public void logoutUser();
 
     @PUT
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Updated user", tags={  })
-    public void  updateUser(@PathParam("username") String username, User body);
+    public void updateUser(@PathParam("username") String username, User body);
 }
 

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
@@ -1,0 +1,82 @@
+package io.swagger.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class AdditionalPropertiesClass  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private Map<String, String> mapProperty = new HashMap<String, String>();
+  @ApiModelProperty(example = "null", value = "")
+  private Map<String, Map<String, String>> mapOfMapProperty = new HashMap<String, Map<String, String>>();
+
+ /**
+   * Get mapProperty
+   * @return mapProperty
+  **/
+  public Map<String, String> getMapProperty() {
+    return mapProperty;
+  }
+
+  public void setMapProperty(Map<String, String> mapProperty) {
+    this.mapProperty = mapProperty;
+  }
+
+  public AdditionalPropertiesClass mapProperty(Map<String, String> mapProperty) {
+    this.mapProperty = mapProperty;
+    return this;
+  }
+
+  public AdditionalPropertiesClass putMapPropertyItem(String key, String mapPropertyItem) {
+    this.mapProperty.put(key, mapPropertyItem);
+    return this;
+  }
+
+ /**
+   * Get mapOfMapProperty
+   * @return mapOfMapProperty
+  **/
+  public Map<String, Map<String, String>> getMapOfMapProperty() {
+    return mapOfMapProperty;
+  }
+
+  public void setMapOfMapProperty(Map<String, Map<String, String>> mapOfMapProperty) {
+    this.mapOfMapProperty = mapOfMapProperty;
+  }
+
+  public AdditionalPropertiesClass mapOfMapProperty(Map<String, Map<String, String>> mapOfMapProperty) {
+    this.mapOfMapProperty = mapOfMapProperty;
+    return this;
+  }
+
+  public AdditionalPropertiesClass putMapOfMapPropertyItem(String key, Map<String, String> mapOfMapPropertyItem) {
+    this.mapOfMapProperty.put(key, mapOfMapPropertyItem);
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AdditionalPropertiesClass {\n");
+    
+    sb.append("    mapProperty: ").append(toIndentedString(mapProperty)).append("\n");
+    sb.append("    mapOfMapProperty: ").append(toIndentedString(mapOfMapProperty)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Animal.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Animal.java
@@ -1,0 +1,70 @@
+package io.swagger.model;
+
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class Animal  {
+  
+  @ApiModelProperty(example = "null", required = true, value = "")
+  private String className = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String color = "red";
+
+ /**
+   * Get className
+   * @return className
+  **/
+  public String getClassName() {
+    return className;
+  }
+
+  public void setClassName(String className) {
+    this.className = className;
+  }
+
+  public Animal className(String className) {
+    this.className = className;
+    return this;
+  }
+
+ /**
+   * Get color
+   * @return color
+  **/
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
+
+  public Animal color(String color) {
+    this.color = color;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Animal {\n");
+    
+    sb.append("    className: ").append(toIndentedString(className)).append("\n");
+    sb.append("    color: ").append(toIndentedString(color)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/AnimalFarm.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/AnimalFarm.java
@@ -1,0 +1,29 @@
+package io.swagger.model;
+
+import java.util.ArrayList;
+
+public class AnimalFarm extends ArrayList<Animal> {
+  
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AnimalFarm {\n");
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
@@ -1,0 +1,58 @@
+package io.swagger.model;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class ArrayOfArrayOfNumberOnly  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
+
+ /**
+   * Get arrayArrayNumber
+   * @return arrayArrayNumber
+  **/
+  public List<List<BigDecimal>> getArrayArrayNumber() {
+    return arrayArrayNumber;
+  }
+
+  public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    this.arrayArrayNumber = arrayArrayNumber;
+  }
+
+  public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    this.arrayArrayNumber = arrayArrayNumber;
+    return this;
+  }
+
+  public ArrayOfArrayOfNumberOnly addArrayArrayNumberItem(List<BigDecimal> arrayArrayNumberItem) {
+    this.arrayArrayNumber.add(arrayArrayNumberItem);
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ArrayOfArrayOfNumberOnly {\n");
+    
+    sb.append("    arrayArrayNumber: ").append(toIndentedString(arrayArrayNumber)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
@@ -1,0 +1,58 @@
+package io.swagger.model;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class ArrayOfNumberOnly  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
+
+ /**
+   * Get arrayNumber
+   * @return arrayNumber
+  **/
+  public List<BigDecimal> getArrayNumber() {
+    return arrayNumber;
+  }
+
+  public void setArrayNumber(List<BigDecimal> arrayNumber) {
+    this.arrayNumber = arrayNumber;
+  }
+
+  public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    this.arrayNumber = arrayNumber;
+    return this;
+  }
+
+  public ArrayOfNumberOnly addArrayNumberItem(BigDecimal arrayNumberItem) {
+    this.arrayNumber.add(arrayNumberItem);
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ArrayOfNumberOnly {\n");
+    
+    sb.append("    arrayNumber: ").append(toIndentedString(arrayNumber)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ArrayTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ArrayTest.java
@@ -1,0 +1,107 @@
+package io.swagger.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class ArrayTest  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private List<String> arrayOfString = new ArrayList<String>();
+  @ApiModelProperty(example = "null", value = "")
+  private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
+  @ApiModelProperty(example = "null", value = "")
+  private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
+
+ /**
+   * Get arrayOfString
+   * @return arrayOfString
+  **/
+  public List<String> getArrayOfString() {
+    return arrayOfString;
+  }
+
+  public void setArrayOfString(List<String> arrayOfString) {
+    this.arrayOfString = arrayOfString;
+  }
+
+  public ArrayTest arrayOfString(List<String> arrayOfString) {
+    this.arrayOfString = arrayOfString;
+    return this;
+  }
+
+  public ArrayTest addArrayOfStringItem(String arrayOfStringItem) {
+    this.arrayOfString.add(arrayOfStringItem);
+    return this;
+  }
+
+ /**
+   * Get arrayArrayOfInteger
+   * @return arrayArrayOfInteger
+  **/
+  public List<List<Long>> getArrayArrayOfInteger() {
+    return arrayArrayOfInteger;
+  }
+
+  public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    this.arrayArrayOfInteger = arrayArrayOfInteger;
+  }
+
+  public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    this.arrayArrayOfInteger = arrayArrayOfInteger;
+    return this;
+  }
+
+  public ArrayTest addArrayArrayOfIntegerItem(List<Long> arrayArrayOfIntegerItem) {
+    this.arrayArrayOfInteger.add(arrayArrayOfIntegerItem);
+    return this;
+  }
+
+ /**
+   * Get arrayArrayOfModel
+   * @return arrayArrayOfModel
+  **/
+  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+    return arrayArrayOfModel;
+  }
+
+  public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    this.arrayArrayOfModel = arrayArrayOfModel;
+  }
+
+  public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    this.arrayArrayOfModel = arrayArrayOfModel;
+    return this;
+  }
+
+  public ArrayTest addArrayArrayOfModelItem(List<ReadOnlyFirst> arrayArrayOfModelItem) {
+    this.arrayArrayOfModel.add(arrayArrayOfModelItem);
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ArrayTest {\n");
+    
+    sb.append("    arrayOfString: ").append(toIndentedString(arrayOfString)).append("\n");
+    sb.append("    arrayArrayOfInteger: ").append(toIndentedString(arrayArrayOfInteger)).append("\n");
+    sb.append("    arrayArrayOfModel: ").append(toIndentedString(arrayArrayOfModel)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Capitalization.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Capitalization.java
@@ -1,0 +1,150 @@
+package io.swagger.model;
+
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class Capitalization  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private String smallCamel = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String capitalCamel = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String smallSnake = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String capitalSnake = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String scAETHFlowPoints = null;
+  @ApiModelProperty(example = "null", value = "Name of the pet ")
+  private String ATT_NAME = null;
+
+ /**
+   * Get smallCamel
+   * @return smallCamel
+  **/
+  public String getSmallCamel() {
+    return smallCamel;
+  }
+
+  public void setSmallCamel(String smallCamel) {
+    this.smallCamel = smallCamel;
+  }
+
+  public Capitalization smallCamel(String smallCamel) {
+    this.smallCamel = smallCamel;
+    return this;
+  }
+
+ /**
+   * Get capitalCamel
+   * @return capitalCamel
+  **/
+  public String getCapitalCamel() {
+    return capitalCamel;
+  }
+
+  public void setCapitalCamel(String capitalCamel) {
+    this.capitalCamel = capitalCamel;
+  }
+
+  public Capitalization capitalCamel(String capitalCamel) {
+    this.capitalCamel = capitalCamel;
+    return this;
+  }
+
+ /**
+   * Get smallSnake
+   * @return smallSnake
+  **/
+  public String getSmallSnake() {
+    return smallSnake;
+  }
+
+  public void setSmallSnake(String smallSnake) {
+    this.smallSnake = smallSnake;
+  }
+
+  public Capitalization smallSnake(String smallSnake) {
+    this.smallSnake = smallSnake;
+    return this;
+  }
+
+ /**
+   * Get capitalSnake
+   * @return capitalSnake
+  **/
+  public String getCapitalSnake() {
+    return capitalSnake;
+  }
+
+  public void setCapitalSnake(String capitalSnake) {
+    this.capitalSnake = capitalSnake;
+  }
+
+  public Capitalization capitalSnake(String capitalSnake) {
+    this.capitalSnake = capitalSnake;
+    return this;
+  }
+
+ /**
+   * Get scAETHFlowPoints
+   * @return scAETHFlowPoints
+  **/
+  public String getScAETHFlowPoints() {
+    return scAETHFlowPoints;
+  }
+
+  public void setScAETHFlowPoints(String scAETHFlowPoints) {
+    this.scAETHFlowPoints = scAETHFlowPoints;
+  }
+
+  public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    this.scAETHFlowPoints = scAETHFlowPoints;
+    return this;
+  }
+
+ /**
+   * Name of the pet 
+   * @return ATT_NAME
+  **/
+  public String getATTNAME() {
+    return ATT_NAME;
+  }
+
+  public void setATTNAME(String ATT_NAME) {
+    this.ATT_NAME = ATT_NAME;
+  }
+
+  public Capitalization ATT_NAME(String ATT_NAME) {
+    this.ATT_NAME = ATT_NAME;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Capitalization {\n");
+    
+    sb.append("    smallCamel: ").append(toIndentedString(smallCamel)).append("\n");
+    sb.append("    capitalCamel: ").append(toIndentedString(capitalCamel)).append("\n");
+    sb.append("    smallSnake: ").append(toIndentedString(smallSnake)).append("\n");
+    sb.append("    capitalSnake: ").append(toIndentedString(capitalSnake)).append("\n");
+    sb.append("    scAETHFlowPoints: ").append(toIndentedString(scAETHFlowPoints)).append("\n");
+    sb.append("    ATT_NAME: ").append(toIndentedString(ATT_NAME)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Cat.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Cat.java
@@ -1,0 +1,49 @@
+package io.swagger.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class Cat extends Animal {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private Boolean declawed = null;
+
+ /**
+   * Get declawed
+   * @return declawed
+  **/
+  public Boolean getDeclawed() {
+    return declawed;
+  }
+
+  public void setDeclawed(Boolean declawed) {
+    this.declawed = declawed;
+  }
+
+  public Cat declawed(Boolean declawed) {
+    this.declawed = declawed;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Cat {\n");
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("    declawed: ").append(toIndentedString(declawed)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Category.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Category.java
@@ -1,17 +1,8 @@
 package io.swagger.model;
 
-import io.swagger.annotations.ApiModel;
 
 import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@ApiModel(description="A category for a pet")
 public class Category  {
   
   @ApiModelProperty(example = "null", value = "")
@@ -26,9 +17,16 @@ public class Category  {
   public Long getId() {
     return id;
   }
+
   public void setId(Long id) {
     this.id = id;
   }
+
+  public Category id(Long id) {
+    this.id = id;
+    return this;
+  }
+
  /**
    * Get name
    * @return name
@@ -36,9 +34,16 @@ public class Category  {
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }
+
+  public Category name(String name) {
+    this.name = name;
+    return this;
+  }
+
 
   @Override
   public String toString() {

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ClassModel.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ClassModel.java
@@ -1,0 +1,51 @@
+package io.swagger.model;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description="Model for testing model with \"_class\" property")
+public class ClassModel  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private String propertyClass = null;
+
+ /**
+   * Get propertyClass
+   * @return propertyClass
+  **/
+  public String getPropertyClass() {
+    return propertyClass;
+  }
+
+  public void setPropertyClass(String propertyClass) {
+    this.propertyClass = propertyClass;
+  }
+
+  public ClassModel propertyClass(String propertyClass) {
+    this.propertyClass = propertyClass;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ClassModel {\n");
+    
+    sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Client.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Client.java
@@ -1,0 +1,50 @@
+package io.swagger.model;
+
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class Client  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private String client = null;
+
+ /**
+   * Get client
+   * @return client
+  **/
+  public String getClient() {
+    return client;
+  }
+
+  public void setClient(String client) {
+    this.client = client;
+  }
+
+  public Client client(String client) {
+    this.client = client;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Client {\n");
+    
+    sb.append("    client: ").append(toIndentedString(client)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Dog.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Dog.java
@@ -1,0 +1,49 @@
+package io.swagger.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class Dog extends Animal {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private String breed = null;
+
+ /**
+   * Get breed
+   * @return breed
+  **/
+  public String getBreed() {
+    return breed;
+  }
+
+  public void setBreed(String breed) {
+    this.breed = breed;
+  }
+
+  public Dog breed(String breed) {
+    this.breed = breed;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Dog {\n");
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("    breed: ").append(toIndentedString(breed)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumArrays.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumArrays.java
@@ -1,0 +1,147 @@
+package io.swagger.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class EnumArrays  {
+  
+
+@XmlType(name="JustSymbolEnum")
+@XmlEnum(String.class)
+public enum JustSymbolEnum {
+
+@XmlEnumValue(">=") GREATER_THAN_OR_EQUAL_TO(String.valueOf(">=")), @XmlEnumValue("$") DOLLAR(String.valueOf("$"));
+
+
+    private String value;
+
+    JustSymbolEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static JustSymbolEnum fromValue(String v) {
+        for (JustSymbolEnum b : JustSymbolEnum.values()) {
+            if (String.valueOf(b.value).equals(v)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}
+
+  @ApiModelProperty(example = "null", value = "")
+  private JustSymbolEnum justSymbol = null;
+
+@XmlType(name="ArrayEnumEnum")
+@XmlEnum(String.class)
+public enum ArrayEnumEnum {
+
+@XmlEnumValue("fish") FISH(String.valueOf("fish")), @XmlEnumValue("crab") CRAB(String.valueOf("crab"));
+
+
+    private String value;
+
+    ArrayEnumEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static ArrayEnumEnum fromValue(String v) {
+        for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
+            if (String.valueOf(b.value).equals(v)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}
+
+  @ApiModelProperty(example = "null", value = "")
+  private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
+
+ /**
+   * Get justSymbol
+   * @return justSymbol
+  **/
+  public JustSymbolEnum getJustSymbol() {
+    return justSymbol;
+  }
+
+  public void setJustSymbol(JustSymbolEnum justSymbol) {
+    this.justSymbol = justSymbol;
+  }
+
+  public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    this.justSymbol = justSymbol;
+    return this;
+  }
+
+ /**
+   * Get arrayEnum
+   * @return arrayEnum
+  **/
+  public List<ArrayEnumEnum> getArrayEnum() {
+    return arrayEnum;
+  }
+
+  public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    this.arrayEnum = arrayEnum;
+  }
+
+  public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    this.arrayEnum = arrayEnum;
+    return this;
+  }
+
+  public EnumArrays addArrayEnumItem(ArrayEnumEnum arrayEnumItem) {
+    this.arrayEnum.add(arrayEnumItem);
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class EnumArrays {\n");
+    
+    sb.append("    justSymbol: ").append(toIndentedString(justSymbol)).append("\n");
+    sb.append("    arrayEnum: ").append(toIndentedString(arrayEnum)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumClass.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumClass.java
@@ -1,0 +1,39 @@
+package io.swagger.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Gets or Sets EnumClass
+ */
+public enum EnumClass {
+  
+  _ABC("_abc"),
+  
+  _EFG("-efg"),
+  
+  _XYZ_("(xyz)");
+
+  private String value;
+
+  EnumClass(String value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static EnumClass fromValue(String text) {
+    for (EnumClass b : EnumClass.values()) {
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
+    }
+    return null;
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/EnumTest.java
@@ -1,0 +1,212 @@
+package io.swagger.model;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class EnumTest  {
+  
+
+@XmlType(name="EnumStringEnum")
+@XmlEnum(String.class)
+public enum EnumStringEnum {
+
+@XmlEnumValue("UPPER") UPPER(String.valueOf("UPPER")), @XmlEnumValue("lower") LOWER(String.valueOf("lower")), @XmlEnumValue("") EMPTY(String.valueOf(""));
+
+
+    private String value;
+
+    EnumStringEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static EnumStringEnum fromValue(String v) {
+        for (EnumStringEnum b : EnumStringEnum.values()) {
+            if (String.valueOf(b.value).equals(v)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}
+
+  @ApiModelProperty(example = "null", value = "")
+  private EnumStringEnum enumString = null;
+
+@XmlType(name="EnumIntegerEnum")
+@XmlEnum(Integer.class)
+public enum EnumIntegerEnum {
+
+@XmlEnumValue("1") NUMBER_1(Integer.valueOf(1)), @XmlEnumValue("-1") NUMBER_MINUS_1(Integer.valueOf(-1));
+
+
+    private Integer value;
+
+    EnumIntegerEnum (Integer v) {
+        value = v;
+    }
+
+    public Integer value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static EnumIntegerEnum fromValue(String v) {
+        for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
+            if (String.valueOf(b.value).equals(v)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}
+
+  @ApiModelProperty(example = "null", value = "")
+  private EnumIntegerEnum enumInteger = null;
+
+@XmlType(name="EnumNumberEnum")
+@XmlEnum(Double.class)
+public enum EnumNumberEnum {
+
+@XmlEnumValue("1.1") NUMBER_1_DOT_1(Double.valueOf(1.1)), @XmlEnumValue("-1.2") NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
+
+
+    private Double value;
+
+    EnumNumberEnum (Double v) {
+        value = v;
+    }
+
+    public Double value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static EnumNumberEnum fromValue(String v) {
+        for (EnumNumberEnum b : EnumNumberEnum.values()) {
+            if (String.valueOf(b.value).equals(v)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}
+
+  @ApiModelProperty(example = "null", value = "")
+  private EnumNumberEnum enumNumber = null;
+  @ApiModelProperty(example = "null", value = "")
+  private OuterEnum outerEnum = null;
+
+ /**
+   * Get enumString
+   * @return enumString
+  **/
+  public EnumStringEnum getEnumString() {
+    return enumString;
+  }
+
+  public void setEnumString(EnumStringEnum enumString) {
+    this.enumString = enumString;
+  }
+
+  public EnumTest enumString(EnumStringEnum enumString) {
+    this.enumString = enumString;
+    return this;
+  }
+
+ /**
+   * Get enumInteger
+   * @return enumInteger
+  **/
+  public EnumIntegerEnum getEnumInteger() {
+    return enumInteger;
+  }
+
+  public void setEnumInteger(EnumIntegerEnum enumInteger) {
+    this.enumInteger = enumInteger;
+  }
+
+  public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    this.enumInteger = enumInteger;
+    return this;
+  }
+
+ /**
+   * Get enumNumber
+   * @return enumNumber
+  **/
+  public EnumNumberEnum getEnumNumber() {
+    return enumNumber;
+  }
+
+  public void setEnumNumber(EnumNumberEnum enumNumber) {
+    this.enumNumber = enumNumber;
+  }
+
+  public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    this.enumNumber = enumNumber;
+    return this;
+  }
+
+ /**
+   * Get outerEnum
+   * @return outerEnum
+  **/
+  public OuterEnum getOuterEnum() {
+    return outerEnum;
+  }
+
+  public void setOuterEnum(OuterEnum outerEnum) {
+    this.outerEnum = outerEnum;
+  }
+
+  public EnumTest outerEnum(OuterEnum outerEnum) {
+    this.outerEnum = outerEnum;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class EnumTest {\n");
+    
+    sb.append("    enumString: ").append(toIndentedString(enumString)).append("\n");
+    sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
+    sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
+    sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/FormatTest.java
@@ -1,0 +1,304 @@
+package io.swagger.model;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.joda.time.LocalDate;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class FormatTest  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private Integer integer = null;
+  @ApiModelProperty(example = "null", value = "")
+  private Integer int32 = null;
+  @ApiModelProperty(example = "null", value = "")
+  private Long int64 = null;
+  @ApiModelProperty(example = "null", required = true, value = "")
+  private BigDecimal number = null;
+  @ApiModelProperty(example = "null", value = "")
+  private Float _float = null;
+  @ApiModelProperty(example = "null", value = "")
+  private Double _double = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String string = null;
+  @ApiModelProperty(example = "null", required = true, value = "")
+  private byte[] _byte = null;
+  @ApiModelProperty(example = "null", value = "")
+  private byte[] binary = null;
+  @ApiModelProperty(example = "null", required = true, value = "")
+  private LocalDate date = null;
+  @ApiModelProperty(example = "null", value = "")
+  private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+  @ApiModelProperty(example = "null", value = "")
+  private UUID uuid = null;
+  @ApiModelProperty(example = "null", required = true, value = "")
+  private String password = null;
+
+ /**
+   * Get integer
+   * minimum: 10
+   * maximum: 100
+   * @return integer
+  **/
+  public Integer getInteger() {
+    return integer;
+  }
+
+  public void setInteger(Integer integer) {
+    this.integer = integer;
+  }
+
+  public FormatTest integer(Integer integer) {
+    this.integer = integer;
+    return this;
+  }
+
+ /**
+   * Get int32
+   * minimum: 20
+   * maximum: 200
+   * @return int32
+  **/
+  public Integer getInt32() {
+    return int32;
+  }
+
+  public void setInt32(Integer int32) {
+    this.int32 = int32;
+  }
+
+  public FormatTest int32(Integer int32) {
+    this.int32 = int32;
+    return this;
+  }
+
+ /**
+   * Get int64
+   * @return int64
+  **/
+  public Long getInt64() {
+    return int64;
+  }
+
+  public void setInt64(Long int64) {
+    this.int64 = int64;
+  }
+
+  public FormatTest int64(Long int64) {
+    this.int64 = int64;
+    return this;
+  }
+
+ /**
+   * Get number
+   * minimum: 32.1
+   * maximum: 543.2
+   * @return number
+  **/
+  public BigDecimal getNumber() {
+    return number;
+  }
+
+  public void setNumber(BigDecimal number) {
+    this.number = number;
+  }
+
+  public FormatTest number(BigDecimal number) {
+    this.number = number;
+    return this;
+  }
+
+ /**
+   * Get _float
+   * minimum: 54.3
+   * maximum: 987.6
+   * @return _float
+  **/
+  public Float getFloat() {
+    return _float;
+  }
+
+  public void setFloat(Float _float) {
+    this._float = _float;
+  }
+
+  public FormatTest _float(Float _float) {
+    this._float = _float;
+    return this;
+  }
+
+ /**
+   * Get _double
+   * minimum: 67.8
+   * maximum: 123.4
+   * @return _double
+  **/
+  public Double getDouble() {
+    return _double;
+  }
+
+  public void setDouble(Double _double) {
+    this._double = _double;
+  }
+
+  public FormatTest _double(Double _double) {
+    this._double = _double;
+    return this;
+  }
+
+ /**
+   * Get string
+   * @return string
+  **/
+  public String getString() {
+    return string;
+  }
+
+  public void setString(String string) {
+    this.string = string;
+  }
+
+  public FormatTest string(String string) {
+    this.string = string;
+    return this;
+  }
+
+ /**
+   * Get _byte
+   * @return _byte
+  **/
+  public byte[] getByte() {
+    return _byte;
+  }
+
+  public void setByte(byte[] _byte) {
+    this._byte = _byte;
+  }
+
+  public FormatTest _byte(byte[] _byte) {
+    this._byte = _byte;
+    return this;
+  }
+
+ /**
+   * Get binary
+   * @return binary
+  **/
+  public byte[] getBinary() {
+    return binary;
+  }
+
+  public void setBinary(byte[] binary) {
+    this.binary = binary;
+  }
+
+  public FormatTest binary(byte[] binary) {
+    this.binary = binary;
+    return this;
+  }
+
+ /**
+   * Get date
+   * @return date
+  **/
+  public LocalDate getDate() {
+    return date;
+  }
+
+  public void setDate(LocalDate date) {
+    this.date = date;
+  }
+
+  public FormatTest date(LocalDate date) {
+    this.date = date;
+    return this;
+  }
+
+ /**
+   * Get dateTime
+   * @return dateTime
+  **/
+  public javax.xml.datatype.XMLGregorianCalendar getDateTime() {
+    return dateTime;
+  }
+
+  public void setDateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+    this.dateTime = dateTime;
+  }
+
+  public FormatTest dateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+    this.dateTime = dateTime;
+    return this;
+  }
+
+ /**
+   * Get uuid
+   * @return uuid
+  **/
+  public UUID getUuid() {
+    return uuid;
+  }
+
+  public void setUuid(UUID uuid) {
+    this.uuid = uuid;
+  }
+
+  public FormatTest uuid(UUID uuid) {
+    this.uuid = uuid;
+    return this;
+  }
+
+ /**
+   * Get password
+   * @return password
+  **/
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public FormatTest password(String password) {
+    this.password = password;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class FormatTest {\n");
+    
+    sb.append("    integer: ").append(toIndentedString(integer)).append("\n");
+    sb.append("    int32: ").append(toIndentedString(int32)).append("\n");
+    sb.append("    int64: ").append(toIndentedString(int64)).append("\n");
+    sb.append("    number: ").append(toIndentedString(number)).append("\n");
+    sb.append("    _float: ").append(toIndentedString(_float)).append("\n");
+    sb.append("    _double: ").append(toIndentedString(_double)).append("\n");
+    sb.append("    string: ").append(toIndentedString(string)).append("\n");
+    sb.append("    _byte: ").append(toIndentedString(_byte)).append("\n");
+    sb.append("    binary: ").append(toIndentedString(binary)).append("\n");
+    sb.append("    date: ").append(toIndentedString(date)).append("\n");
+    sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
+    sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
+    sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
@@ -1,0 +1,54 @@
+package io.swagger.model;
+
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class HasOnlyReadOnly  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private String bar = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String foo = null;
+
+ /**
+   * Get bar
+   * @return bar
+  **/
+  public String getBar() {
+    return bar;
+  }
+
+
+ /**
+   * Get foo
+   * @return foo
+  **/
+  public String getFoo() {
+    return foo;
+  }
+
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class HasOnlyReadOnly {\n");
+    
+    sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
+    sb.append("    foo: ").append(toIndentedString(foo)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/MapTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/MapTest.java
@@ -1,0 +1,119 @@
+package io.swagger.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class MapTest  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
+
+@XmlType(name="InnerEnum")
+@XmlEnum(String.class)
+public enum InnerEnum {
+
+@XmlEnumValue("UPPER") UPPER(String.valueOf("UPPER")), @XmlEnumValue("lower") LOWER(String.valueOf("lower"));
+
+
+    private String value;
+
+    InnerEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static InnerEnum fromValue(String v) {
+        for (InnerEnum b : InnerEnum.values()) {
+            if (String.valueOf(b.value).equals(v)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}
+
+  @ApiModelProperty(example = "null", value = "")
+  private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
+
+ /**
+   * Get mapMapOfString
+   * @return mapMapOfString
+  **/
+  public Map<String, Map<String, String>> getMapMapOfString() {
+    return mapMapOfString;
+  }
+
+  public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    this.mapMapOfString = mapMapOfString;
+  }
+
+  public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    this.mapMapOfString = mapMapOfString;
+    return this;
+  }
+
+  public MapTest putMapMapOfStringItem(String key, Map<String, String> mapMapOfStringItem) {
+    this.mapMapOfString.put(key, mapMapOfStringItem);
+    return this;
+  }
+
+ /**
+   * Get mapOfEnumString
+   * @return mapOfEnumString
+  **/
+  public Map<String, InnerEnum> getMapOfEnumString() {
+    return mapOfEnumString;
+  }
+
+  public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    this.mapOfEnumString = mapOfEnumString;
+  }
+
+  public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    this.mapOfEnumString = mapOfEnumString;
+    return this;
+  }
+
+  public MapTest putMapOfEnumStringItem(String key, InnerEnum mapOfEnumStringItem) {
+    this.mapOfEnumString.put(key, mapOfEnumStringItem);
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class MapTest {\n");
+    
+    sb.append("    mapMapOfString: ").append(toIndentedString(mapMapOfString)).append("\n");
+    sb.append("    mapOfEnumString: ").append(toIndentedString(mapOfEnumString)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -1,0 +1,98 @@
+package io.swagger.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class MixedPropertiesAndAdditionalPropertiesClass  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private UUID uuid = null;
+  @ApiModelProperty(example = "null", value = "")
+  private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+  @ApiModelProperty(example = "null", value = "")
+  private Map<String, Animal> map = new HashMap<String, Animal>();
+
+ /**
+   * Get uuid
+   * @return uuid
+  **/
+  public UUID getUuid() {
+    return uuid;
+  }
+
+  public void setUuid(UUID uuid) {
+    this.uuid = uuid;
+  }
+
+  public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    this.uuid = uuid;
+    return this;
+  }
+
+ /**
+   * Get dateTime
+   * @return dateTime
+  **/
+  public javax.xml.datatype.XMLGregorianCalendar getDateTime() {
+    return dateTime;
+  }
+
+  public void setDateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+    this.dateTime = dateTime;
+  }
+
+  public MixedPropertiesAndAdditionalPropertiesClass dateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+    this.dateTime = dateTime;
+    return this;
+  }
+
+ /**
+   * Get map
+   * @return map
+  **/
+  public Map<String, Animal> getMap() {
+    return map;
+  }
+
+  public void setMap(Map<String, Animal> map) {
+    this.map = map;
+  }
+
+  public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    this.map = map;
+    return this;
+  }
+
+  public MixedPropertiesAndAdditionalPropertiesClass putMapItem(String key, Animal mapItem) {
+    this.map.put(key, mapItem);
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class MixedPropertiesAndAdditionalPropertiesClass {\n");
+    
+    sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
+    sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
+    sb.append("    map: ").append(toIndentedString(map)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Model200Response.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Model200Response.java
@@ -1,0 +1,71 @@
+package io.swagger.model;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description="Model for testing model name starting with number")
+public class Model200Response  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private Integer name = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String propertyClass = null;
+
+ /**
+   * Get name
+   * @return name
+  **/
+  public Integer getName() {
+    return name;
+  }
+
+  public void setName(Integer name) {
+    this.name = name;
+  }
+
+  public Model200Response name(Integer name) {
+    this.name = name;
+    return this;
+  }
+
+ /**
+   * Get propertyClass
+   * @return propertyClass
+  **/
+  public String getPropertyClass() {
+    return propertyClass;
+  }
+
+  public void setPropertyClass(String propertyClass) {
+    this.propertyClass = propertyClass;
+  }
+
+  public Model200Response propertyClass(String propertyClass) {
+    this.propertyClass = propertyClass;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Model200Response {\n");
+    
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -1,17 +1,8 @@
 package io.swagger.model;
 
-import io.swagger.annotations.ApiModel;
 
 import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@ApiModel(description="Describes the result of uploading an image resource")
 public class ModelApiResponse  {
   
   @ApiModelProperty(example = "null", value = "")
@@ -28,9 +19,16 @@ public class ModelApiResponse  {
   public Integer getCode() {
     return code;
   }
+
   public void setCode(Integer code) {
     this.code = code;
   }
+
+  public ModelApiResponse code(Integer code) {
+    this.code = code;
+    return this;
+  }
+
  /**
    * Get type
    * @return type
@@ -38,9 +36,16 @@ public class ModelApiResponse  {
   public String getType() {
     return type;
   }
+
   public void setType(String type) {
     this.type = type;
   }
+
+  public ModelApiResponse type(String type) {
+    this.type = type;
+    return this;
+  }
+
  /**
    * Get message
    * @return message
@@ -48,9 +53,16 @@ public class ModelApiResponse  {
   public String getMessage() {
     return message;
   }
+
   public void setMessage(String message) {
     this.message = message;
   }
+
+  public ModelApiResponse message(String message) {
+    this.message = message;
+    return this;
+  }
+
 
   @Override
   public String toString() {

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ModelReturn.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ModelReturn.java
@@ -1,0 +1,51 @@
+package io.swagger.model;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description="Model for testing reserved words")
+public class ModelReturn  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private Integer _return = null;
+
+ /**
+   * Get _return
+   * @return _return
+  **/
+  public Integer getReturn() {
+    return _return;
+  }
+
+  public void setReturn(Integer _return) {
+    this._return = _return;
+  }
+
+  public ModelReturn _return(Integer _return) {
+    this._return = _return;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ModelReturn {\n");
+    
+    sb.append("    _return: ").append(toIndentedString(_return)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Name.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Name.java
@@ -1,0 +1,95 @@
+package io.swagger.model;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description="Model for testing model name same as property name")
+public class Name  {
+  
+  @ApiModelProperty(example = "null", required = true, value = "")
+  private Integer name = null;
+  @ApiModelProperty(example = "null", value = "")
+  private Integer snakeCase = null;
+  @ApiModelProperty(example = "null", value = "")
+  private String property = null;
+  @ApiModelProperty(example = "null", value = "")
+  private Integer _123Number = null;
+
+ /**
+   * Get name
+   * @return name
+  **/
+  public Integer getName() {
+    return name;
+  }
+
+  public void setName(Integer name) {
+    this.name = name;
+  }
+
+  public Name name(Integer name) {
+    this.name = name;
+    return this;
+  }
+
+ /**
+   * Get snakeCase
+   * @return snakeCase
+  **/
+  public Integer getSnakeCase() {
+    return snakeCase;
+  }
+
+
+ /**
+   * Get property
+   * @return property
+  **/
+  public String getProperty() {
+    return property;
+  }
+
+  public void setProperty(String property) {
+    this.property = property;
+  }
+
+  public Name property(String property) {
+    this.property = property;
+    return this;
+  }
+
+ /**
+   * Get _123Number
+   * @return _123Number
+  **/
+  public Integer get123Number() {
+    return _123Number;
+  }
+
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Name {\n");
+    
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    snakeCase: ").append(toIndentedString(snakeCase)).append("\n");
+    sb.append("    property: ").append(toIndentedString(property)).append("\n");
+    sb.append("    _123Number: ").append(toIndentedString(_123Number)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/NumberOnly.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/NumberOnly.java
@@ -1,0 +1,51 @@
+package io.swagger.model;
+
+import java.math.BigDecimal;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class NumberOnly  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private BigDecimal justNumber = null;
+
+ /**
+   * Get justNumber
+   * @return justNumber
+  **/
+  public BigDecimal getJustNumber() {
+    return justNumber;
+  }
+
+  public void setJustNumber(BigDecimal justNumber) {
+    this.justNumber = justNumber;
+  }
+
+  public NumberOnly justNumber(BigDecimal justNumber) {
+    this.justNumber = justNumber;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NumberOnly {\n");
+    
+    sb.append("    justNumber: ").append(toIndentedString(justNumber)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Order.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Order.java
@@ -1,17 +1,12 @@
 package io.swagger.model;
 
-import io.swagger.annotations.ApiModel;
 
-import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
 
-@ApiModel(description="An order for a pets from the pet store")
+import io.swagger.annotations.ApiModelProperty;
+
 public class Order  {
   
   @ApiModelProperty(example = "null", value = "")
@@ -27,7 +22,7 @@ public class Order  {
 @XmlEnum(String.class)
 public enum StatusEnum {
 
-    @XmlEnumValue("placed") PLACED(String.valueOf("placed")), @XmlEnumValue("approved") APPROVED(String.valueOf("approved")), @XmlEnumValue("delivered") DELIVERED(String.valueOf("delivered"));
+@XmlEnumValue("placed") PLACED(String.valueOf("placed")), @XmlEnumValue("approved") APPROVED(String.valueOf("approved")), @XmlEnumValue("delivered") DELIVERED(String.valueOf("delivered"));
 
 
     private String value;
@@ -67,9 +62,16 @@ public enum StatusEnum {
   public Long getId() {
     return id;
   }
+
   public void setId(Long id) {
     this.id = id;
   }
+
+  public Order id(Long id) {
+    this.id = id;
+    return this;
+  }
+
  /**
    * Get petId
    * @return petId
@@ -77,9 +79,16 @@ public enum StatusEnum {
   public Long getPetId() {
     return petId;
   }
+
   public void setPetId(Long petId) {
     this.petId = petId;
   }
+
+  public Order petId(Long petId) {
+    this.petId = petId;
+    return this;
+  }
+
  /**
    * Get quantity
    * @return quantity
@@ -87,9 +96,16 @@ public enum StatusEnum {
   public Integer getQuantity() {
     return quantity;
   }
+
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
+
+  public Order quantity(Integer quantity) {
+    this.quantity = quantity;
+    return this;
+  }
+
  /**
    * Get shipDate
    * @return shipDate
@@ -97,9 +113,16 @@ public enum StatusEnum {
   public javax.xml.datatype.XMLGregorianCalendar getShipDate() {
     return shipDate;
   }
+
   public void setShipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
     this.shipDate = shipDate;
   }
+
+  public Order shipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+    this.shipDate = shipDate;
+    return this;
+  }
+
  /**
    * Order Status
    * @return status
@@ -107,9 +130,16 @@ public enum StatusEnum {
   public StatusEnum getStatus() {
     return status;
   }
+
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
+
+  public Order status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
  /**
    * Get complete
    * @return complete
@@ -117,9 +147,16 @@ public enum StatusEnum {
   public Boolean getComplete() {
     return complete;
   }
+
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }
+
+  public Order complete(Boolean complete) {
+    this.complete = complete;
+    return this;
+  }
+
 
   @Override
   public String toString() {

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/OuterEnum.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/OuterEnum.java
@@ -1,0 +1,39 @@
+package io.swagger.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Gets or Sets OuterEnum
+ */
+public enum OuterEnum {
+  
+  PLACED("placed"),
+  
+  APPROVED("approved"),
+  
+  DELIVERED("delivered");
+
+  private String value;
+
+  OuterEnum(String value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static OuterEnum fromValue(String text) {
+    for (OuterEnum b : OuterEnum.values()) {
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
+    }
+    return null;
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Pet.java
@@ -1,21 +1,14 @@
 package io.swagger.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.model.Category;
-import io.swagger.model.Tag;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
 
-@ApiModel(description="A pet for sale in the pet store")
+import io.swagger.annotations.ApiModelProperty;
+
 public class Pet  {
   
   @ApiModelProperty(example = "null", value = "")
@@ -33,7 +26,7 @@ public class Pet  {
 @XmlEnum(String.class)
 public enum StatusEnum {
 
-    @XmlEnumValue("available") AVAILABLE(String.valueOf("available")), @XmlEnumValue("pending") PENDING(String.valueOf("pending")), @XmlEnumValue("sold") SOLD(String.valueOf("sold"));
+@XmlEnumValue("available") AVAILABLE(String.valueOf("available")), @XmlEnumValue("pending") PENDING(String.valueOf("pending")), @XmlEnumValue("sold") SOLD(String.valueOf("sold"));
 
 
     private String value;
@@ -71,9 +64,16 @@ public enum StatusEnum {
   public Long getId() {
     return id;
   }
+
   public void setId(Long id) {
     this.id = id;
   }
+
+  public Pet id(Long id) {
+    this.id = id;
+    return this;
+  }
+
  /**
    * Get category
    * @return category
@@ -81,9 +81,16 @@ public enum StatusEnum {
   public Category getCategory() {
     return category;
   }
+
   public void setCategory(Category category) {
     this.category = category;
   }
+
+  public Pet category(Category category) {
+    this.category = category;
+    return this;
+  }
+
  /**
    * Get name
    * @return name
@@ -91,9 +98,16 @@ public enum StatusEnum {
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }
+
+  public Pet name(String name) {
+    this.name = name;
+    return this;
+  }
+
  /**
    * Get photoUrls
    * @return photoUrls
@@ -101,9 +115,21 @@ public enum StatusEnum {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
+
+  public Pet photoUrls(List<String> photoUrls) {
+    this.photoUrls = photoUrls;
+    return this;
+  }
+
+  public Pet addPhotoUrlsItem(String photoUrlsItem) {
+    this.photoUrls.add(photoUrlsItem);
+    return this;
+  }
+
  /**
    * Get tags
    * @return tags
@@ -111,9 +137,21 @@ public enum StatusEnum {
   public List<Tag> getTags() {
     return tags;
   }
+
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
+
+  public Pet tags(List<Tag> tags) {
+    this.tags = tags;
+    return this;
+  }
+
+  public Pet addTagsItem(Tag tagsItem) {
+    this.tags.add(tagsItem);
+    return this;
+  }
+
  /**
    * pet status in the store
    * @return status
@@ -121,9 +159,16 @@ public enum StatusEnum {
   public StatusEnum getStatus() {
     return status;
   }
+
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
+
+  public Pet status(StatusEnum status) {
+    this.status = status;
+    return this;
+  }
+
 
   @Override
   public String toString() {

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ReadOnlyFirst.java
@@ -3,44 +3,36 @@ package io.swagger.model;
 
 import io.swagger.annotations.ApiModelProperty;
 
-public class Tag  {
+public class ReadOnlyFirst  {
   
   @ApiModelProperty(example = "null", value = "")
-  private Long id = null;
+  private String bar = null;
   @ApiModelProperty(example = "null", value = "")
-  private String name = null;
+  private String baz = null;
 
  /**
-   * Get id
-   * @return id
+   * Get bar
+   * @return bar
   **/
-  public Long getId() {
-    return id;
+  public String getBar() {
+    return bar;
   }
 
-  public void setId(Long id) {
-    this.id = id;
-  }
-
-  public Tag id(Long id) {
-    this.id = id;
-    return this;
-  }
 
  /**
-   * Get name
-   * @return name
+   * Get baz
+   * @return baz
   **/
-  public String getName() {
-    return name;
+  public String getBaz() {
+    return baz;
   }
 
-  public void setName(String name) {
-    this.name = name;
+  public void setBaz(String baz) {
+    this.baz = baz;
   }
 
-  public Tag name(String name) {
-    this.name = name;
+  public ReadOnlyFirst baz(String baz) {
+    this.baz = baz;
     return this;
   }
 
@@ -48,10 +40,10 @@ public class Tag  {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class Tag {\n");
+    sb.append("class ReadOnlyFirst {\n");
     
-    sb.append("    id: ").append(toIndentedString(id)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
+    sb.append("    baz: ").append(toIndentedString(baz)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/SpecialModelName.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/SpecialModelName.java
@@ -1,0 +1,50 @@
+package io.swagger.model;
+
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class SpecialModelName  {
+  
+  @ApiModelProperty(example = "null", value = "")
+  private Long specialPropertyName = null;
+
+ /**
+   * Get specialPropertyName
+   * @return specialPropertyName
+  **/
+  public Long getSpecialPropertyName() {
+    return specialPropertyName;
+  }
+
+  public void setSpecialPropertyName(Long specialPropertyName) {
+    this.specialPropertyName = specialPropertyName;
+  }
+
+  public SpecialModelName specialPropertyName(Long specialPropertyName) {
+    this.specialPropertyName = specialPropertyName;
+    return this;
+  }
+
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SpecialModelName {\n");
+    
+    sb.append("    specialPropertyName: ").append(toIndentedString(specialPropertyName)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/User.java
+++ b/samples/client/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/User.java
@@ -1,17 +1,8 @@
 package io.swagger.model;
 
-import io.swagger.annotations.ApiModel;
 
 import io.swagger.annotations.ApiModelProperty;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
 
-@ApiModel(description="A User who is purchasing from the pet store")
 public class User  {
   
   @ApiModelProperty(example = "null", value = "")
@@ -38,9 +29,16 @@ public class User  {
   public Long getId() {
     return id;
   }
+
   public void setId(Long id) {
     this.id = id;
   }
+
+  public User id(Long id) {
+    this.id = id;
+    return this;
+  }
+
  /**
    * Get username
    * @return username
@@ -48,9 +46,16 @@ public class User  {
   public String getUsername() {
     return username;
   }
+
   public void setUsername(String username) {
     this.username = username;
   }
+
+  public User username(String username) {
+    this.username = username;
+    return this;
+  }
+
  /**
    * Get firstName
    * @return firstName
@@ -58,9 +63,16 @@ public class User  {
   public String getFirstName() {
     return firstName;
   }
+
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
+
+  public User firstName(String firstName) {
+    this.firstName = firstName;
+    return this;
+  }
+
  /**
    * Get lastName
    * @return lastName
@@ -68,9 +80,16 @@ public class User  {
   public String getLastName() {
     return lastName;
   }
+
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
+
+  public User lastName(String lastName) {
+    this.lastName = lastName;
+    return this;
+  }
+
  /**
    * Get email
    * @return email
@@ -78,9 +97,16 @@ public class User  {
   public String getEmail() {
     return email;
   }
+
   public void setEmail(String email) {
     this.email = email;
   }
+
+  public User email(String email) {
+    this.email = email;
+    return this;
+  }
+
  /**
    * Get password
    * @return password
@@ -88,9 +114,16 @@ public class User  {
   public String getPassword() {
     return password;
   }
+
   public void setPassword(String password) {
     this.password = password;
   }
+
+  public User password(String password) {
+    this.password = password;
+    return this;
+  }
+
  /**
    * Get phone
    * @return phone
@@ -98,9 +131,16 @@ public class User  {
   public String getPhone() {
     return phone;
   }
+
   public void setPhone(String phone) {
     this.phone = phone;
   }
+
+  public User phone(String phone) {
+    this.phone = phone;
+    return this;
+  }
+
  /**
    * User Status
    * @return userStatus
@@ -108,9 +148,16 @@ public class User  {
   public Integer getUserStatus() {
     return userStatus;
   }
+
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }
+
+  public User userStatus(Integer userStatus) {
+    this.userStatus = userStatus;
+    return this;
+  }
+
 
   @Override
   public String toString() {

--- a/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/FakeApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/FakeApiTest.java
@@ -38,6 +38,9 @@ import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
 
 
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
+
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/FakeApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/FakeApiTest.java
@@ -25,7 +25,9 @@
 
 package io.swagger.api;
 
-import io.swagger.model.Order;
+import java.math.BigDecimal;
+import io.swagger.model.Client;
+import org.joda.time.LocalDate;
 import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
@@ -47,12 +49,12 @@ import java.util.Map;
 
 
 /**
- * API tests for StoreApi
+ * API tests for FakeApi
  */
-public class StoreApiTest {
+public class FakeApiTest {
 
 
-    private StoreApi api;
+    private FakeApi api;
     
     @Before
     public void setup() {
@@ -60,7 +62,7 @@ public class StoreApiTest {
         List providers = new ArrayList();
         providers.add(provider);
         
-        api = JAXRSClientFactory.create("http://petstore.swagger.io/v2", StoreApi.class, providers);
+        api = JAXRSClientFactory.create("http://petstore.swagger.io/v2", FakeApi.class, providers);
         org.apache.cxf.jaxrs.client.Client client = WebClient.client(api);
         
         ClientConfiguration config = WebClient.getConfig(client); 
@@ -68,34 +70,17 @@ public class StoreApiTest {
 
     
     /**
-     * Delete purchase order by ID
+     * To test \&quot;client\&quot; model
      *
-     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
-     *
-     * @throws ApiException
-     *          if the Api call fails
-     */
-    @Test
-    public void deleteOrderTest() {
-        String orderId = null;
-        api.deleteOrder(orderId);
-        
-        // TODO: test validations
-        
-        
-    }
-    
-    /**
-     * Returns pet inventories by status
-     *
-     * Returns a map of status codes to quantities
+     * To test \&quot;client\&quot; model
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void getInventoryTest() {
-        Map<String, Map<String, Integer>> response = api.getInventory();
+    public void testClientModelTest() {
+        Client body = null;
+        Client response = api.testClientModel(body);
         assertNotNull(response);
         // TODO: test validations
         
@@ -103,36 +88,56 @@ public class StoreApiTest {
     }
     
     /**
-     * Find purchase order by ID
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      *
-     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void getOrderByIdTest() {
-        Long orderId = null;
-        Order response = api.getOrderById(orderId);
-        assertNotNull(response);
+    public void testEndpointParametersTest() {
+        BigDecimal number = null;
+        Double _double = null;
+        String patternWithoutDelimiter = null;
+        byte[] _byte = null;
+        Integer integer = null;
+        Integer int32 = null;
+        Long int64 = null;
+        Float _float = null;
+        String string = null;
+        byte[] binary = null;
+        LocalDate date = null;
+        javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+        String password = null;
+        String paramCallback = null;
+        api.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        
         // TODO: test validations
         
         
     }
     
     /**
-     * Place an order for a pet
+     * To test enum parameters
      *
-     * 
+     * To test enum parameters
      *
      * @throws ApiException
      *          if the Api call fails
      */
     @Test
-    public void placeOrderTest() {
-        Order body = null;
-        Order response = api.placeOrder(body);
-        assertNotNull(response);
+    public void testEnumParametersTest() {
+        List<String> enumFormStringArray = null;
+        String enumFormString = null;
+        List<String> enumHeaderStringArray = null;
+        String enumHeaderString = null;
+        List<String> enumQueryStringArray = null;
+        String enumQueryString = null;
+        Integer enumQueryInteger = null;
+        Double enumQueryDouble = null;
+        api.testEnumParameters(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble);
+        
         // TODO: test validations
         
         

--- a/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/PetApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/PetApiTest.java
@@ -38,6 +38,9 @@ import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
 
 
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
+
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 import java.util.ArrayList;
@@ -210,7 +213,11 @@ public class PetApiTest {
     public void uploadFileTest() {
         Long petId = null;
         String additionalMetadata = null;
-        org.apache.cxf.jaxrs.ext.multipart.Attachment file = null;
+        
+        String fileFilename = "myfile.txt";
+        InputStream fileInputStream = null; // TODO: new FileInputStream("...");
+        ContentDisposition cd = new ContentDisposition("attachment;filename=" + fileFilename);
+        Attachment file = new Attachment("file", fileInputStream, cd);
         ModelApiResponse response = api.uploadFile(petId, additionalMetadata, file);
         assertNotNull(response);
         // TODO: test validations

--- a/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/PetApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/PetApiTest.java
@@ -1,6 +1,6 @@
 /**
  * Swagger Petstore
- * This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io
@@ -25,9 +25,9 @@
 
 package io.swagger.api;
 
-import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
+import io.swagger.model.Pet;
 import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
@@ -80,9 +80,11 @@ public class PetApiTest {
     @Test
     public void addPetTest() {
         Pet body = null;
-        // response = api.addPet(body);
-        //assertNotNull(response);
+        api.addPet(body);
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -97,9 +99,11 @@ public class PetApiTest {
     public void deletePetTest() {
         Long petId = null;
         String apiKey = null;
-        // response = api.deletePet(petId, apiKey);
-        //assertNotNull(response);
+        api.deletePet(petId, apiKey);
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -113,9 +117,11 @@ public class PetApiTest {
     @Test
     public void findPetsByStatusTest() {
         List<String> status = null;
-        //List<Pet> response = api.findPetsByStatus(status);
-        //assertNotNull(response);
+        List<List<Pet>> response = api.findPetsByStatus(status);
+        assertNotNull(response);
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -129,9 +135,11 @@ public class PetApiTest {
     @Test
     public void findPetsByTagsTest() {
         List<String> tags = null;
-        //List<Pet> response = api.findPetsByTags(tags);
-        //assertNotNull(response);
+        List<List<Pet>> response = api.findPetsByTags(tags);
+        assertNotNull(response);
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -145,9 +153,11 @@ public class PetApiTest {
     @Test
     public void getPetByIdTest() {
         Long petId = null;
-        //Pet response = api.getPetById(petId);
-        //assertNotNull(response);
+        Pet response = api.getPetById(petId);
+        assertNotNull(response);
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -161,9 +171,11 @@ public class PetApiTest {
     @Test
     public void updatePetTest() {
         Pet body = null;
-        // response = api.updatePet(body);
-        //assertNotNull(response);
+        api.updatePet(body);
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -179,9 +191,11 @@ public class PetApiTest {
         Long petId = null;
         String name = null;
         String status = null;
-        // response = api.updatePetWithForm(petId, name, status);
-        //assertNotNull(response);
+        api.updatePetWithForm(petId, name, status);
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -196,10 +210,12 @@ public class PetApiTest {
     public void uploadFileTest() {
         Long petId = null;
         String additionalMetadata = null;
-        File file = null;
-        //ModelApiResponse response = api.uploadFile(petId, additionalMetadata, file);
-        //assertNotNull(response);
+        org.apache.cxf.jaxrs.ext.multipart.Attachment file = null;
+        ModelApiResponse response = api.uploadFile(petId, additionalMetadata, file);
+        assertNotNull(response);
         // TODO: test validations
+        
+        
     }
     
 }

--- a/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/StoreApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/StoreApiTest.java
@@ -36,6 +36,9 @@ import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
 
 
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
+
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/UserApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/UserApiTest.java
@@ -36,6 +36,9 @@ import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
 
 
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
+
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 import java.util.ArrayList;

--- a/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/UserApiTest.java
+++ b/samples/client/petstore/jaxrs-cxf/src/test/java/io/swagger/api/UserApiTest.java
@@ -1,6 +1,6 @@
 /**
  * Swagger Petstore
- * This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io
@@ -78,9 +78,11 @@ public class UserApiTest {
     @Test
     public void createUserTest() {
         User body = null;
-        // response = api.createUser(body);
-        //assertNotNull(response);
+        api.createUser(body);
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -94,9 +96,11 @@ public class UserApiTest {
     @Test
     public void createUsersWithArrayInputTest() {
         List<User> body = null;
-        // response = api.createUsersWithArrayInput(body);
-        //assertNotNull(response);
+        api.createUsersWithArrayInput(body);
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -110,9 +114,11 @@ public class UserApiTest {
     @Test
     public void createUsersWithListInputTest() {
         List<User> body = null;
-        // response = api.createUsersWithListInput(body);
-        //assertNotNull(response);
+        api.createUsersWithListInput(body);
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -126,9 +132,11 @@ public class UserApiTest {
     @Test
     public void deleteUserTest() {
         String username = null;
-        // response = api.deleteUser(username);
-        //assertNotNull(response);
+        api.deleteUser(username);
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -142,9 +150,11 @@ public class UserApiTest {
     @Test
     public void getUserByNameTest() {
         String username = null;
-        //User response = api.getUserByName(username);
-        //assertNotNull(response);
+        User response = api.getUserByName(username);
+        assertNotNull(response);
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -159,9 +169,11 @@ public class UserApiTest {
     public void loginUserTest() {
         String username = null;
         String password = null;
-        //String response = api.loginUser(username, password);
-        //assertNotNull(response);
+        String response = api.loginUser(username, password);
+        assertNotNull(response);
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -174,9 +186,11 @@ public class UserApiTest {
      */
     @Test
     public void logoutUserTest() {
-        // response = api.logoutUser();
-        //assertNotNull(response);
+        api.logoutUser();
+        
         // TODO: test validations
+        
+        
     }
     
     /**
@@ -191,9 +205,11 @@ public class UserApiTest {
     public void updateUserTest() {
         String username = null;
         User body = null;
-        // response = api.updateUser(username, body);
-        //assertNotNull(response);
+        api.updateUser(username, body);
+        
         // TODO: test validations
+        
+        
     }
     
 }

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/io/swagger/api/FakeApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/io/swagger/api/FakeApiTest.java
@@ -38,6 +38,9 @@ import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
 
 
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
+
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 import java.util.ArrayList;
@@ -80,8 +83,8 @@ public class FakeApiTest {
     @Test
     public void testClientModelTest() {
         Client body = null;
-	//Client response = api.testClientModel(body);
-        //assertNotNull(response);
+        Client response = api.testClientModel(body);
+        assertNotNull(response);
         // TODO: test validations
         
         
@@ -111,7 +114,7 @@ public class FakeApiTest {
         javax.xml.datatype.XMLGregorianCalendar dateTime = null;
         String password = null;
         String paramCallback = null;
-	//api.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        api.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
         
         // TODO: test validations
         
@@ -136,7 +139,7 @@ public class FakeApiTest {
         String enumQueryString = null;
         Integer enumQueryInteger = null;
         Double enumQueryDouble = null;
-	//api.testEnumParameters(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble);
+        api.testEnumParameters(enumFormStringArray, enumFormString, enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble);
         
         // TODO: test validations
         

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/io/swagger/api/PetApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/io/swagger/api/PetApiTest.java
@@ -1,6 +1,6 @@
 /**
  * Swagger Petstore
- * This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io
@@ -25,9 +25,9 @@
 
 package io.swagger.api;
 
-import io.swagger.model.Pet;
-import io.swagger.model.ModelApiResponse;
 import java.io.File;
+import io.swagger.model.ModelApiResponse;
+import io.swagger.model.Pet;
 import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
@@ -37,6 +37,9 @@ import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
 
+
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
@@ -80,7 +83,7 @@ public class PetApiTest {
     @Test
     public void addPetTest() {
         Pet body = null;
-        //api.addPet(body);
+        api.addPet(body);
         
         // TODO: test validations
         
@@ -99,7 +102,7 @@ public class PetApiTest {
     public void deletePetTest() {
         Long petId = null;
         String apiKey = null;
-        //api.deletePet(petId, apiKey);
+        api.deletePet(petId, apiKey);
         
         // TODO: test validations
         
@@ -117,8 +120,8 @@ public class PetApiTest {
     @Test
     public void findPetsByStatusTest() {
         List<String> status = null;
-        //Pet response = api.findPetsByStatus(status);
-        //assertNotNull(response);
+        List<Pet> response = api.findPetsByStatus(status);
+        assertNotNull(response);
         // TODO: test validations
         
         
@@ -135,8 +138,8 @@ public class PetApiTest {
     @Test
     public void findPetsByTagsTest() {
         List<String> tags = null;
-        //Pet response = api.findPetsByTags(tags);
-        //assertNotNull(response);
+        List<Pet> response = api.findPetsByTags(tags);
+        assertNotNull(response);
         // TODO: test validations
         
         
@@ -153,8 +156,8 @@ public class PetApiTest {
     @Test
     public void getPetByIdTest() {
         Long petId = null;
-        //Pet response = api.getPetById(petId);
-        //assertNotNull(response);
+        Pet response = api.getPetById(petId);
+        assertNotNull(response);
         // TODO: test validations
         
         
@@ -171,7 +174,7 @@ public class PetApiTest {
     @Test
     public void updatePetTest() {
         Pet body = null;
-        //api.updatePet(body);
+        api.updatePet(body);
         
         // TODO: test validations
         
@@ -191,7 +194,7 @@ public class PetApiTest {
         Long petId = null;
         String name = null;
         String status = null;
-        //api.updatePetWithForm(petId, name, status);
+        api.updatePetWithForm(petId, name, status);
         
         // TODO: test validations
         
@@ -210,9 +213,13 @@ public class PetApiTest {
     public void uploadFileTest() {
         Long petId = null;
         String additionalMetadata = null;
-        org.apache.cxf.jaxrs.ext.multipart.Attachment file = null;
-        //ModelApiResponse response = api.uploadFile(petId, additionalMetadata, file);
-        //assertNotNull(response);
+        
+        String fileFilename = "myfile.txt";
+        InputStream fileInputStream = null; // TODO: new FileInputStream("...");
+        ContentDisposition cd = new ContentDisposition("attachment;filename=" + fileFilename);
+        Attachment file = new Attachment("file", fileInputStream, cd);
+        ModelApiResponse response = api.uploadFile(petId, additionalMetadata, file);
+        assertNotNull(response);
         // TODO: test validations
         
         

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/io/swagger/api/StoreApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/io/swagger/api/StoreApiTest.java
@@ -1,6 +1,6 @@
 /**
  * Swagger Petstore
- * This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io
@@ -36,6 +36,9 @@ import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
 
+
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
@@ -79,7 +82,7 @@ public class StoreApiTest {
     @Test
     public void deleteOrderTest() {
         String orderId = null;
-        //api.deleteOrder(orderId);
+        api.deleteOrder(orderId);
         
         // TODO: test validations
         
@@ -96,8 +99,8 @@ public class StoreApiTest {
      */
     @Test
     public void getInventoryTest() {
-        //Integer response = api.getInventory();
-        //assertNotNull(response);
+        Map<String, Integer> response = api.getInventory();
+        assertNotNull(response);
         // TODO: test validations
         
         
@@ -114,8 +117,8 @@ public class StoreApiTest {
     @Test
     public void getOrderByIdTest() {
         Long orderId = null;
-        //Order response = api.getOrderById(orderId);
-        //assertNotNull(response);
+        Order response = api.getOrderById(orderId);
+        assertNotNull(response);
         // TODO: test validations
         
         
@@ -132,8 +135,8 @@ public class StoreApiTest {
     @Test
     public void placeOrderTest() {
         Order body = null;
-        //Order response = api.placeOrder(body);
-        //assertNotNull(response);
+        Order response = api.placeOrder(body);
+        assertNotNull(response);
         // TODO: test validations
         
         

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/io/swagger/api/UserApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/io/swagger/api/UserApiTest.java
@@ -1,6 +1,6 @@
 /**
  * Swagger Petstore
- * This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.
+ * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
  *
  * OpenAPI spec version: 1.0.0
  * Contact: apiteam@swagger.io
@@ -25,8 +25,8 @@
 
 package io.swagger.api;
 
-import io.swagger.model.User;
 import java.util.List;
+import io.swagger.model.User;
 import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
@@ -36,6 +36,9 @@ import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 import org.apache.cxf.jaxrs.client.ClientConfiguration;
 import org.apache.cxf.jaxrs.client.WebClient;
 
+
+import org.apache.cxf.jaxrs.ext.multipart.*;
+import java.io.*;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
@@ -79,7 +82,7 @@ public class UserApiTest {
     @Test
     public void createUserTest() {
         User body = null;
-        //api.createUser(body);
+        api.createUser(body);
         
         // TODO: test validations
         
@@ -97,7 +100,7 @@ public class UserApiTest {
     @Test
     public void createUsersWithArrayInputTest() {
         List<User> body = null;
-        //api.createUsersWithArrayInput(body);
+        api.createUsersWithArrayInput(body);
         
         // TODO: test validations
         
@@ -115,7 +118,7 @@ public class UserApiTest {
     @Test
     public void createUsersWithListInputTest() {
         List<User> body = null;
-        //api.createUsersWithListInput(body);
+        api.createUsersWithListInput(body);
         
         // TODO: test validations
         
@@ -133,7 +136,7 @@ public class UserApiTest {
     @Test
     public void deleteUserTest() {
         String username = null;
-        //api.deleteUser(username);
+        api.deleteUser(username);
         
         // TODO: test validations
         
@@ -151,8 +154,8 @@ public class UserApiTest {
     @Test
     public void getUserByNameTest() {
         String username = null;
-        //User response = api.getUserByName(username);
-        //assertNotNull(response);
+        User response = api.getUserByName(username);
+        assertNotNull(response);
         // TODO: test validations
         
         
@@ -170,8 +173,8 @@ public class UserApiTest {
     public void loginUserTest() {
         String username = null;
         String password = null;
-        //String response = api.loginUser(username, password);
-        //assertNotNull(response);
+        String response = api.loginUser(username, password);
+        assertNotNull(response);
         // TODO: test validations
         
         
@@ -187,7 +190,7 @@ public class UserApiTest {
      */
     @Test
     public void logoutUserTest() {
-        //api.logoutUser();
+        api.logoutUser();
         
         // TODO: test validations
         
@@ -206,7 +209,7 @@ public class UserApiTest {
     public void updateUserTest() {
         String username = null;
         User body = null;
-        //api.updateUser(username, body);
+        api.updateUser(username, body);
         
         // TODO: test validations
         


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
see #4513

* Uncomment api invocations in unittests 
* Also add processing for void to AbstractJavaCodegen.java so it is available to all languages.
* Add snippet to deal with CXF Attachments

Sidenote: the currently used PetApi.uploadFile with the FormParam additionalMetadata doesn't work with CXF as it only supports one Attachment parameter. If the parameter additionalMetadata  is removed, the unittest works.


