### PR TITLE
[JAVA][jaxrs-spec] Add @DefaultValue for query parameters in API (#5023)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/queryParams.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#isQueryParam}}@QueryParam("{{baseName}}"){{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}} {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}}@QueryParam("{{baseName}}"){{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{#defaultValue}} @DefaultValue("{{{defaultValue}}}"){{/defaultValue}} {{{dataType}}} {{paramName}}{{/isQueryParam}}

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/FakeApi.java
@@ -2,6 +2,7 @@ package io.swagger.api;
 
 import java.math.BigDecimal;
 import io.swagger.model.Client;
+import java.util.Date;
 import org.joda.time.LocalDate;
 
 import javax.ws.rs.*;
@@ -42,7 +43,7 @@ public class FakeApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid username supplied", response = void.class),
         @ApiResponse(code = 404, message = "User not found", response = void.class) })
-    public Response testEndpointParameters(@FormParam(value = "number")  BigDecimal number,@FormParam(value = "_double")  Double _double,@FormParam(value = "patternWithoutDelimiter")  String patternWithoutDelimiter,@FormParam(value = "_byte")  byte[] _byte,@FormParam(value = "integer")  Integer integer,@FormParam(value = "int32")  Integer int32,@FormParam(value = "int64")  Long int64,@FormParam(value = "_float")  Float _float,@FormParam(value = "string")  String string,@FormParam(value = "binary")  byte[] binary,@FormParam(value = "date")  LocalDate date,@FormParam(value = "dateTime")  javax.xml.datatype.XMLGregorianCalendar dateTime,@FormParam(value = "password")  String password,@FormParam(value = "paramCallback")  String paramCallback) {
+    public Response testEndpointParameters(@FormParam(value = "number")  BigDecimal number,@FormParam(value = "double")  Double _double,@FormParam(value = "pattern_without_delimiter")  String patternWithoutDelimiter,@FormParam(value = "byte")  byte[] _byte,@FormParam(value = "integer")  Integer integer,@FormParam(value = "int32")  Integer int32,@FormParam(value = "int64")  Long int64,@FormParam(value = "float")  Float _float,@FormParam(value = "string")  String string,@FormParam(value = "binary")  byte[] binary,@FormParam(value = "date")  LocalDate date,@FormParam(value = "dateTime")  Date dateTime,@FormParam(value = "password")  String password,@FormParam(value = "callback")  String paramCallback) {
     	return Response.ok().entity("magic!").build();
     }
 
@@ -54,7 +55,7 @@ public class FakeApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid request", response = void.class),
         @ApiResponse(code = 404, message = "Not found", response = void.class) })
-    public Response testEnumParameters(@FormParam(value = "enumFormStringArray")  List<String> enumFormStringArray,@FormParam(value = "enumFormString")  String enumFormString,@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray,@HeaderParam("enum_header_string") String enumHeaderString,@QueryParam("enum_query_string_array")  List<String> enumQueryStringArray,@QueryParam("enum_query_string")  String enumQueryString,@QueryParam("enum_query_integer")  Integer enumQueryInteger,@FormParam(value = "enumQueryDouble")  Double enumQueryDouble) {
+    public Response testEnumParameters(@FormParam(value = "enum_form_string_array")  List<String> enumFormStringArray,@FormParam(value = "enum_form_string")  String enumFormString,@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray,@HeaderParam("enum_header_string") String enumHeaderString,@QueryParam("enum_query_string_array")  List<String> enumQueryStringArray,@QueryParam("enum_query_string")  @DefaultValue("-efg") String enumQueryString,@QueryParam("enum_query_integer")  Integer enumQueryInteger,@FormParam(value = "enum_query_double")  Double enumQueryDouble) {
     	return Response.ok().entity("magic!").build();
     }
 }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
@@ -23,7 +23,7 @@ public class AdditionalPropertiesClass   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, String> getMapProperty() {
     return mapProperty;
   }
@@ -39,7 +39,7 @@ public class AdditionalPropertiesClass   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapOfMapProperty() {
     return mapOfMapProperty;
   }
