### PR TITLE
[CLI] #5147: make -D work like system properties

### DIFF
--- a/bin/flaskConnexion-python2.sh
+++ b/bin/flaskConnexion-python2.sh
@@ -27,7 +27,7 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 #ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -DsupportPython2=true"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/flaskConnexion -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -c bin/supportPython2.json"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/flaskConnexion -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -c bin/supportPython2.json -D service"
 
 rm -rf samples/server/petstore/flaskConnexion-python2/*
-java $JAVA_OPTS -Dservice -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/flaskConnexion.sh
+++ b/bin/flaskConnexion.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/flaskConnexion -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion "
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/flaskConnexion -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion -Dservice"
 
 rm -rf samples/server/petstore/flaskConnexion/*
-java $JAVA_OPTS -Dservice -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/go-petstore-server.sh
+++ b/bin/go-petstore-server.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l go-server -o samples/server/petstore/go-api-server -DpackageName=petstoreserver --additional-properties hideGenerationTimestamp=true "
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l go-server -o samples/server/petstore/go-api-server -DpackageName=petstoreserver --additional-properties hideGenerationTimestamp=true -Dservice"
 
-java $JAVA_OPTS -Dservice -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/javascript-petstore.sh
+++ b/bin/javascript-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples/client/petstore/javascript"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples/client/petstore/javascript  -DappName=PetstoreClient"
 
-java -DappName=PetstoreClient $JAVA_OPTS -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/javascript-promise-petstore.sh
+++ b/bin/javascript-promise-petstore.sh
@@ -26,9 +26,12 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript \
--i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l javascript \
+ags="$@ generate \
+-t modules/swagger-codegen/src/main/resources/Javascript \
+-i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml \
+-l javascript \
 -o samples/client/petstore/javascript-promise \
---additional-properties usePromises=true"
+--additional-properties usePromises=true \
+-DappName=PetstoreClient"
 
-java -DappName=PetstoreClient $JAVA_OPTS -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/nodejs-petstore-google-cloud-functions.sh
+++ b/bin/nodejs-petstore-google-cloud-functions.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l nodejs-server --additional-properties=googleCloudFunctions=true -o samples/server/petstore/nodejs-google-cloud-functions"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l nodejs-server --additional-properties=googleCloudFunctions=true -o samples/server/petstore/nodejs-google-cloud-functions -Dservice"
 
-java $JAVA_OPTS -Dservice -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/nodejs-petstore-server.sh
+++ b/bin/nodejs-petstore-server.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l nodejs-server -o samples/server/petstore/nodejs"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l nodejs-server -o samples/server/petstore/nodejs -Dservice"
 
-java $JAVA_OPTS -Dservice -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/objc-petstore-coredata.sh
+++ b/bin/objc-petstore-coredata.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/objc -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l objc -DapiDocs=false,modelDocs=false -o samples/client/petstore/objc/core-data --additional-properties coreData=true"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/objc -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l objc -D apiDocs=false -D modelDocs=false -o samples/client/petstore/objc/core-data --additional-properties coreData=true -D appName=PetstoreClient"
 
-java -DappName=PetstoreClient $JAVA_OPTS -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/objc-petstore.sh
+++ b/bin/objc-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/objc -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l objc -o samples/client/petstore/objc/default"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/objc -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l objc -o samples/client/petstore/objc/default -D appName=PetstoreClient"
 
-java -DappName=PetstoreClient $JAVA_OPTS -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/javascript-petstore.sh
+++ b/bin/security/javascript-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript -i modules/swagger-codegen/src/test/resources/2_0/petstore-security-test.yaml -l javascript -o samples/client/petstore-security-test/javascript"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript -i modules/swagger-codegen/src/test/resources/2_0/petstore-security-test.yaml -l javascript -o samples/client/petstore-security-test/javascript  -DappName=PetstoreClient"
 
-java -DappName=PetstoreClient $JAVA_OPTS -jar $executable $ags
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/javascript-petstore.bat
+++ b/bin/windows/javascript-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples\client\petstore\javascript
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples\client\petstore\javascript -DappName=PetstoreClient
 
-java -DappName=PetstoreClient %JAVA_OPTS% -jar %executable% %ags%
+java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/javascript-promise-petstore.bat
+++ b/bin/windows/javascript-promise-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples\client\petstore\javascript-promise --additional-properties usePromises=true
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples\client\petstore\javascript-promise --additional-properties usePromises=true -DappName=PetstoreClient
 
-java -DappName=PetstoreClient %JAVA_OPTS% -jar %executable% %ags%
+java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/objc-petstore.bat
+++ b/bin/windows/objc-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -l objc -o samples\client\petstore\objc\default
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -l objc -o samples\client\petstore\objc\default -DappName=PetstoreClient
 
-java %JAVA_OPTS% -DappName=PetstoreClient -jar %executable% %ags%
+java %JAVA_OPTS% -jar %executable% %ags%

--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -12,6 +12,9 @@ import org.slf4j.LoggerFactory;
 import static io.swagger.codegen.config.CodegenConfiguratorUtils.*;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * User: lanwen
  * Date: 24.03.15
@@ -48,8 +51,8 @@ public class Generate implements Runnable {
     private String auth;
 
     @Option(name = {"-D"}, title = "system properties", description = "sets specified system properties in " +
-            "the format of name=value,name=value")
-    private String systemProperties;
+            "the format of name=value,name=value (or multiple options, each with name=value)")
+    private List<String> systemProperties = new ArrayList<>();
 
     @Option(name = {"-c", "--config"}, title = "configuration file", description = "Path to json configuration file. " +
             "File content should be in a json format {\"optionKey\":\"optionValue\", \"optionKey1\":\"optionValue1\"...} " +
@@ -229,7 +232,7 @@ public class Generate implements Runnable {
             configurator.setRemoveOperationIdPrefix(removeOperationIdPrefix);
         }
 
-        applySystemPropertiesKvp(systemProperties, configurator);
+        applySystemPropertiesKvpList(systemProperties, configurator);
         applyInstantiationTypesKvp(instantiationTypes, configurator);
         applyImportMappingsKvp(importMappings, configurator);
         applyTypeMappingsKvp(typeMappings, configurator);

--- a/modules/swagger-codegen-cli/src/test/java/io/swagger/codegen/cmd/GenerateTest.java
+++ b/modules/swagger-codegen-cli/src/test/java/io/swagger/codegen/cmd/GenerateTest.java
@@ -114,6 +114,15 @@ public class GenerateTest {
             times = 1;
         }};
 
+        setupAndRunGenericTest("-Dhello=world,foo=bar");
+
+        new FullVerifications() {{
+            configurator.addSystemProperty("hello", "world");
+            times = 1;
+            configurator.addSystemProperty("foo", "bar");
+            times = 1;
+        }};
+
         setupAndRunGenericTest("-D", "hello=world,key=,foo=bar");
 
         new FullVerifications() {{
@@ -124,7 +133,30 @@ public class GenerateTest {
             configurator.addSystemProperty("key", "");
             times = 1;
         }};
+
         setupAndRunGenericTest("-D", "hello=world,key,foo=bar");
+
+        new FullVerifications() {{
+            configurator.addSystemProperty("hello", "world");
+            times = 1;
+            configurator.addSystemProperty("foo", "bar");
+            times = 1;
+            configurator.addSystemProperty("key", "");
+            times = 1;
+        }};
+
+        setupAndRunGenericTest("-D", "hello=world", "-D", "key", "-D", "foo=bar");
+
+        new FullVerifications() {{
+            configurator.addSystemProperty("hello", "world");
+            times = 1;
+            configurator.addSystemProperty("foo", "bar");
+            times = 1;
+            configurator.addSystemProperty("key", "");
+            times = 1;
+        }};
+
+        setupAndRunGenericTest("-Dhello=world", "-Dkey", "-Dfoo=bar");
 
         new FullVerifications() {{
             configurator.addSystemProperty("hello", "world");

--- a/modules/swagger-codegen-cli/src/test/java/io/swagger/codegen/cmd/GenerateTest.java
+++ b/modules/swagger-codegen-cli/src/test/java/io/swagger/codegen/cmd/GenerateTest.java
@@ -121,8 +121,18 @@ public class GenerateTest {
             times = 1;
             configurator.addSystemProperty("foo", "bar");
             times = 1;
-            configurator.addSystemProperty("key", anyString);
-            times = 0;
+            configurator.addSystemProperty("key", "");
+            times = 1;
+        }};
+        setupAndRunGenericTest("-D", "hello=world,key,foo=bar");
+
+        new FullVerifications() {{
+            configurator.addSystemProperty("hello", "world");
+            times = 1;
+            configurator.addSystemProperty("foo", "bar");
+            times = 1;
+            configurator.addSystemProperty("key", "");
+            times = 1;
         }};
     }
 
@@ -183,8 +193,8 @@ public class GenerateTest {
             times = 1;
             configurator.addInstantiationType("foo", "bar");
             times = 1;
-            configurator.addInstantiationType("key", anyString);
-            times = 0;
+            configurator.addInstantiationType("key", "");
+            times = 1;
         }};
     }
 
@@ -197,8 +207,8 @@ public class GenerateTest {
             times = 1;
             configurator.addTypeMapping("foo", "bar");
             times = 1;
-            configurator.addTypeMapping("key", anyString);
-            times = 0;
+            configurator.addTypeMapping("key", "");
+            times = 1;
         }};
     }
 
@@ -211,8 +221,8 @@ public class GenerateTest {
             times = 1;
             configurator.addAdditionalProperty("foo", "bar");
             times = 1;
-            configurator.addAdditionalProperty("key", anyString);
-            times = 0;
+            configurator.addAdditionalProperty("key", "");
+            times = 1;
         }};
     }
 
@@ -241,8 +251,8 @@ public class GenerateTest {
             times = 1;
             configurator.addImportMapping("foo", "bar");
             times = 1;
-            configurator.addImportMapping("key", anyString);
-            times = 0;
+            configurator.addImportMapping("key", "");
+            times = 1;
         }};
     }
 

--- a/modules/swagger-codegen-cli/src/test/java/io/swagger/codegen/cmd/utils/OptionUtilsTest.java
+++ b/modules/swagger-codegen-cli/src/test/java/io/swagger/codegen/cmd/utils/OptionUtilsTest.java
@@ -2,12 +2,12 @@ package io.swagger.codegen.cmd.utils;
 
 import io.swagger.codegen.utils.OptionUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -16,39 +16,40 @@ public class OptionUtilsTest {
 
     @Test
     public void splitCommaSeparatedList() throws Exception {
-        doCommaSeparatedListTest("a,b,c", Arrays.asList("a", "b", "c"));
-        doCommaSeparatedListTest("a,,c", Arrays.asList("a", "c"));
-        doCommaSeparatedListTest("", new ArrayList<String>());
-        doCommaSeparatedListTest(null, new ArrayList<String>());
+        doCommaSeparatedListTest("a,b,c", asList("a", "b", "c"));
+        doCommaSeparatedListTest("a,,c", asList("a", "c"));
+        doCommaSeparatedListTest("", emptyList());
+        doCommaSeparatedListTest(null, emptyList());
     }
 
     @Test
     public void testParseCommaSeparatedTuples() throws Exception {
-        doTupleListTest("a=1,b=2,c=3", Arrays.asList(Pair.of("a", "1"), Pair.of("b", "2"), Pair.of("c", "3")));
-        doTupleListTest("a=1,,c=3", Arrays.asList(Pair.of("a", "1"), Pair.of("c", "3")));
-        doTupleListTest("a=1,xyz,c=3", Arrays.asList(Pair.of("a", "1"), Pair.of("c", "3")));
-        doTupleListTest("a=1,=,c=3", Arrays.asList(Pair.of("a", "1"), Pair.of("c", "3")));
-        doTupleListTest("", new ArrayList<Pair<String, String>>());
-        doTupleListTest(null, new ArrayList<Pair<String, String>>());
+        doTupleListTest("a=1,b=2,c=3", asList(Pair.of("a", "1"), Pair.of("b", "2"), Pair.of("c", "3")));
+        doTupleListTest("xyz", asList(Pair.of("xyz", "")));
+        doTupleListTest("a=1,,c=3", asList(Pair.of("a", "1"), Pair.of("c", "3")));
+        doTupleListTest("a=1,xyz=,c=3", asList(Pair.of("a", "1"), Pair.of("xyz", ""), Pair.of("c", "3")));
+        doTupleListTest("a=1,xyz,c=3", asList(Pair.of("a", "1"), Pair.of("xyz", ""), Pair.of("c", "3")));
+        doTupleListTest("a=1,=,c=3", asList(Pair.of("a", "1"), Pair.of("c", "3")));
+        doTupleListTest("", emptyPairList());
+        doTupleListTest(null, emptyPairList());
     }
-
+    
     private static void doTupleListTest(String input, List<Pair<String, String>> expectedResults) {
         final List<Pair<String, String>> result = OptionUtils.parseCommaSeparatedTuples(input);
         assertNotNull(result);
-        assertEquals(result.size(), expectedResults.size());
-        for (int i = 0; i < expectedResults.size(); i++) {
-            final Pair<String, String> actualPair = result.get(i);
-            final Pair<String, String> expected = expectedResults.get(i);
-            assertEquals(actualPair, expected);
-        }
+        assertEquals(result, expectedResults);
     }
 
     private static void doCommaSeparatedListTest(String csvStr, List<String> expectedResults) {
         final List<String> result = OptionUtils.splitCommaSeparatedList(csvStr);
         assertNotNull(result);
-        assertEquals(result.size(), expectedResults.size());
-        for (int i = 0; i < expectedResults.size(); i++) {
-            assertEquals(result.get(i), expectedResults.get(i));
-        }
+        assertEquals(result, expectedResults);
+    }
+    private static List<Pair<String,String>> emptyPairList() {
+        return Collections.emptyList();
+    }
+    
+    private static List<String> emptyList() {
+        return Collections.emptyList();
     }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfiguratorUtils.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfiguratorUtils.java
@@ -16,6 +16,12 @@ import java.util.*;
  */
 public final class CodegenConfiguratorUtils {
 
+    public static void applySystemPropertiesKvpList(List<String> systemProperties, CodegenConfigurator configurator) {
+        for(String propString : systemProperties) {
+            applySystemPropertiesKvp(propString, configurator);
+        }
+    }
+
     public static void applySystemPropertiesKvp(String systemProperties, CodegenConfigurator configurator) {
         final Map<String, String> map = createMapFromKeyValuePairs(systemProperties);
         for (Map.Entry<String, String> entry : map.entrySet()) {
@@ -81,6 +87,4 @@ public final class CodegenConfiguratorUtils {
 
         return result;
     }
-    
-    
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/OptionUtils.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/OptionUtils.java
@@ -2,28 +2,29 @@ package io.swagger.codegen.utils;
 
 import org.apache.commons.lang3.tuple.Pair;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import joptsimple.internal.Strings;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class OptionUtils {
 
-    public static List<Pair<String, String>> parseCommaSeparatedTuples(String input) {
+    public static List<Pair<String, String>> parseCommaSeparatedTuples(final String input) {
 
-        List<Pair<String, String>> results = new ArrayList<Pair<String, String>>();
+        final List<Pair<String, String>> results = new ArrayList<Pair<String, String>>();
 
         final List<String> tuples = splitCommaSeparatedList(input);
 
         for (String tuple : tuples) {
             int ix = tuple.indexOf('=');
-            if (ix > 0 && ix < tuple.length() - 1) {
+            if (ix > 0 && ix <= tuple.length() - 1) {
                 final Pair<String, String> pair = Pair.of(tuple.substring(0, ix), tuple.substring(ix + 1));
+                results.add(pair);
+            } else if (ix < 0){
+                final Pair<String, String> pair = Pair.of(tuple, "");
                 results.add(pair);
             }
         }
-        //Strings.isNullOrEmpty(input)
+
         return results;
     }
    


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
    - bin/run-all-petstore – no changes after latest rebase (2017-04-04, based on 22c80588f63629a17ae0113da11e2d9b437bd4cf).
    - bin/security/run-all-petstore-security-test → same changes as in #5325 + #5324. Not committed here, I will rebase and redo it when those are merged.
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes. → **Not sure about this, see below** 

### Description of the PR

As detailed in #5147, this implements two changes (in separate commits, so it should be easy to separate those if needed).

* When parsing comma-separated key-value pairs we know accept empty values (and keys without value are also handled as empty values). This applies to the `-D` option as well as to `--instantiation-type`, `--type-mappings`, `--additional-properties`, `--import-mappings`.

   (Previously those keys were simply ignored, which made it impossible to pass just `-D models` (or `-D models=`) as an argument after the class/jar name (it needed to be a Java system property before the class/jar name).

* It is now possible to give several `-D` options, and have all of them apply – the key-value-lists are merged, in case of conflicting keys the last one wins.

  Previously the last `-D` option was the only one which had any effect, simply overwriting any earlier ones.

I modified some tests (and added some new ones) to reflect the new behavior.

#### About (non)breaking changes

This changes the behavior of all the key-value options to allow keys with empty values, or without values. If anyone had a script which would use e.g. `-D foo=bar,foo`, this previously would have passed `foo` with the value `bar`, now it is passing the empty string to the `bar` property. I think nobody should have done that, but who knows. **Opinions on that?**

#### Allowing several options for other plural options

It would be easy to allow the same behavior as for `-D` (allow multiple options, merge values) for some other plural options too. This applies to the key-value-list ones `--instantiation-type`, `--type-mappings`, `--additional-properties`, `--import-mappings`, but also to `--language-specific-primitives` (which is just a list of strings). **Opinions on that?**