### PR TITLE
Add Selective Generation support to the Maven plugin.

### DIFF
--- a/modules/swagger-codegen-maven-plugin/README.md
+++ b/modules/swagger-codegen-maven-plugin/README.md
@@ -50,6 +50,15 @@ mvn clean compile
 - `configOptions` - a map of language-specific parameters (see below)
 - `configHelp` - dumps the configuration help for the specified library (generates no sources)
 - `ignoreFileOverride` - specifies the full path to a `.swagger-codegen-ignore` used for pattern based overrides of generated outputs
+- `generateApis` - generate the apis (`true` by default)
+- `generateApiTests` - generate the api tests (`true` by default. Only available if `generateApis` is `true`)
+- `generateApiDocumentation` - generate the api documentation (`true` by default. Only available if `generateApis` is `true`)
+- `generateModels` - generate the models (`true` by default)
+- `modelsToGenerate` - A comma separated list of models to generate.  All models is the default.
+- `generateModelTests` - generate the model tests (`true` by default. Only available if `generateModels` is `true`)
+- `generateModelDocumentation` - generate the model documentation (`true` by default. Only available if `generateModels` is `true`)
+- `generateSupportingFiles` - generate the supporting files (`true` by default)
+- `supportingFilesToGenerate` - A comma separated list of supporting files to generate.  All files is the default.
 
 ### Custom Generator
 

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -186,6 +186,9 @@ public class CodeGenMojo extends AbstractMojo {
     @Parameter(name = "generateModels", required = false)
     private Boolean generateModels = true;
 
+    /**
+     * A comma separated list of models to generate.  All models is the default.
+     */
     @Parameter(name = "modelsToGenerate", required = false)
     private String modelsToGenerate = "";
 
@@ -195,6 +198,12 @@ public class CodeGenMojo extends AbstractMojo {
     @Parameter(name = "generateSupportingFiles", required = false)
     private Boolean generateSupportingFiles = true;
 
+    /**
+     * A comma separated list of models to generate.  All models is the default.
+     */
+    @Parameter(name = "supportingFilesToGenerate", required = false)
+    private String supportingFilesToGenerate = "";
+    
     /**
      * Generate the model tests
      */
@@ -330,7 +339,7 @@ public class CodeGenMojo extends AbstractMojo {
         }
 
         if (null != generateSupportingFiles && generateSupportingFiles) {
-            System.setProperty("supportingFiles", "");
+            System.setProperty("supportingFiles", supportingFilesToGenerate);
         }
         
         System.setProperty("modelTests", generateModelTests.toString());

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -175,6 +175,53 @@ public class CodeGenMojo extends AbstractMojo {
     private Map<?, ?> configOptions;
 
     /**
+     * Generate the apis
+     */
+    @Parameter(name = "generateApis", required = false)
+    private Boolean generateApis = true;
+
+    /**
+     * Generate the models
+     */
+    @Parameter(name = "generateModels", required = false)
+    private Boolean generateModels = true;
+
+    @Parameter(name = "modelsToGenerate", required = false)
+    private String modelsToGenerate = "";
+
+    /**
+     * Generate the supporting files
+     */
+    @Parameter(name = "generateSupportingFiles", required = false)
+    private Boolean generateSupportingFiles = true;
+
+    /**
+     * Generate the model tests
+     */
+    @Parameter(name = "generateModelTests", required = false)
+    private Boolean generateModelTests = true;
+
+    /**
+     * Generate the model documentation
+     */
+    @Parameter(name = "generateModelDocumentation", required = false)
+    private Boolean generateModelDocumentation = true;
+
+    /**
+     * Generate the api tests
+     */
+    @Parameter(name = "generateApiTests", required = false)
+    private Boolean generateApiTests = true;
+
+    /**
+     * Generate the api documentation
+     */
+    @Parameter(name = "generateApiDocumentation", required = false)
+    private Boolean generateApiDocumentation = true;
+
+
+
+    /**
      * Add the output directory to the project as a source root, so that the
      * generated java types are compiled and included in the project artifact.
      */
@@ -273,6 +320,23 @@ public class CodeGenMojo extends AbstractMojo {
         if (null != templateDirectory) {
             configurator.setTemplateDir(templateDirectory.getAbsolutePath());
         }
+
+        // Set generation options
+        if (null != generateApis && generateApis) {
+            System.setProperty("apis", "");
+        }
+        if (null != generateModels && generateModels) {
+            System.setProperty("models", modelsToGenerate);
+        }
+
+        if (null != generateSupportingFiles && generateSupportingFiles) {
+            System.setProperty("supportingFiles", "");
+        }
+        
+        System.setProperty("modelTests", generateModelTests.toString());
+        System.setProperty("modelDocs", generateModelDocumentation.toString());
+        System.setProperty("apiTests", generateApiTests.toString());
+        System.setProperty("apiDocs", generateApiDocumentation.toString());
 
         if (configOptions != null) {
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This adds support to the maven plugin to support the selective generation options.