@@ -49,7 +49,7 @@ public class AdditionalPropertiesClass   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class AdditionalPropertiesClass   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Animal.java
@@ -22,7 +22,7 @@ public class Animal   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public String getClassName() {
     return className;
@@ -39,7 +39,7 @@ public class Animal   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getColor() {
     return color;
   }
@@ -49,7 +49,7 @@ public class Animal   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class Animal   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AnimalFarm.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AnimalFarm.java
@@ -15,7 +15,7 @@ public class AnimalFarm extends ArrayList<Animal>  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -44,7 +44,7 @@ public class AnimalFarm extends ArrayList<Animal>  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
@@ -22,7 +22,7 @@ public class ArrayOfArrayOfNumberOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
@@ -32,7 +32,7 @@ public class ArrayOfArrayOfNumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -62,7 +62,7 @@ public class ArrayOfArrayOfNumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
@@ -22,7 +22,7 @@ public class ArrayOfNumberOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
@@ -32,7 +32,7 @@ public class ArrayOfNumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -62,7 +62,7 @@ public class ArrayOfNumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayTest.java
@@ -24,7 +24,7 @@ public class ArrayTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -40,7 +40,7 @@ public class ArrayTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -56,7 +56,7 @@ public class ArrayTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
@@ -66,7 +66,7 @@ public class ArrayTest   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -100,7 +100,7 @@ public class ArrayTest   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Capitalization.java
@@ -24,7 +24,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -40,7 +40,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -56,7 +56,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -72,7 +72,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -88,7 +88,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -105,7 +105,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "Name of the pet ")
+  @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;
   }
@@ -115,7 +115,7 @@ public class Capitalization   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -155,7 +155,7 @@ public class Capitalization   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Cat.java
@@ -20,7 +20,7 @@ public class Cat extends Animal  {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;
   }
@@ -30,7 +30,7 @@ public class Cat extends Animal  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class Cat extends Animal  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Category.java
@@ -20,7 +20,7 @@ public class Category   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -36,7 +36,7 @@ public class Category   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getName() {
     return name;
   }
@@ -46,7 +46,7 @@ public class Category   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class Category   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ClassModel.java
@@ -23,7 +23,7 @@ public class ClassModel   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;
   }
@@ -33,7 +33,7 @@ public class ClassModel   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -63,7 +63,7 @@ public class ClassModel   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Client.java
@@ -19,7 +19,7 @@ public class Client   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getClient() {
     return client;
   }
@@ -29,7 +29,7 @@ public class Client   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -59,7 +59,7 @@ public class Client   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Dog.java
@@ -20,7 +20,7 @@ public class Dog extends Animal  {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;
   }
@@ -30,7 +30,7 @@ public class Dog extends Animal  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class Dog extends Animal  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumArrays.java
@@ -84,7 +84,7 @@ public enum ArrayEnumEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -100,7 +100,7 @@ public enum ArrayEnumEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
@@ -110,7 +110,7 @@ public enum ArrayEnumEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -142,7 +142,7 @@ public enum ArrayEnumEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumTest.java
@@ -116,7 +116,7 @@ public enum EnumNumberEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -132,7 +132,7 @@ public enum EnumNumberEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -148,7 +148,7 @@ public enum EnumNumberEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -164,7 +164,7 @@ public enum EnumNumberEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
@@ -174,7 +174,7 @@ public enum EnumNumberEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -210,7 +210,7 @@ public enum EnumNumberEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/FormatTest.java
@@ -1,6 +1,7 @@
 package io.swagger.model;
 
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.UUID;
 import org.joda.time.LocalDate;
 import javax.validation.constraints.*;
@@ -22,7 +23,7 @@ public class FormatTest   {
   private byte[] _byte = null;
   private byte[] binary = null;
   private LocalDate date = null;
-  private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+  private Date dateTime = null;
   private UUID uuid = null;
   private String password = null;
 
@@ -36,7 +37,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @Min(10) @Max(100)  public Integer getInteger() {
     return integer;
   }
@@ -54,7 +55,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @Min(20) @Max(200)  public Integer getInt32() {
     return int32;
   }
@@ -70,7 +71,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
   }
@@ -88,7 +89,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
  @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
     return number;
@@ -107,7 +108,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
     return _float;
   }
@@ -125,7 +126,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
     return _double;
   }
@@ -141,7 +142,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @Pattern(regexp="/[a-z]/i")  public String getString() {
     return string;
   }
