### PR TITLE
Support Swagger collectionFormat encodings in Feign

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -176,6 +176,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         if ("feign".equals(getLibrary())) {
             additionalProperties.put("jackson", "true");
             supportingFiles.add(new SupportingFile("ParamExpander.mustache", invokerFolder, "ParamExpander.java"));
+            supportingFiles.add(new SupportingFile("EncodingUtils.mustache", invokerFolder, "EncodingUtils.java"));
         } else if ("okhttp-gson".equals(getLibrary()) || StringUtils.isEmpty(getLibrary())) {
             // the "okhttp-gson" library template requires "ApiCallback.mustache" for async call
             supportingFiles.add(new SupportingFile("ApiCallback.mustache", invokerFolder, "ApiCallback.java"));

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/EncodingUtils.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/EncodingUtils.mustache
@@ -30,7 +30,7 @@ public final class EncodingUtils {
    *                   not be changed.
    * @param collectionFormat The Swagger collection format (eg, "csv", "tsv",
    *                         "pipes"). See the
-   *                         <a http="http://swagger.io/specification/#parameter-object-44">
+   *                         <a href="http://swagger.io/specification/#parameter-object-44">
    *                         Swagger Spec</a> for more details.
    * @return An object that will be correctly formatted by Feign.
    */

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/EncodingUtils.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/EncodingUtils.mustache
@@ -1,0 +1,86 @@
+package {{invokerPackage}};
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+* Utilities to support Swagger encoding formats in Feign.
+*/
+public final class EncodingUtils {
+
+  /**
+   * Private constructor. Do not construct this class.
+   */
+  private EncodingUtils() {}
+
+  /**
+   * <p>Encodes a collection of query parameters according to the Swagger
+   * collection format.</p>
+   *
+   * <p>Of the various collection formats defined by Swagger ("csv", "tsv",
+   * etc), Feign only natively supports "multi". This utility generates the
+   * other format types so it will be properly processed by Feign.</p>
+   *
+   * <p>Note, as part of reformatting, it URL encodes the parameters as
+   * well.</p>
+   * @param parameters The collection object to be formatted. This object will
+   *                   not be changed.
+   * @param collectionFormat The Swagger collection format (eg, "csv", "tsv",
+   *                         "pipes"). See the
+   *                         <a http="http://swagger.io/specification/#parameter-object-44">
+   *                         Swagger Spec</a> for more details.
+   * @return An object that will be correctly formatted by Feign.
+   */
+  public static Object encodeCollection(Collection<?> parameters,
+                                     String collectionFormat) {
+    if (parameters == null) {
+      return parameters;
+    }
+    List<String> stringValues = new ArrayList<>(parameters.size());
+    for (Object parameter : parameters) {
+      // ignore null values (same behavior as Feign)
+      if (parameter != null) {
+        stringValues.add(encode(parameter));
+      }
+    }
+    // Feign natively handles single-element lists and the "multi" format.
+    if (stringValues.size() < 2 || "multi".equals(collectionFormat)) {
+      return stringValues;
+    }
+    // Otherwise return a formatted String
+    String[] stringArray = stringValues.toArray(new String[0]);
+    switch (collectionFormat) {
+      case "csv":
+      default:
+        return StringUtil.join(stringArray, ",");
+      case "ssv":
+        return StringUtil.join(stringArray, " ");
+      case "tsv":
+        return StringUtil.join(stringArray, "\t");
+      case "pipes":
+        return StringUtil.join(stringArray, "|");
+    }
+  }
+
+  /**
+   * URL encode a single query parameter.
+   * @param parameter The query parameter to encode. This object will not be
+   *                  changed.
+   * @return The URL encoded string representation of the parameter. If the
+   *         parameter is null, returns null.
+   */
+  public static String encode(Object parameter) {
+    if (parameter == null) {
+      return null;
+    }
+    try {
+      return URLEncoder.encode(parameter.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // Should never happen, UTF-8 is always supported
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
@@ -1,6 +1,7 @@
 package {{package}};
 
 import {{invokerPackage}}.ApiClient;
+import {{invokerPackage}}.EncodingUtils;
 {{#legacyDates}}
 import {{invokerPackage}}.ParamExpander;
 {{/legacyDates}}
@@ -71,7 +72,7 @@ public interface {{classname}} extends ApiClient.Api {
       "{{baseName}}: {{=<% %>=}}{<%paramName%>}<%={{ }}=%>"{{#hasMore}},
       {{/hasMore}}{{/headerParams}}
   })
-  {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}}({{#allParams}}{{^isQueryParam}}{{^isBodyParam}}{{^legacyDates}}@Param("{{paramName}}") {{/legacyDates}}{{#legacyDates}}@Param(value="{{paramName}}", expander=ParamExpander.class) {{/legacyDates}}{{/isBodyParam}}{{{dataType}}} {{paramName}}, {{/isQueryParam}}{{/allParams}}@QueryMap Map<String, Object> queryParams);
+  {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}}({{#allParams}}{{^isQueryParam}}{{^isBodyParam}}{{^legacyDates}}@Param("{{paramName}}") {{/legacyDates}}{{#legacyDates}}@Param(value="{{paramName}}", expander=ParamExpander.class) {{/legacyDates}}{{/isBodyParam}}{{{dataType}}} {{paramName}}, {{/isQueryParam}}{{/allParams}}@QueryMap(encoded=true) Map<String, Object> queryParams);
 
   /**
    * A convenience class for generating query parameters for the
@@ -80,7 +81,12 @@ public interface {{classname}} extends ApiClient.Api {
   public static class {{operationIdCamelCase}}QueryParams extends HashMap<String, Object> {
       {{#queryParams}}
     public {{operationIdCamelCase}}QueryParams {{paramName}}(final {{{dataType}}} value) {
-      put("{{baseName}}", value);
+        {{#collectionFormat}}
+      put("{{baseName}}", EncodingUtils.encodeCollection(value, "{{collectionFormat}}"));
+        {{/collectionFormat}}
+        {{^collectionFormat}}
+      put("{{baseName}}", EncodingUtils.encode(value));
+        {{/collectionFormat}}
       return this;
     }
       {{/queryParams}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
@@ -230,6 +230,18 @@
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -230,6 +230,18 @@
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <java.version>1.7</java.version>

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/EncodingUtils.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/EncodingUtils.java
@@ -30,7 +30,7 @@ public final class EncodingUtils {
    *                   not be changed.
    * @param collectionFormat The Swagger collection format (eg, "csv", "tsv",
    *                         "pipes"). See the
-   *                         <a http="http://swagger.io/specification/#parameter-object-44">
+   *                         <a href="http://swagger.io/specification/#parameter-object-44">
    *                         Swagger Spec</a> for more details.
    * @return An object that will be correctly formatted by Feign.
    */

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/EncodingUtils.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/EncodingUtils.java
@@ -1,0 +1,86 @@
+package io.swagger.client;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+* Utilities to support Swagger encoding formats in Feign.
+*/
+public final class EncodingUtils {
+
+  /**
+   * Private constructor. Do not construct this class.
+   */
+  private EncodingUtils() {}
+
+  /**
+   * <p>Encodes a collection of query parameters according to the Swagger
+   * collection format.</p>
+   *
+   * <p>Of the various collection formats defined by Swagger ("csv", "tsv",
+   * etc), Feign only natively supports "multi". This utility generates the
+   * other format types so it will be properly processed by Feign.</p>
+   *
+   * <p>Note, as part of reformatting, it URL encodes the parameters as
+   * well.</p>
+   * @param parameters The collection object to be formatted. This object will
+   *                   not be changed.
+   * @param collectionFormat The Swagger collection format (eg, "csv", "tsv",
+   *                         "pipes"). See the
+   *                         <a http="http://swagger.io/specification/#parameter-object-44">
+   *                         Swagger Spec</a> for more details.
+   * @return An object that will be correctly formatted by Feign.
+   */
+  public static Object encodeCollection(Collection<?> parameters,
+                                     String collectionFormat) {
+    if (parameters == null) {
+      return parameters;
+    }
+    List<String> stringValues = new ArrayList<>(parameters.size());
+    for (Object parameter : parameters) {
+      // ignore null values (same behavior as Feign)
+      if (parameter != null) {
+        stringValues.add(encode(parameter));
+      }
+    }
+    // Feign natively handles single-element lists and the "multi" format.
+    if (stringValues.size() < 2 || "multi".equals(collectionFormat)) {
+      return stringValues;
+    }
+    // Otherwise return a formatted String
+    String[] stringArray = stringValues.toArray(new String[0]);
+    switch (collectionFormat) {
+      case "csv":
+      default:
+        return StringUtil.join(stringArray, ",");
+      case "ssv":
+        return StringUtil.join(stringArray, " ");
+      case "tsv":
+        return StringUtil.join(stringArray, "\t");
+      case "pipes":
+        return StringUtil.join(stringArray, "|");
+    }
+  }
+
+  /**
+   * URL encode a single query parameter.
+   * @param parameter The query parameter to encode. This object will not be
+   *                  changed.
+   * @return The URL encoded string representation of the parameter. If the
+   *         parameter is null, returns null.
+   */
+  public static String encode(Object parameter) {
+    if (parameter == null) {
+      return null;
+    }
+    try {
+      return URLEncoder.encode(parameter.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // Should never happen, UTF-8 is always supported
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
@@ -1,6 +1,7 @@
 package io.swagger.client.api;
 
 import io.swagger.client.ApiClient;
+import io.swagger.client.EncodingUtils;
 
 import java.math.BigDecimal;
 import io.swagger.client.model.Client;
@@ -106,7 +107,7 @@ public interface FakeApi extends ApiClient.Api {
       
       "enum_header_string: {enumHeaderString}"
   })
-  void testEnumParameters(@Param("enumFormStringArray") List<String> enumFormStringArray, @Param("enumFormString") String enumFormString, @Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enumQueryDouble") Double enumQueryDouble, @QueryMap Map<String, Object> queryParams);
+  void testEnumParameters(@Param("enumFormStringArray") List<String> enumFormStringArray, @Param("enumFormString") String enumFormString, @Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enumQueryDouble") Double enumQueryDouble, @QueryMap(encoded=true) Map<String, Object> queryParams);
 
   /**
    * A convenience class for generating query parameters for the
@@ -114,15 +115,15 @@ public interface FakeApi extends ApiClient.Api {
    */
   public static class TestEnumParametersQueryParams extends HashMap<String, Object> {
     public TestEnumParametersQueryParams enumQueryStringArray(final List<String> value) {
-      put("enum_query_string_array", value);
+      put("enum_query_string_array", EncodingUtils.encodeCollection(value, "csv"));
       return this;
     }
     public TestEnumParametersQueryParams enumQueryString(final String value) {
-      put("enum_query_string", value);
+      put("enum_query_string", EncodingUtils.encode(value));
       return this;
     }
     public TestEnumParametersQueryParams enumQueryInteger(final Integer value) {
-      put("enum_query_integer", value);
+      put("enum_query_integer", EncodingUtils.encode(value));
       return this;
     }
   }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
@@ -1,6 +1,7 @@
 package io.swagger.client.api;
 
 import io.swagger.client.ApiClient;
+import io.swagger.client.EncodingUtils;
 
 import java.io.File;
 import io.swagger.client.model.ModelApiResponse;
@@ -75,7 +76,7 @@ public interface PetApi extends ApiClient.Api {
   "Content-Type: application/json",
   "Accept: application/json",
   })
-  List<Pet> findPetsByStatus(@QueryMap Map<String, Object> queryParams);
+  List<Pet> findPetsByStatus(@QueryMap(encoded=true) Map<String, Object> queryParams);
 
   /**
    * A convenience class for generating query parameters for the
@@ -83,7 +84,7 @@ public interface PetApi extends ApiClient.Api {
    */
   public static class FindPetsByStatusQueryParams extends HashMap<String, Object> {
     public FindPetsByStatusQueryParams status(final List<String> value) {
-      put("status", value);
+      put("status", EncodingUtils.encodeCollection(value, "csv"));
       return this;
     }
   }
@@ -121,7 +122,7 @@ public interface PetApi extends ApiClient.Api {
   "Content-Type: application/json",
   "Accept: application/json",
   })
-  List<Pet> findPetsByTags(@QueryMap Map<String, Object> queryParams);
+  List<Pet> findPetsByTags(@QueryMap(encoded=true) Map<String, Object> queryParams);
 
   /**
    * A convenience class for generating query parameters for the
@@ -129,7 +130,7 @@ public interface PetApi extends ApiClient.Api {
    */
   public static class FindPetsByTagsQueryParams extends HashMap<String, Object> {
     public FindPetsByTagsQueryParams tags(final List<String> value) {
-      put("tags", value);
+      put("tags", EncodingUtils.encodeCollection(value, "csv"));
       return this;
     }
   }

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/StoreApi.java
@@ -1,6 +1,7 @@
 package io.swagger.client.api;
 
 import io.swagger.client.ApiClient;
+import io.swagger.client.EncodingUtils;
 
 import io.swagger.client.model.Order;
 

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/UserApi.java
@@ -1,6 +1,7 @@
 package io.swagger.client.api;
 
 import io.swagger.client.ApiClient;
+import io.swagger.client.EncodingUtils;
 
 import io.swagger.client.model.User;
 
@@ -110,7 +111,7 @@ public interface UserApi extends ApiClient.Api {
   "Content-Type: application/json",
   "Accept: application/json",
   })
-  String loginUser(@QueryMap Map<String, Object> queryParams);
+  String loginUser(@QueryMap(encoded=true) Map<String, Object> queryParams);
 
   /**
    * A convenience class for generating query parameters for the
@@ -118,11 +119,11 @@ public interface UserApi extends ApiClient.Api {
    */
   public static class LoginUserQueryParams extends HashMap<String, Object> {
     public LoginUserQueryParams username(final String value) {
-      put("username", value);
+      put("username", EncodingUtils.encode(value));
       return this;
     }
     public LoginUserQueryParams password(final String value) {
-      put("password", value);
+      put("password", EncodingUtils.encode(value));
       return this;
     }
   }


### PR DESCRIPTION
Feign only natively supports the "multi" collectionFormat for encoding lists
of parameter values. This change adds manual encoding of the other formats, such
as "csv" (the default for collections), "tsv", space-separated, and pipes.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Suggested fix for #5265.

Defines a new utility class for encoding query parameters. For QueryMap parameters, uses the convenience class to manually encode the parameters instead of having Feign encode them. Unfortunately, this doesn't help with the API that lists out the query parameters individually, but users can directly call the utility methods as a workaround.

It also adds finer-grained testing of the generated URL with the MockWebServer from okhttp.

