### PR TITLE
Spring Framework resource file streams issue 5089

### DIFF
--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
@@ -20,6 +20,7 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
     public static final String USE_TAGS = "useTags";
     public static final String USE_BEANVALIDATION = "false";
     public static final String IMPLICIT_HEADERS = "false";
+    public static final String RESOURCE_FILE_STREAMS = "false";
 
     @Override
     public String getLanguage() {
@@ -42,6 +43,7 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
         options.put(SpringCodegen.USE_TAGS, USE_TAGS);
         options.put(SpringCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION);
         options.put(SpringCodegen.IMPLICIT_HEADERS, IMPLICIT_HEADERS);
+        options.put(SpringCodegen.RESOURCE_FILE_STREAMS, RESOURCE_FILE_STREAMS);
 
         return options;
     }


### PR DESCRIPTION
I left a description of the issue here:  #5089

This adds a new additional command line property called `resourceStreams` that replaces `java.io.File` with `org.springframework.core.io.Resource` in Spring Framework when specifying a `file` type in the yaml.  I ran normal unit tests, and they passed, and what I added is simple, and should have no effect without specifying the command line option, but it allows me to return file data that isn't stored locally on the rest server serving the api, and it lets me stream it from the original place, through the server, and down to the client without having to store the whole file all at once.

The largest block of the code change is providing an example value that shows how to make it work exactly the same as it did by wrapping a `java.io.File` in a `FileSystemResource`, which is an implementation of the Resource interface.