### PR TITLE
Update maven-bundle-plugin version in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -872,7 +872,7 @@
     <properties>
         <swagger-parser-version>1.0.28</swagger-parser-version>
         <scala-version>2.11.1</scala-version>
-        <felix-version>2.3.4</felix-version>
+        <felix-version>3.3.0</felix-version>
         <swagger-core-version>1.5.12</swagger-core-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
Not applicable... simple POM change.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Update maven-bundle-plugin to 3.3.0 to fix CVE-2012-2098, per issue #5148