### PR TITLE
[Java,Jersey2] Files.copy in generated code throws FileAlreadyExistsException

### DIFF
--- a/modules/swagger-codegen/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
@@ -27,6 +27,7 @@ import java.io.InputStream;
 
 {{^supportJava6}}
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 {{/supportJava6}}
 {{#supportJava6}}
 import org.apache.commons.io.FileUtils;
@@ -581,7 +582,7 @@ public class ApiClient {
     try {
       File file = prepareDownloadFile(response);
 {{^supportJava6}}
-      Files.copy(response.readEntity(InputStream.class), file.toPath());
+      Files.copy(response.readEntity(InputStream.class), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
 {{/supportJava6}}
 {{#supportJava6}}
       // Java6 falls back to commons.io for file copying


### PR DESCRIPTION
The code generated for Jersey2 is unable to dowload file responses.
For an endpoint with the file response type, the API call with the generated client results in a FileAlreadyExistsException.

A sample response:
      responses:
        200:
          description: The template workbook
          schema:
            type: file

The exception:
xyz.client.ApiException: java.nio.file.FileAlreadyExistsException: e:\temp-dir\download-4619092686092804097
    at xyz.client.ApiClient.downloadFileFromResponse(ApiClient.java:576)
    at xyz.client.ApiClient.deserialize(ApiClient.java:550)
    at xyz.client.ApiClient.invokeAPI(ApiClient.java:693)
    at xyz.client.api.DefaultApi.getTemplateFile(DefaultApi.java:79)

In order for Files.copy to not fail, Files.copy needs to have the StandardCopyOption.REPLACE_EXISTING option specified (prepareDownloadFile creates an empty temp file, it doesn't just create a path)
