### PR TITLE
Issue #3084: remove timestamps from bash samples.

### DIFF
--- a/bin/bash-petstore.sh
+++ b/bin/bash-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-args="$@ generate -t modules/swagger-codegen/src/main/resources/bash -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l bash -o samples/client/petstore/bash -c modules/swagger-codegen/src/test/resources/2_0/bash-config.json"
+args="$@ generate -t modules/swagger-codegen/src/main/resources/bash -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l bash -o samples/client/petstore/bash -c modules/swagger-codegen/src/test/resources/2_0/bash-config.json --additional-properties hideGenerationTimestamp=true"
 
 java $JAVA_OPTS -jar $executable $args

--- a/modules/swagger-codegen/src/main/resources/bash/bash-completion.mustache
+++ b/modules/swagger-codegen/src/main/resources/bash/bash-completion.mustache
@@ -8,8 +8,8 @@
 # ! swagger-codegen (https://github.com/swagger-api/swagger-codegen)
 # ! FROM SWAGGER SPECIFICATION IN JSON.
 # !
-# ! Generated on: {{generatedDate}}
-# !
+{{^hideGenerationTimestamp}}# ! Generated on: {{generatedDate}}
+{{/hideGenerationTimestamp}}# !
 # !
 # ! System wide installation:
 # !

--- a/modules/swagger-codegen/src/main/resources/bash/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/bash/client.mustache
@@ -8,8 +8,8 @@
 # ! swagger-codegen (https://github.com/swagger-api/swagger-codegen)
 # ! FROM SWAGGER SPECIFICATION IN JSON.
 # !
-# ! Generated on: {{generatedDate}}
-# !
+{{^hideGenerationTimestamp}}# ! Generated on: {{generatedDate}}
+{{/hideGenerationTimestamp}}# !
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #

--- a/modules/swagger-codegen/src/main/resources/bash/zsh-completion.mustache
+++ b/modules/swagger-codegen/src/main/resources/bash/zsh-completion.mustache
@@ -10,8 +10,8 @@
 # !
 # ! Based on: https://github.com/Valodim/zsh-curl-completion/blob/master/_curl
 # !
-# ! Generated on: {{generatedDate}}
-# !
+{{^hideGenerationTimestamp}}# ! Generated on: {{generatedDate}}
+{{/hideGenerationTimestamp}}# !
 # !
 # ! Installation:
 # !

--- a/samples/client/petstore/bash/_petstore-cli
+++ b/samples/client/petstore/bash/_petstore-cli
@@ -10,7 +10,6 @@
 # !
 # ! Based on: https://github.com/Valodim/zsh-curl-completion/blob/master/_curl
 # !
-# ! Generated on: 2017-02-22T08:48:10.130+01:00
 # !
 # !
 # ! Installation:

--- a/samples/client/petstore/bash/petstore-cli
+++ b/samples/client/petstore/bash/petstore-cli
@@ -8,7 +8,6 @@
 # ! swagger-codegen (https://github.com/swagger-api/swagger-codegen)
 # ! FROM SWAGGER SPECIFICATION IN JSON.
 # !
-# ! Generated on: 2017-02-22T08:48:10.130+01:00
 # !
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/samples/client/petstore/bash/petstore-cli.bash-completion
+++ b/samples/client/petstore/bash/petstore-cli.bash-completion
@@ -8,7 +8,6 @@
 # ! swagger-codegen (https://github.com/swagger-api/swagger-codegen)
 # ! FROM SWAGGER SPECIFICATION IN JSON.
 # !
-# ! Generated on: 2017-02-22T08:48:10.130+01:00
 # !
 # !
 # ! System wide installation:


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
    → bin/bash-petstore.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

This removes the output of the timestamp for the bash petstore samples, as a part of #3084.

This consists of two steps:

* make the templates aware of `hideGenerationTimestamp`
* pass the value `true` in the sample generation script.

This does not try to change the default behavior, if wished this can be done in a separate pull request.