### PR TITLE
[ASP.NET] Issue #5196: add packageGuid parameter to AspNetCoreServerCodegen.

### DIFF
--- a/bin/aspnetcore-petstore-server.sh
+++ b/bin/aspnetcore-petstore-server.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -l aspnetcore -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -o samples/server/petstore/aspnetcore"
+ags="$@ generate -l aspnetcore -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -o samples/server/petstore/aspnetcore --additional-properties packageGuid={3C799344-F285-4669-8FD5-7ED9B795D5C5}"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/aspnetcore-petstore-server.bat
+++ b/bin/windows/aspnetcore-petstore-server.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M -DloggerPath=conf/log4j.properties
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l aspnetcore -o samples\server\petstore\aspnetcore\
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.json -l aspnetcore -o samples\server\petstore\aspnetcore\ --additional-properties packageGuid={3C799344-F285-4669-8FD5-7ED9B795D5C5}
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AspNetCoreServerCodegen.java
@@ -14,7 +14,7 @@ import static java.util.UUID.randomUUID;
 
 public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
-    private final String packageGuid = "{" + randomUUID().toString().toUpperCase() + "}";
+    private String packageGuid = "{" + randomUUID().toString().toUpperCase() + "}";
 
     @SuppressWarnings("hiding")
     protected Logger LOGGER = LoggerFactory.getLogger(AspNetCoreServerCodegen.class);
@@ -43,6 +43,10 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         addOption(CodegenConstants.PACKAGE_VERSION,
                 "C# package version.",
                 this.packageVersion);
+
+        addOption(CodegenConstants.OPTIONAL_PROJECT_GUID,
+                CodegenConstants.OPTIONAL_PROJECT_GUID_DESC,
+                null);
 
         addOption(CodegenConstants.SOURCE_FOLDER,
                 CodegenConstants.SOURCE_FOLDER_DESC,
@@ -85,7 +89,11 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public void processOpts() {
         super.processOpts();
 
+        if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_PROJECT_GUID)) {
+            setPackageGuid((String) additionalProperties.get(CodegenConstants.OPTIONAL_PROJECT_GUID));
+        }
         additionalProperties.put("packageGuid", packageGuid);
+        
         additionalProperties.put("dockerTag", this.packageName.toLowerCase());
 
         apiPackage = packageName + ".Controllers";
@@ -130,6 +138,10 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         }
     }
 
+    public void setPackageGuid(String packageGuid) {
+        this.packageGuid = packageGuid;
+    }
+    
     @Override
     public String apiFileFolder() {
         return outputFolder + File.separator + sourceFolder + File.separator + packageName + File.separator + "Controllers";

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/aspnetcore/AspNetCoreServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/aspnetcore/AspNetCoreServerOptionsTest.java
@@ -31,6 +31,8 @@ public class AspNetCoreServerOptionsTest extends AbstractOptionsTest {
             times = 1;
             serverCodegen.setSourceFolder(AspNetCoreServerOptionsProvider.SOURCE_FOLDER_VALUE);
             times = 1;
+            serverCodegen.setPackageGuid(AspNetCoreServerOptionsProvider.PROJECT_GUID_VALUE);
+            times = 1;
             serverCodegen.useDateTimeOffset(true);
             times = 1;
             serverCodegen.setUseCollection(false);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AspNetCoreServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/AspNetCoreServerOptionsProvider.java
@@ -6,6 +6,7 @@ import io.swagger.codegen.CodegenConstants;
 import java.util.Map;
 
 public class AspNetCoreServerOptionsProvider implements OptionsProvider {
+    public static final String PROJECT_GUID_VALUE = "{0FBE6C2F-40D5-4F36-85B0-365EBF0D7EE3}";
     public static final String PACKAGE_NAME_VALUE = "swagger_server_aspnetcore";
     public static final String PACKAGE_VERSION_VALUE = "1.0.0-SNAPSHOT";
     public static final String SOURCE_FOLDER_VALUE = "src_aspnetcore";
@@ -21,6 +22,7 @@ public class AspNetCoreServerOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.PACKAGE_NAME, PACKAGE_NAME_VALUE)
                 .put(CodegenConstants.PACKAGE_VERSION, PACKAGE_VERSION_VALUE)
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
+                .put(CodegenConstants.OPTIONAL_PROJECT_GUID, PROJECT_GUID_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, "true")
                 .put(CodegenConstants.USE_DATETIME_OFFSET, "true")
                 .put(CodegenConstants.USE_COLLECTION, "false")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → bin/aspnetcore-petstore-server.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

This adds a `packageGuid` parameter to the AspNetCoreServerCodegen generator, which allows passing a fixed GUID as a parameter, analogously to the argument of CSharpClientCodegen. (I actually copied some code from there.)

I also added this parameter to the sample generation script, with the value being the latest randomly generated value from master.
This way, the generated files won't randomly change with every sample-update, and actual changes are better visible. (This is a part of #5196.)

I also changed the windows .bat file, though **I'm not able to test this here.**