### PR TITLE
Update samples for JaxRS/CXF.

### DIFF
--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/PetApi.java
@@ -19,6 +19,7 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/")
 @Api(value = "/", description = "")
@@ -31,7 +32,7 @@ public interface PetApi  {
     @ApiOperation(value = "Add a new pet to the store", tags={ "pet",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 405, message = "Invalid input") })
-    public void addPet(Pet body);
+    public void addPet(@Valid Pet body);
 
     @DELETE
     @Path("/pet/{petId}")
@@ -78,7 +79,7 @@ public interface PetApi  {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
-    public void updatePet(Pet body);
+    public void updatePet(@Valid Pet body);
 
     @POST
     @Path("/pet/{petId}")

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/")
 @Api(value = "/", description = "")
@@ -57,6 +58,6 @@ public interface StoreApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
         @ApiResponse(code = 400, message = "Invalid Order") })
-    public Order placeOrder(Order body);
+    public Order placeOrder(@Valid Order body);
 }
 

--- a/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/jaxrs-cxf-client/src/gen/java/io/swagger/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/")
 @Api(value = "/", description = "")
@@ -29,7 +30,7 @@ public interface UserApi  {
     @ApiOperation(value = "Create user", tags={ "user",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUser(User body);
+    public void createUser(@Valid User body);
 
     @POST
     @Path("/user/createWithArray")
@@ -37,7 +38,7 @@ public interface UserApi  {
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUsersWithArrayInput(List<User> body);
+    public void createUsersWithArrayInput(@Valid List<User> body);
 
     @POST
     @Path("/user/createWithList")
@@ -45,7 +46,7 @@ public interface UserApi  {
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
-    public void createUsersWithListInput(List<User> body);
+    public void createUsersWithListInput(@Valid List<User> body);
 
     @DELETE
     @Path("/user/{username}")
@@ -90,6 +91,6 @@ public interface UserApi  {
     @ApiResponses(value = { 
         @ApiResponse(code = 400, message = "Invalid user supplied"),
         @ApiResponse(code = 404, message = "User not found") })
-    public void updateUser(@PathParam("username") String username, User body);
+    public void updateUser(@PathParam("username") String username, @Valid User body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/PetApi.java
@@ -15,8 +15,11 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/v2")
 @Api(value = "/", description = "")
@@ -27,30 +30,44 @@ public interface PetApi  {
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Add a new pet to the store", tags={ "pet",  })
-    public void addPet(Pet body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 405, message = "Invalid input") })
+    public void addPet(@Valid Pet body);
 
     @DELETE
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Deletes a pet", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid pet value") })
     public void deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
 
     @GET
     @Path("/pet/findByStatus")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Finds Pets by status", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value") })
     public List<Pet> findPetsByStatus(@QueryParam("status") @NotNull List<String> status);
 
     @GET
     @Path("/pet/findByTags")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Finds Pets by tags", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value") })
     public List<Pet> findPetsByTags(@QueryParam("tags") @NotNull List<String> tags);
 
     @GET
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Find pet by ID", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
+        @ApiResponse(code = 400, message = "Invalid ID supplied"),
+        @ApiResponse(code = 404, message = "Pet not found") })
     public Pet getPetById(@PathParam("petId") Long petId);
 
     @PUT
@@ -58,13 +75,19 @@ public interface PetApi  {
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Update an existing pet", tags={ "pet",  })
-    public void updatePet(Pet body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid ID supplied"),
+        @ApiResponse(code = 404, message = "Pet not found"),
+        @ApiResponse(code = 405, message = "Validation exception") })
+    public void updatePet(@Valid Pet body);
 
     @POST
     @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Updates a pet in the store with form data", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 405, message = "Invalid input") })
     public void updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
 
     @POST
@@ -72,6 +95,8 @@ public interface PetApi  {
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
     @ApiOperation(value = "uploads an image", tags={ "pet" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public ModelApiResponse uploadFile(@PathParam("petId") Long petId, @Multipart(value = "additionalMetadata", required = false)  String additionalMetadata,  @Multipart(value = "file" , required = false) Attachment fileDetail);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/StoreApi.java
@@ -14,8 +14,11 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/v2")
 @Api(value = "/", description = "")
@@ -25,24 +28,36 @@ public interface StoreApi  {
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Delete purchase order by ID", tags={ "store",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid ID supplied"),
+        @ApiResponse(code = 404, message = "Order not found") })
     public void deleteOrder(@PathParam("orderId") String orderId);
 
     @GET
     @Path("/store/inventory")
     @Produces({ "application/json" })
     @ApiOperation(value = "Returns pet inventories by status", tags={ "store",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Map.class, responseContainer = "Map") })
     public Map<String, Integer> getInventory();
 
     @GET
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Find purchase order by ID", tags={ "store",  })
-    public Order getOrderById(@PathParam("orderId") Long orderId);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        @ApiResponse(code = 400, message = "Invalid ID supplied"),
+        @ApiResponse(code = 404, message = "Order not found") })
+    public Order getOrderById(@PathParam("orderId") @Min(1) @Max(5) Long orderId);
 
     @POST
     @Path("/store/order")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Place an order for a pet", tags={ "store" })
