### PR TITLE
[JaxRS Server][Jersey1/2] Pass server port by cli

### DIFF
--- a/bin/jaxrs-jersey1-petstore-server.sh
+++ b/bin/jaxrs-jersey1-petstore-server.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1 -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true --library=jersey1 --artifact-id=swagger-jaxrs-jersey1-server"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1 -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true,serverPort=8080 --library=jersey1 --artifact-id=swagger-jaxrs-jersey1-server"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey1/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey1/src/main

--- a/bin/jaxrs-petstore-server.sh
+++ b/bin/jaxrs-petstore-server.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true,serverPort=8080"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey2/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey2/src/main

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -45,6 +45,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         cliOptions.add(new CliOption("title", "a title describing the application"));
 
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations"));
+        cliOptions.add(new CliOption("serverPort", "The port on which the server should be started"));
 
     }
 
@@ -83,15 +84,19 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
             swagger.setBasePath("");
         }
 
-        String host = swagger.getHost();
-        String port = "8080"; // Default value for a JEE Server
-        if ( host != null ) {
-            String[] parts = host.split(":");
-            if ( parts.length > 1 ) {
-                port = parts[1];
+        if(!this.additionalProperties.containsKey("serverPort")) {
+            final String host = swagger.getHost();
+            String port = "8080"; // Default value for a JEE Server
+            if ( host != null ) {
+                String[] parts = host.split(":");
+                if ( parts.length > 1 ) {
+                    port = parts[1];
+                }
             }
+
+            this.additionalProperties.put("serverPort", port);
         }
-        this.additionalProperties.put("serverPort", port);
+
         if ( swagger.getPaths() != null ) {
             for ( String pathname : swagger.getPaths().keySet() ) {
                 Path path = swagger.getPath(pathname);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaCXFServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaCXFServerOptionsProvider.java
@@ -92,6 +92,7 @@ public class JavaCXFServerOptionsProvider extends JavaOptionsProvider {
         builder.put(JavaCXFServerCodegen.USE_ANNOTATED_BASE_PATH, USE_ANNOTATED_BASE_PATH);
 
         builder.put(JavaCXFServerCodegen.GENERATE_NON_SPRING_APPLICATION, GENERATE_NON_SPRING_APPLICATION);
+        builder.put("serverPort", "3456");
 
         return builder.build();
         

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaResteasyEapServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaResteasyEapServerOptionsProvider.java
@@ -43,6 +43,7 @@ public class JavaResteasyEapServerOptionsProvider extends JavaOptionsProvider {
         builder.put(JavaCXFServerCodegen.GENERATE_JBOSS_DEPLOYMENT_DESCRIPTOR, GENERATE_JBOSS_DEPLOYMENT_DESCRIPTOR);
         builder.put(JavaResteasyServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION);
           builder.put(JavaResteasyEapServerCodegen.USE_SWAGGER_FEATURE, USE_SWAGGER_FEATURE);
+          builder.put("serverPort", "1234");
 
         return builder.build();
         

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaResteasyServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaResteasyServerOptionsProvider.java
@@ -39,6 +39,7 @@ public class JavaResteasyServerOptionsProvider extends JavaOptionsProvider {
         
         builder.put(JavaCXFServerCodegen.GENERATE_JBOSS_DEPLOYMENT_DESCRIPTOR, GENERATE_JBOSS_DEPLOYMENT_DESCRIPTOR);
         builder.put(JavaResteasyServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION);
+        builder.put("serverPort", "1234");
 
         return builder.build();
         

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
@@ -84,6 +84,7 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
             //.put(JavaClientCodegen.DATE_LIBRARY, "joda")
             .put("hideGenerationTimestamp", "true")
             .put(JavaCXFServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION)
+            .put("serverPort", "2345")
             .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE);
 
         return builder.build();

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/api/FakeApi.java
@@ -92,8 +92,8 @@ public class FakeApi  {
         @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString,
         @ApiParam(value = "Query parameter enum test (string array)", allowableValues=">, $") @QueryParam("enum_query_string_array") List<String> enumQueryStringArray,
         @ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg") @QueryParam("enum_query_string") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)") @QueryParam("enum_query_integer") Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)")  @FormParam("enum_query_double")  Double enumQueryDouble,
+        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer") Integer enumQueryInteger,
+        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")  @FormParam("enum_query_double")  Double enumQueryDouble,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testEnumParameters(enumFormStringArray,enumFormString,enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/io/swagger/model/FormatTest.java
@@ -80,9 +80,7 @@ public class FormatTest   {
   **/
   @JsonProperty("integer")
   @ApiModelProperty(value = "")
-  @Min(10)
-  @Max(100)
-  public Integer getInteger() {
+ @Min(10) @Max(100)  public Integer getInteger() {
     return integer;
   }
 
@@ -103,9 +101,7 @@ public class FormatTest   {
   **/
   @JsonProperty("int32")
   @ApiModelProperty(value = "")
-  @Min(20)
-  @Max(200)
-  public Integer getInt32() {
+ @Min(20) @Max(200)  public Integer getInt32() {
     return int32;
   }
 
@@ -146,9 +142,7 @@ public class FormatTest   {
   @JsonProperty("number")
   @ApiModelProperty(required = true, value = "")
   @NotNull
-  @DecimalMin("32.1")
-  @DecimalMax("543.2")
-  public BigDecimal getNumber() {
+ @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
     return number;
   }
 
@@ -169,9 +163,7 @@ public class FormatTest   {
   **/
   @JsonProperty("float")
   @ApiModelProperty(value = "")
-  @DecimalMin("54.3")
-  @DecimalMax("987.6")
-  public Float getFloat() {
+ @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
     return _float;
   }
 
@@ -192,9 +184,7 @@ public class FormatTest   {
   **/
   @JsonProperty("double")
   @ApiModelProperty(value = "")
-  @DecimalMin("67.8")
-  @DecimalMax("123.4")
-  public Double getDouble() {
+ @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
     return _double;
   }
 
@@ -213,8 +203,7 @@ public class FormatTest   {
   **/
   @JsonProperty("string")
   @ApiModelProperty(value = "")
-  @Pattern(regexp="/[a-z]/i")
-  public String getString() {
+ @Pattern(regexp="/[a-z]/i")  public String getString() {
     return string;
   }
 
@@ -331,8 +320,7 @@ public class FormatTest   {
   @JsonProperty("password")
   @ApiModelProperty(required = true, value = "")
   @NotNull
-  @Size(min=10,max=64)
-  public String getPassword() {
+ @Size(min=10,max=64)  public String getPassword() {
     return password;
   }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/main/webapp/WEB-INF/web.xml
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/webapp/WEB-INF/web.xml
@@ -34,7 +34,7 @@
     </init-param>
     <init-param>
       <param-name>swagger.api.basepath</param-name>
-      <param-value>http://petstore.swagger.io/v2</param-value>
+      <param-value>http://petstore.swagger.io:80/v2</param-value>
     </init-param>
     <load-on-startup>2</load-on-startup>
   </servlet>

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApi.java
@@ -89,8 +89,8 @@ public class FakeApi  {
 ,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString
 ,@ApiParam(value = "Query parameter enum test (string array)", allowableValues=">, $") @QueryParam("enum_query_string_array") List<String> enumQueryStringArray
 ,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg") @QueryParam("enum_query_string") String enumQueryString
-,@ApiParam(value = "Query parameter enum test (double)") @QueryParam("enum_query_integer") Integer enumQueryInteger
-,@ApiParam(value = "Query parameter enum test (double)")  @FormParam("enum_query_double")  Double enumQueryDouble
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer") Integer enumQueryInteger
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")  @FormParam("enum_query_double")  Double enumQueryDouble
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testEnumParameters(enumFormStringArray,enumFormString,enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,securityContext);

--- a/samples/server/petstore/jaxrs/jersey2/src/main/webapp/WEB-INF/web.xml
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/webapp/WEB-INF/web.xml
@@ -38,7 +38,7 @@
         </init-param>
         <init-param>
             <param-name>swagger.api.basepath</param-name>
-            <param-value>http://petstore.swagger.io/v2</param-value>
+            <param-value>http://petstore.swagger.io:80/v2</param-value>
         </init-param>
 
         <load-on-startup>2</load-on-startup>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
  → bin/jaxrs-jersey1-petstore-server.sh, bin/jaxrs-petstore-server.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

We are introducing a CLI argument `serverPort` to the generators which overrides the port given in the API definition's `host` or the default of `8080`.
This we use from the generating scripts, so the CI tests won't try to use `80` (which is usually reserved to privileged processes).

(Triggered by the change in #5232 and the failing tests in #5243.)