### PR TITLE
[Java] Change build call visibility

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -63,8 +63,15 @@ public class {{classname}} {
     }
 
     {{#operation}}
-    /* Build call for {{operationId}} */
-    private com.squareup.okhttp.Call {{operationId}}Call({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    /**
+     * Build call for {{operationId}}{{#allParams}}
+     * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
+     * @param progressListener Progress listener
+     * @param progressRequestListener Progress request listener
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     */
+    public com.squareup.okhttp.Call {{operationId}}Call({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
         
         // create path and map variables


### PR DESCRIPTION
Change the build call method visibility for operations.

This allows to access the input stream of the body response to monitor a progress for instance. See #5007

