### PR TITLE
Fixes in escaping when generating Java from swagger.json (2)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -705,6 +705,15 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     @Override
+    public String toExampleValue(Property p) {
+        if(p.getExample() != null) {
+            return escapeText(p.getExample().toString());
+        } else {
+        	return super.toExampleValue(p);
+        }
+    }
+    
+    @Override
     public String getSwaggerType(Property p) {
         String swaggerType = super.getSwaggerType(p);
 

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -67,7 +67,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/maximum}}
    * @return {{name}}
   **/
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{example}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}


### PR DESCRIPTION
Some valid json expressions within a swagger.json file result in uncompilable Java code.

How to test:
Use [this pom.xml](https://gist.github.com/spr3nk3ls/d7021930cc42941d413ef120b710beb9) and [this swagger.json](https://gist.github.com/spr3nk3ls/f165f0f19656a9e1ef8bf0f900f5067a) to generate an example swagger API client in Java.

Expected: the code generated results in compilable Java.

Result: the resulting Java does not compile, because expressions like `"example": "[\"RABO23124NL\",\"RABO12345NL\"]",` and `"example": "\\\"[A-Z.]{1,10}\\",` are escaped incorrectly.

I was unable to fix my original PR (https://github.com/swagger-api/swagger-codegen/pull/5234), so I created this one instead. Suggestions made on the original PR have been processed in this one.