### PR TITLE
[C#] fix path with {{{ .. }}} in c# API mustache file

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -208,7 +208,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/required}}
             {{/allParams}}
 
-            var localVarPath = "{{path}}";
+            var localVarPath = "{{{path}}}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
@@ -339,7 +339,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/required}}
             {{/allParams}}
 
-            var localVarPath = "{{path}}";
+            var localVarPath = "{{{path}}}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);

--- a/samples/client/petstore/csharp/SwaggerClient/IO.Swagger.sln
+++ b/samples/client/petstore/csharp/SwaggerClient/IO.Swagger.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{D445A874-7512-4B21-AC14-0CC1180C9B9A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{8FBEE4BD-85D4-4A5A-B723-C98D2EDB387A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger.Test", "src\IO.Swagger.Test\IO.Swagger.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Debug|Any CPU = Debug|Any CPU
 Release|Any CPU = Release|Any CPU
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
-{D445A874-7512-4B21-AC14-0CC1180C9B9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{D445A874-7512-4B21-AC14-0CC1180C9B9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{D445A874-7512-4B21-AC14-0CC1180C9B9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{D445A874-7512-4B21-AC14-0CC1180C9B9A}.Release|Any CPU.Build.0 = Release|Any CPU
+{8FBEE4BD-85D4-4A5A-B723-C98D2EDB387A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{8FBEE4BD-85D4-4A5A-B723-C98D2EDB387A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{8FBEE4BD-85D4-4A5A-B723-C98D2EDB387A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{8FBEE4BD-85D4-4A5A-B723-C98D2EDB387A}.Release|Any CPU.Build.0 = Release|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
@@ -11,7 +11,7 @@ Contact: apiteam@swagger.io
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D445A874-7512-4B21-AC14-0CC1180C9B9A}</ProjectGuid>
+    <ProjectGuid>{8FBEE4BD-85D4-4A5A-B723-C98D2EDB387A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IO.Swagger</RootNamespace>

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/IO.Swagger.sln
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/IO.Swagger.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{6D420517-C79A-4919-BDE7-8CEEAC1BC6B4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{415C09BC-2D6E-4641-960C-8E382CECF46C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger.Test", "src\IO.Swagger.Test\IO.Swagger.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Debug|Any CPU = Debug|Any CPU
 Release|Any CPU = Release|Any CPU
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
-{6D420517-C79A-4919-BDE7-8CEEAC1BC6B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{6D420517-C79A-4919-BDE7-8CEEAC1BC6B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{6D420517-C79A-4919-BDE7-8CEEAC1BC6B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{6D420517-C79A-4919-BDE7-8CEEAC1BC6B4}.Release|Any CPU.Build.0 = Release|Any CPU
+{415C09BC-2D6E-4641-960C-8E382CECF46C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{415C09BC-2D6E-4641-960C-8E382CECF46C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{415C09BC-2D6E-4641-960C-8E382CECF46C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{415C09BC-2D6E-4641-960C-8E382CECF46C}.Release|Any CPU.Build.0 = Release|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger.Test/IO.Swagger.Test.csproj
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger.Test/IO.Swagger.Test.csproj
@@ -74,7 +74,7 @@ Contact: apiteam@swagger.io
   <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
       <ProjectReference Include="..\IO.Swagger\IO.Swagger.csproj">
-          <Project>{6D420517-C79A-4919-BDE7-8CEEAC1BC6B4}</Project>
+          <Project>{415C09BC-2D6E-4641-960C-8E382CECF46C}</Project>
           <Name>IO.Swagger</Name>
       </ProjectReference>
   </ItemGroup>

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/IO.Swagger.csproj
@@ -11,7 +11,7 @@ Contact: apiteam@swagger.io
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6D420517-C79A-4919-BDE7-8CEEAC1BC6B4}</ProjectGuid>
+    <ProjectGuid>{415C09BC-2D6E-4641-960C-8E382CECF46C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IO.Swagger</RootNamespace>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

To fix https://github.com/swagger-api/swagger-codegen/issues/4977
