### PR TITLE
[CI] fix shippable config due to JAVA_HOME issue in openjdk8

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -2,7 +2,8 @@ language: java
 
 jdk:
 - openjdk7
-- openjdk8
+  # comment out due to issue with JAVA_HOME
+  #- openjdk8
 
 build:
   cache: true


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Commented out openjdk8 to avoid issue due to JAVA_HOME missing.
