### PR TITLE
Cache module directories to improve Travis CI performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,8 @@ samples/client/petstore/typescript-node/**/typings
 samples/client/petstore/typescript-angular/**/typings
 samples/client/petstore/typescript-fetch/**/dist/
 samples/client/petstore/typescript-fetch/**/typings
+samples/client/petstore/typescript-angular2/npm/npm-debug.log
+samples/client/petstore/typescript-node/npm/npm-debug.log
 
 # aspnetcore
 samples/server/petstore/aspnetcore/.vs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,21 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
+  - $HOME/samples/client/petstore/php/SwaggerClient-php/vendor
+  - $HOME/samples/client/petstore/ruby/venodr/bundle
+  - $HOME/samples/client/petstore/python/.venv/
+  - $HOME/samples/client/petstore/typescript-node/npm/node_modules
+  - $HOME/samples/client/petstore/typescript-node/npm/typings/
+  - $HOME/samples/client/petstore/typescript-fetch/tests/default/node_modules
+  - $HOME/samples/client/petstore/typescript-fetch/tests/default/typings
+  - $HOME/samples/client/petstore/typescript-fetch/builds/default/node_modules
+  - $HOME/samples/client/petstore/typescript-fetch/builds/default/typings
+  - $HOME/samples/client/petstore/typescript-fetch/builds/es6-target/node_modules
+  - $HOME/samples/client/petstore/typescript-fetch/builds/es6-target/typings
+  - $HOME/samples/client/petstore/typescript-fetch/builds/with-npm-version/node_modules
+  - $HOME/samples/client/petstore/typescript-fetch/npm/with-npm-version/typings
+  - $HOME/samples/client/petstore/typescript-angular/node_modules
+  - $HOME/samples/client/petstore/typescript-angular/typings
 
 services:
   - docker

--- a/samples/client/petstore/ruby/pom.xml
+++ b/samples/client/petstore/ruby/pom.xml
@@ -36,6 +36,8 @@
                             <executable>bundle</executable>
                             <arguments>
                                 <argument>install</argument>
+                                <argument>--path</argument>
+                                <argument>vendor/bundle</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guildelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Cache module directories to improve Travis CI performance
