### PR TITLE
Fixes a bug in #5142 for multi-word parameters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
@@ -80,7 +80,7 @@ public interface {{classname}} extends ApiClient.Api {
   public static class {{operationIdCamelCase}}QueryParams extends HashMap<String, Object> {
       {{#queryParams}}
     public {{operationIdCamelCase}}QueryParams {{paramName}}(final {{{dataType}}} value) {
-      put("{{paramName}}", value);
+      put("{{baseName}}", value);
       return this;
     }
       {{/queryParams}}

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
@@ -114,15 +114,15 @@ public interface FakeApi extends ApiClient.Api {
    */
   public static class TestEnumParametersQueryParams extends HashMap<String, Object> {
     public TestEnumParametersQueryParams enumQueryStringArray(final List<String> value) {
-      put("enumQueryStringArray", value);
+      put("enum_query_string_array", value);
       return this;
     }
     public TestEnumParametersQueryParams enumQueryString(final String value) {
-      put("enumQueryString", value);
+      put("enum_query_string", value);
       return this;
     }
     public TestEnumParametersQueryParams enumQueryInteger(final Integer value) {
-      put("enumQueryInteger", value);
+      put("enum_query_integer", value);
       return this;
     }
   }


### PR DESCRIPTION
In the convenience class defined for generating a Map of query parameters, the
parameter name was mistakenly being set to the Java variable name, not the
actual parameter name. These are often the same, but can be different in the
case of multi-word parameters, such as in the sample API's `enum_query_string`
vs `enumQueryString`.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

In the convenience class for building up a query parameter map in the Feign API, changed the value of the URL parameter name from the Java variable name to the proper parameter name. You can see how this affects the code in the pet store sample, which has a few cases of multi-word parameters where the parameter name is different from the Java variable name.
