### PR TITLE
Updating samples after #5232.

### DIFF
--- a/bin/jaxrs-jersey1-petstore-server.sh
+++ b/bin/jaxrs-jersey1-petstore-server.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1 -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true --library=jersey1 --artifact-id=swagger-jaxrs-jersey1-server"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1 -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true,serverPort=8080 --library=jersey1 --artifact-id=swagger-jaxrs-jersey1-server"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey1/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey1/src/main

--- a/bin/jaxrs-petstore-server.sh
+++ b/bin/jaxrs-petstore-server.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true,serverPort=8080"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey2/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey2/src/main

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -45,6 +45,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         cliOptions.add(new CliOption("title", "a title describing the application"));
 
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
+        cliOptions.add(new CliOption("serverPort", "The port on which the server should be started"));
 
     }
 
@@ -83,15 +84,19 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
             swagger.setBasePath("");
         }
 
-        String host = swagger.getHost();
-        String port = "8080"; // Default value for a JEE Server
-        if ( host != null ) {
-            String[] parts = host.split(":");
-            if ( parts.length > 1 ) {
-                port = parts[1];
+        if(!this.additionalProperties.containsKey("serverPort")) {
+            final String host = swagger.getHost();
+            String port = "8080"; // Default value for a JEE Server
+            if ( host != null ) {
+                String[] parts = host.split(":");
+                if ( parts.length > 1 ) {
+                    port = parts[1];
+                }
             }
+
+            this.additionalProperties.put("serverPort", port);
         }
-        this.additionalProperties.put("serverPort", port);
+
         if ( swagger.getPaths() != null ) {
             for ( String pathname : swagger.getPaths().keySet() ) {
                 Path path = swagger.getPath(pathname);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaCXFServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaCXFServerOptionsProvider.java
@@ -92,6 +92,7 @@ public class JavaCXFServerOptionsProvider extends JavaOptionsProvider {
         builder.put(JavaCXFServerCodegen.USE_ANNOTATED_BASE_PATH, USE_ANNOTATED_BASE_PATH);
 
         builder.put(JavaCXFServerCodegen.GENERATE_NON_SPRING_APPLICATION, GENERATE_NON_SPRING_APPLICATION);
+        builder.put("serverPort", "3456");
 
         return builder.build();
         

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaResteasyEapServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaResteasyEapServerOptionsProvider.java
@@ -43,6 +43,7 @@ public class JavaResteasyEapServerOptionsProvider extends JavaOptionsProvider {
         builder.put(JavaCXFServerCodegen.GENERATE_JBOSS_DEPLOYMENT_DESCRIPTOR, GENERATE_JBOSS_DEPLOYMENT_DESCRIPTOR);
         builder.put(JavaResteasyServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION);
           builder.put(JavaResteasyEapServerCodegen.USE_SWAGGER_FEATURE, USE_SWAGGER_FEATURE);
+          builder.put("serverPort", "1234");
 
         return builder.build();
         

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaResteasyServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaResteasyServerOptionsProvider.java
@@ -39,6 +39,7 @@ public class JavaResteasyServerOptionsProvider extends JavaOptionsProvider {
         
         builder.put(JavaCXFServerCodegen.GENERATE_JBOSS_DEPLOYMENT_DESCRIPTOR, GENERATE_JBOSS_DEPLOYMENT_DESCRIPTOR);
         builder.put(JavaResteasyServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION);
+        builder.put("serverPort", "1234");
 
         return builder.build();
         

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
@@ -84,6 +84,7 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
             //.put(JavaClientCodegen.DATE_LIBRARY, "joda")
             .put("hideGenerationTimestamp", "true")
             .put(JavaCXFServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION)
+            .put("serverPort", "2345")
             .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE);
 
         return builder.build();

--- a/samples/client/petstore/bash/petstore-cli
+++ b/samples/client/petstore/bash/petstore-cli
@@ -760,7 +760,7 @@ echo "  $ops" | column -t -s ';'
     echo -e "  -V,--version\t\t\t\tPrint API version"
     echo -e "  --about\t\t\t\tPrint the information about service"
     echo -e "  --host $(tput setaf 6)<url>$(tput sgr0)\t\t\t\tSpecify the host URL "
-echo -e "              \t\t\t\t(e.g. 'https://petstore.swagger.io')"
+echo -e "              \t\t\t\t(e.g. 'https://petstore.swagger.io:80')"
 
     echo -e "  --force\t\t\t\tForce command invocation in spite of missing"
     echo -e "         \t\t\t\trequired parameters or wrong content type"

--- a/samples/client/petstore/csharp/SwaggerClient/README.md
+++ b/samples/client/petstore/csharp/SwaggerClient/README.md
@@ -89,7 +89,7 @@ namespace Example
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # IO.Swagger.Api.FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClient/docs/PetApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/PetApi.md
@@ -1,6 +1,6 @@
 # IO.Swagger.Api.PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClient/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # IO.Swagger.Api.StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClient/docs/UserApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/UserApi.md
@@ -1,6 +1,6 @@
 # IO.Swagger.Api.UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Client/ApiClient.cs
@@ -48,17 +48,17 @@ namespace IO.Swagger.Client
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class
-        /// with default configuration and base path (http://petstore.swagger.io/v2).
+        /// with default configuration and base path (http://petstore.swagger.io:80/v2).
         /// </summary>
         public ApiClient()
         {
             Configuration = Configuration.Default;
-            RestClient = new RestClient("http://petstore.swagger.io/v2");
+            RestClient = new RestClient("http://petstore.swagger.io:80/v2");
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class
-        /// with default base path (http://petstore.swagger.io/v2).
+        /// with default base path (http://petstore.swagger.io:80/v2).
         /// </summary>
         /// <param name="config">An instance of Configuration.</param>
         public ApiClient(Configuration config = null)
@@ -68,7 +68,7 @@ namespace IO.Swagger.Client
             else
                 Configuration = config;
 
-            RestClient = new RestClient("http://petstore.swagger.io/v2");
+            RestClient = new RestClient("http://petstore.swagger.io:80/v2");
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace IO.Swagger.Client
         /// with default configuration.
         /// </summary>
         /// <param name="basePath">The base path.</param>
-        public ApiClient(String basePath = "http://petstore.swagger.io/v2")
+        public ApiClient(String basePath = "http://petstore.swagger.io:80/v2")
         {
            if (String.IsNullOrEmpty(basePath))
                 throw new ArgumentException("basePath cannot be empty");

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/README.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/README.md
@@ -89,7 +89,7 @@ namespace Example
 <a name="documentation-for-api-endpoints"></a>
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # IO.Swagger.Api.FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/PetApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/PetApi.md
@@ -1,6 +1,6 @@
 # IO.Swagger.Api.PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # IO.Swagger.Api.StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/UserApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/UserApi.md
@@ -1,6 +1,6 @@
 # IO.Swagger.Api.UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Client/ApiClient.cs
@@ -48,17 +48,17 @@ namespace IO.Swagger.Client
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class
-        /// with default configuration and base path (http://petstore.swagger.io/v2).
+        /// with default configuration and base path (http://petstore.swagger.io:80/v2).
         /// </summary>
         public ApiClient()
         {
             Configuration = Configuration.Default;
-            RestClient = new RestClient("http://petstore.swagger.io/v2");
+            RestClient = new RestClient("http://petstore.swagger.io:80/v2");
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class
-        /// with default base path (http://petstore.swagger.io/v2).
+        /// with default base path (http://petstore.swagger.io:80/v2).
         /// </summary>
         /// <param name="config">An instance of Configuration.</param>
         public ApiClient(Configuration config = null)
@@ -68,7 +68,7 @@ namespace IO.Swagger.Client
             else
                 Configuration = config;
 
-            RestClient = new RestClient("http://petstore.swagger.io/v2");
+            RestClient = new RestClient("http://petstore.swagger.io:80/v2");
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace IO.Swagger.Client
         /// with default configuration.
         /// </summary>
         /// <param name="basePath">The base path.</param>
-        public ApiClient(String basePath = "http://petstore.swagger.io/v2")
+        public ApiClient(String basePath = "http://petstore.swagger.io:80/v2")
         {
            if (String.IsNullOrEmpty(basePath))
                 throw new ArgumentException("basePath cannot be empty");

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/fake.ex
@@ -5,7 +5,7 @@ defmodule SwaggerPetstore.Api.Fake do
 
   use Tesla
 
-  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io/v2"
+  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io:80/v2"
   plug Tesla.Middleware.JSON
 
   def test_client_model(body) do

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/pet.ex
@@ -5,7 +5,7 @@ defmodule SwaggerPetstore.Api.Pet do
 
   use Tesla
 
-  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io/v2"
+  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io:80/v2"
   plug Tesla.Middleware.JSON
 
   def add_pet(body) do

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/store.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/store.ex
@@ -5,7 +5,7 @@ defmodule SwaggerPetstore.Api.Store do
 
   use Tesla
 
-  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io/v2"
+  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io:80/v2"
   plug Tesla.Middleware.JSON
 
   def delete_order(order_id) do

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/user.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/user.ex
@@ -5,7 +5,7 @@ defmodule SwaggerPetstore.Api.User do
 
   use Tesla
 
-  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io/v2"
+  plug Tesla.Middleware.BaseUrl, "http://petstore.swagger.io:80/v2"
   plug Tesla.Middleware.JSON
 
   def create_user(body) do

--- a/samples/client/petstore/go/go-petstore/README.md
+++ b/samples/client/petstore/go/go-petstore/README.md
@@ -17,7 +17,7 @@ Put the package under your project folder and add the following in import:
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/go/go-petstore/configuration.go
+++ b/samples/client/petstore/go/go-petstore/configuration.go
@@ -38,7 +38,7 @@ type Configuration struct {
 
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:      "http://petstore.swagger.io/v2",
+		BasePath:      "http://petstore.swagger.io:80/v2",
 		DefaultHeader: make(map[string]string),
 		APIKey:        make(map[string]string),
 		APIKeyPrefix:  make(map[string]string),

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # \FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -1,6 +1,6 @@
 # \PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # \StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -1,6 +1,6 @@
 # \UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
@@ -25,7 +25,7 @@ public class ApiClient {
   public interface Api {}
 
   protected ObjectMapper objectMapper;
-  private String basePath = "http://petstore.swagger.io/v2";
+  private String basePath = "http://petstore.swagger.io:80/v2";
   private Map<String, RequestInterceptor> apiAuthorizations;
   private Feign.Builder feignBuilder;
 

--- a/samples/client/petstore/java/feign/src/test/java/io/swagger/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/feign/src/test/java/io/swagger/client/api/PetApiTest.java
@@ -29,7 +29,7 @@ public class PetApiTest {
     @Test
     public void testApiClient() {
         // the default api client is used
-        assertEquals("http://petstore.swagger.io/v2", apiClient.getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", apiClient.getBasePath());
 
         ApiClient newClient = new ApiClient();
         newClient.setBasePath("http://example.com");

--- a/samples/client/petstore/java/jersey1/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey1/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey1/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey1/docs/PetApi.md
@@ -1,6 +1,6 @@
 # PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey1/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey1/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey1/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey1/docs/UserApi.md
@@ -1,6 +1,6 @@
 # UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
@@ -56,7 +56,7 @@ import io.swagger.client.auth.OAuth;
 
 public class ApiClient {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private String basePath = "http://petstore.swagger.io/v2";
+  private String basePath = "http://petstore.swagger.io:80/v2";
   private boolean debugging = false;
   private int connectionTimeout = 0;
 

--- a/samples/client/petstore/java/jersey1/src/test/java/io/swagger/client/ConfigurationTest.java
+++ b/samples/client/petstore/java/jersey1/src/test/java/io/swagger/client/ConfigurationTest.java
@@ -9,7 +9,7 @@ public class ConfigurationTest {
     public void testDefaultApiClient() {
         ApiClient apiClient = Configuration.getDefaultApiClient();
         assertNotNull(apiClient);
-        assertEquals("http://petstore.swagger.io/v2", apiClient.getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", apiClient.getBasePath());
         assertFalse(apiClient.isDebugging());
     }
 }

--- a/samples/client/petstore/java/jersey1/src/test/java/io/swagger/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/jersey1/src/test/java/io/swagger/client/api/PetApiTest.java
@@ -39,7 +39,7 @@ public class PetApiTest {
         // the default api client is used
         assertEquals(Configuration.getDefaultApiClient(), api.getApiClient());
         assertNotNull(api.getApiClient());
-        assertEquals("http://petstore.swagger.io/v2", api.getApiClient().getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", api.getApiClient().getBasePath());
         assertFalse(api.getApiClient().isDebugging());
 
         ApiClient oldClient = api.getApiClient();
@@ -57,7 +57,7 @@ public class PetApiTest {
         // set api client via setter method
         api.setApiClient(oldClient);
         assertNotNull(api.getApiClient());
-        assertEquals("http://petstore.swagger.io/v2", api.getApiClient().getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", api.getApiClient().getBasePath());
         assertFalse(api.getApiClient().isDebugging());
     }
 

--- a/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2-java6/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/PetApi.md
@@ -1,6 +1,6 @@
 # PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2-java6/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2-java6/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/UserApi.md
@@ -1,6 +1,6 @@
 # UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/ApiClient.java
@@ -51,7 +51,7 @@ import io.swagger.client.auth.OAuth;
 
 public class ApiClient {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private String basePath = "http://petstore.swagger.io/v2";
+  private String basePath = "http://petstore.swagger.io:80/v2";
   private boolean debugging = false;
   private int connectionTimeout = 0;
 

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
@@ -1,6 +1,6 @@
 # PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2-java8/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2-java8/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/UserApi.md
@@ -1,6 +1,6 @@
 # UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/ApiClient.java
@@ -51,7 +51,7 @@ import io.swagger.client.auth.OAuth;
 
 public class ApiClient {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private String basePath = "http://petstore.swagger.io/v2";
+  private String basePath = "http://petstore.swagger.io:80/v2";
   private boolean debugging = false;
   private int connectionTimeout = 0;
 

--- a/samples/client/petstore/java/jersey2/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2/docs/PetApi.md
@@ -1,6 +1,6 @@
 # PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2/docs/UserApi.md
@@ -1,6 +1,6 @@
 # UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
@@ -51,7 +51,7 @@ import io.swagger.client.auth.OAuth;
 
 public class ApiClient {
   private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private String basePath = "http://petstore.swagger.io/v2";
+  private String basePath = "http://petstore.swagger.io:80/v2";
   private boolean debugging = false;
   private int connectionTimeout = 0;
 

--- a/samples/client/petstore/java/jersey2/src/test/java/io/swagger/client/ConfigurationTest.java
+++ b/samples/client/petstore/java/jersey2/src/test/java/io/swagger/client/ConfigurationTest.java
@@ -9,7 +9,7 @@ public class ConfigurationTest {
     public void testDefaultApiClient() {
         ApiClient apiClient = Configuration.getDefaultApiClient();
         assertNotNull(apiClient);
-        assertEquals("http://petstore.swagger.io/v2", apiClient.getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", apiClient.getBasePath());
         assertFalse(apiClient.isDebugging());
     }
 }

--- a/samples/client/petstore/java/jersey2/src/test/java/io/swagger/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/jersey2/src/test/java/io/swagger/client/api/PetApiTest.java
@@ -36,7 +36,7 @@ public class PetApiTest {
         // the default api client is used
         assertEquals(Configuration.getDefaultApiClient(), api.getApiClient());
         assertNotNull(api.getApiClient());
-        assertEquals("http://petstore.swagger.io/v2", api.getApiClient().getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", api.getApiClient().getBasePath());
         assertFalse(api.getApiClient().isDebugging());
 
         ApiClient oldClient = api.getApiClient();
@@ -54,7 +54,7 @@ public class PetApiTest {
         // set api client via setter method
         api.setApiClient(oldClient);
         assertNotNull(api.getApiClient());
-        assertEquals("http://petstore.swagger.io/v2", api.getApiClient().getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", api.getApiClient().getBasePath());
         assertFalse(api.getApiClient().isDebugging());
     }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/PetApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/PetApi.md
@@ -1,6 +1,6 @@
 # PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/StoreApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/UserApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/UserApi.md
@@ -1,6 +1,6 @@
 # UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/ApiClient.java
@@ -112,7 +112,7 @@ public class ApiClient {
      */
     public static final String LENIENT_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    private String basePath = "http://petstore.swagger.io:80/v2";
     private boolean lenientOnJson = false;
     private boolean debugging = false;
     private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -181,7 +181,7 @@ public class ApiClient {
     /**
      * Set base path
      *
-     * @param basePath Base path of the URL (e.g http://petstore.swagger.io/v2
+     * @param basePath Base path of the URL (e.g http://petstore.swagger.io:80/v2
      * @return An instance of OkHttpClient
      */
     public ApiClient setBasePath(String basePath) {

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/okhttp-gson/docs/PetApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/PetApi.md
@@ -1,6 +1,6 @@
 # PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/okhttp-gson/docs/StoreApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/okhttp-gson/docs/UserApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/UserApi.md
@@ -1,6 +1,6 @@
 # UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ApiClient.java
@@ -112,7 +112,7 @@ public class ApiClient {
      */
     public static final String LENIENT_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    private String basePath = "http://petstore.swagger.io:80/v2";
     private boolean lenientOnJson = false;
     private boolean debugging = false;
     private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
@@ -181,7 +181,7 @@ public class ApiClient {
     /**
      * Set base path
      *
-     * @param basePath Base path of the URL (e.g http://petstore.swagger.io/v2
+     * @param basePath Base path of the URL (e.g http://petstore.swagger.io:80/v2
      * @return An instance of OkHttpClient
      */
     public ApiClient setBasePath(String basePath) {

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ConfigurationTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/ConfigurationTest.java
@@ -9,7 +9,7 @@ public class ConfigurationTest {
     public void testDefaultApiClient() {
         ApiClient apiClient = Configuration.getDefaultApiClient();
         assertNotNull(apiClient);
-        assertEquals("http://petstore.swagger.io/v2", apiClient.getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", apiClient.getBasePath());
         assertFalse(apiClient.isDebugging());
     }
 }

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/io/swagger/client/api/PetApiTest.java
@@ -35,7 +35,7 @@ public class PetApiTest {
         // the default api client is used
         assertEquals(Configuration.getDefaultApiClient(), api.getApiClient());
         assertNotNull(api.getApiClient());
-        assertEquals("http://petstore.swagger.io/v2", api.getApiClient().getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", api.getApiClient().getBasePath());
         assertFalse(api.getApiClient().isDebugging());
 
         ApiClient oldClient = api.getApiClient();
@@ -53,7 +53,7 @@ public class PetApiTest {
         // set api client via setter method
         api.setApiClient(oldClient);
         assertNotNull(api.getApiClient());
-        assertEquals("http://petstore.swagger.io/v2", api.getApiClient().getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", api.getApiClient().getBasePath());
         assertFalse(api.getApiClient().isDebugging());
     }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/ApiClient.java
@@ -126,7 +126,7 @@ public class ApiClient {
 
         adapterBuilder = new RestAdapter
                 .Builder()
-                .setEndpoint("http://petstore.swagger.io/v2")
+                .setEndpoint("http://petstore.swagger.io:80/v2")
                 .setClient(new OkClient(okClient))
                 .setConverter(new GsonConverterWrapper(gson));
     }

--- a/samples/client/petstore/javascript-promise/README.md
+++ b/samples/client/petstore/javascript-promise/README.md
@@ -67,7 +67,7 @@ api.testClientModel(body).then(function(data) {
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript-promise/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-promise/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # SwaggerPetstore.FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript-promise/docs/PetApi.md
+++ b/samples/client/petstore/javascript-promise/docs/PetApi.md
@@ -1,6 +1,6 @@
 # SwaggerPetstore.PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript-promise/docs/StoreApi.md
+++ b/samples/client/petstore/javascript-promise/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # SwaggerPetstore.StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript-promise/docs/UserApi.md
+++ b/samples/client/petstore/javascript-promise/docs/UserApi.md
@@ -1,6 +1,6 @@
 # SwaggerPetstore.UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -44,9 +44,9 @@
     /**
      * The base URL against which to resolve every API call's (relative) path.
      * @type {String}
-     * @default http://petstore.swagger.io/v2
+     * @default http://petstore.swagger.io:80/v2
      */
-    this.basePath = 'http://petstore.swagger.io/v2'.replace(/\/+$/, '');
+    this.basePath = 'http://petstore.swagger.io:80/v2'.replace(/\/+$/, '');
 
     /**
      * The authentication methods to be included for all API calls.

--- a/samples/client/petstore/javascript/README.md
+++ b/samples/client/petstore/javascript/README.md
@@ -70,7 +70,7 @@ api.testClientModel(body, callback);
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript/docs/FakeApi.md
+++ b/samples/client/petstore/javascript/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # SwaggerPetstore.FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript/docs/PetApi.md
+++ b/samples/client/petstore/javascript/docs/PetApi.md
@@ -1,6 +1,6 @@
 # SwaggerPetstore.PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript/docs/StoreApi.md
+++ b/samples/client/petstore/javascript/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # SwaggerPetstore.StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript/docs/UserApi.md
+++ b/samples/client/petstore/javascript/docs/UserApi.md
@@ -1,6 +1,6 @@
 # SwaggerPetstore.UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -44,9 +44,9 @@
     /**
      * The base URL against which to resolve every API call's (relative) path.
      * @type {String}
-     * @default http://petstore.swagger.io/v2
+     * @default http://petstore.swagger.io:80/v2
      */
-    this.basePath = 'http://petstore.swagger.io/v2'.replace(/\/+$/, '');
+    this.basePath = 'http://petstore.swagger.io:80/v2'.replace(/\/+$/, '');
 
     /**
      * The authentication methods to be included for all API calls.

--- a/samples/client/petstore/javascript/test/ApiClientTest.js
+++ b/samples/client/petstore/javascript/test/ApiClientTest.js
@@ -10,7 +10,7 @@ describe('ApiClient', function() {
   describe('defaults', function() {
     it('should have correct default values with the default API client', function() {
       expect(apiClient).to.be.ok();
-      expect(apiClient.basePath).to.be('http://petstore.swagger.io/v2');
+      expect(apiClient.basePath).to.be('http://petstore.swagger.io:80/v2');
       expect(apiClient.authentications).to.eql({
         petstore_auth: {type: 'oauth2'},
         http_basic_test: {type: 'basic'},
@@ -45,8 +45,8 @@ describe('ApiClient', function() {
 
     it('should have correct default values with new API client and can customize it', function() {
       var newClient = new SwaggerPetstore.ApiClient;
-      expect(newClient.basePath).to.be('http://petstore.swagger.io/v2');
-      expect(newClient.buildUrl('/abc', {})).to.be('http://petstore.swagger.io/v2/abc');
+      expect(newClient.basePath).to.be('http://petstore.swagger.io:80/v2');
+      expect(newClient.buildUrl('/abc', {})).to.be('http://petstore.swagger.io:80/v2/abc');
 
       newClient.basePath = 'http://example.com';
       expect(newClient.basePath).to.be('http://example.com');
@@ -102,16 +102,16 @@ describe('ApiClient', function() {
   describe('#buildUrl', function() {
     it('should work without path parameters in the path', function() {
       expect(apiClient.buildUrl('/abc', {})).to
-        .be('http://petstore.swagger.io/v2/abc');
+        .be('http://petstore.swagger.io:80/v2/abc');
       expect(apiClient.buildUrl('/abc/def?ok', {id: 123})).to
-        .be('http://petstore.swagger.io/v2/abc/def?ok');
+        .be('http://petstore.swagger.io:80/v2/abc/def?ok');
     });
 
     it('should work with path parameters in the path', function() {
       expect(apiClient.buildUrl('/{id}', {id: 123})).to
-        .be('http://petstore.swagger.io/v2/123');
+        .be('http://petstore.swagger.io:80/v2/123');
       expect(apiClient.buildUrl('/abc/{id}/{name}?ok', {id: 456, name: 'a b'})).to.
-        be('http://petstore.swagger.io/v2/abc/456/a%20b?ok');
+        be('http://petstore.swagger.io:80/v2/abc/456/a%20b?ok');
     });
   });
 

--- a/samples/client/petstore/perl/README.md
+++ b/samples/client/petstore/perl/README.md
@@ -333,7 +333,7 @@ if ($@) {
 
 # DOCUMENTATION FOR API ENDPOINTS
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/perl/docs/FakeApi.md
+++ b/samples/client/petstore/perl/docs/FakeApi.md
@@ -5,7 +5,7 @@
 use WWW::SwaggerClient::Object::FakeApi;
 ```
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/perl/docs/PetApi.md
+++ b/samples/client/petstore/perl/docs/PetApi.md
@@ -5,7 +5,7 @@
 use WWW::SwaggerClient::Object::PetApi;
 ```
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/perl/docs/StoreApi.md
+++ b/samples/client/petstore/perl/docs/StoreApi.md
@@ -5,7 +5,7 @@
 use WWW::SwaggerClient::Object::StoreApi;
 ```
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/perl/docs/UserApi.md
+++ b/samples/client/petstore/perl/docs/UserApi.md
@@ -5,7 +5,7 @@
 use WWW::SwaggerClient::Object::UserApi;
 ```
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/ApiClient.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/ApiClient.pm
@@ -46,7 +46,7 @@ sub _new_instance
     my $class = shift;
     my (%args) = (
         'ua' => LWP::UserAgent->new,
-        'base_url' => 'http://petstore.swagger.io/v2',
+        'base_url' => 'http://petstore.swagger.io:80/v2',
         @_
     );
   

--- a/samples/client/petstore/php/SwaggerClient-php/README.md
+++ b/samples/client/petstore/php/SwaggerClient-php/README.md
@@ -71,7 +71,7 @@ try {
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Api/FakeApi.md
@@ -1,6 +1,6 @@
 # Swagger\Client\FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Api/PetApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Api/PetApi.md
@@ -1,6 +1,6 @@
 # Swagger\Client\PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Api/StoreApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Api/StoreApi.md
@@ -1,6 +1,6 @@
 # Swagger\Client\StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Api/UserApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Api/UserApi.md
@@ -1,6 +1,6 @@
 # Swagger\Client\UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
@@ -88,7 +88,7 @@ class Configuration
      *
      * @var string
      */
-    protected $host = 'http://petstore.swagger.io/v2';
+    protected $host = 'http://petstore.swagger.io:80/v2';
 
     /**
      * Timeout (second) of the HTTP request, by default set to 0, no timeout

--- a/samples/client/petstore/python/README.md
+++ b/samples/client/petstore/python/README.md
@@ -65,7 +65,7 @@ except ApiException as e:
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # petstore_api.FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/python/docs/PetApi.md
+++ b/samples/client/petstore/python/docs/PetApi.md
@@ -1,6 +1,6 @@
 # petstore_api.PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/python/docs/StoreApi.md
+++ b/samples/client/petstore/python/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # petstore_api.StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/python/docs/UserApi.md
+++ b/samples/client/petstore/python/docs/UserApi.md
@@ -1,6 +1,6 @@
 # petstore_api.UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -45,7 +45,7 @@ class Configuration(object):
         Constructor
         """
         # Default Base url
-        self.host = "http://petstore.swagger.io/v2"
+        self.host = "http://petstore.swagger.io:80/v2"
         # Default api client
         self.api_client = None
         # Temp file folder for downloading files

--- a/samples/client/petstore/ruby/README.md
+++ b/samples/client/petstore/ruby/README.md
@@ -71,7 +71,7 @@ end
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -1,6 +1,6 @@
 # Petstore::FakeApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/ruby/docs/PetApi.md
+++ b/samples/client/petstore/ruby/docs/PetApi.md
@@ -1,6 +1,6 @@
 # Petstore::PetApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/ruby/docs/StoreApi.md
+++ b/samples/client/petstore/ruby/docs/StoreApi.md
@@ -1,6 +1,6 @@
 # Petstore::StoreApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/ruby/docs/UserApi.md
+++ b/samples/client/petstore/ruby/docs/UserApi.md
@@ -1,6 +1,6 @@
 # Petstore::UserApi
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -123,7 +123,7 @@ module Petstore
 
     def initialize
       @scheme = 'http'
-      @host = 'petstore.swagger.io'
+      @host = 'petstore.swagger.io:80'
       @base_path = '/v2'
       @api_key = {}
       @api_key_prefix = {}

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 open class PetstoreClientAPI {
-    open static var basePath = "http://petstore.swagger.io/v2"
+    open static var basePath = "http://petstore.swagger.io:80/v2"
     open static var credential: URLCredential?
     open static var customHeaders: [String:String] = [:]
     static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 open class PetstoreClientAPI {
-    open static var basePath = "http://petstore.swagger.io/v2"
+    open static var basePath = "http://petstore.swagger.io:80/v2"
     open static var credential: URLCredential?
     open static var customHeaders: [String:String] = [:]
     static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 open class PetstoreClientAPI {
-    open static var basePath = "http://petstore.swagger.io/v2"
+    open static var basePath = "http://petstore.swagger.io:80/v2"
     open static var credential: URLCredential?
     open static var customHeaders: [String:String] = [:]
     static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()

--- a/samples/server/petstore/java-inflector/src/main/swagger/swagger.yaml
+++ b/samples/server/petstore/java-inflector/src/main/swagger/swagger.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-host: "petstore.swagger.io"
+host: "petstore.swagger.io:80"
 basePath: "/v2"
 tags:
 - name: "pet"

--- a/samples/server/petstore/jaxrs-spec/swagger.json
+++ b/samples/server/petstore/jaxrs-spec/swagger.json
@@ -13,7 +13,7 @@
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
-  "host" : "petstore.swagger.io",
+  "host" : "petstore.swagger.io:80",
   "basePath" : "/v2",
   "tags" : [ {
     "name" : "pet",

--- a/samples/server/petstore/jaxrs/jersey1/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey1/pom.xml
@@ -38,7 +38,7 @@
           <stopKey>stopit</stopKey>
           <stopWait>10</stopWait>
           <httpConnector>
-            <port>80</port>
+            <port>8080</port>
             <idleTimeout>60000</idleTimeout>
           </httpConnector>
         </configuration>

--- a/samples/server/petstore/jaxrs/jersey1/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey1/pom.xml
@@ -38,7 +38,7 @@
           <stopKey>stopit</stopKey>
           <stopWait>10</stopWait>
           <httpConnector>
-            <port>8080</port>
+            <port>80</port>
             <idleTimeout>60000</idleTimeout>
           </httpConnector>
         </configuration>

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/api/FakeApi.java
@@ -92,8 +92,8 @@ public class FakeApi  {
         @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString,
         @ApiParam(value = "Query parameter enum test (string array)", allowableValues=">, $") @QueryParam("enum_query_string_array") List<String> enumQueryStringArray,
         @ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg") @QueryParam("enum_query_string") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)") @QueryParam("enum_query_integer") Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)")  @FormParam("enum_query_double")  Double enumQueryDouble,
+        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer") Integer enumQueryInteger,
+        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")  @FormParam("enum_query_double")  Double enumQueryDouble,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testEnumParameters(enumFormStringArray,enumFormString,enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/model/FormatTest.java
@@ -80,9 +80,7 @@ public class FormatTest   {
   **/
   @JsonProperty("integer")
   @ApiModelProperty(value = "")
-  @Min(10)
-  @Max(100)
-  public Integer getInteger() {
+ @Min(10) @Max(100)  public Integer getInteger() {
     return integer;
   }
 
@@ -103,9 +101,7 @@ public class FormatTest   {
   **/
   @JsonProperty("int32")
   @ApiModelProperty(value = "")
-  @Min(20)
-  @Max(200)
-  public Integer getInt32() {
+ @Min(20) @Max(200)  public Integer getInt32() {
     return int32;
   }
 
@@ -146,9 +142,7 @@ public class FormatTest   {
   @JsonProperty("number")
   @ApiModelProperty(required = true, value = "")
   @NotNull
-  @DecimalMin("32.1")
-  @DecimalMax("543.2")
-  public BigDecimal getNumber() {
+ @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
     return number;
   }
 
@@ -169,9 +163,7 @@ public class FormatTest   {
   **/
   @JsonProperty("float")
   @ApiModelProperty(value = "")
-  @DecimalMin("54.3")
-  @DecimalMax("987.6")
-  public Float getFloat() {
+ @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
     return _float;
   }
 
@@ -192,9 +184,7 @@ public class FormatTest   {
   **/
   @JsonProperty("double")
   @ApiModelProperty(value = "")
-  @DecimalMin("67.8")
-  @DecimalMax("123.4")
-  public Double getDouble() {
+ @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
     return _double;
   }
 
@@ -213,8 +203,7 @@ public class FormatTest   {
   **/
   @JsonProperty("string")
   @ApiModelProperty(value = "")
-  @Pattern(regexp="/[a-z]/i")
-  public String getString() {
+ @Pattern(regexp="/[a-z]/i")  public String getString() {
     return string;
   }
 
@@ -331,8 +320,7 @@ public class FormatTest   {
   @JsonProperty("password")
   @ApiModelProperty(required = true, value = "")
   @NotNull
-  @Size(min=10,max=64)
-  public String getPassword() {
+ @Size(min=10,max=64)  public String getPassword() {
     return password;
   }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/main/webapp/WEB-INF/web.xml
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/webapp/WEB-INF/web.xml
@@ -34,7 +34,7 @@
     </init-param>
     <init-param>
       <param-name>swagger.api.basepath</param-name>
-      <param-value>http://petstore.swagger.io/v2</param-value>
+      <param-value>http://petstore.swagger.io:80/v2</param-value>
     </init-param>
     <load-on-startup>2</load-on-startup>
   </servlet>

--- a/samples/server/petstore/jaxrs/jersey2/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2/pom.xml
@@ -47,7 +47,7 @@
           <stopKey>stopit</stopKey>
           <stopWait>10</stopWait>
           <httpConnector>
-            <port>80</port>
+            <port>8080</port>
             <idleTimeout>60000</idleTimeout>
           </httpConnector>
         </configuration>

--- a/samples/server/petstore/jaxrs/jersey2/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2/pom.xml
@@ -47,7 +47,7 @@
           <stopKey>stopit</stopKey>
           <stopWait>10</stopWait>
           <httpConnector>
-            <port>8080</port>
+            <port>80</port>
             <idleTimeout>60000</idleTimeout>
           </httpConnector>
         </configuration>

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApi.java
@@ -89,8 +89,8 @@ public class FakeApi  {
 ,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString
 ,@ApiParam(value = "Query parameter enum test (string array)", allowableValues=">, $") @QueryParam("enum_query_string_array") List<String> enumQueryStringArray
 ,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg") @QueryParam("enum_query_string") String enumQueryString
-,@ApiParam(value = "Query parameter enum test (double)") @QueryParam("enum_query_integer") Integer enumQueryInteger
-,@ApiParam(value = "Query parameter enum test (double)")  @FormParam("enum_query_double")  Double enumQueryDouble
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer") Integer enumQueryInteger
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")  @FormParam("enum_query_double")  Double enumQueryDouble
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testEnumParameters(enumFormStringArray,enumFormString,enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,securityContext);

--- a/samples/server/petstore/jaxrs/jersey2/src/main/webapp/WEB-INF/web.xml
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/webapp/WEB-INF/web.xml
@@ -38,7 +38,7 @@
         </init-param>
         <init-param>
             <param-name>swagger.api.basepath</param-name>
-            <param-value>http://petstore.swagger.io/v2</param-value>
+            <param-value>http://petstore.swagger.io:80/v2</param-value>
         </init-param>
 
         <load-on-startup>2</load-on-startup>

--- a/samples/server/petstore/springboot-delegate-j8/src/main/resources/application.properties
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/v2
-server.port=8080
+server.port=80
 spring.jackson.date-format=io.swagger.RFC3339DateFormat
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false

--- a/samples/server/petstore/springboot-delegate/src/main/resources/application.properties
+++ b/samples/server/petstore/springboot-delegate/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/v2
-server.port=8080
+server.port=80
 spring.jackson.date-format=io.swagger.RFC3339DateFormat
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/resources/application.properties
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/v2
-server.port=8080
+server.port=80
 spring.jackson.date-format=io.swagger.RFC3339DateFormat
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false

--- a/samples/server/petstore/springboot/src/main/resources/application.properties
+++ b/samples/server/petstore/springboot/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/v2
-server.port=8080
+server.port=80
 spring.jackson.date-format=io.swagger.RFC3339DateFormat
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
  I ran bin/run-all-petstore, but before committing I omitted some changes listed below.
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

No code changes, just updating the samples.

All the changes here come from #5232, which forgot to update the samples.
I omitted the changes covered by #5242, #5241, #5212, as well as changes in typescript-angular2/npm and typescript-jquery/npm, which have the date in their artifact ID (see #3084).

Interesting in the diff might be the several cases which replaced 8080 → 80.