### PR TITLE
fix (partially) #4898 for dart.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/dart/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/dart/api.mustache
@@ -25,7 +25,7 @@ class {{classname}} {
     {{/allParams}}
 
     // create path and map variables
-    String path = "{{path}}".replaceAll("{format}","json"){{#pathParams}}.replaceAll("{" + "{{paramName}}" + "}", {{{paramName}}}.toString()){{/pathParams}};
+    String path = "{{path}}".replaceAll("{format}","json"){{#pathParams}}.replaceAll("{" + "{{baseName}}" + "}", {{{paramName}}}.toString()){{/pathParams}};
 
     // query params
     List<QueryParam> queryParams = [];


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → ran bin/dart-petstore.sh, with no changes in the produced samples.
- [x] Filed the PR against the correct branch: master for non-breaking changes

### Description of the PR

This fixes (or hopes to fix) part of #4898 for the `dart` generator.

The problem likely occurred when a path parameter name (as declared in the OpenAPI definition) is of a form which doesn't match the form used in Dart, or is a reserved word there. In this case the parameter gets renamed for use in the code, and the algorithm for creating the actual path tries to replace the renamed parameter in the path (which will do nothing), not the original one (which would be correct).

This commit changes the replacement to using `{{baseName}}` (which is the original name of the parameter definition as parsed from the API definition) instead of `{{paramName}}` (which is the sanitized version of the parameter name).

Our Petstore API definition doesn't seem to contain a path parameter which would get modified by the sanitation, therefore there is no difference in the generated samples.

I don't know anything about Dart, so this needs review by Dart experts. /cc @yissachar @close2 @ircecho @hcwilhelm 