### PR TITLE
Update petstore samples for scala client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/pom.mustache
@@ -157,6 +157,11 @@
       <version>${jackson-version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>${jackson-version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
       <version>${jersey-version}</version>

--- a/samples/client/petstore/scala/pom.xml
+++ b/samples/client/petstore/scala/pom.xml
@@ -210,7 +210,7 @@
     <joda-version>1.2</joda-version>
     <joda-time-version>2.2</joda-time-version>
     <jersey-version>1.19</jersey-version>
-    <swagger-core-version>1.5.9</swagger-core-version>
+    <swagger-core-version>1.5.12</swagger-core-version>
     <jersey-async-version>1.0.5</jersey-async-version>
     <maven-plugin.version>1.0.0</maven-plugin.version>
     <jackson-version>2.4.2</jackson-version>

--- a/samples/client/petstore/scala/pom.xml
+++ b/samples/client/petstore/scala/pom.xml
@@ -157,6 +157,11 @@
       <version>${jackson-version}</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>${jackson-version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
       <version>${jersey-version}</version>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. 
   → bin/scala-petstore.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

I noticed that my merge of master and 2.3.0 had a different version number than both master and 2.3.0.
The reason is that the master sample was not up-to-date (#4881 forgot to update the scala samples).

~~~This updates it – CI will fail here, I'll try to fix this in a follow-up commit. Please do not merge yet.~~~