### PR TITLE
Update samples for javascript + javascript-promise.

### DIFF
--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -414,7 +414,7 @@
     if (accept) {
       request.accept(accept);
     }
-    
+
     if (returnType === 'Blob') {
       request.responseType('blob');
     }

--- a/samples/client/petstore/javascript-promise/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript-promise/src/model/FormatTest.js
@@ -97,10 +97,10 @@
         obj['string'] = ApiClient.convertToType(data['string'], 'String');
       }
       if (data.hasOwnProperty('byte')) {
-        obj['byte'] = ApiClient.convertToType(data['byte'], Blob);
+        obj['byte'] = ApiClient.convertToType(data['byte'], 'Blob');
       }
       if (data.hasOwnProperty('binary')) {
-        obj['binary'] = ApiClient.convertToType(data['binary'], Blob);
+        obj['binary'] = ApiClient.convertToType(data['binary'], 'Blob');
       }
       if (data.hasOwnProperty('date')) {
         obj['date'] = ApiClient.convertToType(data['date'], 'Date');

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -423,7 +423,7 @@
     if (accept) {
       request.accept(accept);
     }
-    
+
     if (returnType === 'Blob') {
       request.responseType('blob');
     }

--- a/samples/client/petstore/javascript/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript/src/model/FormatTest.js
@@ -97,10 +97,10 @@
         obj['string'] = ApiClient.convertToType(data['string'], 'String');
       }
       if (data.hasOwnProperty('byte')) {
-        obj['byte'] = ApiClient.convertToType(data['byte'], Blob);
+        obj['byte'] = ApiClient.convertToType(data['byte'], 'Blob');
       }
       if (data.hasOwnProperty('binary')) {
-        obj['binary'] = ApiClient.convertToType(data['binary'], Blob);
+        obj['binary'] = ApiClient.convertToType(data['binary'], 'Blob');
       }
       if (data.hasOwnProperty('date')) {
         obj['date'] = ApiClient.convertToType(data['date'], 'Date');


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
   → bin/javascript-petstore.sh, bin/javascript-promise-petstore.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

No code changes, just updating the samples (so later sample updates show what happened).

It looks like #5194 (which added the blob feature) didn't update the samples with the latest version of the code, but an earlier one.