### PR TITLE
Fix sample script to set the correct artifact ID in the generated POM

### DIFF
--- a/bin/akka-scala-petstore.sh
+++ b/bin/akka-scala-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/akka-scala -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l akka-scala -o samples/client/petstore/akka-scala"
+ags="$@ generate --artifact-id "scala-akka-petstore-client" -t modules/swagger-codegen/src/main/resources/akka-scala -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l akka-scala -o samples/client/petstore/akka-scala"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/akka-scala-petstore.bat
+++ b/bin/windows/akka-scala-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M -DloggerPath=conf/log4j.properties
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l akka-scala -o samples\client\petstore\akka-scala
+set ags=generate  --artifact-id "scala-akka-petstore-client" -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l akka-scala -o samples\client\petstore\akka-scala
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/samples/client/petstore/akka-scala/pom.xml
+++ b/samples/client/petstore/akka-scala/pom.xml
@@ -2,9 +2,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.swagger</groupId>
-    <artifactId>scala-akka-petstore-client</artifactId>
+    <artifactId>swagger-client</artifactId>
     <packaging>jar</packaging>
-    <name>scala-akka-petstore-client</name>
+    <name>swagger-client</name>
     <version>1.0.0</version>
     <prerequisites>
         <maven>2.2.0</maven>

--- a/samples/client/petstore/akka-scala/pom.xml
+++ b/samples/client/petstore/akka-scala/pom.xml
@@ -2,9 +2,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.swagger</groupId>
-    <artifactId>swagger-client</artifactId>
+    <artifactId>scala-akka-petstore-client</artifactId>
     <packaging>jar</packaging>
-    <name>swagger-client</name>
+    <name>scala-akka-petstore-client</name>
     <version>1.0.0</version>
     <prerequisites>
         <maven>2.2.0</maven>

--- a/samples/client/petstore/akka-scala/src/main/resources/reference.conf
+++ b/samples/client/petstore/akka-scala/src/main/resources/reference.conf
@@ -12,7 +12,7 @@ io.swagger.client {
         connection-timeout: 5000ms
 
         default-headers {
-            "userAgent": "swagger-client_1.0.0"
+            "userAgent": "scala-akka-petstore-client_1.0.0"
         }
 
         // let you define custom http status code, as in :


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
     → bin/akka-scala-petstore.sh (twice, once before and once after the change).
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

This was first just meant to update the Akka samples, there are no code changes here.
The first commit (updating samples from the script) undoes part of the change from #5073, which changed the name + artifact ID manually.
This shows that the default artifact ID is not what is used when running CI.

The second commit changes the sample update scripts to set the correct `--artifact-id` parameter.

The third commit updates the samples again, showing that everything is fine now. (There is a change in the generated reference.conf, not sure if it is relevant.)