### PR TITLE
[nancyfx] Issue #5196: make package GUID nonrandom for nancyfx samples

### DIFF
--- a/bin/nancyfx-petstore-server.sh
+++ b/bin/nancyfx-petstore-server.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -t modules/swagger-codegen/src/main/resources/nancyfx -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l nancyfx -o samples/server/petstore/nancyfx"
+ags="generate $@ -t modules/swagger-codegen/src/main/resources/nancyfx -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l nancyfx -o samples/server/petstore/nancyfx --additional-properties packageGuid={768B8DC6-54EE-4D40-9B20-7857E1D742A4}"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NancyFXServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/NancyFXServerCodegen.java
@@ -6,6 +6,7 @@ import static io.swagger.codegen.CodegenType.SERVER;
 import static java.util.Arrays.asList;
 import static java.util.UUID.randomUUID;
 import static org.apache.commons.lang3.StringUtils.capitalize;
+
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.CodegenProperty;
@@ -47,7 +48,7 @@ public class NancyFXServerCodegen extends AbstractCSharpCodegen {
     private static final Map<String, Predicate<Property>> propertyToSwaggerTypeMapping =
             createPropertyToSwaggerTypeMapping();
 
-    private final String packageGuid = "{" + randomUUID().toString().toUpperCase() + "}";
+    private String packageGuid = "{" + randomUUID().toString().toUpperCase() + "}";
 
     private final Map<String, DependencyInfo> dependencies = new HashMap<>();
     private final Set<String> parentModels = new HashSet<>();
@@ -73,6 +74,7 @@ public class NancyFXServerCodegen extends AbstractCSharpCodegen {
         addOption(PACKAGE_VERSION, "C# package version.", packageVersion);
         addOption(SOURCE_FOLDER, SOURCE_FOLDER_DESC, sourceFolder);
         addOption(INTERFACE_PREFIX, INTERFACE_PREFIX_DESC, interfacePrefix);
+        addOption(OPTIONAL_PROJECT_GUID,OPTIONAL_PROJECT_GUID_DESC, null);
 
         // CLI Switches
         addSwitch(SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_BY_REQUIRED_FLAG_DESC, sortParamsByRequiredFlag);
@@ -118,6 +120,11 @@ public class NancyFXServerCodegen extends AbstractCSharpCodegen {
             supportingFiles.add(new SupportingFile("Solution.mustache", "", packageName + ".sln"));
             supportingFiles.add(new SupportingFile("Project.mustache", sourceFolder(), packageName + ".csproj"));
         }
+        
+        if (additionalProperties.containsKey(OPTIONAL_PROJECT_GUID)) {
+            setPackageGuid((String) additionalProperties.get(OPTIONAL_PROJECT_GUID));
+        }
+
         additionalProperties.put("packageGuid", packageGuid);
 
         setupModelTemplate();
@@ -186,6 +193,10 @@ public class NancyFXServerCodegen extends AbstractCSharpCodegen {
         return sourceFolder() + File.separator + fileName;
     }
 
+    public void setPackageGuid(String packageGuid) {
+        this.packageGuid = packageGuid;
+    }
+    
     @Override
     public String apiFileFolder() {
         return outputFolder + File.separator + sourceFolder() + File.separator + API_NAMESPACE;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/NancyFXServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/NancyFXServerOptionsProvider.java
@@ -11,6 +11,7 @@ public class NancyFXServerOptionsProvider implements OptionsProvider {
     public static final String PACKAGE_VERSION_VALUE = "1.0.0-SNAPSHOT";
     public static final String SOURCE_FOLDER_VALUE = "src_nancyfx";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
+    public static final String PROJECT_GUID_VALUE = "{6885796E-A4C1-48EA-9766-CCD1563C90DF}";
 
 
     @Override
@@ -25,6 +26,7 @@ public class NancyFXServerOptionsProvider implements OptionsProvider {
                 .put(PACKAGE_VERSION, PACKAGE_VERSION_VALUE)
                 .put(SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
                 .put(SORT_PARAMS_BY_REQUIRED_FLAG, "true")
+                .put(OPTIONAL_PROJECT_GUID, PROJECT_GUID_VALUE)
                 .put(USE_DATETIME_OFFSET, "true")
                 .put(USE_COLLECTION, "false")
                 .put(RETURN_ICOLLECTION, "false")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
  → bin/nancyfx-petstore-server.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

This adds a `packageGuid` parameter to NancyFXServerCodegen, which allows to pass a fixed GUID, instead of a randomly generated one.

The petstore sample generation script then uses this option (with the last random value from master) to generate the samples. This way there are no random changes between sample updates which obscured the real changes.  (This is a part of #5196.)