### PR TITLE
[Scala] Override `escapeQuotationMark` in Async Scala generator to prevent code injection

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AsyncScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AsyncScalaClientCodegen.java
@@ -97,4 +97,10 @@ public class AsyncScalaClientCodegen extends AbstractScalaCodegen implements Cod
     public String getHelp() {
         return "Generates an Asynchronous Scala client library.";
     }
+
+    @Override
+    public String escapeQuotationMark(String input) {
+        // remove " to avoid code injection
+        return input.replace("\"", "");
+    }
 }

--- a/samples/client/petstore/async-scala/src/main/scala/io/swagger/client/api/PetApi.scala
+++ b/samples/client/petstore/async-scala/src/main/scala/io/swagger/client/api/PetApi.scala
@@ -1,8 +1,8 @@
 package io.swagger.client.api
 
-import io.swagger.client.model.Pet
-import java.io.File
 import io.swagger.client.model.ApiResponse
+import java.io.File
+import io.swagger.client.model.Pet
 import com.wordnik.swagger.client._
 import scala.concurrent.Future
 import collection.mutable


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Override `escapeQuotationMark` in Async Scala generator to prevent code injection
