### PR TITLE
[C#] fix typo in c# docstring

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
@@ -199,7 +199,7 @@ this.{{name}} = {{name}};
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { {{#vars}}{{#hasValidation}}{{#maxLength}}

--- a/samples/client/petstore/csharp/SwaggerClient/IO.Swagger.sln
+++ b/samples/client/petstore/csharp/SwaggerClient/IO.Swagger.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{D23EBB29-C5C8-4000-BF1B-B91E26DD19DB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{B4460E5B-0F76-4FD0-A23A-50FAEE57DFE8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger.Test", "src\IO.Swagger.Test\IO.Swagger.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Debug|Any CPU = Debug|Any CPU
 Release|Any CPU = Release|Any CPU
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
-{D23EBB29-C5C8-4000-BF1B-B91E26DD19DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{D23EBB29-C5C8-4000-BF1B-B91E26DD19DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{D23EBB29-C5C8-4000-BF1B-B91E26DD19DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{D23EBB29-C5C8-4000-BF1B-B91E26DD19DB}.Release|Any CPU.Build.0 = Release|Any CPU
+{B4460E5B-0F76-4FD0-A23A-50FAEE57DFE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{B4460E5B-0F76-4FD0-A23A-50FAEE57DFE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{B4460E5B-0F76-4FD0-A23A-50FAEE57DFE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{B4460E5B-0F76-4FD0-A23A-50FAEE57DFE8}.Release|Any CPU.Build.0 = Release|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
@@ -12,7 +12,7 @@ Contact: apiteam@swagger.io
     
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D23EBB29-C5C8-4000-BF1B-B91E26DD19DB}</ProjectGuid>
+    <ProjectGuid>{B4460E5B-0F76-4FD0-A23A-50FAEE57DFE8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IO.Swagger</RootNamespace>

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/AdditionalPropertiesClass.cs
@@ -130,7 +130,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Animal.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Animal.cs
@@ -151,7 +151,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/AnimalFarm.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/AnimalFarm.cs
@@ -101,7 +101,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ApiResponse.cs
@@ -145,7 +145,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ArrayOfArrayOfNumberOnly.cs
@@ -115,7 +115,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ArrayOfNumberOnly.cs
@@ -115,7 +115,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ArrayTest.cs
@@ -145,7 +145,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Capitalization.cs
@@ -191,7 +191,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Cat.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Cat.cs
@@ -166,7 +166,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Category.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Category.cs
@@ -130,7 +130,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ClassModel.cs
@@ -115,7 +115,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Dog.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Dog.cs
@@ -166,7 +166,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/EnumArrays.cs
@@ -171,7 +171,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/EnumTest.cs
@@ -226,7 +226,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/FormatTest.cs
@@ -332,7 +332,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/HasOnlyReadOnly.cs
@@ -127,7 +127,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/List.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/List.cs
@@ -115,7 +115,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/MapTest.cs
@@ -151,7 +151,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -145,7 +145,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Model200Response.cs
@@ -130,7 +130,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ModelClient.cs
@@ -115,7 +115,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ModelReturn.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ModelReturn.cs
@@ -115,7 +115,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Name.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Name.cs
@@ -169,7 +169,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/NumberOnly.cs
@@ -115,7 +115,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Order.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Order.cs
@@ -226,7 +226,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Pet.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Pet.cs
@@ -239,7 +239,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/ReadOnlyFirst.cs
@@ -128,7 +128,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/SpecialModelName.cs
@@ -115,7 +115,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Tag.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/Tag.cs
@@ -130,7 +130,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/User.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/User.cs
@@ -221,7 +221,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/IO.Swagger.sln
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/IO.Swagger.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{05E9062F-6473-433C-92E3-F7EF63B6A0CB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger", "src\IO.Swagger\IO.Swagger.csproj", "{6C01F92F-3611-4F84-AC86-927E3625E0A8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IO.Swagger.Test", "src\IO.Swagger.Test\IO.Swagger.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Debug|Any CPU = Debug|Any CPU
 Release|Any CPU = Release|Any CPU
 EndGlobalSection
 GlobalSection(ProjectConfigurationPlatforms) = postSolution
-{05E9062F-6473-433C-92E3-F7EF63B6A0CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{05E9062F-6473-433C-92E3-F7EF63B6A0CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{05E9062F-6473-433C-92E3-F7EF63B6A0CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{05E9062F-6473-433C-92E3-F7EF63B6A0CB}.Release|Any CPU.Build.0 = Release|Any CPU
+{6C01F92F-3611-4F84-AC86-927E3625E0A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6C01F92F-3611-4F84-AC86-927E3625E0A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6C01F92F-3611-4F84-AC86-927E3625E0A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6C01F92F-3611-4F84-AC86-927E3625E0A8}.Release|Any CPU.Build.0 = Release|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger.Test/IO.Swagger.Test.csproj
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger.Test/IO.Swagger.Test.csproj
@@ -74,7 +74,7 @@ Contact: apiteam@swagger.io
   <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
       <ProjectReference Include="..\IO.Swagger\IO.Swagger.csproj">
-          <Project>{05E9062F-6473-433C-92E3-F7EF63B6A0CB}</Project>
+          <Project>{6C01F92F-3611-4F84-AC86-927E3625E0A8}</Project>
           <Name>IO.Swagger</Name>
       </ProjectReference>
   </ItemGroup>

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/IO.Swagger.csproj
@@ -12,7 +12,7 @@ Contact: apiteam@swagger.io
     
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{05E9062F-6473-433C-92E3-F7EF63B6A0CB}</ProjectGuid>
+    <ProjectGuid>{6C01F92F-3611-4F84-AC86-927E3625E0A8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IO.Swagger</RootNamespace>

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/AdditionalPropertiesClass.cs
@@ -153,7 +153,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Animal.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Animal.cs
@@ -174,7 +174,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/AnimalFarm.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/AnimalFarm.cs
@@ -124,7 +124,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ApiResponse.cs
@@ -168,7 +168,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ArrayOfArrayOfNumberOnly.cs
@@ -138,7 +138,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ArrayOfNumberOnly.cs
@@ -138,7 +138,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ArrayTest.cs
@@ -168,7 +168,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Capitalization.cs
@@ -214,7 +214,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Cat.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Cat.cs
@@ -189,7 +189,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Category.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Category.cs
@@ -153,7 +153,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ClassModel.cs
@@ -138,7 +138,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Dog.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Dog.cs
@@ -189,7 +189,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/EnumArrays.cs
@@ -194,7 +194,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/EnumTest.cs
@@ -249,7 +249,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/FormatTest.cs
@@ -355,7 +355,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/HasOnlyReadOnly.cs
@@ -150,7 +150,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/List.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/List.cs
@@ -138,7 +138,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/MapTest.cs
@@ -174,7 +174,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -168,7 +168,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Model200Response.cs
@@ -153,7 +153,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ModelClient.cs
@@ -138,7 +138,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ModelReturn.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ModelReturn.cs
@@ -138,7 +138,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Name.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Name.cs
@@ -192,7 +192,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/NumberOnly.cs
@@ -138,7 +138,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Order.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Order.cs
@@ -249,7 +249,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Pet.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Pet.cs
@@ -262,7 +262,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/ReadOnlyFirst.cs
@@ -151,7 +151,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/SpecialModelName.cs
@@ -138,7 +138,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Tag.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/Tag.cs
@@ -153,7 +153,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/User.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/User.cs
@@ -244,7 +244,7 @@ namespace IO.Swagger.Model
         /// <summary>
         /// To validate all properties of the instance
         /// </summary>
-        /// <param name="validationContex">Validation context</param>
+        /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         { 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- fix typo
- update Petstore samples