-    public Order placeOrder(Order body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        @ApiResponse(code = 400, message = "Invalid Order") })
+    public Order placeOrder(@Valid Order body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/api/UserApi.java
@@ -14,8 +14,11 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/v2")
 @Api(value = "/", description = "")
@@ -25,48 +28,69 @@ public interface UserApi  {
     @Path("/user")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Create user", tags={ "user",  })
-    public void createUser(User body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation") })
+    public void createUser(@Valid User body);
 
     @POST
     @Path("/user/createWithArray")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user",  })
-    public void createUsersWithArrayInput(List<User> body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation") })
+    public void createUsersWithArrayInput(@Valid List<User> body);
 
     @POST
     @Path("/user/createWithList")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user",  })
-    public void createUsersWithListInput(List<User> body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation") })
+    public void createUsersWithListInput(@Valid List<User> body);
 
     @DELETE
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Delete user", tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid username supplied"),
+        @ApiResponse(code = 404, message = "User not found") })
     public void deleteUser(@PathParam("username") String username);
 
     @GET
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Get user by user name", tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = User.class),
+        @ApiResponse(code = 400, message = "Invalid username supplied"),
+        @ApiResponse(code = 404, message = "User not found") })
     public User getUserByName(@PathParam("username") String username);
 
     @GET
     @Path("/user/login")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Logs user into the system", tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = String.class),
+        @ApiResponse(code = 400, message = "Invalid username/password supplied") })
     public String loginUser(@QueryParam("username") @NotNull String username, @QueryParam("password") @NotNull String password);
 
     @GET
     @Path("/user/logout")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Logs out current logged in user session", tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation") })
     public void logoutUser();
 
     @PUT
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Updated user", tags={ "user" })
-    public void updateUser(@PathParam("username") String username, User body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid user supplied"),
+        @ApiResponse(code = 404, message = "User not found") })
+    public void updateUser(@PathParam("username") String username, @Valid User body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Category.java
@@ -15,9 +15,9 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="A category for a pet")
 public class Category  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String name = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -15,11 +15,11 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="Describes the result of uploading an image resource")
 public class ModelApiResponse  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Integer code = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String type = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String message = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Order.java
@@ -1,6 +1,7 @@
 package io.swagger.model;
 
 import io.swagger.annotations.ApiModel;
+import java.util.Date;
 import javax.validation.constraints.*;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -15,14 +16,14 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="An order for a pets from the pet store")
 public class Order  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long petId = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Integer quantity = null;
-  @ApiModelProperty(example = "null", value = "")
-  private javax.xml.datatype.XMLGregorianCalendar shipDate = null;
+  @ApiModelProperty(value = "")
+  private Date shipDate = null;
 
 @XmlType(name="StatusEnum")
 @XmlEnum(String.class)
@@ -56,9 +57,9 @@ public enum StatusEnum {
     }
 }
 
-  @ApiModelProperty(example = "null", value = "Order Status")
+  @ApiModelProperty(value = "Order Status")
   private StatusEnum status = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Boolean complete = false;
 
  /**
@@ -116,15 +117,15 @@ public enum StatusEnum {
    * Get shipDate
    * @return shipDate
   **/
-  public javax.xml.datatype.XMLGregorianCalendar getShipDate() {
+  public Date getShipDate() {
     return shipDate;
   }
 
-  public void setShipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public void setShipDate(Date shipDate) {
     this.shipDate = shipDate;
   }
 
-  public Order shipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public Order shipDate(Date shipDate) {
     this.shipDate = shipDate;
     return this;
   }

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Pet.java
@@ -19,15 +19,15 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="A pet for sale in the pet store")
 public class Pet  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Category category = null;
   @ApiModelProperty(example = "doggie", required = true, value = "")
   private String name = null;
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   private List<String> photoUrls = new ArrayList<String>();
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private List<Tag> tags = new ArrayList<Tag>();
 
 @XmlType(name="StatusEnum")
@@ -62,7 +62,7 @@ public enum StatusEnum {
     }
 }
 
