### PR TITLE
remove indentation of the comment

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,17 +14,17 @@ Also please indicate in the issue title which language/library is concerned. Eg:
 ##### Swagger declaration file content or url
 
 <!-- if it is a bug, a json or yaml that produces it.
-    If you post the code inline, please wrap it with
-    ```yaml
-    (here your code)
-    ```
-    (for YAML code) or
-    ```json
-    (here your code)
-    ```
-    (for JSON code), so it becomes more readable. If it is longer than about ten lines,
-    please create a Gist (https://gist.github.com) or upload it somewhere else and
-    link it here.
+If you post the code inline, please wrap it with
+```yaml
+(here your code)
+```
+(for YAML code) or
+```json
+(here your code)
+```
+(for JSON code), so it becomes more readable. If it is longer than about ten lines,
+please create a Gist (https://gist.github.com) or upload it somewhere else and
+link it here.
   -->
 
 ##### Command line used for generation


### PR DESCRIPTION
This template seems to lead to people wrapping their code with indented code markers, which won't work.
Hopefully not indenting it here helps a bit.

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (no generator changes.)
- [x] Filed the PR against the correct branch: master for non-breaking changes

### Description of the PR

Latest example I've seen was #5009, but there was already a different example some days ago (and I don't succeed to look at every issue).
