### PR TITLE
Fix (partially) #4898 for elixir

### DIFF
--- a/modules/swagger-codegen/src/main/resources/elixir/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/elixir/api.mustache
@@ -13,10 +13,10 @@ defmodule {{#modulized}}{{appName}}{{/modulized}}.Api.{{classname}} do
   def {{#underscored}}{{operationId}}{{/underscored}}({{#allParams}}{{^-first}}, {{/-first}}{{#underscored}}{{paramName}}{{/underscored}}{{/allParams}}) do
     method = [method: :{{#underscored}}{{httpMethod}}{{/underscored}}]
     url = [url: "{{replacedPathName}}"]
-    query_params = [{{^queryParams.isEmpty}}query: [{{#queryParams}}{{^-first}}, {{/-first}}{:"{{paramName}}", {{#underscored}}{{paramName}}{{/underscored}}}{{/queryParams}}]{{/queryParams.isEmpty}}]
-    header_params = [{{^headerParams.isEmpty}}header: [{{#headerParams}}{{^-first}}, {{/-first}}{:"{{paramName}}", {{#underscored}}{{paramName}}{{/underscored}}}{{/headerParams}}]{{/headerParams.isEmpty}}]
+    query_params = [{{^queryParams.isEmpty}}query: [{{#queryParams}}{{^-first}}, {{/-first}}{:"{{baseName}}", {{#underscored}}{{paramName}}{{/underscored}}}{{/queryParams}}]{{/queryParams.isEmpty}}]
+    header_params = [{{^headerParams.isEmpty}}header: [{{#headerParams}}{{^-first}}, {{/-first}}{:"{{baseName}}", {{#underscored}}{{paramName}}{{/underscored}}}{{/headerParams}}]{{/headerParams.isEmpty}}]
     body_params = [{{^bodyParams.isEmpty}}body: {{#bodyParams}}{{#underscored}}{{paramName}}{{/underscored}}{{/bodyParams}}{{/bodyParams.isEmpty}}]
-    form_params = [{{^formParams.isEmpty}}body: Enum.map_join([{{#formParams}}{{^-first}}, {{/-first}}{:"{{paramName}}", {{#underscored}}{{paramName}}{{/underscored}}}{{/formParams}}], "&", &("#{elem(&1, 0)}=#{elem(&1, 1)}")){{/formParams.isEmpty}}]
+    form_params = [{{^formParams.isEmpty}}body: Enum.map_join([{{#formParams}}{{^-first}}, {{/-first}}{:"{{baseName}}", {{#underscored}}{{paramName}}{{/underscored}}}{{/formParams}}], "&", &("#{elem(&1, 0)}=#{elem(&1, 1)}")){{/formParams.isEmpty}}]
     params = query_params ++ header_params ++ body_params ++ form_params
     opts = []
     options = method ++ url ++ params ++ opts

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/fake.ex
@@ -28,7 +28,7 @@ defmodule SwaggerPetstore.Api.Fake do
     query_params = []
     header_params = []
     body_params = []
-    form_params = [body: Enum.map_join([{:"integer", integer}, {:"int32", int32}, {:"int64", int64}, {:"number", number}, {:"float", float}, {:"double", double}, {:"string", string}, {:"patternWithoutDelimiter", pattern_without_delimiter}, {:"byte", byte}, {:"binary", binary}, {:"date", date}, {:"dateTime", date_time}, {:"password", password}, {:"callback", callback}], "&", &("#{elem(&1, 0)}=#{elem(&1, 1)}"))]
+    form_params = [body: Enum.map_join([{:"integer", integer}, {:"int32", int32}, {:"int64", int64}, {:"number", number}, {:"float", float}, {:"double", double}, {:"string", string}, {:"pattern_without_delimiter", pattern_without_delimiter}, {:"byte", byte}, {:"binary", binary}, {:"date", date}, {:"dateTime", date_time}, {:"password", password}, {:"callback", callback}], "&", &("#{elem(&1, 0)}=#{elem(&1, 1)}"))]
     params = query_params ++ header_params ++ body_params ++ form_params
     opts = []
     options = method ++ url ++ params ++ opts
@@ -39,10 +39,10 @@ defmodule SwaggerPetstore.Api.Fake do
   def test_enum_parameters(enum_form_string_array, enum_form_string, enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double) do
     method = [method: :get]
     url = [url: "/fake"]
-    query_params = [query: [{:"enumQueryStringArray", enum_query_string_array}, {:"enumQueryString", enum_query_string}, {:"enumQueryInteger", enum_query_integer}]]
-    header_params = [header: [{:"enumHeaderStringArray", enum_header_string_array}, {:"enumHeaderString", enum_header_string}]]
+    query_params = [query: [{:"enum_query_string_array", enum_query_string_array}, {:"enum_query_string", enum_query_string}, {:"enum_query_integer", enum_query_integer}]]
+    header_params = [header: [{:"enum_header_string_array", enum_header_string_array}, {:"enum_header_string", enum_header_string}]]
     body_params = []
-    form_params = [body: Enum.map_join([{:"enumFormStringArray", enum_form_string_array}, {:"enumFormString", enum_form_string}, {:"enumQueryDouble", enum_query_double}], "&", &("#{elem(&1, 0)}=#{elem(&1, 1)}"))]
+    form_params = [body: Enum.map_join([{:"enum_form_string_array", enum_form_string_array}, {:"enum_form_string", enum_form_string}, {:"enum_query_double", enum_query_double}], "&", &("#{elem(&1, 0)}=#{elem(&1, 1)}"))]
     params = query_params ++ header_params ++ body_params ++ form_params
     opts = []
     options = method ++ url ++ params ++ opts

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/pet.ex
@@ -26,7 +26,7 @@ defmodule SwaggerPetstore.Api.Pet do
     method = [method: :delete]
     url = [url: "/pet/#{pet_id}"]
     query_params = []
-    header_params = [header: [{:"apiKey", api_key}]]
+    header_params = [header: [{:"api_key", api_key}]]
     body_params = []
     form_params = []
     params = query_params ++ header_params ++ body_params ++ form_params


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
  → bin/elixir-petstore.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes

### Description of the PR

This fixes (or hopes to fix) part of #4898 for the `elixir` generator.

The problem likely occurred when a query/form/header parameter name (as declared in the OpenAPI definition) is of a form which doesn't match the form used in Elixir, or is a reserved word there. In this case the parameter gets renamed for use in the code, and the algorithm for including the parameter in the request uses the sanitized name instead of the original one.

This commit changes the replacement to using `{{baseName}}` (which is the original name of the parameter definition as parsed from the API definition) instead of `{{paramName}}` (which is the sanitized version of the parameter name).

There are some places in the Petstore samples where this makes some difference, to me it looks like the new ones are more sensible.

I don't know anything about Elixir (don't even have a compiler on my computer), so this needs intensive review by Elixir experts. /cc @niku 