### PR TITLE
[Jaxrs-cxf-client] Add jackson dependencies to pom for cxf-client #4924

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -145,6 +145,18 @@
         <version>${cxf-version}</version>
         <scope>compile</scope>
     </dependency>
+    <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson-jaxrs-version}</version>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+       <groupId>com.fasterxml.jackson.datatype</groupId>
+       <artifactId>jackson-datatype-joda</artifactId>
+       <version>${jackson-jaxrs-version}</version>
+       <scope>compile</scope>
+    </dependency>
 {{#useBeanValidationFeature}}    
     <dependency>
         <groupId>org.hibernate</groupId>
@@ -176,6 +188,7 @@
     <beanvalidation-version>1.1.0.Final</beanvalidation-version>
 {{/useBeanValidation}}    
     <cxf-version>3.1.6</cxf-version>
+    <jackson-jaxrs-version>2.8.4</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/samples/client/petstore/jaxrs-cxf/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf/pom.xml
@@ -136,6 +136,18 @@
         <version>${cxf-version}</version>
         <scope>compile</scope>
     </dependency>
+    <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson-jaxrs-version}</version>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+       <groupId>com.fasterxml.jackson.datatype</groupId>
+       <artifactId>jackson-datatype-joda</artifactId>
+       <version>${jackson-jaxrs-version}</version>
+       <scope>compile</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>
@@ -150,13 +162,14 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.9</swagger-core-version>
+    <swagger-core-version>1.5.12</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
     <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>
     <cxf-version>3.1.6</cxf-version>
+    <jackson-jaxrs-version>2.8.4</jackson-jaxrs-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

fix dependencies for swagger-core 1.5.12 for CXF client see #4924

