### PR TITLE
Swift3 enum: number variable names fix

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -516,6 +516,10 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
             return "empty";
         }
 
+        if (name.matches("\\d.*")) { // starts with number
+            name = "number" + name;
+        }
+        
         // for symbol, e.g. $, #
         if (getSymbolName(name) != null) {
             return camelize(WordUtils.capitalizeFully(getSymbolName(name).toUpperCase()), true);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -516,10 +516,15 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
             return "empty";
         }
 
-        if (name.matches("\\d.*")) { // starts with number
-            name = "number" + name;
+        Pattern startWithNumberPattern = Pattern.compile("^\\d+");
+        Matcher startWithNumberMatcher = startWithNumberPattern.matcher(name);
+        if (startWithNumberMatcher.find()) {
+            String startingNumbers = startWithNumberMatcher.group(0);
+            String nameWithoutStartingNumbers = name.substring(startingNumbers.length());
+
+            return "_" + startingNumbers + camelize(nameWithoutStartingNumbers);
         }
-        
+
         // for symbol, e.g. $, #
         if (getSymbolName(name) != null) {
             return camelize(WordUtils.capitalizeFully(getSymbolName(name).toUpperCase()), true);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -522,7 +522,7 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
             String startingNumbers = startWithNumberMatcher.group(0);
             String nameWithoutStartingNumbers = name.substring(startingNumbers.length());
 
-            return "_" + startingNumbers + camelize(nameWithoutStartingNumbers);
+            return "_" + startingNumbers + camelize(nameWithoutStartingNumbers, true);
         }
 
         // for symbol, e.g. $, #

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3CodegenTest.java
@@ -65,9 +65,9 @@ public class Swift3CodegenTest {
 
     @Test
     public void testStartingWithNumber() throws Exception {
-        Assert.assertEquals(swiftCodegen.toEnumVarName("123EntryName", null), "_123EntryName");
-        Assert.assertEquals(swiftCodegen.toEnumVarName("123Entry_name", null), "_123EntryName");
-        Assert.assertEquals(swiftCodegen.toEnumVarName("123EntryName123", null), "_123EntryName123");
+        Assert.assertEquals(swiftCodegen.toEnumVarName("123EntryName", null), "_123entryName");
+        Assert.assertEquals(swiftCodegen.toEnumVarName("123Entry_name", null), "_123entryName");
+        Assert.assertEquals(swiftCodegen.toEnumVarName("123EntryName123", null), "_123entryName123");
     }
 
     @Test(description = "returns NSData when response format is binary")

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3CodegenTest.java
@@ -63,6 +63,13 @@ public class Swift3CodegenTest {
         Assert.assertEquals(swiftCodegen.toEnumVarName("entry_name", null), "entryName");
     }
 
+    @Test
+    public void testStartingWithNumber() throws Exception {
+        Assert.assertEquals(swiftCodegen.toEnumVarName("123EntryName", null), "_123EntryName");
+        Assert.assertEquals(swiftCodegen.toEnumVarName("123Entry_name", null), "_123EntryName");
+        Assert.assertEquals(swiftCodegen.toEnumVarName("123EntryName123", null), "_123EntryName123");
+    }
+
     @Test(description = "returns NSData when response format is binary")
     public void binaryDataTest() {
         final Swagger model = new SwaggerParser().read("src/test/resources/2_0/binaryDataTest.json");


### PR DESCRIPTION
Swift3 generator: added 'number' prefix to enum variable names that start with a number

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Same issue as #3934, but for the Swift3 Generator.

