### PR TITLE
[Haskell] Bump dependencies

### DIFF
--- a/modules/swagger-codegen/src/main/resources/haskell-servant/stack.mustache
+++ b/modules/swagger-codegen/src/main/resources/haskell-servant/stack.mustache
@@ -1,8 +1,8 @@
-resolver: lts-5.11
+resolver: lts-8.5
 extra-deps:
-- servant-0.6
-- servant-client-0.6
-- servant-server-0.6
-- http-api-data-0.2.2
+- servant-0.9.1.1
+- servant-client-0.9.1.1
+- servant-server-0.9.1.1
+- http-api-data-0.3.5
 packages:
 - '.'

--- a/samples/server/petstore/haskell-servant/lib/SwaggerPetstore/Types.hs
+++ b/samples/server/petstore/haskell-servant/lib/SwaggerPetstore/Types.hs
@@ -22,10 +22,10 @@ import GHC.Generics (Generic)
 import Data.Function ((&))
 
 
--- | 
+-- | Describes the result of uploading an image resource
 data ApiResponse = ApiResponse
     { apiResponseCode :: Int -- ^ 
-    , apiResponseType_ :: Text -- ^ 
+    , apiResponseType :: Text -- ^ 
     , apiResponseMessage :: Text -- ^ 
     } deriving (Show, Eq, Generic)
 
@@ -34,7 +34,7 @@ instance FromJSON ApiResponse where
 instance ToJSON ApiResponse where
   toJSON     = genericToJSON     (removeFieldLabelPrefix False "apiResponse")
 
--- | 
+-- | A category for a pet
 data Category = Category
     { categoryId :: Integer -- ^ 
     , categoryName :: Text -- ^ 
@@ -45,7 +45,7 @@ instance FromJSON Category where
 instance ToJSON Category where
   toJSON     = genericToJSON     (removeFieldLabelPrefix False "category")
 
--- | 
+-- | An order for a pets from the pet store
 data Order = Order
     { orderId :: Integer -- ^ 
     , orderPetId :: Integer -- ^ 
@@ -60,7 +60,7 @@ instance FromJSON Order where
 instance ToJSON Order where
   toJSON     = genericToJSON     (removeFieldLabelPrefix False "order")
 
--- | 
+-- | A pet for sale in the pet store
 data Pet = Pet
     { petId :: Integer -- ^ 
     , petCategory :: Category -- ^ 
@@ -75,7 +75,7 @@ instance FromJSON Pet where
 instance ToJSON Pet where
   toJSON     = genericToJSON     (removeFieldLabelPrefix False "pet")
 
--- | 
+-- | A tag for a pet
 data Tag = Tag
     { tagId :: Integer -- ^ 
     , tagName :: Text -- ^ 
@@ -86,7 +86,7 @@ instance FromJSON Tag where
 instance ToJSON Tag where
   toJSON     = genericToJSON     (removeFieldLabelPrefix False "tag")
 
--- | 
+-- | A User who is purchasing from the pet store
 data User = User
     { userId :: Integer -- ^ 
     , userUsername :: Text -- ^ 
@@ -112,7 +112,7 @@ removeFieldLabelPrefix forParsing prefix =
     }
   where
     replaceSpecialChars field = foldl (&) field (map mkCharReplacement specialChars)
-    specialChars = [("#", "'Hash"), ("!", "'Exclamation"), ("&", "'Ampersand"), ("@", "'At"), ("$", "'Dollar"), ("%", "'Percent"), ("*", "'Star"), ("+", "'Plus"), (">=", "'Greater_Than_Or_Equal_To"), ("-", "'Dash"), ("<=", "'Less_Than_Or_Equal_To"), ("!=", "'Greater_Than_Or_Equal_To"), (":", "'Colon"), ("^", "'Caret"), ("|", "'Pipe"), (">", "'GreaterThan"), ("=", "'Equal"), ("<", "'LessThan")]
+    specialChars = [("@", "'At"), ("<=", "'Less_Than_Or_Equal_To"), ("[", "'Left_Square_Bracket"), ("\", "'Back_Slash"), ("]", "'Right_Square_Bracket"), ("^", "'Caret"), ("_", "'Underscore"), ("`", "'Backtick"), ("!", "'Exclamation"), (""", "'Double_Quote"), ("#", "'Hash"), ("$", "'Dollar"), ("%", "'Percent"), ("&", "'Ampersand"), ("'", "'Quote"), ("(", "'Left_Parenthesis"), (")", "'Right_Parenthesis"), ("*", "'Star"), ("+", "'Plus"), (",", "'Comma"), ("-", "'Dash"), (".", "'Period"), ("/", "'Slash"), (":", "'Colon"), ("{", "'Left_Curly_Bracket"), ("|", "'Pipe"), ("<", "'LessThan"), ("!=", "'Not_Equal"), ("=", "'Equal"), ("}", "'Right_Curly_Bracket"), (">", "'GreaterThan"), ("~", "'Tilde"), ("?", "'Question_Mark"), (">=", "'Greater_Than_Or_Equal_To")]
     mkCharReplacement (replaceStr, searchStr) = T.unpack . replacer (T.pack searchStr) (T.pack replaceStr) . T.pack
     replacer = if forParsing then flip T.replace else T.replace
 

--- a/samples/server/petstore/haskell-servant/stack.yaml
+++ b/samples/server/petstore/haskell-servant/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-5.11
+resolver: lts-8.5
 extra-deps:
-- servant-0.6
-- servant-client-0.6
-- servant-server-0.6
-- http-api-data-0.2.2
+- servant-0.9.1.1
+- servant-client-0.9.1.1
+- servant-server-0.9.1.1
+- http-api-data-0.3.5
 packages:
 - '.'


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Bumps the `servant` dependencies from `0.6` to `0.9.1.1` and haskell from `lts-5.11` to `lts-8.5`.

Fixes issue #4162.