### PR TITLE
#4788: remove System.getProperty("noservice") in NodeJSServerCodegen

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NodeJSServerCodegen.java
@@ -22,7 +22,9 @@ import java.util.Map.Entry;
 
 public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NodeJSServerCodegen.class);
+    public static final String NOSERVICE = "noservice";
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(NodeJSServerCodegen.class);
 
     public static final String GOOGLE_CLOUD_FUNCTIONS = "googleCloudFunctions";
     public static final String EXPORTED_NAME = "exportedName";
@@ -91,6 +93,8 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
             "When the generated code will be deployed to Google Cloud Functions, this option can be "
                 + "used to update the name of the exported function. By default, it refers to the "
                 + "basePath. This does not affect normal standalone nodejs server code."));
+        cliOptions.add(new CliOption(NOSERVICE,
+        		"If this option is given, no service.js file will be generated."));
     }
 
     @Override
@@ -286,7 +290,8 @@ public class NodeJSServerCodegen extends DefaultCodegen implements CodegenConfig
         }
         writeOptional(outputFolder, new SupportingFile("package.mustache", "", "package.json"));
         writeOptional(outputFolder, new SupportingFile("README.mustache", "", "README.md"));
-        if (System.getProperty("noservice") == null) {
+
+        if(!additionalProperties.containsKey(NOSERVICE)) {
             apiTemplateFiles.put(
                     "service.mustache",   // the template to use
                     "Service.js");       // the extension for each file to write

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/NodeJSServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/NodeJSServerOptionsProvider.java
@@ -12,6 +12,7 @@ public class NodeJSServerOptionsProvider implements OptionsProvider {
     public static final String GOOGLE_CLOUD_FUNCTIONS = "false";
     public static final String EXPORTED_NAME = "exported";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
+    public static final String NOSERVICE_VALUE = "true";
 
 
     @Override
@@ -27,6 +28,7 @@ public class NodeJSServerOptionsProvider implements OptionsProvider {
                 .put(NodeJSServerCodegen.GOOGLE_CLOUD_FUNCTIONS, GOOGLE_CLOUD_FUNCTIONS)
                 .put(NodeJSServerCodegen.EXPORTED_NAME, EXPORTED_NAME)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
+                .put(NodeJSServerCodegen.NOSERVICE, NOSERVICE_VALUE)
                 .build();
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → bin/nodejs-petstore-google-cloud-functions.sh && bin/nodejs-petstore-server.sh. (Ran this before the change and again after the code change, with no changes, so nothing to commit.)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes. **(not sure, see below.)**

### Description of the PR

This introduces a CliOption `noservice` for NodeJSServerCodegen, with the same effect of the previous system property. The system property is not read anymore. This is part of a bigger effort to get rid of system properties, see #4788.)

**I'm not sure this counts as non-breaking** – if the parameter was passed via CodegenConfigurator's `systemProperties` map (e.g. via maven or `-Dnoservice` at the end of the command line in swagger-codegen-cli), it should still work now (though I didn't yet test this). If the parameter was a real system property passed from the outside (e.g. `java -D noservice ...` (i.e. before the class name, not after it), it will now not work anymore. If it is deemed to be breaking, I can move this to 2.3.0 and create a version for master which still reads the system property, but displays a warning.

(I also adapted the test so it still runs, but I'm not sure I did this correctly.)