### PR TITLE
[Java] add logic to camelize path variables for Feign client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -242,14 +242,14 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     @Override
     public Map<String, Object> postProcessOperations(Map<String, Object> objs) {
         super.postProcessOperations(objs);
-        if(usesAnyRetrofitLibrary()) {
+        if (usesAnyRetrofitLibrary()) {
             Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
             if (operations != null) {
                 List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
                 for (CodegenOperation operation : ops) {
                     if (operation.hasConsumes == Boolean.TRUE) {
 
-                        if ( isMultipartType(operation.consumes) ) { 
+                        if (isMultipartType(operation.consumes)) {
                             operation.isMultipart = Boolean.TRUE;
                         }
                         else {
@@ -264,6 +264,27 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                 }
             }
         }
+
+        // camelize path variables for Feign client
+        if ("feign".equals(getLibrary())) {
+            Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+            List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
+            for (CodegenOperation op : operationList) {
+                String path = new String(op.path);
+                String[] items = path.split("/", -1);
+                String opsPath = "";
+                int pathParamIndex = 0;
+
+                for (int i = 0; i < items.length; ++i) {
+                    if (items[i].matches("^\\{(.*)\\}$")) { // wrap in {}
+                        // camelize path variable
+                        items[i] = "{" + camelize(items[i].substring(1, items[i].length()-1), true) + "}";
+                    }
+                }
+                op.path = StringUtils.join(items, "/");
+            }
+        }
+
         return objs;
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

For https://github.com/swagger-api/swagger-codegen/issues/5296
