### PR TITLE
[Clojure] update Clojure test cases after restoring to petstore.json

### DIFF
--- a/samples/client/petstore/clojure/src/swagger_petstore/api/pet.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/pet.clj
@@ -24,28 +24,6 @@
   ([optional-params]
    (:data (add-pet-with-http-info optional-params))))
 
-(defn add-pet-using-byte-array-with-http-info
-  "Fake endpoint to test byte array in body parameter for adding a new pet to the store
-  "
-  ([] (add-pet-using-byte-array-with-http-info nil))
-  ([{:keys [body ]}]
-   (call-api "/pet?testing_byte_array=true" :post
-             {:path-params   {}
-              :header-params {}
-              :query-params  {}
-              :form-params   {}
-              :body-param    body
-              :content-types ["application/json" "application/xml"]
-              :accepts       ["application/json" "application/xml"]
-              :auth-names    ["petstore_auth"]})))
-
-(defn add-pet-using-byte-array
-  "Fake endpoint to test byte array in body parameter for adding a new pet to the store
-  "
-  ([] (add-pet-using-byte-array nil))
-  ([optional-params]
-   (:data (add-pet-using-byte-array-with-http-info optional-params))))
-
 (defn delete-pet-with-http-info
   "Deletes a pet
   "
@@ -120,51 +98,13 @@
              :form-params   {}
              :content-types []
              :accepts       ["application/json" "application/xml"]
-             :auth-names    ["api_key" "petstore_auth"]}))
+             :auth-names    ["petstore_auth" "api_key"]}))
 
 (defn get-pet-by-id
   "Find pet by ID
   Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
   [pet-id ]
   (:data (get-pet-by-id-with-http-info pet-id)))
-
-(defn get-pet-by-id-in-object-with-http-info
-  "Fake endpoint to test inline arbitrary object return by 'Find pet by ID'
-  Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
-  [pet-id ]
-  (call-api "/pet/{petId}?response=inline_arbitrary_object" :get
-            {:path-params   {"petId" pet-id }
-             :header-params {}
-             :query-params  {}
-             :form-params   {}
-             :content-types []
-             :accepts       ["application/json" "application/xml"]
-             :auth-names    ["api_key" "petstore_auth"]}))
-
-(defn get-pet-by-id-in-object
-  "Fake endpoint to test inline arbitrary object return by 'Find pet by ID'
-  Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
-  [pet-id ]
-  (:data (get-pet-by-id-in-object-with-http-info pet-id)))
-
-(defn pet-pet-idtesting-byte-arraytrue-get-with-http-info
-  "Fake endpoint to test byte array return by 'Find pet by ID'
-  Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
-  [pet-id ]
-  (call-api "/pet/{petId}?testing_byte_array=true" :get
-            {:path-params   {"petId" pet-id }
-             :header-params {}
-             :query-params  {}
-             :form-params   {}
-             :content-types []
-             :accepts       ["application/json" "application/xml"]
-             :auth-names    ["api_key" "petstore_auth"]}))
-
-(defn pet-pet-idtesting-byte-arraytrue-get
-  "Fake endpoint to test byte array return by 'Find pet by ID'
-  Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions"
-  [pet-id ]
-  (:data (pet-pet-idtesting-byte-arraytrue-get-with-http-info pet-id)))
 
 (defn update-pet-with-http-info
   "Update an existing pet
@@ -229,3 +169,4 @@
   ([pet-id ] (upload-file pet-id nil))
   ([pet-id optional-params]
    (:data (upload-file-with-http-info pet-id optional-params))))
+

--- a/samples/client/petstore/clojure/src/swagger_petstore/api/store.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/store.clj
@@ -21,27 +21,6 @@
   [order-id ]
   (:data (delete-order-with-http-info order-id)))
 
-(defn find-orders-by-status-with-http-info
-  "Finds orders by status
-  A single status value can be provided as a string"
-  ([] (find-orders-by-status-with-http-info nil))
-  ([{:keys [status ]}]
-   (call-api "/store/findByStatus" :get
-             {:path-params   {}
-              :header-params {}
-              :query-params  {"status" status }
-              :form-params   {}
-              :content-types []
-              :accepts       ["application/json" "application/xml"]
-              :auth-names    ["test_api_client_id" "test_api_client_secret"]})))
-
-(defn find-orders-by-status
-  "Finds orders by status
-  A single status value can be provided as a string"
-  ([] (find-orders-by-status nil))
-  ([optional-params]
-   (:data (find-orders-by-status-with-http-info optional-params))))
-
 (defn get-inventory-with-http-info
   "Returns pet inventories by status
   Returns a map of status codes to quantities"
@@ -61,25 +40,6 @@
   []
   (:data (get-inventory-with-http-info)))
 
