### PR TITLE
[C#][aspnetcore] Fix broken Docker build option & documentation

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNetCoreServerCodegen.java
@@ -86,6 +86,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         super.processOpts();
 
         additionalProperties.put("packageGuid", packageGuid);
+        additionalProperties.put("dockerTag", this.packageName.toLowerCase());
 
         apiPackage = packageName + ".Controllers";
         modelPackage = packageName + ".Models";

--- a/modules/swagger-codegen/src/main/resources/aspnetcore/Dockerfile.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/Dockerfile.mustache
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:latest
+FROM microsoft/dotnet:1.0.3-sdk-projectjson
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 

--- a/modules/swagger-codegen/src/main/resources/aspnetcore/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/aspnetcore/README.mustache
@@ -22,6 +22,6 @@ build.bat
 
 ```
 cd src/{{packageName}}
-docker build -t {{packageName}} .
-docker run -p 5000:5000 {{packageName}}
+docker build -t {{dockerTag}} .
+docker run -p 5000:5000 {{dockerTag}}
 ```

--- a/samples/server/petstore/aspnetcore/IO.Swagger.sln
+++ b/samples/server/petstore/aspnetcore/IO.Swagger.sln
@@ -7,7 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
                 global.json = global.json
         EndProjectSection
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.xproj", "{795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}"
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.xproj", "{3C799344-F285-4669-8FD5-7ED9B795D5C5}"
 EndProject
 Global
         GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,10 +15,10 @@ Global
                 Release|Any CPU = Release|Any CPU
         EndGlobalSection
         GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                {795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3C799344-F285-4669-8FD5-7ED9B795D5C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3C799344-F285-4669-8FD5-7ED9B795D5C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3C799344-F285-4669-8FD5-7ED9B795D5C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3C799344-F285-4669-8FD5-7ED9B795D5C5}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
         GlobalSection(SolutionProperties) = preSolution
                 HideSolutionNode = FALSE

--- a/samples/server/petstore/aspnetcore/README.md
+++ b/samples/server/petstore/aspnetcore/README.md
@@ -20,6 +20,6 @@ build.bat
 
 ```
 cd src/IO.Swagger
-docker build -t IO.Swagger .
-docker run -p 5000:5000 IO.Swagger
+docker build -t io.swagger .
+docker run -p 5000:5000 io.swagger
 ```

--- a/samples/server/petstore/aspnetcore/global.json
+++ b/samples/server/petstore/aspnetcore/global.json
@@ -1,7 +1,7 @@
 {
   "projects": [ "src" ],
   "sdk": {
-    "version": "1.0.0-preview3-003171",
+    "version": "1.0.0-preview2-003121",
     "runtime": "coreclr"
   }
 }

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/Dockerfile
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:latest
+FROM microsoft/dotnet:1.0.3-sdk-projectjson
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 

--- a/samples/server/petstore/aspnetcore/src/IO.Swagger/IO.Swagger.xproj
+++ b/samples/server/petstore/aspnetcore/src/IO.Swagger/IO.Swagger.xproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
     <PropertyGroup Label="Globals">
-        <ProjectGuid>{795C6B14-1C3E-45F5-AF6F-EE47B197FF1E}</ProjectGuid>
+        <ProjectGuid>{3C799344-F285-4669-8FD5-7ED9B795D5C5}</ProjectGuid>
         <RootNamespace>IO.Swagger</RootNamespace>
         <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
         <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

* Use lower-case packageName for README.md docker build example
* Use dotnet:1.0.3-sdk instead of just "latest"
* Regenerate Petstore server sample

Fixes #5126.