### PR TITLE
[swift] Open buildHeaders() and requestBuilderFactory property to allow extension. Even though AlamofireRequestBuilderFactory looks like is designed for extension, it is not because property has private access.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
@@ -10,7 +10,7 @@ open class {{projectName}}API {
     open static var basePath = "{{{basePath}}}"
     open static var credential: URLCredential?
     open static var customHeaders: [String:String] = [:]
-    static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
+    open static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()
 }
 
 open class APIBase {

--- a/modules/swagger-codegen/src/main/resources/swift3/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/AlamofireImplementations.mustache
@@ -212,7 +212,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         }
     }
 
-    private func buildHeaders() -> [String: String] {
+    open func buildHeaders() -> [String: String] {
         var httpHeaders = SessionManager.defaultHTTPHeaders
         for (key, value) in self.headers {
             httpHeaders[key] = value


### PR DESCRIPTION
This change is to make possible to override AlamofireRequestBuilderFactory in order to perform
custom initialization of URLSession, for example to enable SSL pinning.