### PR TITLE
Issue #3084: remove timestamps from undertow samples

### DIFF
--- a/bin/java-undertow-petstore-server.sh
+++ b/bin/java-undertow-petstore-server.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/undertow -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l undertow -o samples/server/petstore/undertow"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/undertow -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l undertow -o samples/server/petstore/undertow --additional-properties hideGenerationTimestamp=true"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/resources/undertow/generatedAnnotation.mustache
+++ b/modules/swagger-codegen/src/main/resources/undertow/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}")
+@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/samples/server/petstore/undertow/src/main/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/undertow/src/main/java/io/swagger/model/Category.java
@@ -13,7 +13,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "A category for a pet")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen", date = "2017-03-26T17:33:39.915+02:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen")
 public class Category   {
   
   private Long id = null;

--- a/samples/server/petstore/undertow/src/main/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/undertow/src/main/java/io/swagger/model/ModelApiResponse.java
@@ -13,7 +13,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "Describes the result of uploading an image resource")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen", date = "2017-03-26T17:33:39.915+02:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen")
 public class ModelApiResponse   {
   
   private Integer code = null;

--- a/samples/server/petstore/undertow/src/main/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/undertow/src/main/java/io/swagger/model/Order.java
@@ -15,7 +15,7 @@ import java.util.Date;
  **/
 
 @ApiModel(description = "An order for a pets from the pet store")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen", date = "2017-03-26T17:33:39.915+02:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen")
 public class Order   {
   
   private Long id = null;

--- a/samples/server/petstore/undertow/src/main/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/undertow/src/main/java/io/swagger/model/Pet.java
@@ -18,7 +18,7 @@ import java.util.List;
  **/
 
 @ApiModel(description = "A pet for sale in the pet store")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen", date = "2017-03-26T17:33:39.915+02:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen")
 public class Pet   {
   
   private Long id = null;

--- a/samples/server/petstore/undertow/src/main/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/undertow/src/main/java/io/swagger/model/Tag.java
@@ -13,7 +13,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "A tag for a pet")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen", date = "2017-03-26T17:33:39.915+02:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen")
 public class Tag   {
   
   private Long id = null;

--- a/samples/server/petstore/undertow/src/main/java/io/swagger/model/User.java
+++ b/samples/server/petstore/undertow/src/main/java/io/swagger/model/User.java
@@ -13,7 +13,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "A User who is purchasing from the pet store")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen", date = "2017-03-26T17:33:39.915+02:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.UndertowCodegen")
 public class User   {
   
   private Long id = null;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → bin/java-undertow-petstore-server.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

* implement the `hideGenerationTimestamp` option for the undertow generator
* use the option in the sample generation script
* update the samples