### PR TITLE
Add docker support to python flask

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -107,6 +107,8 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
         supportingFiles.add(new SupportingFile("travis.mustache", "", ".travis.yml"));
+        supportingFiles.add(new SupportingFile("Dockerfile.mustache", "", "Dockerfile"));
+        supportingFiles.add(new SupportingFile("dockerignore.mustache", "", ".dockerignore"));
 
         cliOptions.add(new CliOption(CodegenConstants.PACKAGE_NAME, "python package name (convention: snake_case).")
                 .defaultValue("swagger_server"));

--- a/modules/swagger-codegen/src/main/resources/flaskConnexion/Dockerfile.mustache
+++ b/modules/swagger-codegen/src/main/resources/flaskConnexion/Dockerfile.mustache
@@ -1,0 +1,31 @@
+{{#supportPython2}}
+FROM python:2-alpine
+{{/supportPython2}}
+{{^supportPython2}}
+FROM python:3-alpine
+{{/supportPython2}}
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+
+{{#supportPython2}}
+RUN pip install --no-cache-dir -r requirements.txt
+{{/supportPython2}}
+{{^supportPython2}}
+RUN pip3 install --no-cache-dir -r requirements.txt
+{{/supportPython2}}
+
+COPY . /usr/src/app
+
+EXPOSE {{serverPort}}
+
+{{#supportPython2}}
+ENTRYPOINT ["python"]
+{{/supportPython2}}
+{{^supportPython2}}
+ENTRYPOINT ["python3"]
+{{/supportPython2}}
+
+CMD ["-m", "{{packageName}}"]

--- a/modules/swagger-codegen/src/main/resources/flaskConnexion/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/flaskConnexion/README.mustache
@@ -46,3 +46,15 @@ To launch the integration tests, use tox:
 sudo pip install tox
 tox
 ```
+
+## Running with Docker
+
+To run the server on a Docker container, please execute the following from the root directory:
+
+```bash
+# building the image
+docker build -t {{packageName}} .
+
+# starting up a container
+docker run -p {{serverPort}}:{{serverPort}} {{packageName}}
+```

--- a/modules/swagger-codegen/src/main/resources/flaskConnexion/dockerignore.mustache
+++ b/modules/swagger-codegen/src/main/resources/flaskConnexion/dockerignore.mustache
@@ -1,0 +1,72 @@
+.travis.yaml
+.swagger-codegen-ignore
+README.md
+tox.ini
+git_push.sh
+test-requirements.txt
+setup.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+venv/
+.python-version
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+#Ipython Notebook
+.ipynb_checkpoints

--- a/samples/server/petstore/flaskConnexion/.dockerignore
+++ b/samples/server/petstore/flaskConnexion/.dockerignore
@@ -1,0 +1,72 @@
+.travis.yaml
+.swagger-codegen-ignore
+README.md
+tox.ini
+git_push.sh
+test-requirements.txt
+setup.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+venv/
+.python-version
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+#Ipython Notebook
+.ipynb_checkpoints

--- a/samples/server/petstore/flaskConnexion/Dockerfile
+++ b/samples/server/petstore/flaskConnexion/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3-alpine
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
+
+EXPOSE 8080
+
+ENTRYPOINT ["python3"]
+
+CMD ["-m", "swagger_server"]

--- a/samples/server/petstore/flaskConnexion/README.md
+++ b/samples/server/petstore/flaskConnexion/README.md
@@ -35,3 +35,15 @@ To launch the integration tests, use tox:
 sudo pip install tox
 tox
 ```
+
+## Running with Docker
+
+To run the server on a Docker container, please execute the following from the root directory:
+
+```bash
+# building the image
+docker build -t swagger_server .
+
+# starting up a container
+docker run -p 8080:8080 swagger_server
+```

--- a/samples/server/petstore/flaskConnexion/swagger_server/swagger/swagger.yaml
+++ b/samples/server/petstore/flaskConnexion/swagger_server/swagger/swagger.yaml
@@ -108,11 +108,11 @@ paths:
         type: "array"
         items:
           type: "string"
-          default: "available"
           enum:
           - "available"
           - "pending"
           - "sold"
+          default: "available"
         collectionFormat: "csv"
       responses:
         200:


### PR DESCRIPTION
Adds Docker support for the `python-flask` lang.
Generates a Dockerfile for python2 and python3.