### PR TITLE
[all] Map additionalParameters.$ref into a RefModel

### DIFF
--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpRegressionTests.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpRegressionTests.java
@@ -55,6 +55,6 @@ public class CSharpRegressionTests {
         assertTrue(cp.isBodyParam, "Failed to expose isBodyParam");
         assertEquals(cp.paramName, "resourceParameters");
         assertNotEquals(cp.dataType, "Object", "Regression of issue 5132 found, see https://github.com/swagger-api/swagger-codegen/issues/5132.");
-        assertEquals(cp.dataType, "ResourceParameters", "Possible regression of issue 5132 found, see https://github.com/swagger-api/swagger-codegen/issues/5132."););
+        assertEquals(cp.dataType, "ResourceParameters", "Possible regression of issue 5132 found, see https://github.com/swagger-api/swagger-codegen/issues/5132.");
     }
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpRegressionTests.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/csharp/CSharpRegressionTests.java
@@ -1,0 +1,60 @@
+package io.swagger.codegen.csharp;
+
+import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.CodegenParameter;
+import io.swagger.codegen.CodegenResponse;
+import io.swagger.codegen.DefaultCodegen;
+import io.swagger.codegen.languages.CSharpClientCodegen;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.parser.SwaggerParser;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class CSharpRegressionTests {
+
+    @Test(description = "convert parameters from additionalProperties mapped $ref")
+    public void issue5132() {
+
+        final Swagger swagger = new SwaggerParser().read("src/test/resources/2_0/5132.json");
+        final DefaultCodegen codegen = new CSharpClientCodegen();
+        final Operation operation = swagger.getPath("/Resources").getGet();
+
+        // First we verify the parser is exposing ResourceParameters in the expected way
+        final BodyParameter parameter = (BodyParameter) operation.getParameters().get(0);
+        assertEquals(parameter.getIn(), "body");
+        assertEquals(parameter.getDescription(), "ResourceParameters object that needs to be added");
+        assertEquals(parameter.getRequired(), true);
+
+        final ModelImpl modelImpl = (ModelImpl)parameter.getSchema();
+        assertEquals(modelImpl.getType(), "object");
+
+        final RefProperty refProperty = (RefProperty)modelImpl.getAdditionalProperties();
+        assertEquals(refProperty.getSimpleRef(), "ResourceParameters");
+
+        final CodegenOperation co = codegen.fromOperation(
+                "/Resources",
+                "GET",
+                operation,
+                swagger.getDefinitions(),
+                swagger
+        );
+
+        final CodegenResponse response = co.responses.get(0);
+        assertTrue(response.isMapContainer);
+
+        // Then we verify CodeGen is exposing the parameter as expected.
+        // Here we expect a body parameter of type ResourceParameters { firstName, lastName, skip, top }
+        assertTrue(co.getHasBodyParam(), "Expected body param");
+        final CodegenParameter cp = co.bodyParam;
+
+        assertTrue(cp.isBodyParam, "Failed to expose isBodyParam");
+        assertEquals(cp.paramName, "resourceParameters");
+        assertNotEquals(cp.dataType, "Object", "Regression of issue 5132 found, see https://github.com/swagger-api/swagger-codegen/issues/5132.");
+        assertEquals(cp.dataType, "ResourceParameters", "Possible regression of issue 5132 found, see https://github.com/swagger-api/swagger-codegen/issues/5132."););
+    }
+}

--- a/modules/swagger-codegen/src/test/resources/2_0/5132.json
+++ b/modules/swagger-codegen/src/test/resources/2_0/5132.json
@@ -1,0 +1,130 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "sample",
+    "version": "1.0.0",
+    "title": "Swagger sample",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "test@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "test.swagger.io",
+  "basePath": "/v2",
+  "tags": [
+    {
+      "name": "Resource",
+      "description": "Everything about resource"
+    }
+  ],
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/Resources": {
+      "get": {
+        "tags": [
+          "Resource"
+        ],
+        "summary": "Find Resource",
+        "description": "",
+        "operationId": "getResource",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ResourceParameters",
+            "in": "body",
+            "description": "ResourceParameters object that needs to be added",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/ResourceParameters"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Resource"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "username": {
+          "type": "string"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "User Status"
+        }
+      }
+    },
+    "ResourceParameters": {
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "description": "firstName"
+        },
+        "lastName": {
+          "type": "string",
+          "description": "lastName"
+        },
+        "skip": {
+          "type": "integer",
+          "description": "skip"
+        },
+        "top": {
+          "type": "integer",
+          "description": "top"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Possible fix for #5132 in which a RefModel defined as additionalProperties on a body parameter was being ignored.

I'm not entirely sure this is an appropriate fix because this assumes additionalProperties.$ref refers to *the* model definition, rather than a mixin of properties to be applied to some dictionary of key/values.

The way `additionalProperties` is meant to work is to validate additional allowed values for a JSON structure defined outside of `patternProperties` or `properties` (although Swagger 2.0 specification doesn't mention `patternProperties`). Ideally, I'd assume this would mean all properties from both are merged into a final object model for generation. This PR *does not* do that. This PR assumes the existence of `additionalProperties.$ref` means the definition of the RefModel (as opposed to common RefModel processing). This may not be correct, but I'm opening the PR to open discussion.