### PR TITLE
#4788: remove System.getProperty in DefaultGenerator

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/ClientOptInput.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/ClientOptInput.java
@@ -5,13 +5,16 @@ import io.swagger.codegen.auth.AuthParser;
 import io.swagger.models.Swagger;
 import io.swagger.models.auth.AuthorizationValue;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class ClientOptInput {
     private CodegenConfig config;
     private ClientOpts opts;
     private Swagger swagger;
     private List<AuthorizationValue> auths;
+    private Map<String,String> systemProperties;
 
     public ClientOptInput swagger(Swagger swagger) {
         this.setSwagger(swagger);
@@ -25,6 +28,11 @@ public class ClientOptInput {
 
     public ClientOptInput config(CodegenConfig codegenConfig) {
         this.setConfig(codegenConfig);
+        return this;
+    }
+
+    public ClientOptInput systemProperties(Map<String,String> properties) {
+        this.setSystemProperties(properties);
         return this;
     }
 
@@ -63,6 +71,18 @@ public class ClientOptInput {
 
     public void setOpts(ClientOpts opts) {
         this.opts = opts;
+    }
+
+    public Map<String, String> getSystemProperties() {
+        if(systemProperties == null) {
+            return Collections.emptyMap();
+        } else {
+            return systemProperties;
+        }
+    }
+
+    public void setSystemProperties(Map<String, String> systemProperties) {
+        this.systemProperties = systemProperties;
     }
 
     @ApiModelProperty(dataType = "Object")

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -25,9 +25,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     protected ClientOptInput opts;
     protected Swagger swagger;
     protected CodegenIgnoreProcessor ignoreProcessor;
-    private Boolean generateApis = null;
-    private Boolean generateModels = null;
-    private Boolean generateSupportingFiles = null;
+    private boolean generateApis;
+    private boolean generateModels;
+    private boolean generateSupportingFiles;
     private Boolean generateApiTests = null;
     private Boolean generateApiDocumentation = null;
     private Boolean generateModelTests = null;
@@ -86,33 +86,56 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         return hostBuilder.toString();
     }
 
+    /**
+     * Checks whether a system property is set.
+     * "System property" here means a value in the systemProperty map of {@code opts}.
+     * 
+     * @param name the name of the property.
+     * @return {@code true} if the property is set, otherwise false.
+     */
+    private boolean isSystemPropertySet(String name) {
+        return opts.getSystemProperties().get(name) != null;
+    }
+
+    /**
+     * Returns the value of the "system property" as a boolean, with default {@code true}.
+     * "System property" here means a value in the systemProperty map of {@code opts}.
+     * 
+     * @param name The name of the system property.
+     * @return {@code true} if the property is not set, or if the value is (case-insensitive) "true", otherwise {@code false}.
+     */
+    private boolean getSystemPropertyAsBoolean(String name) {
+        String value = opts.getSystemProperties().get(name);
+        return value == null || Boolean.valueOf(value);
+    }
+
+    private Set<String> getSystemPropertyAsStringSet(String name) {
+        String value = opts.getSystemProperties().get(name);
+        if (value != null && !value.isEmpty()) {
+            return new HashSet<String>(Arrays.asList(value.split(",")));
+        } else {
+            return null;
+        }
+    }
+
     private void configureGeneratorProperties() {
 
         // allows generating only models by specifying a CSV of models to generate, or empty for all
-        generateApis = System.getProperty("apis") != null ? true:null;
-        generateModels = System.getProperty("models") != null ? true: null;
-        generateSupportingFiles = System.getProperty("supportingFiles") != null ? true:null;
 
-        if (generateApis == null && generateModels == null && generateSupportingFiles == null) {
+        generateApis = isSystemPropertySet("apis");
+        generateModels = isSystemPropertySet("models");
+        generateSupportingFiles = isSystemPropertySet("supportingFiles");
+
+        if (!generateApis && !generateModels && !generateSupportingFiles) {
             // no specifics are set, generate everything
             generateApis = generateModels = generateSupportingFiles = true;
-        } else {
-            if(generateApis == null) {
-                generateApis = false;
-            }
-            if(generateModels == null) {
-                generateModels = false;
-            }
-            if(generateSupportingFiles == null) {
-                generateSupportingFiles = false;
-            }
         }
         // model/api tests and documentation options rely on parent generate options (api or model) and no other options.
         // They default to true in all scenarios and can only be marked false explicitly
-        generateModelTests = System.getProperty("modelTests") != null ? Boolean.valueOf(System.getProperty("modelTests")): true;
-        generateModelDocumentation = System.getProperty("modelDocs") != null ? Boolean.valueOf(System.getProperty("modelDocs")):true;
-        generateApiTests = System.getProperty("apiTests") != null ? Boolean.valueOf(System.getProperty("apiTests")): true;
-        generateApiDocumentation = System.getProperty("apiDocs") != null ? Boolean.valueOf(System.getProperty("apiDocs")):true;
+        generateModelTests = getSystemPropertyAsBoolean("modelTests");
+        generateModelDocumentation = getSystemPropertyAsBoolean("modelDocs");
+        generateApiTests = getSystemPropertyAsBoolean("apiTests");
+        generateApiDocumentation = getSystemPropertyAsBoolean("apiDocs");
 
 
         // Additional properties added for tests to exclude references in project related files
@@ -121,7 +144,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if(!generateApiTests && !generateModelTests) {
             config.additionalProperties().put(CodegenConstants.EXCLUDE_TESTS, true);
         }
-        if (System.getProperty("debugSwagger") != null) {
+        if (isSystemPropertySet("debugSwagger")) {
             Json.prettyPrint(swagger);
         }
         config.processOpts();
@@ -227,11 +250,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             return;
         }
 
-        String modelNames = System.getProperty("models");
-        Set<String> modelsToGenerate = null;
-        if(modelNames != null && !modelNames.isEmpty()) {
-            modelsToGenerate = new HashSet<String>(Arrays.asList(modelNames.split(",")));
-        }
+        Set<String> modelsToGenerate = getSystemPropertyAsStringSet("models");
 
         Set<String> modelKeys = definitions.keySet();
         if(modelsToGenerate != null && !modelsToGenerate.isEmpty()) {
@@ -342,7 +361,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 throw new RuntimeException("Could not generate model '" + modelName + "'", e);
             }
         }
-        if (System.getProperty("debugModels") != null) {
+        if (isSystemPropertySet("debugModels")) {
             LOGGER.info("############ Model info ############");
             Json.prettyPrint(allModels);
         }
@@ -354,11 +373,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             return;
         }
         Map<String, List<CodegenOperation>> paths = processPaths(swagger.getPaths());
-        Set<String> apisToGenerate = null;
-        String apiNames = System.getProperty("apis");
-        if(apiNames != null && !apiNames.isEmpty()) {
-            apisToGenerate = new HashSet<String>(Arrays.asList(apiNames.split(",")));
-        }
+        Set<String> apisToGenerate = getSystemPropertyAsStringSet("apis");
+
         if(apisToGenerate != null && !apisToGenerate.isEmpty()) {
             Map<String, List<CodegenOperation>> updatedPaths = new TreeMap<String, List<CodegenOperation>>();
             for(String m : paths.keySet()) {
@@ -463,7 +479,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 throw new RuntimeException("Could not generate api file for '" + tag + "'", e);
             }
         }
-        if (System.getProperty("debugOperations") != null) {
+        if (isSystemPropertySet("debugOperations")) {
             LOGGER.info("############ Operation info ############");
             Json.prettyPrint(allOperations);
         }
@@ -474,11 +490,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if (!generateSupportingFiles) {
             return;
         }
-        Set<String> supportingFilesToGenerate = null;
-        String supportingFiles = System.getProperty("supportingFiles");
-        if(supportingFiles!= null && !supportingFiles.isEmpty()) {
-            supportingFilesToGenerate = new HashSet<String>(Arrays.asList(supportingFiles.split(",")));
-        }
+        Set<String> supportingFilesToGenerate = getSystemPropertyAsStringSet("supportingFiles");
 
         for (SupportingFile support : config.supportingFiles()) {
             try {
@@ -637,7 +649,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
         config.postProcessSupportingFileData(bundle);
 
-        if (System.getProperty("debugSupportingFiles") != null) {
+        if(isSystemPropertySet("debugSupportingFiles")) {
             LOGGER.info("############ Supporting file info ############");
             Json.prettyPrint(bundle);
         }
@@ -739,7 +751,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if (operation == null) {
             return;
         }
-        if (System.getProperty("debugOperations") != null) {
+        if (isSystemPropertySet("debugOperations")) {
             LOGGER.info("processOperation: resourcePath= " + resourcePath + "\t;" + httpMethod + " " + operation + "\n");
         }
         List<String> tags = operation.getTags();
@@ -751,7 +763,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
          build up a set of parameter "ids" defined at the operation level
          per the swagger 2.0 spec "A unique parameter is defined by a combination of a name and location"
           i'm assuming "location" == "in"
-        */
+         */
         Set<String> operationParameters = new HashSet<String>();
         if (operation.getParameters() != null) {
             for (Parameter parameter : operation.getParameters()) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfigurator.java
@@ -412,14 +412,14 @@ public class CodegenConfigurator implements Serializable {
 
         config.additionalProperties().putAll(additionalProperties);
 
-        ClientOptInput input = new ClientOptInput()
-                .config(config);
-
         final List<AuthorizationValue> authorizationValues = AuthParser.parse(auth);
 
         Swagger swagger = new SwaggerParser().read(inputSpec, authorizationValues, true);
 
-        input.opts(new ClientOpts())
+        ClientOptInput input = new ClientOptInput()
+                .config(config)
+                .opts(new ClientOpts())
+                .systemProperties(systemProperties)
                 .swagger(swagger);
 
         return input;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   (I tried to run all ... there are many unrelated changes. So I first opened a bunch of PRs for just updating the stuff. More to come. When those are merged, I'll rebase this on master and run it again.) :x: Please do not merge yet.
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes. → **not sure, see below.**

### Description of the PR

(This is a part of a larger effort to get rid of the usage system properties for customizing the behavior of Swagger-Codegen, see #4788.)

#### Old state

DefaultGenerator was using System.getProperty for these purposes:
- knowing if debug mode was requested (just the existence is enough)
     - `debugSwagger`
     - `debugModels`
     - `debugOperations`
     - `debugSupportingFiles`
- knowing if the user wants to generate tests and/or documentation (these are (stringified) booleans, default true):
     - `modelTests`
     - `apiTests`
     - `modelDocs`
     - `apiDocs`
- knowing if the user wants to generate just some of the models/APIs/supporting files (and which ones) – these are comma-separated lists.
    - `supportingFiles`
    - `apis`
    - `models`

#### Changes

We introduced a `systemProperties` property (a `Map<String,String>`) in ClientOptInput, which is used by DefaultGenerator instead of System.getProperty() now. I introduced some private convenience methods here to make the access easier for the three use cases we have.

CodegenConfigurator now puts its own `systemProperties` map (which comes from either the maven plugin or the CLI's `-D` options) into this field. (Currently, it also uses `System.setProperty`, I'll remove this in a later PR when all usages are removed.)

One test which used System.setProperties needed to be fixed.

#### Open issues

**Samples**: I did not update any samples. In theory, those should not be affected, but who knows if I missed anything. I tried to use bin/run_all_petstore, but there were many (mostly unrelated) changes. So I started to update samples based on master first (see e.g. #5118 and #5117, there will be some more.)

**Breaking change?** I'm not sure this counts as a breaking change. Strictly said, if one did give those properties as real system properties (e.g. in the CLI version with `-DapiDocs=false` before the class name instead of after it, or in maven from outside the project instead of in the `<systemProperties>` element), it won't work anymore. For the "usual" way of giving them (`<systemProperties>` or `-D` after the class name), it still works. Should this go into master, 2.3.0 or even a later version?
Should we introduce some compatibility layer, which fetches real system properties and collects them into the `systemProperties` map?