### PR TITLE
[JAVA-SpringFramework][5089] Added a new additional option that allows one to replace the the 'fil…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
@@ -5,7 +5,6 @@ import io.swagger.codegen.languages.features.BeanValidationFeatures;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
-import io.swagger.models.properties.Property;
 
 import java.io.File;
 import java.util.*;
@@ -25,7 +24,6 @@ public class SpringCodegen extends AbstractJavaCodegen implements BeanValidation
     public static final String SPRING_MVC_LIBRARY = "spring-mvc";
     public static final String SPRING_CLOUD_LIBRARY = "spring-cloud";
     public static final String IMPLICIT_HEADERS = "implicitHeaders";
-    public static final String RESOURCE_FILE_STREAMS = "resourceStreams";
 
     protected String title = "swagger-petstore";
     protected String configPackage = "io.swagger.configuration";
@@ -68,7 +66,6 @@ public class SpringCodegen extends AbstractJavaCodegen implements BeanValidation
         cliOptions.add(CliOption.newBoolean(USE_TAGS, "use tags for creating interface and controller classnames"));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
         cliOptions.add(CliOption.newBoolean(IMPLICIT_HEADERS, "Use of @ApiImplicitParams for headers."));
-        cliOptions.add(CliOption.newBoolean(RESOURCE_FILE_STREAMS, "When \"file\" is specified as a type, generate the type as org.springframework.core.io.Resource, and FileSystemResource for example values."));
 
         supportedLibraries.put(DEFAULT_LIBRARY, "Spring-boot Server application using the SpringFox integration.");
         supportedLibraries.put(SPRING_MVC_LIBRARY, "Spring-MVC Server application using the SpringFox integration.");
@@ -151,11 +148,6 @@ public class SpringCodegen extends AbstractJavaCodegen implements BeanValidation
             this.setUseBeanValidation(convertPropertyToBoolean(USE_BEANVALIDATION));
         }
 
-        if (additionalProperties.containsKey(RESOURCE_FILE_STREAMS)) {
-            typeMapping.put("file", "Resource");
-            importMapping.put("Resource", "org.springframework.core.io.Resource");
-        }
-
         if (useBeanValidation) {
             writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
         }
@@ -164,6 +156,9 @@ public class SpringCodegen extends AbstractJavaCodegen implements BeanValidation
         if (additionalProperties.containsKey(IMPLICIT_HEADERS)) {
             this.setImplicitHeaders(Boolean.valueOf(additionalProperties.get(IMPLICIT_HEADERS).toString()));
         }
+
+        typeMapping.put("file", "Resource");
+        importMapping.put("Resource", "org.springframework.core.io.Resource");
 
         supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
@@ -20,6 +20,7 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
     public static final String USE_TAGS = "useTags";
     public static final String USE_BEANVALIDATION = "false";
     public static final String IMPLICIT_HEADERS = "false";
+    public static final String RESOURCE_FILE_STREAMS = "false";
 
     @Override
     public String getLanguage() {
@@ -42,6 +43,7 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
         options.put(SpringCodegen.USE_TAGS, USE_TAGS);
         options.put(SpringCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION);
         options.put(SpringCodegen.IMPLICIT_HEADERS, IMPLICIT_HEADERS);
+        options.put(SpringCodegen.RESOURCE_FILE_STREAMS, RESOURCE_FILE_STREAMS);
 
         return options;
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SpringOptionsProvider.java
@@ -20,7 +20,6 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
     public static final String USE_TAGS = "useTags";
     public static final String USE_BEANVALIDATION = "false";
     public static final String IMPLICIT_HEADERS = "false";
-    public static final String RESOURCE_FILE_STREAMS = "false";
 
     @Override
     public String getLanguage() {
@@ -43,7 +42,6 @@ public class SpringOptionsProvider extends JavaOptionsProvider {
         options.put(SpringCodegen.USE_TAGS, USE_TAGS);
         options.put(SpringCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION);
         options.put(SpringCodegen.IMPLICIT_HEADERS, IMPLICIT_HEADERS);
-        options.put(SpringCodegen.RESOURCE_FILE_STREAMS, RESOURCE_FILE_STREAMS);
 
         return options;
     }


### PR DESCRIPTION
 **I reworked this PR from an earlier one.  All it really does is fix the commit email.**

I left a description of the issue here:  #5089

This adds a new additional command line property called `resourceStreams` that replaces `java.io.File` with `org.springframework.core.io.Resource` in Spring Framework when specifying a `file` type in the yaml.  I ran normal unit tests, and they passed, and what I added is simple, and should have no effect without specifying the command line option, but it allows me to return file data that isn't stored locally on the rest server serving the api, and it lets me stream it from the original place, through the server, and down to the client without having to store the whole file all at once.

The largest block of the code change is providing an example value that shows how to make it work exactly the same as it did by wrapping a `java.io.File` in a `FileSystemResource`, which is an implementation of the Resource interface.