@@ -157,7 +158,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public byte[] getByte() {
     return _byte;
@@ -174,7 +175,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public byte[] getBinary() {
     return binary;
   }
@@ -190,7 +191,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public LocalDate getDate() {
     return date;
@@ -201,17 +202,17 @@ public class FormatTest   {
 
   /**
    **/
-  public FormatTest dateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public FormatTest dateTime(Date dateTime) {
     this.dateTime = dateTime;
     return this;
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getDateTime() {
+  @ApiModelProperty(value = "")
+  public Date getDateTime() {
     return dateTime;
   }
-  public void setDateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public void setDateTime(Date dateTime) {
     this.dateTime = dateTime;
   }
 
@@ -223,7 +224,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
   }
@@ -239,7 +240,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
  @Size(min=10,max=64)  public String getPassword() {
     return password;
@@ -250,7 +251,7 @@ public class FormatTest   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -304,7 +305,7 @@ public class FormatTest   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
@@ -20,7 +20,7 @@ public class HasOnlyReadOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
   }
@@ -36,7 +36,7 @@ public class HasOnlyReadOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;
   }
@@ -46,7 +46,7 @@ public class HasOnlyReadOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class HasOnlyReadOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MapTest.java
@@ -54,7 +54,7 @@ public enum InnerEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -70,7 +70,7 @@ public enum InnerEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -80,7 +80,7 @@ public enum InnerEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -112,7 +112,7 @@ public enum InnerEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -1,6 +1,7 @@
 package io.swagger.model;
 
 import io.swagger.model.Animal;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,7 @@ import java.util.Objects;
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   
   private UUID uuid = null;
-  private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+  private Date dateTime = null;
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   /**
@@ -26,7 +27,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
   }
@@ -36,17 +37,17 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
 
   /**
    **/
-  public MixedPropertiesAndAdditionalPropertiesClass dateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public MixedPropertiesAndAdditionalPropertiesClass dateTime(Date dateTime) {
     this.dateTime = dateTime;
     return this;
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getDateTime() {
+  @ApiModelProperty(value = "")
+  public Date getDateTime() {
     return dateTime;
   }
-  public void setDateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public void setDateTime(Date dateTime) {
     this.dateTime = dateTime;
   }
 
@@ -58,7 +59,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;
   }
@@ -68,7 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -102,7 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Model200Response.java
@@ -24,7 +24,7 @@ public class Model200Response   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
   }
@@ -40,7 +40,7 @@ public class Model200Response   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;
   }
@@ -50,7 +50,7 @@ public class Model200Response   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -82,7 +82,7 @@ public class Model200Response   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -21,7 +21,7 @@ public class ModelApiResponse   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
   }
@@ -37,7 +37,7 @@ public class ModelApiResponse   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getType() {
     return type;
   }
@@ -53,7 +53,7 @@ public class ModelApiResponse   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getMessage() {
     return message;
   }
@@ -63,7 +63,7 @@ public class ModelApiResponse   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -97,7 +97,7 @@ public class ModelApiResponse   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelReturn.java
@@ -23,7 +23,7 @@ public class ModelReturn   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;
   }
@@ -33,7 +33,7 @@ public class ModelReturn   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -63,7 +63,7 @@ public class ModelReturn   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Name.java
@@ -26,7 +26,7 @@ public class Name   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public Integer getName() {
     return name;
@@ -43,7 +43,7 @@ public class Name   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -59,7 +59,7 @@ public class Name   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
   }
@@ -75,7 +75,7 @@ public class Name   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer get123Number() {
     return _123Number;
   }
@@ -85,7 +85,7 @@ public class Name   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -121,7 +121,7 @@ public class Name   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/NumberOnly.java
@@ -20,7 +20,7 @@ public class NumberOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;
   }
@@ -30,7 +30,7 @@ public class NumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class NumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Order.java
@@ -1,5 +1,6 @@
 package io.swagger.model;
 
+import java.util.Date;
 import javax.validation.constraints.*;
 
 
@@ -12,7 +13,7 @@ public class Order   {
   private Long id = null;
   private Long petId = null;
   private Integer quantity = null;
-  private javax.xml.datatype.XMLGregorianCalendar shipDate = null;
+  private Date shipDate = null;
 
 public enum StatusEnum {
 
@@ -55,7 +56,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -71,7 +72,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
   }
@@ -87,7 +88,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
   }
@@ -97,17 +98,17 @@ public enum StatusEnum {
 
   /**
    **/
-  public Order shipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public Order shipDate(Date shipDate) {
     this.shipDate = shipDate;
     return this;
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getShipDate() {
+  @ApiModelProperty(value = "")
+  public Date getShipDate() {
     return shipDate;
   }
-  public void setShipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public void setShipDate(Date shipDate) {
     this.shipDate = shipDate;
   }
 
@@ -120,7 +121,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "Order Status")
+  @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
   }
@@ -136,7 +137,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;
   }
@@ -146,7 +147,7 @@ public enum StatusEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -186,7 +187,7 @@ public enum StatusEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Pet.java
@@ -59,7 +59,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -75,7 +75,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
   }
@@ -108,7 +108,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -125,7 +125,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
   }
@@ -142,7 +142,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "pet status in the store")
+  @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;
   }
