### PR TITLE
[python/flask] Fix #4752 by adding missing import when pattern constraing is used

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -620,11 +620,26 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
 
     @Override
     public String toModelImport(String name) {
-        String modelImport = "from ";
-        if (!"".equals(modelPackage())) {
-            modelImport += modelPackage() + ".";
+        String modelImport;
+        if (StringUtils.startsWithAny(name,"import", "from")) {
+            modelImport = name;
+        } else {
+            modelImport = "from ";
+            if (!"".equals(modelPackage())) {
+                modelImport += modelPackage() + ".";
+            }
+            modelImport += toModelFilename(name)+ " import " + name;
         }
-        modelImport += toModelFilename(name)+ " import " + name;
         return modelImport;
     }
+
+    @Override
+    public void postProcessModelProperty(CodegenModel model, CodegenProperty property){
+        if (StringUtils.isNotEmpty(property.pattern)) {
+            addImport(model, "import re");
+        }
+    }
+
+
+
 }


### PR DESCRIPTION
Solves #4752 by adding the `import re` when model has any property using the `pattern` constraint.
