### PR TITLE
[Swift] Fix issue #4764

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -279,6 +279,11 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
+    public boolean isDataTypeFile(String dataType) {
+        return dataType != null && dataType.equals("URL");
+    }
+
+    @Override
     public boolean isDataTypeBinary(final String dataType) {
         return dataType != null && dataType.equals("Data");
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SwiftCodegen.java
@@ -277,8 +277,13 @@ public class SwiftCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
+    public boolean isDataTypeFile(String dataType) {
+        return dataType != null && dataType.equals("NSURL");
+    }
+
+    @Override
     public boolean isDataTypeBinary(final String dataType) {
-      return dataType != null && dataType.equals("NSData");
+        return dataType != null && dataType.equals("NSData");
     }
 
     /**


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates) - **This does not affect the Petstore sample**
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Adds file type detection to Swift codegen, which was previously missing. This was causing Swift codegen to never know when a parameter or response type was defined with type file.

This fixes issue #4764. 