-  @ApiModelProperty(example = "null", value = "pet status in the store")
+  @ApiModelProperty(value = "pet status in the store")
   private StatusEnum status = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/Tag.java
@@ -15,9 +15,9 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="A tag for a pet")
 public class Tag  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String name = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/io/swagger/model/User.java
@@ -15,21 +15,21 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="A User who is purchasing from the pet store")
 public class User  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String username = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String firstName = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String lastName = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String email = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String password = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String phone = null;
-  @ApiModelProperty(example = "null", value = "User Status")
+  @ApiModelProperty(value = "User Status")
   private Integer userStatus = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/PetApi.java
@@ -15,8 +15,11 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/")
 @Api(value = "/", description = "")
@@ -27,30 +30,44 @@ public interface PetApi  {
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Add a new pet to the store", tags={ "pet",  })
-    public void addPet(Pet body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 405, message = "Invalid input") })
+    public void addPet(@Valid Pet body);
 
     @DELETE
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Deletes a pet", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid pet value") })
     public void deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
 
     @GET
     @Path("/pet/findByStatus")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Finds Pets by status", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value") })
     public List<Pet> findPetsByStatus(@QueryParam("status") @NotNull List<String> status);
 
     @GET
     @Path("/pet/findByTags")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Finds Pets by tags", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value") })
     public List<Pet> findPetsByTags(@QueryParam("tags") @NotNull List<String> tags);
 
     @GET
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Find pet by ID", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
+        @ApiResponse(code = 400, message = "Invalid ID supplied"),
+        @ApiResponse(code = 404, message = "Pet not found") })
     public Pet getPetById(@PathParam("petId") Long petId);
 
     @PUT
@@ -58,13 +75,19 @@ public interface PetApi  {
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Update an existing pet", tags={ "pet",  })
-    public void updatePet(Pet body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid ID supplied"),
+        @ApiResponse(code = 404, message = "Pet not found"),
+        @ApiResponse(code = 405, message = "Validation exception") })
+    public void updatePet(@Valid Pet body);
 
     @POST
     @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Updates a pet in the store with form data", tags={ "pet",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 405, message = "Invalid input") })
     public void updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
 
     @POST
@@ -72,6 +95,8 @@ public interface PetApi  {
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
     @ApiOperation(value = "uploads an image", tags={ "pet" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public ModelApiResponse uploadFile(@PathParam("petId") Long petId, @Multipart(value = "additionalMetadata", required = false)  String additionalMetadata,  @Multipart(value = "file" , required = false) Attachment fileDetail);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/StoreApi.java
@@ -14,8 +14,11 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/")
 @Api(value = "/", description = "")
@@ -25,24 +28,36 @@ public interface StoreApi  {
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Delete purchase order by ID", tags={ "store",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid ID supplied"),
+        @ApiResponse(code = 404, message = "Order not found") })
     public void deleteOrder(@PathParam("orderId") String orderId);
 
     @GET
     @Path("/store/inventory")
     @Produces({ "application/json" })
     @ApiOperation(value = "Returns pet inventories by status", tags={ "store",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Map.class, responseContainer = "Map") })
     public Map<String, Integer> getInventory();
 
     @GET
     @Path("/store/order/{orderId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Find purchase order by ID", tags={ "store",  })
-    public Order getOrderById(@PathParam("orderId") Long orderId);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        @ApiResponse(code = 400, message = "Invalid ID supplied"),
+        @ApiResponse(code = 404, message = "Order not found") })
+    public Order getOrderById(@PathParam("orderId") @Min(1) @Max(5) Long orderId);
 
     @POST
     @Path("/store/order")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Place an order for a pet", tags={ "store" })
-    public Order placeOrder(Order body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = Order.class),
+        @ApiResponse(code = 400, message = "Invalid Order") })
+    public Order placeOrder(@Valid Order body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/api/UserApi.java
@@ -14,8 +14,11 @@ import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ApiResponse;
 import io.swagger.jaxrs.PATCH;
 import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 @Path("/")
 @Api(value = "/", description = "")
@@ -25,48 +28,69 @@ public interface UserApi  {
     @Path("/user")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Create user", tags={ "user",  })
-    public void createUser(User body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation") })
+    public void createUser(@Valid User body);
 
     @POST
     @Path("/user/createWithArray")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user",  })
-    public void createUsersWithArrayInput(List<User> body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation") })
+    public void createUsersWithArrayInput(@Valid List<User> body);
 
     @POST
     @Path("/user/createWithList")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Creates list of users with given input array", tags={ "user",  })
-    public void createUsersWithListInput(List<User> body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation") })
+    public void createUsersWithListInput(@Valid List<User> body);
 
     @DELETE
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Delete user", tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid username supplied"),
+        @ApiResponse(code = 404, message = "User not found") })
     public void deleteUser(@PathParam("username") String username);
 
     @GET
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Get user by user name", tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = User.class),
+        @ApiResponse(code = 400, message = "Invalid username supplied"),
+        @ApiResponse(code = 404, message = "User not found") })
     public User getUserByName(@PathParam("username") String username);
 
     @GET
     @Path("/user/login")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Logs user into the system", tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation", response = String.class),
