### PR TITLE
Fix (partially) #4898 for groovy

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Groovy/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Groovy/api.mustache
@@ -18,7 +18,7 @@ class {{classname}} {
 
     {{#operation}}
     def {{operationId}} ({{#allParams}} {{{dataType}}} {{paramName}},{{/allParams}} Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "{{path}}"
 
         // query params
@@ -35,12 +35,14 @@ class {{classname}} {
         {{/allParams}}
 
         {{#queryParams}}if (!"null".equals(String.valueOf({{paramName}})))
-            queryParams.put("{{paramName}}", String.valueOf({{paramName}}))
+            queryParams.put("{{baseName}}", String.valueOf({{paramName}}))
         {{/queryParams}}
 
         {{#headerParams}}
-        headerParams.put("{{paramName}}", {{paramName}})
+        headerParams.put("{{baseName}}", {{paramName}})
         {{/headerParams}}
+
+        // Also still TODO: form params, body param
 
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "{{httpMethod}}", "{{returnContainer}}",

--- a/samples/client/petstore/groovy/src/main/groovy/io/swagger/api/PetApi.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/io/swagger/api/PetApi.groovy
@@ -17,7 +17,7 @@ class PetApi {
     String versionPath = "/api/v1"
 
     def addPet ( Pet body, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/pet"
 
         // query params
@@ -31,13 +31,15 @@ class PetApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "POST", "",
                     null )
                     
     }
     def deletePet ( Long petId, String apiKey, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/pet/{petId}"
 
         // query params
@@ -50,7 +52,9 @@ class PetApi {
         }
 
         
-        headerParams.put("apiKey", apiKey)
+        headerParams.put("api_key", apiKey)
+
+        // Also still TODO: form params, body param
 
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "DELETE", "",
@@ -58,7 +62,7 @@ class PetApi {
                     
     }
     def findPetsByStatus ( List<String> status, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/pet/findByStatus"
 
         // query params
@@ -74,13 +78,15 @@ class PetApi {
             queryParams.put("status", String.valueOf(status))
 
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "GET", "array",
                     Pet.class )
                     
     }
     def findPetsByTags ( List<String> tags, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/pet/findByTags"
 
         // query params
@@ -96,13 +102,15 @@ class PetApi {
             queryParams.put("tags", String.valueOf(tags))
 
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "GET", "array",
                     Pet.class )
                     
     }
     def getPetById ( Long petId, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/pet/{petId}"
 
         // query params
@@ -116,13 +124,15 @@ class PetApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "GET", "",
                     Pet.class )
                     
     }
     def updatePet ( Pet body, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/pet"
 
         // query params
@@ -136,13 +146,15 @@ class PetApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "PUT", "",
                     null )
                     
     }
     def updatePetWithForm ( Long petId, String name, String status, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/pet/{petId}"
 
         // query params
@@ -156,13 +168,15 @@ class PetApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "POST", "",
                     null )
                     
     }
     def uploadFile ( Long petId, String additionalMetadata, File file, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/pet/{petId}/uploadImage"
 
         // query params
@@ -175,6 +189,8 @@ class PetApi {
         }
 
         
+
+        // Also still TODO: form params, body param
 
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "POST", "",

--- a/samples/client/petstore/groovy/src/main/groovy/io/swagger/api/StoreApi.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/io/swagger/api/StoreApi.groovy
@@ -16,7 +16,7 @@ class StoreApi {
     String versionPath = "/api/v1"
 
     def deleteOrder ( String orderId, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/store/order/{orderId}"
 
         // query params
@@ -30,13 +30,15 @@ class StoreApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "DELETE", "",
                     null )
                     
     }
     def getInventory ( Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/store/inventory"
 
         // query params
@@ -46,13 +48,15 @@ class StoreApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "GET", "map",
                     Map.class )
                     
     }
     def getOrderById ( Long orderId, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/store/order/{orderId}"
 
         // query params
@@ -66,13 +70,15 @@ class StoreApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "GET", "",
                     Order.class )
                     
     }
     def placeOrder ( Order body, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/store/order"
 
         // query params
@@ -85,6 +91,8 @@ class StoreApi {
         }
 
         
+
+        // Also still TODO: form params, body param
 
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "POST", "",

--- a/samples/client/petstore/groovy/src/main/groovy/io/swagger/api/UserApi.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/io/swagger/api/UserApi.groovy
@@ -15,7 +15,7 @@ class UserApi {
     String versionPath = "/api/v1"
 
     def createUser ( User body, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/user"
 
         // query params
@@ -29,13 +29,15 @@ class UserApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "POST", "",
                     null )
                     
     }
     def createUsersWithArrayInput ( List<User> body, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/user/createWithArray"
 
         // query params
@@ -49,13 +51,15 @@ class UserApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "POST", "",
                     null )
                     
     }
     def createUsersWithListInput ( List<User> body, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/user/createWithList"
 
         // query params
@@ -69,13 +73,15 @@ class UserApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "POST", "",
                     null )
                     
     }
     def deleteUser ( String username, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/user/{username}"
 
         // query params
@@ -88,6 +94,8 @@ class UserApi {
         }
 
         
+
+        // Also still TODO: form params, body param
 
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "DELETE", "",
@@ -95,7 +103,7 @@ class UserApi {
                     
     }
     def getUserByName ( String username, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/user/{username}"
 
         // query params
@@ -109,13 +117,15 @@ class UserApi {
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "GET", "",
                     User.class )
                     
     }
     def loginUser ( String username, String password, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/user/login"
 
         // query params
@@ -137,13 +147,15 @@ if (!"null".equals(String.valueOf(password)))
             queryParams.put("password", String.valueOf(password))
 
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "GET", "",
                     String.class )
                     
     }
     def logoutUser ( Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/user/logout"
 
         // query params
@@ -153,13 +165,15 @@ if (!"null".equals(String.valueOf(password)))
 
         
 
+        // Also still TODO: form params, body param
+
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "GET", "",
                     null )
                     
     }
     def updateUser ( String username, User body, Closure onSuccess, Closure onFailure)  {
-        // create path and map variables
+        // create path and map path parameters (TODO)
         String resourcePath = "/user/{username}"
 
         // query params
@@ -176,6 +190,8 @@ if (!"null".equals(String.valueOf(password)))
         }
 
         
+
+        // Also still TODO: form params, body param
 
         invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams,
                     "PUT", "",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → bin/groovy-petstore.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes

### Description of the PR

This fixes (or hopes to fix) part of #4898 for the `groovy` generator.

The problem likely occurred when a query or header parameter name (as declared in the OpenAPI definition) is of a form which doesn't match the form used in Groovy, or is a reserved word there. In this case the parameter gets renamed for use in the code, and the parameter will be sent with the sanitized name instead of the original one.

This commit changes the replacement to using `{{baseName}}` (which is the original name of the parameter definition as parsed from the API definition) instead of `{{paramName}}` (which is the sanitized version of the parameter name).

_**Note** that it looks like the Groovy generator has no support at all for path, form or body parameters – those are accepted by the generated code, but then ignored, and not passed to the server. I didn't try to fix this, as my Groovy knowledge is too rusty for this, but added some TODOs in the template. Related issue: #4289_

Our Petstore sample API definition doesn't seem to contain any query parameter which would get modified by the sanitation, so the regenerated samples just have a single difference in a header parameter (which looks better now to me).

I don't know anything about Groovy, so this needs review by Groovy experts. 

