### PR TITLE
#4788: remove System.getProperty() from java-inflector + undertow codegens

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaInflectorServerCodegen.java
@@ -34,9 +34,16 @@ public class JavaInflectorServerCodegen extends AbstractJavaCodegen {
         modelDocTemplateFiles.remove("model_doc.mustache");
         apiDocTemplateFiles.remove("api_doc.mustache");
 
+        if(System.getProperty("swagger.codegen.inflector.apipackage") != null) {
+            LOGGER.warn("System property 'swagger.codegen.inflector.apipackage' is not supported anymore, use the standard apiPackage parameter.");
+        }
 
-        apiPackage = System.getProperty("swagger.codegen.inflector.apipackage", "io.swagger.handler");
-        modelPackage = System.getProperty("swagger.codegen.inflector.modelpackage", "io.swagger.model");
+        if(System.getProperty("swagger.codegen.inflector.modelpackage") != null) {
+            LOGGER.warn("System property 'swagger.codegen.inflector.modelpackage' is not supported anymore, please use the standard modelPackage parameter.");
+        }
+
+        apiPackage = "io.swagger.handler";
+        modelPackage = "io.swagger.model";
 
         additionalProperties.put("title", title);
         // java inflector uses the jackson lib

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/UndertowCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/UndertowCodegen.java
@@ -36,9 +36,16 @@ public class UndertowCodegen extends AbstractJavaCodegen {
         modelDocTemplateFiles.remove("model_doc.mustache");
         apiDocTemplateFiles.remove("api_doc.mustache");
 
+        if(System.getProperty("swagger.codegen.undertow.apipackage") != null) {
+            LOGGER.warn("System property 'swagger.codegen.undertow.apipackage' is not supported anymore, use the standard apiPackage parameter.");
+        }
 
-        apiPackage = System.getProperty("swagger.codegen.undertow.apipackage", "io.swagger.handler");
-        modelPackage = System.getProperty("swagger.codegen.undertow.modelpackage", "io.swagger.model");
+        if(System.getProperty("swagger.codegen.undertow.modelpackage") != null) {
+            LOGGER.warn("System property 'swagger.codegen.undertow.modelpackage' is not supported anymore, please use the standard modelPackage parameter.");
+        }
+
+        apiPackage = "io.swagger.handler";
+        modelPackage = "io.swagger.model";
 
         additionalProperties.put("title", title);
     }


### PR DESCRIPTION
Remove System.getProperty from language codegens.
It was just used for apiPackage/modelPackage, for which we have regular parameters.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
     → bin/java-undertow-server.sh, bin/java-inflector-petstore-server.sh (before the change, afterwards nothing changed.)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes. **(unclear, see below)**

### Description of the PR

This removes the usage of system properties from UndertowCodegen and JavaInflectorCodegen. It adds a warning in case the properties are still used. (This is part of a bigger effort to get rid of system properties, who have bad effects if there are have multiple (consecutive or even parallel) Codegen runs in the same JVM – see #4788.)

**I'm not sure if this counts as a breaking change** – the original effect of the system property being set is not there anymore.  – If so, I can put this against the 2.3.0 branch, and create a similar change for master which just outputs the warning, but still uses the system property. Opinions?
Also, is WARN the right level, or should this be ERROR?