### PR TITLE
Allow for UUID types in akka-scala

### DIFF
--- a/modules/swagger-codegen/src/main/resources/akka-scala/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/akka-scala/model.mustache
@@ -8,6 +8,7 @@ package {{package}}
 
 import {{invokerPackage}}.ApiModel
 import org.joda.time.DateTime
+import java.util.UUID
 
 {{#models}}
 {{#model}}

--- a/samples/client/petstore/akka-scala/pom.xml
+++ b/samples/client/petstore/akka-scala/pom.xml
@@ -217,7 +217,7 @@
         <akka-version>2.3.9</akka-version>
         <joda-version>1.2</joda-version>
         <joda-time-version>2.2</joda-time-version>
-        <swagger-core-version>1.5.9</swagger-core-version>
+        <swagger-core-version>1.5.12</swagger-core-version>
         <maven-plugin.version>1.0.0</maven-plugin.version>
 
         <junit-version>4.8.1</junit-version>

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/api/PetApi.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/api/PetApi.scala
@@ -5,9 +5,9 @@
  */
 package io.swagger.client.api
 
-import io.swagger.client.model.Pet
 import io.swagger.client.model.ApiResponse
 import java.io.File
+import io.swagger.client.model.Pet
 import io.swagger.client.core._
 import io.swagger.client.core.CollectionFormats._
 import io.swagger.client.core.ApiKeyLocations._

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/api/UserApi.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/api/UserApi.scala
@@ -23,7 +23,7 @@ object UserApi {
   def createUser(body: User): ApiRequest[Unit] =
     ApiRequest[Unit](ApiMethods.POST, "http://petstore.swagger.io/v2", "/user", "application/json")
       .withBody(body)
-      .withDefaultSuccessResponse[Unit]
+      .withSuccessResponse[Unit](0)
         /**
    * 
    * Expected answers:
@@ -34,7 +34,7 @@ object UserApi {
   def createUsersWithArrayInput(body: Seq[User]): ApiRequest[Unit] =
     ApiRequest[Unit](ApiMethods.POST, "http://petstore.swagger.io/v2", "/user/createWithArray", "application/json")
       .withBody(body)
-      .withDefaultSuccessResponse[Unit]
+      .withSuccessResponse[Unit](0)
         /**
    * 
    * Expected answers:
@@ -45,7 +45,7 @@ object UserApi {
   def createUsersWithListInput(body: Seq[User]): ApiRequest[Unit] =
     ApiRequest[Unit](ApiMethods.POST, "http://petstore.swagger.io/v2", "/user/createWithList", "application/json")
       .withBody(body)
-      .withDefaultSuccessResponse[Unit]
+      .withSuccessResponse[Unit](0)
         /**
    * This can only be done by the logged in user.
    * 
@@ -105,7 +105,7 @@ object UserApi {
    */
   def logoutUser(): ApiRequest[Unit] =
     ApiRequest[Unit](ApiMethods.GET, "http://petstore.swagger.io/v2", "/user/logout", "application/json")
-      .withDefaultSuccessResponse[Unit]
+      .withSuccessResponse[Unit](0)
         /**
    * This can only be done by the logged in user.
    * 

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/ApiResponse.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/ApiResponse.scala
@@ -8,6 +8,7 @@ package io.swagger.client.model
 
 import io.swagger.client.core.ApiModel
 import org.joda.time.DateTime
+import java.util.UUID
 
 case class ApiResponse (
   code: Option[Int],

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/Category.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/Category.scala
@@ -8,6 +8,7 @@ package io.swagger.client.model
 
 import io.swagger.client.core.ApiModel
 import org.joda.time.DateTime
+import java.util.UUID
 
 case class Category (
   id: Option[Long],

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/Order.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/Order.scala
@@ -8,6 +8,7 @@ package io.swagger.client.model
 
 import io.swagger.client.core.ApiModel
 import org.joda.time.DateTime
+import java.util.UUID
 
 case class Order (
   id: Option[Long],

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/Pet.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/Pet.scala
@@ -8,6 +8,7 @@ package io.swagger.client.model
 
 import io.swagger.client.core.ApiModel
 import org.joda.time.DateTime
+import java.util.UUID
 
 case class Pet (
   id: Option[Long],

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/Tag.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/Tag.scala
@@ -8,6 +8,7 @@ package io.swagger.client.model
 
 import io.swagger.client.core.ApiModel
 import org.joda.time.DateTime
+import java.util.UUID
 
 case class Tag (
   id: Option[Long],

--- a/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/User.scala
+++ b/samples/client/petstore/akka-scala/src/main/scala/io/swagger/client/model/User.scala
@@ -8,6 +8,7 @@ package io.swagger.client.model
 
 import io.swagger.client.core.ApiModel
 import org.joda.time.DateTime
+import java.util.UUID
 
 case class User (
   id: Option[Long],


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

imported java.util.UUID in the model to allow for UUID types