-(defn get-inventory-in-object-with-http-info
-  "Fake endpoint to test arbitrary object return by 'Get inventory'
-  Returns an arbitrary object which is actually a map of status codes to quantities"
-  []
-  (call-api "/store/inventory?response=arbitrary_object" :get
-            {:path-params   {}
-             :header-params {}
-             :query-params  {}
-             :form-params   {}
-             :content-types []
-             :accepts       ["application/json" "application/xml"]
-             :auth-names    ["api_key"]}))
-
-(defn get-inventory-in-object
-  "Fake endpoint to test arbitrary object return by 'Get inventory'
-  Returns an arbitrary object which is actually a map of status codes to quantities"
-  []
-  (:data (get-inventory-in-object-with-http-info)))
-
 (defn get-order-by-id-with-http-info
   "Find purchase order by ID
   For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions"
@@ -91,7 +51,7 @@
              :form-params   {}
              :content-types []
              :accepts       ["application/json" "application/xml"]
-             :auth-names    ["test_api_key_header" "test_api_key_query"]}))
+             :auth-names    []}))
 
 (defn get-order-by-id
   "Find purchase order by ID
@@ -112,7 +72,7 @@
               :body-param    body
               :content-types []
               :accepts       ["application/json" "application/xml"]
-              :auth-names    ["test_api_client_id" "test_api_client_secret"]})))
+              :auth-names    []})))
 
 (defn place-order
   "Place an order for a pet
@@ -120,3 +80,4 @@
   ([] (place-order nil))
   ([optional-params]
    (:data (place-order-with-http-info optional-params))))
+

--- a/samples/client/petstore/clojure/src/swagger_petstore/api/user.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/api/user.clj
@@ -167,3 +167,4 @@
   ([username ] (update-user username nil))
   ([username optional-params]
    (:data (update-user-with-http-info username optional-params))))
+

--- a/samples/client/petstore/clojure/src/swagger_petstore/core.clj
+++ b/samples/client/petstore/clojure/src/swagger_petstore/core.clj
@@ -8,11 +8,7 @@
            (java.text SimpleDateFormat)))
 
 (def auth-definitions
-  {"test_api_key_header" {:type :api-key :in :header :param-name "test_api_key_header"}
-   "api_key" {:type :api-key :in :header :param-name "api_key"}
-   "test_api_client_secret" {:type :api-key :in :header :param-name "x-test_api_client_secret"}
-   "test_api_client_id" {:type :api-key :in :header :param-name "x-test_api_client_id"}
-   "test_api_key_query" {:type :api-key :in :query :param-name "test_api_key_query"}
+  {"api_key" {:type :api-key :in :header :param-name "api_key"}
    "petstore_auth" {:type :oauth2}})
 
 (def default-api-context
@@ -21,11 +17,7 @@
    :date-format     "yyyy-MM-dd"
    :datetime-format "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
    :debug           false
-   :auths           {"test_api_key_header" nil
-                     "api_key" nil
-                     "test_api_client_secret" nil
-                     "test_api_client_id" nil
-                     "test_api_key_query" nil
+   :auths           {"api_key" nil
                      "petstore_auth" nil}})
 
 (def ^:dynamic *api-context*

--- a/samples/client/petstore/clojure/test/swagger_petstore/core_test.clj
+++ b/samples/client/petstore/clojure/test/swagger_petstore/core_test.clj
@@ -11,11 +11,7 @@
             :datetime-format "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
             :debug           false
             :auths           {"api_key"       nil
-                              "petstore_auth" nil
-                              "test_api_client_id" nil
-                              "test_api_client_secret" nil
-                              "test_api_key_query" nil
-                              "test_api_key_header" nil}}
+                              "petstore_auth" nil}}
            default-api-context
            *api-context*
            (with-api-context {}
@@ -50,11 +46,7 @@
             :datetime-format "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
             :debug           false
             :auths           {"api_key"       nil
-                              "petstore_auth" nil
-                              "test_api_client_id" nil
-                              "test_api_client_secret" nil
-                              "test_api_key_query" nil
-                              "test_api_key_header" nil}}
+                              "petstore_auth" nil}}
            default-api-context
            *api-context*))))
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Removed some additional test cases for authentication in Clojure API client as "petstore.json" is being used at the moment.
