### PR TITLE
[CI] use Oracle JDK instead in shippable config

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,9 +1,8 @@
 language: java
 
 jdk:
+- oraclejdk8
 - openjdk7
-  # comment out due to issue with JAVA_HOME
-  #- openjdk8
 
 build:
   cache: true


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Use Oracle JDK 8 instead of OpenJDK 8 in shippable config