+        @ApiResponse(code = 400, message = "Invalid username/password supplied") })
     public String loginUser(@QueryParam("username") @NotNull String username, @QueryParam("password") @NotNull String password);
 
     @GET
     @Path("/user/logout")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Logs out current logged in user session", tags={ "user",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "successful operation") })
     public void logoutUser();
 
     @PUT
     @Path("/user/{username}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Updated user", tags={ "user" })
-    public void updateUser(@PathParam("username") String username, User body);
+    @ApiResponses(value = { 
+        @ApiResponse(code = 400, message = "Invalid user supplied"),
+        @ApiResponse(code = 404, message = "User not found") })
+    public void updateUser(@PathParam("username") String username, @Valid User body);
 }
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Category.java
@@ -15,9 +15,9 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="A category for a pet")
 public class Category  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String name = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -15,11 +15,11 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="Describes the result of uploading an image resource")
 public class ModelApiResponse  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Integer code = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String type = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String message = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Order.java
@@ -1,6 +1,7 @@
 package io.swagger.model;
 
 import io.swagger.annotations.ApiModel;
+import java.util.Date;
 import javax.validation.constraints.*;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -15,14 +16,14 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="An order for a pets from the pet store")
 public class Order  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long petId = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Integer quantity = null;
-  @ApiModelProperty(example = "null", value = "")
-  private javax.xml.datatype.XMLGregorianCalendar shipDate = null;
+  @ApiModelProperty(value = "")
+  private Date shipDate = null;
 
 @XmlType(name="StatusEnum")
 @XmlEnum(String.class)
@@ -56,9 +57,9 @@ public enum StatusEnum {
     }
 }
 
-  @ApiModelProperty(example = "null", value = "Order Status")
+  @ApiModelProperty(value = "Order Status")
   private StatusEnum status = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Boolean complete = false;
 
  /**
@@ -116,15 +117,15 @@ public enum StatusEnum {
    * Get shipDate
    * @return shipDate
   **/
-  public javax.xml.datatype.XMLGregorianCalendar getShipDate() {
+  public Date getShipDate() {
     return shipDate;
   }
 
-  public void setShipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public void setShipDate(Date shipDate) {
     this.shipDate = shipDate;
   }
 
-  public Order shipDate(javax.xml.datatype.XMLGregorianCalendar shipDate) {
+  public Order shipDate(Date shipDate) {
     this.shipDate = shipDate;
     return this;
   }

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Pet.java
@@ -19,15 +19,15 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="A pet for sale in the pet store")
 public class Pet  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Category category = null;
   @ApiModelProperty(example = "doggie", required = true, value = "")
   private String name = null;
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   private List<String> photoUrls = new ArrayList<String>();
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private List<Tag> tags = new ArrayList<Tag>();
 
 @XmlType(name="StatusEnum")
@@ -62,7 +62,7 @@ public enum StatusEnum {
     }
 }
 
-  @ApiModelProperty(example = "null", value = "pet status in the store")
+  @ApiModelProperty(value = "pet status in the store")
   private StatusEnum status = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/Tag.java
@@ -15,9 +15,9 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="A tag for a pet")
 public class Tag  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String name = null;
 
  /**

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/io/swagger/model/User.java
@@ -15,21 +15,21 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @ApiModel(description="A User who is purchasing from the pet store")
 public class User  {
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private Long id = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String username = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String firstName = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String lastName = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String email = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String password = null;
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   private String phone = null;
-  @ApiModelProperty(example = "null", value = "User Status")
+  @ApiModelProperty(value = "User Status")
   private Integer userStatus = null;
 
  /**


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → bin/jaxrs-cxf-petstore-server-non-spring-application.sh, bin/jaxrs-cxf-petstore-server-annotated-base-path.sh, bin/jaxrs-cxf-petstore-server.sh, bin/jaxrs-cxf-client-petstore.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

No code changes, just updating the samples so later updates can easier say what changed.

The `@Valid` was likely added by #4921. #4920 added some `@ApiResponse`. The `@ApiModelProperty` changes came from #5017. Some XmlGregorianCalendar → Date changes came likely from #4724.