@@ -152,7 +152,7 @@ public enum StatusEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -192,7 +192,7 @@ public enum StatusEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ReadOnlyFirst.java
@@ -20,7 +20,7 @@ public class ReadOnlyFirst   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
   }
@@ -36,7 +36,7 @@ public class ReadOnlyFirst   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;
   }
@@ -46,7 +46,7 @@ public class ReadOnlyFirst   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class ReadOnlyFirst   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/SpecialModelName.java
@@ -19,7 +19,7 @@ public class SpecialModelName   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getSpecialPropertyName() {
     return specialPropertyName;
   }
@@ -29,7 +29,7 @@ public class SpecialModelName   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -59,7 +59,7 @@ public class SpecialModelName   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Tag.java
@@ -20,7 +20,7 @@ public class Tag   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -36,7 +36,7 @@ public class Tag   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getName() {
     return name;
   }
@@ -46,7 +46,7 @@ public class Tag   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class Tag   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/User.java
@@ -26,7 +26,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -42,7 +42,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
   }
@@ -58,7 +58,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
   }
@@ -74,7 +74,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
   }
@@ -90,7 +90,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
   }
@@ -106,7 +106,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
   }
@@ -122,7 +122,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
   }
@@ -139,7 +139,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "User Status")
+  @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;
   }
@@ -149,7 +149,7 @@ public class User   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -193,7 +193,7 @@ public class User   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/swagger.json
+++ b/samples/server/petstore/jaxrs-spec/swagger.json
@@ -108,8 +108,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -650,8 +650,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_form_string",
@@ -669,8 +669,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_header_string",
@@ -688,8 +688,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_query_string",
@@ -705,14 +705,16 @@
           "description" : "Query parameter enum test (double)",
           "required" : false,
           "type" : "integer",
-          "format" : "int32"
+          "format" : "int32",
+          "enum" : [ 1, -2 ]
         }, {
           "name" : "enum_query_double",
           "in" : "formData",
           "description" : "Query parameter enum test (double)",
           "required" : false,
           "type" : "number",
-          "format" : "double"
+          "format" : "double",
+          "enum" : [ 1.1, -1.2 ]
         } ],
         "responses" : {
           "400" : {
@@ -725,8 +727,8 @@
       },
       "post" : {
         "tags" : [ "fake" ],
-        "summary" : "Fake endpoint for testing various parameters\n假端點\n偽のエンドポイント\n가짜 엔드 포인트\n",
-        "description" : "Fake endpoint for testing various parameters\n假端點\n偽のエンドポイント\n가짜 엔드 포인트\n",
+        "summary" : "Fake endpoint for testing various parameters\n???\n?????????\n?? ?? ???\n",
+        "description" : "Fake endpoint for testing various parameters\n???\n?????????\n?? ?? ???\n",
         "operationId" : "testEndpointParameters",
         "consumes" : [ "application/xml; charset=utf-8", "application/json; charset=utf-8" ],
         "produces" : [ "application/xml; charset=utf-8", "application/json; charset=utf-8" ],
@@ -760,15 +762,15 @@
           "description" : "None",
           "required" : true,
           "type" : "number",
-          "maximum" : 543.200000000000045474735088646411895751953125,
-          "minimum" : 32.10000000000000142108547152020037174224853515625
+          "maximum" : 543.2,
+          "minimum" : 32.1
         }, {
           "name" : "float",
           "in" : "formData",
           "description" : "None",
           "required" : false,
           "type" : "number",
-          "maximum" : 987.6000000000000227373675443232059478759765625,
+          "maximum" : 987.6,
           "format" : "float"
         }, {
           "name" : "double",
@@ -776,8 +778,8 @@
           "description" : "None",
           "required" : true,
           "type" : "number",
-          "maximum" : 123.400000000000005684341886080801486968994140625,
-          "minimum" : 67.7999999999999971578290569595992565155029296875,
+          "maximum" : 123.4,
+          "minimum" : 67.8,
           "format" : "double"
         }, {
           "name" : "string",
@@ -886,13 +888,13 @@
         "read:pets" : "read your pets"
       }
     },
-    "http_basic_test" : {
-      "type" : "basic"
-    },
     "api_key" : {
       "type" : "apiKey",
       "name" : "api_key",
       "in" : "header"
+    },
+    "http_basic_test" : {
+      "type" : "basic"
     }
   },
   "definitions" : {


### PR DESCRIPTION
This was previously missing and I don't think it was intentional.
It appears that swagger-codegen is already correctly processing
the yaml and the placeholder in the template was the only thing
missing.

This addresses #5023.

### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

It's just a variable added to the mustache template. The variable was always being processed by the Java code, it simply wasn't output in the template.
