### PR TITLE
[typescript-fetch][util] Fix template directory used by samples script.

### DIFF
--- a/bin/security/typescript-fetch.sh
+++ b/bin/security/typescript-fetch.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/typescript-fetch -i modules/swagger-codegen/src/test/resources/2_0/petstore-security-test.yaml -l typescript-fetch -o samples/client/petstore-security-test/typescript-fetch"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/TypeScript-Fetch -i modules/swagger-codegen/src/test/resources/2_0/petstore-security-test.yaml -l typescript-fetch -o samples/client/petstore-security-test/typescript-fetch"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/samples/client/petstore-security-test/typescript-fetch/api.ts
+++ b/samples/client/petstore-security-test/typescript-fetch/api.ts
@@ -51,7 +51,7 @@ export interface ModelReturn {
 /**
  * FakeApi - fetch parameter creator
  */
-export const FakeApiFetchParamCreactor = {
+export const FakeApiFetchParamCreator = {
     /** 
      * To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      * @param test code inject * &#39; &quot; &#x3D;end  rn n r To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
@@ -61,9 +61,9 @@ export const FakeApiFetchParamCreactor = {
         let urlObj = url.parse(baseUrl, true);
         let fetchOptions: RequestInit = assign({}, { method: "PUT" }, options);
 
-        let contentTypeHeader: Dictionary<string>;
+        let contentTypeHeader: Dictionary<string> = {};
         contentTypeHeader = { "Content-Type": "application/x-www-form-urlencoded" };
-        fetchOptions.body = querystring.stringify({ 
+        fetchOptions.body = querystring.stringify({
             "test code inject */ &#39; &quot; &#x3D;end -- \r\n \n \r": params["test code inject * &#39; &quot; &#x3D;end  rn n r"],
         });
         if (contentTypeHeader) {
@@ -84,8 +84,8 @@ export const FakeApiFp = {
      * To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      * @param test code inject * &#39; &quot; &#x3D;end  rn n r To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
      */
-    testCodeInjectEndRnNR(params: { "test code inject * &#39; &quot; &#x3D;end  rn n r"?: string;  }, options?: any): (fetch: FetchAPI, basePath?: string) => Promise<any> {
-        const fetchArgs = FakeApiFetchParamCreactor.testCodeInjectEndRnNR(params, options);
+    testCodeInjectEndRnNR(params: { "test code inject * &#39; &quot; &#x3D;end  rn n r"?: string;  }, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<any> {
+        const fetchArgs = FakeApiFetchParamCreator.testCodeInjectEndRnNR(params, options);
         return (fetch: FetchAPI = isomorphicFetch, basePath: string = BASE_PATH) => {
             return fetch(basePath + fetchArgs.url, fetchArgs.options).then((response) => {
                 if (response.status >= 200 && response.status < 300) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
  → bin/security/typescript-fetch.sh
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

No generator changes, just a sample generation script.

The script bin/security/typescript-fetch.sh complained that the template directory `modules/swagger-codegen/src/main/resources/typescript-fetch` does not exist. It actually is named `.../TypeScript-Fetch`, which is a difference e.g. on case-sensitive file systems (e.g. the usual Linux ones), while it is ignored in case-insensitive ones (e.g. usual on Windows) or case-preserving ones (usual on MacOS).

Also updated the samples after the change.