### PR TITLE
TypeScript client API: Add setter for base path

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -116,7 +116,7 @@ export enum {{classname}}ApiKeys {
 }
 
 export class {{classname}} {
-    protected basePath = defaultBasePath;
+    protected _basePath = defaultBasePath;
     protected defaultHeaders : any = {};
     protected _useQuerystring : boolean = false;
 
@@ -161,6 +161,14 @@ export class {{classname}} {
 
     set useQuerystring(value: boolean) {
         this._useQuerystring = value;
+    }
+
+    set basePath(basePath: string) {
+        this._basePath = basePath;
+    }
+
+    get basePath() {
+        return this._basePath;
     }
 
     public setApiKey(key: {{classname}}ApiKeys, value: string) {

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -140,7 +140,7 @@ export enum PetApiApiKeys {
 }
 
 export class PetApi {
-    protected basePath = defaultBasePath;
+    protected _basePath = defaultBasePath;
     protected defaultHeaders : any = {};
     protected _useQuerystring : boolean = false;
 
@@ -165,6 +165,14 @@ export class PetApi {
 
     set useQuerystring(value: boolean) {
         this._useQuerystring = value;
+    }
+
+    set basePath(basePath: string) {
+        this._basePath = basePath;
+    }
+
+    get basePath() {
+        return this._basePath;
     }
 
     public setApiKey(key: PetApiApiKeys, value: string) {
@@ -413,9 +421,9 @@ export class PetApi {
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
-
         this.authentications.api_key.applyToRequest(requestOptions);
+
+        this.authentications.petstore_auth.applyToRequest(requestOptions);
 
         this.authentications.default.applyToRequest(requestOptions);
 
@@ -624,7 +632,7 @@ export enum StoreApiApiKeys {
 }
 
 export class StoreApi {
-    protected basePath = defaultBasePath;
+    protected _basePath = defaultBasePath;
     protected defaultHeaders : any = {};
     protected _useQuerystring : boolean = false;
 
@@ -649,6 +657,14 @@ export class StoreApi {
 
     set useQuerystring(value: boolean) {
         this._useQuerystring = value;
+    }
+
+    set basePath(basePath: string) {
+        this._basePath = basePath;
+    }
+
+    get basePath() {
+        return this._basePath;
     }
 
     public setApiKey(key: StoreApiApiKeys, value: string) {
@@ -862,7 +878,7 @@ export enum UserApiApiKeys {
 }
 
 export class UserApi {
-    protected basePath = defaultBasePath;
+    protected _basePath = defaultBasePath;
     protected defaultHeaders : any = {};
     protected _useQuerystring : boolean = false;
 
@@ -887,6 +903,14 @@ export class UserApi {
 
     set useQuerystring(value: boolean) {
         this._useQuerystring = value;
+    }
+
+    set basePath(basePath: string) {
+        this._basePath = basePath;
+    }
+
+    get basePath() {
+        return this._basePath;
     }
 
     public setApiKey(key: UserApiApiKeys, value: string) {

--- a/samples/client/petstore/typescript-node/npm/api.ts
+++ b/samples/client/petstore/typescript-node/npm/api.ts
@@ -140,7 +140,7 @@ export enum PetApiApiKeys {
 }
 
 export class PetApi {
-    protected basePath = defaultBasePath;
+    protected _basePath = defaultBasePath;
     protected defaultHeaders : any = {};
     protected _useQuerystring : boolean = false;
 
@@ -165,6 +165,14 @@ export class PetApi {
 
     set useQuerystring(value: boolean) {
         this._useQuerystring = value;
+    }
+
+    set basePath(basePath: string) {
+        this._basePath = basePath;
+    }
+
+    get basePath() {
+        return this._basePath;
     }
 
     public setApiKey(key: PetApiApiKeys, value: string) {
@@ -413,9 +421,9 @@ export class PetApi {
             json: true,
         };
 
-        this.authentications.petstore_auth.applyToRequest(requestOptions);
-
         this.authentications.api_key.applyToRequest(requestOptions);
+
+        this.authentications.petstore_auth.applyToRequest(requestOptions);
 
         this.authentications.default.applyToRequest(requestOptions);
 
@@ -624,7 +632,7 @@ export enum StoreApiApiKeys {
 }
 
 export class StoreApi {
-    protected basePath = defaultBasePath;
+    protected _basePath = defaultBasePath;
     protected defaultHeaders : any = {};
     protected _useQuerystring : boolean = false;
 
@@ -649,6 +657,14 @@ export class StoreApi {
 
     set useQuerystring(value: boolean) {
         this._useQuerystring = value;
+    }
+
+    set basePath(basePath: string) {
+        this._basePath = basePath;
+    }
+
+    get basePath() {
+        return this._basePath;
     }
 
     public setApiKey(key: StoreApiApiKeys, value: string) {
@@ -862,7 +878,7 @@ export enum UserApiApiKeys {
 }
 
 export class UserApi {
-    protected basePath = defaultBasePath;
+    protected _basePath = defaultBasePath;
     protected defaultHeaders : any = {};
     protected _useQuerystring : boolean = false;
 
@@ -887,6 +903,14 @@ export class UserApi {
 
     set useQuerystring(value: boolean) {
         this._useQuerystring = value;
+    }
+
+    set basePath(basePath: string) {
+        this._basePath = basePath;
+    }
+
+    get basePath() {
+        return this._basePath;
     }
 
     public setApiKey(key: UserApiApiKeys, value: string) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This adds a setter for basePath so it can be changed after calling the constructor.

