### PR TITLE
Fix (partially) #4898 for flash

### DIFF
--- a/modules/swagger-codegen/src/main/resources/flash/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/flash/api.mustache
@@ -36,7 +36,7 @@ public class {{classname}} extends SwaggerApi {
      */
     public function {{nickname}} ({{#allParams}}{{paramName}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}): String {
         // create path and map variables
-        var path: String = "{{path}}".replace(/{format}/g,"xml"){{#pathParams}}.replace("{" + "{{paramName}}" + "}", getApiInvoker().escapeString({{{paramName}}})){{/pathParams}};
+        var path: String = "{{path}}".replace(/{format}/g,"xml"){{#pathParams}}.replace("{" + "{{baseName}}" + "}", getApiInvoker().escapeString({{{paramName}}})){{/pathParams}};
 
         // query params
         var queryParams: Dictionary = new Dictionary();
@@ -50,10 +50,10 @@ public class {{classname}} extends SwaggerApi {
         {{/allParams}}
 
         {{#queryParams}}if("null" != String({{paramName}}))
-            queryParams["{{paramName}}"] = toPathValue({{paramName}});
+            queryParams["{{baseName}}"] = toPathValue({{paramName}});
         {{/queryParams}}
 
-        {{#headerParams}}headerParams["{{paramName}}"] = toPathValue({{paramName}});
+        {{#headerParams}}headerParams["{{baseName}}"] = toPathValue({{paramName}});
         {{/headerParams}}
 
         var token:AsyncToken = getApiInvoker().invokeAPI(path, "{{httpMethod}}", queryParams, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, headerParams);

--- a/samples/client/petstore/flash/flash/src/io/swagger/client/api/PetApi.as
+++ b/samples/client/petstore/flash/flash/src/io/swagger/client/api/PetApi.as
@@ -86,7 +86,7 @@ public class PetApi extends SwaggerApi {
         }
 
         
-        headerParams["apiKey"] = toPathValue(apiKey);
+        headerParams["api_key"] = toPathValue(apiKey);
 
         var token:AsyncToken = getApiInvoker().invokeAPI(path, "DELETE", queryParams, null, headerParams);
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → bin/flash-petstore.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

This fixes (or hopes to fix) part of #4898 for the `flash` generator.

The problem likely occurred when a path, query or header parameter name (as declared in the OpenAPI definition) is of a form which doesn't match the form used in Flash, or is a reserved word there. In this case the parameter gets renamed for use in the code, and the algorithm for creating the actual path tries to replace the renamed parameter in the path (which will do nothing), not the original one (which would be correct). For query or header parameters, the parameter will be sent with the sanitized name instead of the original one.

This commit changes the replacement to using `{{baseName}}` (which is the original name of the parameter definition as parsed from the API definition) instead of `{{paramName}}` (which is the sanitized version of the parameter name).

Our Petstore sample API definition doesn't seem to contain any path or query parameter which would get modified by the sanitation, so the regenerated samples just have a single difference in a header parameter (which looks better now to me).

I don't know anything about Flash, so this needs review by Flash experts. /cc @glederrey