### PR TITLE
[C#] Issue #5196: make package GUID non-random for the C# samples.

### DIFF
--- a/bin/csharp-petstore.sh
+++ b/bin/csharp-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClient"
+ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C}"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-property-changed-petstore.sh
+++ b/bin/csharp-property-changed-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClientWithPropertyChanged --additional-properties=generatePropertyChanged=true"
+ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClientWithPropertyChanged --additional-properties=generatePropertyChanged=true,packageGuid={5CD900DE-8266-412F-A758-28E1F9C623D5}"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/csharp-petstore-netstandard.bat
+++ b/bin/windows/csharp-petstore-netstandard.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples\client\petstore\csharp\SwaggerClientNetStandard --additional-properties targetFramework=v5.0
+set ags=generate -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples\client\petstore\csharp\SwaggerClientNetStandard --additional-properties targetFramework=v5.0,packageGuid={3AB1F259-1769-484B-9411-84505FCCBD55}
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/csharp-petstore.bat
+++ b/bin/windows/csharp-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples\client\petstore\csharp\SwaggerClient
+set ags=generate -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples\client\petstore\csharp\SwaggerClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C}
 
 java %JAVA_OPTS% -jar %executable% %ags%


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → bin/csharp-petstore.sh + bin/csharp-property-changed-petstore.sh.
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

This changes the C# sample generation scripts to pass a fixed packageGuid parameter.
The effect is that the generated samples don't change randomly with every update, obfuscating the real changes. (This is a part of #5196.)

The functionality for this was already build in #1941, when the project files with GUIDs were added.

I chose the fixed GUIDs as the latest random value from master, with the effect that an update now doesn't change anything anymore. (When merging into 2.3.0 and regenerating, you'll get a change once.)

(I also changed the .bat files, though **I'm not able to test this here**.)