### PR TITLE
Modify Java/retrofit OAuth templates for #5039

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/auth/OAuth.mustache
@@ -132,7 +132,7 @@ public class OAuth implements Interceptor {
                     if (accessTokenListener != null) {
                         accessTokenListener.notify((BasicOAuthToken) accessTokenResponse.getOAuthToken());
                     }
-                    return getAccessToken().equals(requestAccessToken);
+                    return !getAccessToken().equals(requestAccessToken);
                 } else {
                     return false;
                 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/auth/OAuth.mustache
@@ -132,7 +132,7 @@ public class OAuth implements Interceptor {
                     if (accessTokenListener != null) {
                         accessTokenListener.notify((BasicOAuthToken) accessTokenResponse.getOAuthToken());
                     }
-                    return getAccessToken().equals(requestAccessToken);
+                    return !getAccessToken().equals(requestAccessToken);
                 } else {
                     return false;
                 }

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/auth/OAuth.java
@@ -132,7 +132,7 @@ public class OAuth implements Interceptor {
                     if (accessTokenListener != null) {
                         accessTokenListener.notify((BasicOAuthToken) accessTokenResponse.getOAuthToken());
                     }
-                    return getAccessToken().equals(requestAccessToken);
+                    return !getAccessToken().equals(requestAccessToken);
                 } else {
                     return false;
                 }

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -132,7 +132,7 @@ public class OAuth implements Interceptor {
                     if (accessTokenListener != null) {
                         accessTokenListener.notify((BasicOAuthToken) accessTokenResponse.getOAuthToken());
                     }
-                    return getAccessToken().equals(requestAccessToken);
+                    return !getAccessToken().equals(requestAccessToken);
                 } else {
                     return false;
                 }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/auth/OAuth.java
@@ -132,7 +132,7 @@ public class OAuth implements Interceptor {
                     if (accessTokenListener != null) {
                         accessTokenListener.notify((BasicOAuthToken) accessTokenResponse.getOAuthToken());
                     }
-                    return getAccessToken().equals(requestAccessToken);
+                    return !getAccessToken().equals(requestAccessToken);
                 } else {
                     return false;
                 }


### PR DESCRIPTION
The updateAccessToken method returns `true` when it means `false` and
vice versa. Fixes #5039 .

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixes an issue in the generated OAuth client for Java retrofit, retrofit2, and retrofit2-rx clients.  The `OAuth.updateAccessToken` method is returning true when it means false, and vice versa. This causes some authentication errors to be mistakenly forwarded to the client, even when an automatic retry is possible, and can also cause an infinite recursion loop when the client receives a 401 or 403 that is not related to the OAuth flow.
