### PR TITLE
Update samples for ObjC/core-data.

### DIFF
--- a/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGPetApi.m
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGPetApi.m
@@ -60,9 +60,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -132,9 +129,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/{petId}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (petId != nil) {
         pathParams[@"petId"] = petId;
@@ -195,9 +189,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/findByStatus"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -255,9 +246,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) findPetsByTagsWithTags: (NSArray<NSString*>*) tags
     completionHandler: (void (^)(NSArray<SWGPet>* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/findByTags"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -328,9 +316,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/{petId}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (petId != nil) {
         pathParams[@"petId"] = petId;
@@ -387,9 +372,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) updatePetWithBody: (SWGPet*) body
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -462,9 +444,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
     }
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/{petId}"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (petId != nil) {
@@ -545,9 +524,6 @@ NSInteger kSWGPetApiMissingParamErrorCode = 234513;
     }
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/pet/{petId}/uploadImage"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (petId != nil) {

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGStoreApi.m
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGStoreApi.m
@@ -71,9 +71,6 @@ NSInteger kSWGStoreApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/store/order/{orderId}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (orderId != nil) {
         pathParams[@"orderId"] = orderId;
@@ -128,9 +125,6 @@ NSInteger kSWGStoreApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) getInventoryWithCompletionHandler: 
     (void (^)(NSDictionary<NSString*, NSNumber*>* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/store/inventory"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -197,9 +191,6 @@ NSInteger kSWGStoreApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/store/order/{orderId}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (orderId != nil) {
         pathParams[@"orderId"] = orderId;
@@ -256,9 +247,6 @@ NSInteger kSWGStoreApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) placeOrderWithBody: (SWGOrder*) body
     completionHandler: (void (^)(SWGOrder* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/store/order"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGUserApi.m
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGUserApi.m
@@ -60,9 +60,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -118,9 +115,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/createWithArray"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -175,9 +169,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) createUsersWithListInputWithBody: (NSArray<SWGUser>*) body
     completionHandler: (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/createWithList"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -244,9 +235,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     }
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/{username}"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (username != nil) {
@@ -316,9 +304,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/{username}"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (username != nil) {
         pathParams[@"username"] = username;
@@ -379,9 +364,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     completionHandler: (void (^)(NSString* output, NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/login"];
 
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
-
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
     NSMutableDictionary* queryParams = [[NSMutableDictionary alloc] init];
@@ -439,9 +421,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
 -(NSURLSessionTask*) logoutUserWithCompletionHandler: 
     (void (^)(NSError* error)) handler {
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/logout"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
 
@@ -510,9 +489,6 @@ NSInteger kSWGUserApiMissingParamErrorCode = 234513;
     }
 
     NSMutableString* resourcePath = [NSMutableString stringWithFormat:@"/user/{username}"];
-
-    // remove format in URL if needed
-    [resourcePath replaceOccurrencesOfString:@".{format}" withString:@".json" options:0 range:NSMakeRange(0,resourcePath.length)];
 
     NSMutableDictionary *pathParams = [[NSMutableDictionary alloc] init];
     if (username != nil) {

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Core/SWGApiClient.m
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Core/SWGApiClient.m
@@ -89,7 +89,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 #pragma mark - Task Methods
 
 - (NSURLSessionDataTask*) taskWithCompletionBlock: (NSURLRequest *)request completionBlock: (void (^)(id, NSError *))completionBlock {
-    
+
     NSURLSessionDataTask *task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse * _Nonnull response, id  _Nullable responseObject, NSError * _Nullable error) {
         SWGDebugLogResponse(response, responseObject,request,error);
         if(!error) {
@@ -104,7 +104,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
         NSError *augmentedError = [error initWithDomain:error.domain code:error.code userInfo:userInfo];
         completionBlock(nil, augmentedError);
     }];
-    
+
     return task;
 }
 
@@ -135,7 +135,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
         completionBlock(file, nil);
     }];
-    
+
     return task;
 }
 
@@ -222,7 +222,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
     [self postProcessRequest:request];
 
-    
+
     NSURLSessionTask *task = nil;
 
     if ([self.downloadTaskResponseTypes containsObject:responseType]) {
@@ -241,9 +241,9 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
             completionBlock(response, error);
         }];
     }
-    
+
     [task resume];
-    
+
     return task;
 }
 
@@ -330,7 +330,7 @@ static NSString * SWG__fileNameForResponse(NSURLResponse *response) {
 
     NSMutableDictionary *headersWithAuth = [NSMutableDictionary dictionaryWithDictionary:*headers];
     NSMutableDictionary *querysWithAuth = [NSMutableDictionary dictionaryWithDictionary:*querys];
-    
+
     id<SWGConfiguration> config = self.configuration;
     for (NSString *auth in authSettings) {
         NSDictionary *authSetting = config.authSettings[auth];


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
  → bin/objc-petstore-all.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

No code-changes, just updating the samples so later updates can see what actually changed.

The changes likely come from #4987 (which updated just objc/default, not objc/core-data).