### PR TITLE
[Typescript - Angular2] Add support for multiple API Keys

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
@@ -184,14 +184,14 @@ export class {{classname}} {
         // authentication ({{name}}) required
 {{#isApiKey}}
 {{#isKeyInHeader}}
-        if (this.configuration.apiKey) {
-            headers.set('{{keyParamName}}', this.configuration.apiKey);
+        if (this.configuration.apiKeys["{{keyParamName}}"]) {
+            headers.set('{{keyParamName}}', this.configuration.apiKeys["{{keyParamName}}"]);
         }
 
 {{/isKeyInHeader}}
 {{#isKeyInQuery}}
-        if (this.configuration.apiKey) {
-            queryParameters.set('{{keyParamName}}', this.configuration.apiKey);
+        if (this.configuration.apiKeys["{{keyParamName}}"]) {
+            queryParameters.set('{{keyParamName}}', this.configuration.apiKeys["{{keyParamName}}"]);
         }
 
 {{/isKeyInQuery}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/configuration.mustache
@@ -1,5 +1,5 @@
 export interface ConfigurationParameters {
-	apiKey?: string;
+	apiKeys?: {[ key: string ]: string};
 	username?: string;
 	password?: string;
 	accessToken?: string;
@@ -7,7 +7,7 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-	apiKey: string;
+	apiKeys: {[ key: string ]: string};
 	username: string;
 	password: string;
 	accessToken: string | (() => string);
@@ -15,7 +15,7 @@ export class Configuration {
 
 
 	constructor(configurationParameters: ConfigurationParameters = {}) {
-		this.apiKey = configurationParameters.apiKey;
+		this.apiKeys = configurationParameters.apiKeys;
 		this.username = configurationParameters.username;
 		this.password = configurationParameters.password;
 		this.accessToken = configurationParameters.accessToken;

--- a/samples/client/petstore/typescript-angular2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/pet.service.ts
@@ -429,8 +429,8 @@ export class PetService {
         }
 
         // authentication (api_key) required
-        if (this.configuration.apiKey) {
-            headers.set('api_key', this.configuration.apiKey);
+        if (this.configuration.apiKeys["api_key"]) {
+            headers.set('api_key', this.configuration.apiKeys["api_key"]);
         }
 
             

--- a/samples/client/petstore/typescript-angular2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/store.service.ts
@@ -191,8 +191,8 @@ export class StoreService {
         ];
 
         // authentication (api_key) required
-        if (this.configuration.apiKey) {
-            headers.set('api_key', this.configuration.apiKey);
+        if (this.configuration.apiKeys["api_key"]) {
+            headers.set('api_key', this.configuration.apiKeys["api_key"]);
         }
 
             

--- a/samples/client/petstore/typescript-angular2/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular2/default/configuration.ts
@@ -1,5 +1,5 @@
 export interface ConfigurationParameters {
-	apiKey?: string;
+	apiKeys?: {[ key: string ]: string};
 	username?: string;
 	password?: string;
 	accessToken?: string;
@@ -7,7 +7,7 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-	apiKey: string;
+	apiKeys: {[ key: string ]: string};
 	username: string;
 	password: string;
 	accessToken: string | (() => string);
@@ -15,7 +15,7 @@ export class Configuration {
 
 
 	constructor(configurationParameters: ConfigurationParameters = {}) {
-		this.apiKey = configurationParameters.apiKey;
+		this.apiKeys = configurationParameters.apiKeys;
 		this.username = configurationParameters.username;
 		this.password = configurationParameters.password;
 		this.accessToken = configurationParameters.accessToken;

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201703211709
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201703271250
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201703211709 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201703271250 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/pet.service.ts
@@ -429,8 +429,8 @@ export class PetService {
         }
 
         // authentication (api_key) required
-        if (this.configuration.apiKey) {
-            headers.set('api_key', this.configuration.apiKey);
+        if (this.configuration.apiKeys["api_key"]) {
+            headers.set('api_key', this.configuration.apiKeys["api_key"]);
         }
 
             

--- a/samples/client/petstore/typescript-angular2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/store.service.ts
@@ -191,8 +191,8 @@ export class StoreService {
         ];
 
         // authentication (api_key) required
-        if (this.configuration.apiKey) {
-            headers.set('api_key', this.configuration.apiKey);
+        if (this.configuration.apiKeys["api_key"]) {
+            headers.set('api_key', this.configuration.apiKeys["api_key"]);
         }
 
             

--- a/samples/client/petstore/typescript-angular2/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular2/npm/configuration.ts
@@ -1,5 +1,5 @@
 export interface ConfigurationParameters {
-	apiKey?: string;
+	apiKeys?: {[ key: string ]: string};
 	username?: string;
 	password?: string;
 	accessToken?: string;
@@ -7,7 +7,7 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-	apiKey: string;
+	apiKeys: {[ key: string ]: string};
 	username: string;
 	password: string;
 	accessToken: string | (() => string);
@@ -15,7 +15,7 @@ export class Configuration {
 
 
 	constructor(configurationParameters: ConfigurationParameters = {}) {
-		this.apiKey = configurationParameters.apiKey;
+		this.apiKeys = configurationParameters.apiKeys;
 		this.username = configurationParameters.username;
 		this.password = configurationParameters.password;
 		this.accessToken = configurationParameters.accessToken;

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201703211709",
+  "version": "0.0.1-SNAPSHOT.201703271250",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Please see #5227 for the initial PR (incorrectly set to merge to master)

Fix for #5224
To allow for multiple API Keys, the configuration now expects a dictionary of keys. The key is the name of the header and the value is the API Key itself.

NOTE: I've copied across the relevant Pet Store changes from my previous PR.  However running the scripts to regenerate them made a load of unrelated changes and I'm not sure what to make of them to be honest.  I can submit these as a separate PR if you'd like me to?
