### PR TITLE
[JaxrsResteasy] Fix JacksonConfig package and RestApplication imports

### DIFF
--- a/bin/jaxrs-resteasy-eap-joda-petstore-server.json
+++ b/bin/jaxrs-resteasy-eap-joda-petstore-server.json
@@ -1,0 +1,3 @@
+{
+    "dateLibrary": "joda"
+}

--- a/bin/jaxrs-resteasy-eap-joda-petstore-server.sh
+++ b/bin/jaxrs-resteasy-eap-joda-petstore-server.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+SCRIPT="$0"
+
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+
+if [ ! -d "${APP_DIR}" ]; then
+  APP_DIR=`dirname "$SCRIPT"`/..
+  APP_DIR=`cd "${APP_DIR}"; pwd`
+fi
+
+executable="./modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"
+
+if [ ! -f "$executable" ]
+then
+  mvn clean package
+fi
+
+# if you've executed sbt assembly previously it will use that instead.
+export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+ags="$@ generate --artifact-id swagger-jaxrs-resteasy-eap-joda-server -t modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap-joda -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-eap-joda-petstore-server.json"
+
+echo "Removing files and folders under samples/server/petstore/jaxrs-resteasy/eap-joda/src/main"
+rm -rf samples/server/petstore/jaxrs-resteasy/eap-joda/src/main
+find samples/server/petstore/jaxrs-resteasy/eap-joda -maxdepth 1 -type f ! -name "README.md" -exec rm {} +
+
+java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-resteasy-eap-petstore-server.sh
+++ b/bin/jaxrs-resteasy-eap-petstore-server.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+SCRIPT="$0"
+
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+
+if [ ! -d "${APP_DIR}" ]; then
+  APP_DIR=`dirname "$SCRIPT"`/..
+  APP_DIR=`cd "${APP_DIR}"; pwd`
+fi
+
+executable="./modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"
+
+if [ ! -f "$executable" ]
+then
+  mvn clean package
+fi
+
+# if you've executed sbt assembly previously it will use that instead.
+export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap -DhideGenerationTimestamp=true"
+
+echo "Removing files and folders under samples/server/petstore/jaxrs-resteasy/eap/src/main"
+rm -rf samples/server/petstore/jaxrs-resteasy/eap/src/main
+find samples/server/petstore/jaxrs-resteasy/eap -maxdepth 1 -type f ! -name "README.md" -exec rm {} +
+
+java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/JacksonConfig.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/JacksonConfig.mustache
@@ -1,4 +1,4 @@
-package io.swagger.api;
+package {{invokerPackage}};
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/RestApplication.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/RestApplication.mustache
@@ -11,7 +11,7 @@ import io.swagger.jaxrs.config.BeanConfig;
 
 {{#apiInfo}}
 {{#apis}}
-import {{invokerPackage}}.impl.{{classname}}ServiceImpl;
+import {{package}}.impl.{{classname}}ServiceImpl;
 {{/apis}}
 {{/apiInfo}}   
 

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/web.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/web.mustache
@@ -4,6 +4,6 @@
   xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee    http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
     <context-param> 
         <param-name>resteasy.providers</param-name> 
-        <param-value>io.swagger.api.JacksonConfig</param-value> 
+        <param-value>{{invokerPackage}}.JacksonConfig</param-value>
     </context-param>
 </web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -543,6 +543,30 @@
             </modules>
         </profile>
         <profile>
+            <id>jaxrs-resteasy-eap-server</id>
+            <activation>
+                <property>
+                    <name>env</name>
+                    <value>java</value>
+                </property>
+            </activation>
+            <modules>
+                <module>samples/server/petstore/jaxrs-resteasy/eap</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>jaxrs-resteasy-eap-server-joda</id>
+            <activation>
+                <property>
+                    <name>env</name>
+                    <value>java</value>
+                </property>
+            </activation>
+            <modules>
+                <module>samples/server/petstore/jaxrs-resteasy/eap-joda</module>
+            </modules>
+        </profile>
+        <profile>
             <id>jaxrs-server</id>
             <activation>
                 <property>
@@ -789,6 +813,8 @@
                 <module>samples/server/petstore/jaxrs/jersey1</module>
                 <module>samples/server/petstore/jaxrs/jersey2</module>
                 <module>samples/server/petstore/jaxrs-resteasy/default</module>
+                <module>samples/server/petstore/jaxrs-resteasy/eap</module>
+                <module>samples/server/petstore/jaxrs-resteasy/eap-joda</module>
                 <module>samples/server/petstore/jaxrs-resteasy/joda</module>
                 <module>samples/server/petstore/scalatra</module>
                 <module>samples/server/petstore/spring-mvc</module>

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
@@ -2,9 +2,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.swagger</groupId>
-    <artifactId>swagger-jaxrs-resteasy-eap-server</artifactId>
+    <artifactId>swagger-jaxrs-resteasy-eap-joda-server</artifactId>
     <packaging>war</packaging>
-    <name>swagger-jaxrs-resteasy-eap-server</name>
+    <name>swagger-jaxrs-resteasy-eap-joda-server</name>
     <version>1.0.0</version>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -163,7 +163,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.9</swagger-core-version>
+        <swagger-core-version>1.5.12</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/settings.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = "swagger-jaxrs-resteasy-eap-server"
+rootProject.name = "swagger-jaxrs-resteasy-eap-joda-server"

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/Category.java
@@ -18,7 +18,7 @@ public class Category   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -30,7 +30,7 @@ public class Category   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {
     return name;

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -19,7 +19,7 @@ public class ModelApiResponse   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("code")
   public Integer getCode() {
     return code;
@@ -31,7 +31,7 @@ public class ModelApiResponse   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("type")
   public String getType() {
     return type;
@@ -43,7 +43,7 @@ public class ModelApiResponse   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("message")
   public String getMessage() {
     return message;

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/Order.java
@@ -47,7 +47,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -59,7 +59,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("petId")
   public Long getPetId() {
     return petId;
@@ -71,7 +71,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("quantity")
   public Integer getQuantity() {
     return quantity;
@@ -83,7 +83,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
   public DateTime getShipDate() {
     return shipDate;
@@ -96,7 +96,7 @@ public class Order   {
    * Order Status
    **/
   
-  @ApiModelProperty(example = "null", value = "Order Status")
+  @ApiModelProperty(value = "Order Status")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
@@ -108,7 +108,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("complete")
   public Boolean getComplete() {
     return complete;

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/Pet.java
@@ -49,7 +49,7 @@ public class Pet   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -61,7 +61,7 @@ public class Pet   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("category")
   public Category getCategory() {
     return category;
@@ -86,7 +86,7 @@ public class Pet   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
   @NotNull
   public List<String> getPhotoUrls() {
@@ -99,7 +99,7 @@ public class Pet   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("tags")
   public List<Tag> getTags() {
     return tags;
@@ -112,7 +112,7 @@ public class Pet   {
    * pet status in the store
    **/
   
-  @ApiModelProperty(example = "null", value = "pet status in the store")
+  @ApiModelProperty(value = "pet status in the store")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/Tag.java
@@ -18,7 +18,7 @@ public class Tag   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -30,7 +30,7 @@ public class Tag   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {
     return name;

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/io/swagger/model/User.java
@@ -24,7 +24,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -36,7 +36,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("username")
   public String getUsername() {
     return username;
@@ -48,7 +48,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("firstName")
   public String getFirstName() {
     return firstName;
@@ -60,7 +60,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("lastName")
   public String getLastName() {
     return lastName;
@@ -72,7 +72,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("email")
   public String getEmail() {
     return email;
@@ -84,7 +84,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("password")
   public String getPassword() {
     return password;
@@ -96,7 +96,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("phone")
   public String getPhone() {
     return phone;
@@ -109,7 +109,7 @@ public class User   {
    * User Status
    **/
   
-  @ApiModelProperty(example = "null", value = "User Status")
+  @ApiModelProperty(value = "User Status")
   @JsonProperty("userStatus")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/main/java/io/swagger/api/RestApplication.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/main/java/io/swagger/api/RestApplication.java
@@ -13,15 +13,13 @@ import io.swagger.api.impl.UserApiServiceImpl;
 @ApplicationPath("/")
 public class RestApplication extends Application {
 
+
     public Set<Class<?>> getClasses() {
         Set<Class<?>> resources = new HashSet<Class<?>>();
         resources.add(PetApiServiceImpl.class);
         resources.add(StoreApiServiceImpl.class);
         resources.add(UserApiServiceImpl.class);
-        
-        //resources.add(io.swagger.jaxrs.listing.ApiListingResource.class);
-        //resources.add(io.swagger.jaxrs.listing.SwaggerSerializers.class);
-        
+
         return resources;
     }
 

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/main/webapp/WEB-INF/web.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/main/webapp/WEB-INF/web.xml
@@ -2,8 +2,8 @@
 <web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee"
   xmlns:j2ee="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee    http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
-	<context-param> 
-		<param-name>resteasy.providers</param-name> 
-		<param-value>io.swagger.api.JacksonConfig</param-value> 
-	</context-param>
+    <context-param> 
+        <param-name>resteasy.providers</param-name> 
+        <param-value>io.swagger.api.JacksonConfig</param-value>
+    </context-param>
 </web-app>

--- a/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
@@ -158,7 +158,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-core-version>1.5.9</swagger-core-version>
+        <swagger-core-version>1.5.12</swagger-core-version>
         <jetty-version>9.2.9.v20150224</jetty-version>
         <resteasy-version>3.0.11.Final</resteasy-version>
         <slf4j-version>1.6.3</slf4j-version>

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/Category.java
@@ -18,7 +18,7 @@ public class Category   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -30,7 +30,7 @@ public class Category   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {
     return name;

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -19,7 +19,7 @@ public class ModelApiResponse   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("code")
   public Integer getCode() {
     return code;
@@ -31,7 +31,7 @@ public class ModelApiResponse   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("type")
   public String getType() {
     return type;
@@ -43,7 +43,7 @@ public class ModelApiResponse   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("message")
   public String getMessage() {
     return message;

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/Order.java
@@ -47,7 +47,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -59,7 +59,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("petId")
   public Long getPetId() {
     return petId;
@@ -71,7 +71,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("quantity")
   public Integer getQuantity() {
     return quantity;
@@ -83,7 +83,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
   public Date getShipDate() {
     return shipDate;
@@ -96,7 +96,7 @@ public class Order   {
    * Order Status
    **/
   
-  @ApiModelProperty(example = "null", value = "Order Status")
+  @ApiModelProperty(value = "Order Status")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;
@@ -108,7 +108,7 @@ public class Order   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("complete")
   public Boolean getComplete() {
     return complete;

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/Pet.java
@@ -49,7 +49,7 @@ public class Pet   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -61,7 +61,7 @@ public class Pet   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("category")
   public Category getCategory() {
     return category;
@@ -86,7 +86,7 @@ public class Pet   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", required = true, value = "")
+  @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
   @NotNull
   public List<String> getPhotoUrls() {
@@ -99,7 +99,7 @@ public class Pet   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("tags")
   public List<Tag> getTags() {
     return tags;
@@ -112,7 +112,7 @@ public class Pet   {
    * pet status in the store
    **/
   
-  @ApiModelProperty(example = "null", value = "pet status in the store")
+  @ApiModelProperty(value = "pet status in the store")
   @JsonProperty("status")
   public StatusEnum getStatus() {
     return status;

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/Tag.java
@@ -18,7 +18,7 @@ public class Tag   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -30,7 +30,7 @@ public class Tag   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("name")
   public String getName() {
     return name;

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/io/swagger/model/User.java
@@ -24,7 +24,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("id")
   public Long getId() {
     return id;
@@ -36,7 +36,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("username")
   public String getUsername() {
     return username;
@@ -48,7 +48,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("firstName")
   public String getFirstName() {
     return firstName;
@@ -60,7 +60,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("lastName")
   public String getLastName() {
     return lastName;
@@ -72,7 +72,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("email")
   public String getEmail() {
     return email;
@@ -84,7 +84,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("password")
   public String getPassword() {
     return password;
@@ -96,7 +96,7 @@ public class User   {
   /**
    **/
   
-  @ApiModelProperty(example = "null", value = "")
+  @ApiModelProperty(value = "")
   @JsonProperty("phone")
   public String getPhone() {
     return phone;
@@ -109,7 +109,7 @@ public class User   {
    * User Status
    **/
   
-  @ApiModelProperty(example = "null", value = "User Status")
+  @ApiModelProperty(value = "User Status")
   @JsonProperty("userStatus")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/main/java/io/swagger/api/RestApplication.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/main/java/io/swagger/api/RestApplication.java
@@ -5,7 +5,6 @@ import javax.ws.rs.core.Application;
 
 import java.util.Set;
 import java.util.HashSet;
-import io.swagger.jaxrs.config.BeanConfig;
 
 import io.swagger.api.impl.PetApiServiceImpl;
 import io.swagger.api.impl.StoreApiServiceImpl;
@@ -14,19 +13,6 @@ import io.swagger.api.impl.UserApiServiceImpl;
 @ApplicationPath("/")
 public class RestApplication extends Application {
 
-	public RestApplication() {
-		super();
-		// Customize the dynamic contract
-		BeanConfig beanConfig = new BeanConfig();
-		beanConfig.setTitle("Swagger Petstore");
-		beanConfig.setVersion("1.0.0");
-		beanConfig.setSchemes(new String[] { "http" });
-		beanConfig.setHost("petstore.swagger.io");
-		beanConfig.setBasePath("/v2");
-		beanConfig.setResourcePackage("io.swagger.api");
-		beanConfig.setScan(true);
-
-	}
 
     public Set<Class<?>> getClasses() {
         Set<Class<?>> resources = new HashSet<Class<?>>();
@@ -34,8 +20,6 @@ public class RestApplication extends Application {
         resources.add(StoreApiServiceImpl.class);
         resources.add(UserApiServiceImpl.class);
 
-        resources.add(io.swagger.jaxrs.listing.ApiListingResource.class);
-        resources.add(io.swagger.jaxrs.listing.SwaggerSerializers.class);
         return resources;
     }
 

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/main/webapp/WEB-INF/web.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/main/webapp/WEB-INF/web.xml
@@ -2,8 +2,8 @@
 <web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee"
   xmlns:j2ee="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee    http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
-	<context-param> 
-		<param-name>resteasy.providers</param-name> 
-		<param-value>io.swagger.api.JacksonConfig</param-value> 
-	</context-param>
+    <context-param> 
+        <param-name>resteasy.providers</param-name> 
+        <param-value>io.swagger.api.JacksonConfig</param-value>
+    </context-param>
 </web-app>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This fixes #5302

This is for the EAP version specifically.

* The JacksonConfig class always used the io.swagger.api package
* The RestApplication class did not import the service implementations
  from the correct package
* Added shell script for generating test applications