### PR TITLE
Fix selective generation in successive Maven plugin executions

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -333,13 +333,20 @@ public class CodeGenMojo extends AbstractMojo {
         // Set generation options
         if (null != generateApis && generateApis) {
             System.setProperty("apis", "");
+        } else {
+            System.clearProperty("apis");
         }
+
         if (null != generateModels && generateModels) {
             System.setProperty("models", modelsToGenerate);
+        } else {
+            System.clearProperty("models");
         }
 
         if (null != generateSupportingFiles && generateSupportingFiles) {
             System.setProperty("supportingFiles", supportingFilesToGenerate);
+        } else {
+            System.clearProperty("supportingFiles");
         }
         
         System.setProperty("modelTests", generateModelTests.toString());


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

See  #5151

Options passed as system properties are now properly reset when disabled in the execution configuration.