### PR TITLE
[C#] fix package name in mono test script

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/mono_nunit_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/mono_nunit_test.mustache
@@ -7,7 +7,7 @@ wget -nc https://nuget.org/nuget.exe
 mozroots --import --sync
 
 echo "[INFO] remove bin/Debug/SwaggerClientTest.dll"
-rm src/IO.Swagger.Test/bin/Debug/{{{packageName}}}.Test.dll 2> /dev/null
+rm src/{{{packageName}}}.Test/bin/Debug/{{{packageName}}}.Test.dll 2> /dev/null
 
 echo "[INFO] install NUnit runners via NuGet"
 wget -nc https://nuget.org/nuget.exe


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Similar to https://github.com/swagger-api/swagger-codegen/pull/5264, this fix applies to the mono test script.
