### PR TITLE
[JAVA][jaxrs-spec] Add support for enum as QueryParam argument type (#5075)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/api.mustache
@@ -23,6 +23,9 @@ import javax.validation.constraints.*;
 public class {{classname}}  {
 {{#operations}}
 {{#operation}}
+    {{#queryParams}}{{#datatypeWithEnum}}
+{{>enumClass}}{{/datatypeWithEnum}}{{/queryParams}}
+
 
     @{{httpMethod}}
     {{#subresourceOperation}}@Path("{{path}}"){{/subresourceOperation}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/enumClass.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/enumClass.mustache
@@ -1,31 +1,35 @@
-public enum {{datatypeWithEnum}} {
+    public enum {{datatypeWithEnum}} {
 
-    {{#allowableValues}}
-    {{#enumVars}}{{name}}({{datatype}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
-    {{/allowableValues}}
+        {{#allowableValues}}
+        {{#enumVars}}{{name}}({{#datatype}}{{datatype}}{{/datatype}}{{^datatype}}{{dataType}}{{/datatype}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
+        {{/allowableValues}}
 
 
-    private {{datatype}} value;
+        private {{#datatype}}{{datatype}}{{/datatype}}{{^datatype}}{{dataType}}{{/datatype}} value;
 
-    {{datatypeWithEnum}} ({{datatype}} v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static {{datatypeWithEnum}} fromValue(String v) {
-        for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        {{datatypeWithEnum}} ({{#datatype}}{{datatype}}{{/datatype}}{{^datatype}}{{dataType}}{{/datatype}} v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static {{datatypeWithEnum}} fromValue(String v) {
+            for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static {{datatypeWithEnum}} fromString(String v) {
+            return fromValue(v);
+        }
     }
-}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/queryParams.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#isQueryParam}}@QueryParam("{{baseName}}"){{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}} {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}}@QueryParam("{{baseName}}"){{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}} {{#datatypeWithEnum}}{{{datatypeWithEnum}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{dataType}}}{{/datatypeWithEnum}} {{paramName}}{{/isQueryParam}}

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/FakeApi.java
@@ -2,6 +2,7 @@ package io.swagger.api;
 
 import java.math.BigDecimal;
 import io.swagger.model.Client;
+import java.util.Date;
 import org.joda.time.LocalDate;
 
 import javax.ws.rs.*;
@@ -20,6 +21,8 @@ import javax.validation.constraints.*;
 
 
 public class FakeApi  {
+    
+
 
     @PATCH
     
@@ -31,6 +34,8 @@ public class FakeApi  {
     public Response testClientModel(Client body) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @POST
     
@@ -42,9 +47,113 @@ public class FakeApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid username supplied", response = void.class),
         @ApiResponse(code = 404, message = "User not found", response = void.class) })
-    public Response testEndpointParameters(@FormParam(value = "number")  BigDecimal number,@FormParam(value = "_double")  Double _double,@FormParam(value = "patternWithoutDelimiter")  String patternWithoutDelimiter,@FormParam(value = "_byte")  byte[] _byte,@FormParam(value = "integer")  Integer integer,@FormParam(value = "int32")  Integer int32,@FormParam(value = "int64")  Long int64,@FormParam(value = "_float")  Float _float,@FormParam(value = "string")  String string,@FormParam(value = "binary")  byte[] binary,@FormParam(value = "date")  LocalDate date,@FormParam(value = "dateTime")  javax.xml.datatype.XMLGregorianCalendar dateTime,@FormParam(value = "password")  String password,@FormParam(value = "paramCallback")  String paramCallback) {
+    public Response testEndpointParameters(@FormParam(value = "number")  BigDecimal number,@FormParam(value = "double")  Double _double,@FormParam(value = "pattern_without_delimiter")  String patternWithoutDelimiter,@FormParam(value = "byte")  byte[] _byte,@FormParam(value = "integer")  Integer integer,@FormParam(value = "int32")  Integer int32,@FormParam(value = "int64")  Long int64,@FormParam(value = "float")  Float _float,@FormParam(value = "string")  String string,@FormParam(value = "binary")  byte[] binary,@FormParam(value = "date")  LocalDate date,@FormParam(value = "dateTime")  Date dateTime,@FormParam(value = "password")  String password,@FormParam(value = "callback")  String paramCallback) {
     	return Response.ok().entity("magic!").build();
     }
+    
+    public enum List&lt;EnumQueryStringArrayEnum&gt; {
+
+        GREATER_THAN(List&lt;String&gt;.valueOf(">")), DOLLAR(List&lt;String&gt;.valueOf("$"));
+
+
+        private List&lt;String&gt; value;
+
+        List&lt;EnumQueryStringArrayEnum&gt; (List&lt;String&gt; v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static List&lt;EnumQueryStringArrayEnum&gt; fromValue(String v) {
+            for (List<EnumQueryStringArrayEnum> b : List<EnumQueryStringArrayEnum>.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static List&lt;EnumQueryStringArrayEnum&gt; fromString(String v) {
+            return fromValue(v);
+        }
+    }
+
+    public enum EnumQueryStringEnum {
+
+        _ABC(String.valueOf("_abc")), _EFG(String.valueOf("-efg")), _XYZ_(String.valueOf("(xyz)"));
+
+
+        private String value;
+
+        EnumQueryStringEnum (String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static EnumQueryStringEnum fromValue(String v) {
+            for (EnumQueryStringEnum b : EnumQueryStringEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static EnumQueryStringEnum fromString(String v) {
+            return fromValue(v);
+        }
+    }
+
+    public enum EnumQueryIntegerEnum {
+
+        NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_2(Integer.valueOf(-2));
+
+
+        private Integer value;
+
+        EnumQueryIntegerEnum (Integer v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static EnumQueryIntegerEnum fromValue(String v) {
+            for (EnumQueryIntegerEnum b : EnumQueryIntegerEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static EnumQueryIntegerEnum fromString(String v) {
+            return fromValue(v);
+        }
+    }
+
+
 
     @GET
     
@@ -54,7 +163,7 @@ public class FakeApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid request", response = void.class),
         @ApiResponse(code = 404, message = "Not found", response = void.class) })
-    public Response testEnumParameters(@FormParam(value = "enumFormStringArray")  List<String> enumFormStringArray,@FormParam(value = "enumFormString")  String enumFormString,@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray,@HeaderParam("enum_header_string") String enumHeaderString,@QueryParam("enum_query_string_array")  List<String> enumQueryStringArray,@QueryParam("enum_query_string")  String enumQueryString,@QueryParam("enum_query_integer")  Integer enumQueryInteger,@FormParam(value = "enumQueryDouble")  Double enumQueryDouble) {
+    public Response testEnumParameters(@FormParam(value = "enum_form_string_array")  List<String> enumFormStringArray,@FormParam(value = "enum_form_string")  String enumFormString,@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray,@HeaderParam("enum_header_string") String enumHeaderString,@QueryParam("enum_query_string_array")  List<EnumQueryStringArrayEnum> enumQueryStringArray,@QueryParam("enum_query_string")  EnumQueryStringEnum enumQueryString,@QueryParam("enum_query_integer")  EnumQueryIntegerEnum enumQueryInteger,@FormParam(value = "enum_query_double")  Double enumQueryDouble) {
     	return Response.ok().entity("magic!").build();
     }
 }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/PetApi.java
@@ -20,6 +20,8 @@ import javax.validation.constraints.*;
 
 
 public class PetApi  {
+    
+
 
     @POST
     
@@ -36,6 +38,8 @@ public class PetApi  {
     public Response addPet(Pet body) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @DELETE
     @Path("/{petId}")
@@ -52,6 +56,42 @@ public class PetApi  {
     public Response deletePet(@PathParam("petId") @ApiParam("Pet id to delete") Long petId,@HeaderParam("api_key") String apiKey) {
     	return Response.ok().entity("magic!").build();
     }
+    
+    public enum List&lt;StatusEnum&gt; {
+
+        AVAILABLE(List&lt;String&gt;.valueOf("available")), PENDING(List&lt;String&gt;.valueOf("pending")), SOLD(List&lt;String&gt;.valueOf("sold"));
+
+
+        private List&lt;String&gt; value;
+
+        List&lt;StatusEnum&gt; (List&lt;String&gt; v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static List&lt;StatusEnum&gt; fromValue(String v) {
+            for (List<StatusEnum> b : List<StatusEnum>.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static List&lt;StatusEnum&gt; fromString(String v) {
+            return fromValue(v);
+        }
+    }
+
+
 
     @GET
     @Path("/findByStatus")
@@ -66,9 +106,11 @@ public class PetApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class, responseContainer = "List") })
-    public Response findPetsByStatus(@QueryParam("status") @NotNull  List<String> status) {
+    public Response findPetsByStatus(@QueryParam("status") @NotNull  List<StatusEnum> status) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @GET
     @Path("/findByTags")
@@ -86,6 +128,8 @@ public class PetApi  {
     public Response findPetsByTags(@QueryParam("tags") @NotNull  List<String> tags) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @GET
     @Path("/{petId}")
@@ -101,6 +145,8 @@ public class PetApi  {
     public Response getPetById(@PathParam("petId") @ApiParam("ID of pet to return") Long petId) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @PUT
     
@@ -119,6 +165,8 @@ public class PetApi  {
     public Response updatePet(Pet body) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @POST
     @Path("/{petId}")
@@ -135,6 +183,8 @@ public class PetApi  {
     public Response updatePetWithForm(@PathParam("petId") @ApiParam("ID of pet that needs to be updated") Long petId,@FormParam(value = "name")  String name,@FormParam(value = "status")  String status) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @POST
     @Path("/{petId}/uploadImage")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/StoreApi.java
@@ -19,6 +19,8 @@ import javax.validation.constraints.*;
 
 
 public class StoreApi  {
+    
+
 
     @DELETE
     @Path("/order/{orderId}")
@@ -31,6 +33,8 @@ public class StoreApi  {
     public Response deleteOrder(@PathParam("orderId") @ApiParam("ID of the order that needs to be deleted") String orderId) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @GET
     @Path("/inventory")
@@ -44,6 +48,8 @@ public class StoreApi  {
     public Response getInventory() {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @GET
     @Path("/order/{orderId}")
@@ -57,6 +63,8 @@ public class StoreApi  {
     public Response getOrderById(@PathParam("orderId") @Min(1) @Max(5) @ApiParam("ID of pet that needs to be fetched") Long orderId) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @POST
     @Path("/order")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/api/UserApi.java
@@ -19,6 +19,8 @@ import javax.validation.constraints.*;
 
 
 public class UserApi  {
+    
+
 
     @POST
     
@@ -30,6 +32,8 @@ public class UserApi  {
     public Response createUser(User body) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @POST
     @Path("/createWithArray")
@@ -41,6 +45,8 @@ public class UserApi  {
     public Response createUsersWithArrayInput(List<User> body) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @POST
     @Path("/createWithList")
@@ -52,6 +58,8 @@ public class UserApi  {
     public Response createUsersWithListInput(List<User> body) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @DELETE
     @Path("/{username}")
@@ -64,6 +72,8 @@ public class UserApi  {
     public Response deleteUser(@PathParam("username") @ApiParam("The name that needs to be deleted") String username) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @GET
     @Path("/{username}")
@@ -77,6 +87,8 @@ public class UserApi  {
     public Response getUserByName(@PathParam("username") @ApiParam("The name that needs to be fetched. Use user1 for testing. ") String username) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @GET
     @Path("/login")
@@ -89,6 +101,8 @@ public class UserApi  {
     public Response loginUser(@QueryParam("username") @NotNull  String username,@QueryParam("password") @NotNull  String password) {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @GET
     @Path("/logout")
@@ -100,6 +114,8 @@ public class UserApi  {
     public Response logoutUser() {
     	return Response.ok().entity("magic!").build();
     }
+    
+
 
     @PUT
     @Path("/{username}")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AdditionalPropertiesClass.java
@@ -23,7 +23,7 @@ public class AdditionalPropertiesClass   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, String> getMapProperty() {
     return mapProperty;
   }
@@ -39,7 +39,7 @@ public class AdditionalPropertiesClass   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapOfMapProperty() {
     return mapOfMapProperty;
   }
@@ -49,7 +49,7 @@ public class AdditionalPropertiesClass   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class AdditionalPropertiesClass   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Animal.java
@@ -22,7 +22,7 @@ public class Animal   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public String getClassName() {
     return className;
@@ -39,7 +39,7 @@ public class Animal   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getColor() {
     return color;
   }
@@ -49,7 +49,7 @@ public class Animal   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -81,7 +81,7 @@ public class Animal   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AnimalFarm.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/AnimalFarm.java
@@ -15,7 +15,7 @@ public class AnimalFarm extends ArrayList<Animal>  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -44,7 +44,7 @@ public class AnimalFarm extends ArrayList<Animal>  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfArrayOfNumberOnly.java
@@ -22,7 +22,7 @@ public class ArrayOfArrayOfNumberOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
@@ -32,7 +32,7 @@ public class ArrayOfArrayOfNumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -62,7 +62,7 @@ public class ArrayOfArrayOfNumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayOfNumberOnly.java
@@ -22,7 +22,7 @@ public class ArrayOfNumberOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
@@ -32,7 +32,7 @@ public class ArrayOfNumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -62,7 +62,7 @@ public class ArrayOfNumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ArrayTest.java
@@ -24,7 +24,7 @@ public class ArrayTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -40,7 +40,7 @@ public class ArrayTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -56,7 +56,7 @@ public class ArrayTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
@@ -66,7 +66,7 @@ public class ArrayTest   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -100,7 +100,7 @@ public class ArrayTest   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Capitalization.java
@@ -24,7 +24,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -40,7 +40,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -56,7 +56,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -72,7 +72,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -88,7 +88,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -105,7 +105,7 @@ public class Capitalization   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "Name of the pet ")
+  @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;
   }
@@ -115,7 +115,7 @@ public class Capitalization   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -155,7 +155,7 @@ public class Capitalization   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Cat.java
@@ -20,7 +20,7 @@ public class Cat extends Animal  {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;
   }
@@ -30,7 +30,7 @@ public class Cat extends Animal  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class Cat extends Animal  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Category.java
@@ -20,7 +20,7 @@ public class Category   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -36,7 +36,7 @@ public class Category   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getName() {
     return name;
   }
@@ -46,7 +46,7 @@ public class Category   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class Category   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ClassModel.java
@@ -23,7 +23,7 @@ public class ClassModel   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;
   }
@@ -33,7 +33,7 @@ public class ClassModel   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -63,7 +63,7 @@ public class ClassModel   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Client.java
@@ -19,7 +19,7 @@ public class Client   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getClient() {
     return client;
   }
@@ -29,7 +29,7 @@ public class Client   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -59,7 +59,7 @@ public class Client   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Dog.java
@@ -20,7 +20,7 @@ public class Dog extends Animal  {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;
   }
@@ -30,7 +30,7 @@ public class Dog extends Animal  {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class Dog extends Animal  {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumArrays.java
@@ -12,67 +12,75 @@ import java.util.Objects;
 public class EnumArrays   {
   
 
-public enum JustSymbolEnum {
+    public enum JustSymbolEnum {
 
-    GREATER_THAN_OR_EQUAL_TO(String.valueOf(">=")), DOLLAR(String.valueOf("$"));
+        GREATER_THAN_OR_EQUAL_TO(String.valueOf(">=")), DOLLAR(String.valueOf("$"));
 
 
-    private String value;
+        private String value;
 
-    JustSymbolEnum (String v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static JustSymbolEnum fromValue(String v) {
-        for (JustSymbolEnum b : JustSymbolEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        JustSymbolEnum (String v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static JustSymbolEnum fromValue(String v) {
+            for (JustSymbolEnum b : JustSymbolEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static JustSymbolEnum fromString(String v) {
+            return fromValue(v);
+        }
     }
-}
 
   private JustSymbolEnum justSymbol = null;
 
-public enum ArrayEnumEnum {
+    public enum ArrayEnumEnum {
 
-    FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));
+        FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));
 
 
-    private String value;
+        private String value;
 
-    ArrayEnumEnum (String v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static ArrayEnumEnum fromValue(String v) {
-        for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        ArrayEnumEnum (String v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static ArrayEnumEnum fromValue(String v) {
+            for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static ArrayEnumEnum fromString(String v) {
+            return fromValue(v);
+        }
     }
-}
 
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
@@ -84,7 +92,7 @@ public enum ArrayEnumEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -100,7 +108,7 @@ public enum ArrayEnumEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
@@ -110,7 +118,7 @@ public enum ArrayEnumEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -142,7 +150,7 @@ public enum ArrayEnumEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/EnumTest.java
@@ -11,99 +11,111 @@ import java.util.Objects;
 public class EnumTest   {
   
 
-public enum EnumStringEnum {
+    public enum EnumStringEnum {
 
-    UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
+        UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
 
 
-    private String value;
+        private String value;
 
-    EnumStringEnum (String v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static EnumStringEnum fromValue(String v) {
-        for (EnumStringEnum b : EnumStringEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        EnumStringEnum (String v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static EnumStringEnum fromValue(String v) {
+            for (EnumStringEnum b : EnumStringEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static EnumStringEnum fromString(String v) {
+            return fromValue(v);
+        }
     }
-}
 
   private EnumStringEnum enumString = null;
 
-public enum EnumIntegerEnum {
+    public enum EnumIntegerEnum {
 
-    NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
+        NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
 
 
-    private Integer value;
+        private Integer value;
 
-    EnumIntegerEnum (Integer v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static EnumIntegerEnum fromValue(String v) {
-        for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        EnumIntegerEnum (Integer v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static EnumIntegerEnum fromValue(String v) {
+            for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static EnumIntegerEnum fromString(String v) {
+            return fromValue(v);
+        }
     }
-}
 
   private EnumIntegerEnum enumInteger = null;
 
-public enum EnumNumberEnum {
+    public enum EnumNumberEnum {
 
-    NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
+        NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
 
 
-    private Double value;
+        private Double value;
 
-    EnumNumberEnum (Double v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static EnumNumberEnum fromValue(String v) {
-        for (EnumNumberEnum b : EnumNumberEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        EnumNumberEnum (Double v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static EnumNumberEnum fromValue(String v) {
+            for (EnumNumberEnum b : EnumNumberEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static EnumNumberEnum fromString(String v) {
+            return fromValue(v);
+        }
     }
-}
 
   private EnumNumberEnum enumNumber = null;
   private OuterEnum outerEnum = null;
@@ -116,7 +128,7 @@ public enum EnumNumberEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -132,7 +144,7 @@ public enum EnumNumberEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -148,7 +160,7 @@ public enum EnumNumberEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -164,7 +176,7 @@ public enum EnumNumberEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
@@ -174,7 +186,7 @@ public enum EnumNumberEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -210,7 +222,7 @@ public enum EnumNumberEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/FormatTest.java
@@ -1,6 +1,7 @@
 package io.swagger.model;
 
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.UUID;
 import org.joda.time.LocalDate;
 import javax.validation.constraints.*;
@@ -22,7 +23,7 @@ public class FormatTest   {
   private byte[] _byte = null;
   private byte[] binary = null;
   private LocalDate date = null;
-  private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+  private Date dateTime = null;
   private UUID uuid = null;
   private String password = null;
 
@@ -36,7 +37,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @Min(10) @Max(100)  public Integer getInteger() {
     return integer;
   }
@@ -54,7 +55,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @Min(20) @Max(200)  public Integer getInt32() {
     return int32;
   }
@@ -70,7 +71,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
   }
@@ -88,7 +89,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
  @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
     return number;
@@ -107,7 +108,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
     return _float;
   }
@@ -125,7 +126,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
     return _double;
   }
@@ -141,7 +142,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
  @Pattern(regexp="/[a-z]/i")  public String getString() {
     return string;
   }
@@ -157,7 +158,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public byte[] getByte() {
     return _byte;
@@ -174,7 +175,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public byte[] getBinary() {
     return binary;
   }
@@ -190,7 +191,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public LocalDate getDate() {
     return date;
@@ -201,17 +202,17 @@ public class FormatTest   {
 
   /**
    **/
-  public FormatTest dateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public FormatTest dateTime(Date dateTime) {
     this.dateTime = dateTime;
     return this;
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getDateTime() {
+  @ApiModelProperty(value = "")
+  public Date getDateTime() {
     return dateTime;
   }
-  public void setDateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public void setDateTime(Date dateTime) {
     this.dateTime = dateTime;
   }
 
@@ -223,7 +224,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
   }
@@ -239,7 +240,7 @@ public class FormatTest   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
  @Size(min=10,max=64)  public String getPassword() {
     return password;
@@ -250,7 +251,7 @@ public class FormatTest   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -304,7 +305,7 @@ public class FormatTest   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/HasOnlyReadOnly.java
@@ -20,7 +20,7 @@ public class HasOnlyReadOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
   }
@@ -36,7 +36,7 @@ public class HasOnlyReadOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;
   }
@@ -46,7 +46,7 @@ public class HasOnlyReadOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class HasOnlyReadOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MapTest.java
@@ -14,35 +14,39 @@ public class MapTest   {
   
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
-public enum InnerEnum {
+    public enum InnerEnum {
 
-    UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower"));
+        UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower"));
 
 
-    private String value;
+        private String value;
 
-    InnerEnum (String v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static InnerEnum fromValue(String v) {
-        for (InnerEnum b : InnerEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        InnerEnum (String v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static InnerEnum fromValue(String v) {
+            for (InnerEnum b : InnerEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static InnerEnum fromString(String v) {
+            return fromValue(v);
+        }
     }
-}
 
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
@@ -54,7 +58,7 @@ public enum InnerEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -70,7 +74,7 @@ public enum InnerEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -80,7 +84,7 @@ public enum InnerEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -112,7 +116,7 @@ public enum InnerEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -1,6 +1,7 @@
 package io.swagger.model;
 
 import io.swagger.model.Animal;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,7 @@ import java.util.Objects;
 public class MixedPropertiesAndAdditionalPropertiesClass   {
   
   private UUID uuid = null;
-  private javax.xml.datatype.XMLGregorianCalendar dateTime = null;
+  private Date dateTime = null;
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   /**
@@ -26,7 +27,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
   }
@@ -36,17 +37,17 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
 
   /**
    **/
-  public MixedPropertiesAndAdditionalPropertiesClass dateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public MixedPropertiesAndAdditionalPropertiesClass dateTime(Date dateTime) {
     this.dateTime = dateTime;
     return this;
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getDateTime() {
+  @ApiModelProperty(value = "")
+  public Date getDateTime() {
     return dateTime;
   }
-  public void setDateTime(javax.xml.datatype.XMLGregorianCalendar dateTime) {
+  public void setDateTime(Date dateTime) {
     this.dateTime = dateTime;
   }
 
@@ -58,7 +59,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;
   }
@@ -68,7 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -102,7 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Model200Response.java
@@ -24,7 +24,7 @@ public class Model200Response   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
   }
@@ -40,7 +40,7 @@ public class Model200Response   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;
   }
@@ -50,7 +50,7 @@ public class Model200Response   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -82,7 +82,7 @@ public class Model200Response   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -21,7 +21,7 @@ public class ModelApiResponse   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
   }
@@ -37,7 +37,7 @@ public class ModelApiResponse   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getType() {
     return type;
   }
@@ -53,7 +53,7 @@ public class ModelApiResponse   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getMessage() {
     return message;
   }
@@ -63,7 +63,7 @@ public class ModelApiResponse   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -97,7 +97,7 @@ public class ModelApiResponse   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ModelReturn.java
@@ -23,7 +23,7 @@ public class ModelReturn   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;
   }
@@ -33,7 +33,7 @@ public class ModelReturn   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -63,7 +63,7 @@ public class ModelReturn   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Name.java
@@ -26,7 +26,7 @@ public class Name   {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public Integer getName() {
     return name;
@@ -43,7 +43,7 @@ public class Name   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -59,7 +59,7 @@ public class Name   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
   }
@@ -75,7 +75,7 @@ public class Name   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer get123Number() {
     return _123Number;
   }
@@ -85,7 +85,7 @@ public class Name   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -121,7 +121,7 @@ public class Name   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/NumberOnly.java
@@ -20,7 +20,7 @@ public class NumberOnly   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;
   }
@@ -30,7 +30,7 @@ public class NumberOnly   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -60,7 +60,7 @@ public class NumberOnly   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Order.java
@@ -1,5 +1,6 @@
 package io.swagger.model;
 
+import java.util.Date;
 import javax.validation.constraints.*;
 
 
@@ -12,37 +13,41 @@ public class Order   {
   private Long id = null;
   private Long petId = null;
   private Integer quantity = null;
-  private javax.xml.datatype.XMLGregorianCalendar shipDate = null;
+  private Date shipDate = null;
 
-public enum StatusEnum {
+    public enum StatusEnum {
 
-    PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
+        PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
 
 
-    private String value;
+        private String value;
 
-    StatusEnum (String v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static StatusEnum fromValue(String v) {
-        for (StatusEnum b : StatusEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        StatusEnum (String v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static StatusEnum fromValue(String v) {
+            for (StatusEnum b : StatusEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static StatusEnum fromString(String v) {
+            return fromValue(v);
+        }
     }
-}
 
   private StatusEnum status = null;
   private Boolean complete = false;
@@ -55,7 +60,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -71,7 +76,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
   }
@@ -87,7 +92,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
   }
@@ -97,17 +102,17 @@ public enum StatusEnum {
 
   /**
    **/
-  public Order shipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public Order shipDate(Date shipDate) {
     this.shipDate = shipDate;
     return this;
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
-  public javax.xml.datatype.XMLGregorianCalendar getShipDate() {
+  @ApiModelProperty(value = "")
+  public Date getShipDate() {
     return shipDate;
   }
-  public void setShipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public void setShipDate(Date shipDate) {
     this.shipDate = shipDate;
   }
 
@@ -120,7 +125,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "Order Status")
+  @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
   }
@@ -136,7 +141,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;
   }
@@ -146,7 +151,7 @@ public enum StatusEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -186,7 +191,7 @@ public enum StatusEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Pet.java
@@ -19,35 +19,39 @@ public class Pet   {
   private List<String> photoUrls = new ArrayList<String>();
   private List<Tag> tags = new ArrayList<Tag>();
 
-public enum StatusEnum {
+    public enum StatusEnum {
 
-    AVAILABLE(String.valueOf("available")), PENDING(String.valueOf("pending")), SOLD(String.valueOf("sold"));
+        AVAILABLE(String.valueOf("available")), PENDING(String.valueOf("pending")), SOLD(String.valueOf("sold"));
 
 
-    private String value;
+        private String value;
 
-    StatusEnum (String v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static StatusEnum fromValue(String v) {
-        for (StatusEnum b : StatusEnum.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
+        StatusEnum (String v) {
+            value = v;
         }
-        return null;
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static StatusEnum fromValue(String v) {
+            for (StatusEnum b : StatusEnum.values()) {
+                if (String.valueOf(b.value).equals(v)) {
+                    return b;
+                }
+            }
+            return null;
+        }
+
+        public static StatusEnum fromString(String v) {
+            return fromValue(v);
+        }
     }
-}
 
   private StatusEnum status = null;
 
@@ -59,7 +63,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -75,7 +79,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
   }
@@ -108,7 +112,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @NotNull
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -125,7 +129,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
   }
@@ -142,7 +146,7 @@ public enum StatusEnum {
   }
 
   
-  @ApiModelProperty(example = "null", value = "pet status in the store")
+  @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;
   }
@@ -152,7 +156,7 @@ public enum StatusEnum {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -192,7 +196,7 @@ public enum StatusEnum {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/ReadOnlyFirst.java
@@ -20,7 +20,7 @@ public class ReadOnlyFirst   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
   }
@@ -36,7 +36,7 @@ public class ReadOnlyFirst   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;
   }
@@ -46,7 +46,7 @@ public class ReadOnlyFirst   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class ReadOnlyFirst   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/SpecialModelName.java
@@ -19,7 +19,7 @@ public class SpecialModelName   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getSpecialPropertyName() {
     return specialPropertyName;
   }
@@ -29,7 +29,7 @@ public class SpecialModelName   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -59,7 +59,7 @@ public class SpecialModelName   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/Tag.java
@@ -20,7 +20,7 @@ public class Tag   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -36,7 +36,7 @@ public class Tag   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getName() {
     return name;
   }
@@ -46,7 +46,7 @@ public class Tag   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -78,7 +78,7 @@ public class Tag   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/io/swagger/model/User.java
@@ -26,7 +26,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public Long getId() {
     return id;
   }
@@ -42,7 +42,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
   }
@@ -58,7 +58,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
   }
@@ -74,7 +74,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
   }
@@ -90,7 +90,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
   }
@@ -106,7 +106,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
   }
@@ -122,7 +122,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
   }
@@ -139,7 +139,7 @@ public class User   {
   }
 
   
-  @ApiModelProperty(example = "null", value = "User Status")
+  @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;
   }
@@ -149,7 +149,7 @@ public class User   {
 
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(java.lang.Object o) {
     if (this == o) {
       return true;
     }
@@ -193,7 +193,7 @@ public class User   {
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
    */
-  private String toIndentedString(Object o) {
+  private String toIndentedString(java.lang.Object o) {
     if (o == null) {
       return "null";
     }

--- a/samples/server/petstore/jaxrs-spec/swagger.json
+++ b/samples/server/petstore/jaxrs-spec/swagger.json
@@ -108,8 +108,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],
@@ -650,8 +650,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_form_string",
@@ -669,8 +669,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_header_string",
@@ -688,8 +688,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ ">", "$" ],
-            "default" : "$"
+            "default" : "$",
+            "enum" : [ ">", "$" ]
           }
         }, {
           "name" : "enum_query_string",
@@ -705,14 +705,16 @@
           "description" : "Query parameter enum test (double)",
           "required" : false,
           "type" : "integer",
-          "format" : "int32"
+          "format" : "int32",
+          "enum" : [ 1, -2 ]
         }, {
           "name" : "enum_query_double",
           "in" : "formData",
           "description" : "Query parameter enum test (double)",
           "required" : false,
           "type" : "number",
-          "format" : "double"
+          "format" : "double",
+          "enum" : [ 1.1, -1.2 ]
         } ],
         "responses" : {
           "400" : {
@@ -725,8 +727,8 @@
       },
       "post" : {
         "tags" : [ "fake" ],
-        "summary" : "Fake endpoint for testing various parameters\n假端點\n偽のエンドポイント\n가짜 엔드 포인트\n",
-        "description" : "Fake endpoint for testing various parameters\n假端點\n偽のエンドポイント\n가짜 엔드 포인트\n",
+        "summary" : "Fake endpoint for testing various parameters\n???\n?????????\n?? ?? ???\n",
+        "description" : "Fake endpoint for testing various parameters\n???\n?????????\n?? ?? ???\n",
         "operationId" : "testEndpointParameters",
         "consumes" : [ "application/xml; charset=utf-8", "application/json; charset=utf-8" ],
         "produces" : [ "application/xml; charset=utf-8", "application/json; charset=utf-8" ],
@@ -760,15 +762,15 @@
           "description" : "None",
           "required" : true,
           "type" : "number",
-          "maximum" : 543.200000000000045474735088646411895751953125,
-          "minimum" : 32.10000000000000142108547152020037174224853515625
+          "maximum" : 543.2,
+          "minimum" : 32.1
         }, {
           "name" : "float",
           "in" : "formData",
           "description" : "None",
           "required" : false,
           "type" : "number",
-          "maximum" : 987.6000000000000227373675443232059478759765625,
+          "maximum" : 987.6,
           "format" : "float"
         }, {
           "name" : "double",
@@ -776,8 +778,8 @@
           "description" : "None",
           "required" : true,
           "type" : "number",
-          "maximum" : 123.400000000000005684341886080801486968994140625,
-          "minimum" : 67.7999999999999971578290569595992565155029296875,
+          "maximum" : 123.4,
+          "minimum" : 67.8,
           "format" : "double"
         }, {
           "name" : "string",
@@ -886,13 +888,13 @@
         "read:pets" : "read your pets"
       }
     },
-    "http_basic_test" : {
-      "type" : "basic"
-    },
     "api_key" : {
       "type" : "apiKey",
       "name" : "api_key",
       "in" : "header"
+    },
+    "http_basic_test" : {
+      "type" : "basic"
     }
   },
   "definitions" : {


### PR DESCRIPTION
[JAVA][jaxrs-spec] Add support for generating type-safe query parameters (#5075)

All the logic is already in place so I just make sure parameters in:query
also insert an enum in the generated API and that the type for the REST
operation parameter is that enum (and not just String as it was before).

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

As the code was already in place, I just changed the templates a bit to also include the generated enums. For `enumClass.mustache` - https://github.com/foxx1337/swagger-codegen/blob/12a990f1/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/enumClass.mustache I indented everything by 1 extra level so that everything is properly indented in  the generated models or api classes (it was dedented in models and it looked bad).
