### PR TITLE
[Python] async error handling fix

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -37,20 +37,16 @@ class {{classname}}(object):
         {{{notes}}}
 {{/notes}}
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
+        asynchronous HTTP request, please pass async=True
 {{#sortParamsByRequiredFlag}}
-        >>> thread = api.{{operationId}}({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}callback=callback_function)
+        >>> thread = api.{{operationId}}({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}async=True)
 {{/sortParamsByRequiredFlag}}
 {{^sortParamsByRequiredFlag}}
-        >>> thread = api.{{operationId}}({{#allParams}}{{#required}}{{paramName}}={{paramName}}_value, {{/required}}{{/allParams}}callback=callback_function)
+        >>> thread = api.{{operationId}}({{#allParams}}{{#required}}{{paramName}}={{paramName}}_value, {{/required}}{{/allParams}}async=True)
 {{/sortParamsByRequiredFlag}}
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
 {{#allParams}}
         :param {{dataType}} {{paramName}}:{{#description}} {{{description}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
 {{/allParams}}
@@ -59,7 +55,7 @@ class {{classname}}(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.{{operationId}}_with_http_info({{#sortParamsByRequiredFlag}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/sortParamsByRequiredFlag}}**kwargs)
         else:
             (data) = self.{{operationId}}_with_http_info({{#sortParamsByRequiredFlag}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/sortParamsByRequiredFlag}}**kwargs)
@@ -74,20 +70,16 @@ class {{classname}}(object):
         {{{notes}}}
 {{/notes}}
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
+        asynchronous HTTP request, please pass async=True
 {{#sortParamsByRequiredFlag}}
-        >>> thread = api.{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}callback=callback_function)
+        >>> thread = api.{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}async=True)
 {{/sortParamsByRequiredFlag}}
 {{^sortParamsByRequiredFlag}}
-        >>> thread = api.{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}={{paramName}}_value, {{/required}}{{/allParams}}callback=callback_function)
+        >>> thread = api.{{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}={{paramName}}_value, {{/required}}{{/allParams}}async=True)
 {{/sortParamsByRequiredFlag}}
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
 {{#allParams}}
         :param {{dataType}} {{paramName}}:{{#description}} {{{description}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/optional}}
 {{/allParams}}
@@ -97,7 +89,7 @@ class {{classname}}(object):
         """
 
         all_params = [{{#allParams}}'{{paramName}}'{{#hasMore}}, {{/hasMore}}{{/allParams}}]
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -214,7 +206,7 @@ class {{classname}}(object):
                                         files=local_var_files,
                                         response_type={{#returnType}}'{{returnType}}'{{/returnType}}{{^returnType}}None{{/returnType}},
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),

--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -7,7 +7,7 @@ import re
 import json
 import mimetypes
 import tempfile
-import threading
+from multiprocessing.pool import ThreadPool
 
 from datetime import date, datetime
 
@@ -55,6 +55,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
+        self.pool = ThreadPool()
         self.rest_client = RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -83,7 +84,7 @@ class ApiClient(object):
     def __call_api(self, resource_path, method,
                    path_params=None, query_params=None, header_params=None,
                    body=None, post_params=None, files=None,
-                   response_type=None, auth_settings=None, callback=None,
+                   response_type=None, auth_settings=None,
                    _return_http_data_only=None, collection_formats=None, _preload_content=True,
                    _request_timeout=None):
 
@@ -147,12 +148,7 @@ class ApiClient(object):
             else:
                 return_data = None
 
-        if callback:
-            if _return_http_data_only:
-                callback(return_data)
-            else:
-                callback((return_data, response_data.status, response_data.getheaders()))
-        elif _return_http_data_only:
+        if _return_http_data_only:
             return (return_data)
         else:
             return (return_data, response_data.status, response_data.getheaders())
@@ -266,7 +262,7 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, callback=None,
+                 response_type=None, auth_settings=None, async=None,
                  _return_http_data_only=None, collection_formats=None, _preload_content=True,
                  _request_timeout=None):
         """
@@ -286,9 +282,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param callback function: Callback function for asynchronous request.
-            If provide this parameter,
-            the request will be called asynchronously.
+        :param async bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code and headers
         :param collection_formats: dict of collection formats for path, query,
             header, and post parameters.
@@ -303,22 +297,20 @@ class ApiClient(object):
             If parameter callback is None,
             then the method will return the response directly.
         """
-        if callback is None:
+        if not async:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,
-                                   response_type, auth_settings, callback,
+                                   response_type, auth_settings,
                                    _return_http_data_only, collection_formats, _preload_content, _request_timeout)
         else:
-            thread = threading.Thread(target=self.__call_api,
-                                      args=(resource_path, method,
-                                            path_params, query_params,
-                                            header_params, body,
-                                            post_params, files,
-                                            response_type, auth_settings,
-                                            callback, _return_http_data_only,
-                                            collection_formats, _preload_content, _request_timeout))
-        thread.start()
+            thread = self.pool.apply_async(self.__call_api, (resource_path, method,
+                                           path_params, query_params,
+                                           header_params, body,
+                                           post_params, files,
+                                           response_type, auth_settings,
+                                           _return_http_data_only,
+                                           collection_formats, _preload_content, _request_timeout))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -16,7 +16,7 @@ import re
 import json
 import mimetypes
 import tempfile
-import threading
+from multiprocessing.pool import ThreadPool
 
 from datetime import date, datetime
 
@@ -64,6 +64,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
+        self.pool = ThreadPool()
         self.rest_client = RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -92,7 +93,7 @@ class ApiClient(object):
     def __call_api(self, resource_path, method,
                    path_params=None, query_params=None, header_params=None,
                    body=None, post_params=None, files=None,
-                   response_type=None, auth_settings=None, callback=None,
+                   response_type=None, auth_settings=None,
                    _return_http_data_only=None, collection_formats=None, _preload_content=True,
                    _request_timeout=None):
 
@@ -156,12 +157,7 @@ class ApiClient(object):
             else:
                 return_data = None
 
-        if callback:
-            if _return_http_data_only:
-                callback(return_data)
-            else:
-                callback((return_data, response_data.status, response_data.getheaders()))
-        elif _return_http_data_only:
+        if _return_http_data_only:
             return (return_data)
         else:
             return (return_data, response_data.status, response_data.getheaders())
@@ -275,7 +271,7 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, callback=None,
+                 response_type=None, auth_settings=None, async=None,
                  _return_http_data_only=None, collection_formats=None, _preload_content=True,
                  _request_timeout=None):
         """
@@ -295,9 +291,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param callback function: Callback function for asynchronous request.
-            If provide this parameter,
-            the request will be called asynchronously.
+        :param async bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code and headers
         :param collection_formats: dict of collection formats for path, query,
             header, and post parameters.
@@ -312,22 +306,20 @@ class ApiClient(object):
             If parameter callback is None,
             then the method will return the response directly.
         """
-        if callback is None:
+        if not async:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,
-                                   response_type, auth_settings, callback,
+                                   response_type, auth_settings,
                                    _return_http_data_only, collection_formats, _preload_content, _request_timeout)
         else:
-            thread = threading.Thread(target=self.__call_api,
-                                      args=(resource_path, method,
-                                            path_params, query_params,
-                                            header_params, body,
-                                            post_params, files,
-                                            response_type, auth_settings,
-                                            callback, _return_http_data_only,
-                                            collection_formats, _preload_content, _request_timeout))
-        thread.start()
+            thread = self.pool.apply_async(self.__call_api, (resource_path, method,
+                                           path_params, query_params,
+                                           header_params, body,
+                                           post_params, files,
+                                           response_type, auth_settings,
+                                           _return_http_data_only,
+                                           collection_formats, _preload_content, _request_timeout))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -40,22 +40,18 @@ class FakeApi(object):
         To test \"client\" model
         To test \"client\" model
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.test_client_model(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_client_model(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Client body: client model (required)
         :return: Client
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.test_client_model_with_http_info(body, **kwargs)
         else:
             (data) = self.test_client_model_with_http_info(body, **kwargs)
@@ -66,15 +62,11 @@ class FakeApi(object):
         To test \"client\" model
         To test \"client\" model
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.test_client_model_with_http_info(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_client_model_with_http_info(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Client body: client model (required)
         :return: Client
                  If the method is called asynchronously,
@@ -82,7 +74,7 @@ class FakeApi(object):
         """
 
         all_params = ['body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -135,7 +127,7 @@ class FakeApi(object):
                                         files=local_var_files,
                                         response_type='Client',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -146,15 +138,11 @@ class FakeApi(object):
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param float number: None (required)
         :param float double: None (required)
         :param str pattern_without_delimiter: None (required)
@@ -174,7 +162,7 @@ class FakeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, **kwargs)
         else:
             (data) = self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, **kwargs)
@@ -185,15 +173,11 @@ class FakeApi(object):
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param float number: None (required)
         :param float double: None (required)
         :param str pattern_without_delimiter: None (required)
@@ -214,7 +198,7 @@ class FakeApi(object):
         """
 
         all_params = ['number', 'double', 'pattern_without_delimiter', 'byte', 'integer', 'int32', 'int64', 'float', 'string', 'binary', 'date', 'date_time', 'password', 'param_callback']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -328,7 +312,7 @@ class FakeApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -339,15 +323,11 @@ class FakeApi(object):
         To test enum parameters
         To test enum parameters
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.test_enum_parameters(callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_enum_parameters(async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[str] enum_form_string_array: Form parameter enum test (string array)
         :param str enum_form_string: Form parameter enum test (string)
         :param list[str] enum_header_string_array: Header parameter enum test (string array)
@@ -361,7 +341,7 @@ class FakeApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.test_enum_parameters_with_http_info(**kwargs)
         else:
             (data) = self.test_enum_parameters_with_http_info(**kwargs)
@@ -372,15 +352,11 @@ class FakeApi(object):
         To test enum parameters
         To test enum parameters
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.test_enum_parameters_with_http_info(callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_enum_parameters_with_http_info(async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[str] enum_form_string_array: Form parameter enum test (string array)
         :param str enum_form_string: Form parameter enum test (string)
         :param list[str] enum_header_string_array: Header parameter enum test (string array)
@@ -395,7 +371,7 @@ class FakeApi(object):
         """
 
         all_params = ['enum_form_string_array', 'enum_form_string', 'enum_header_string_array', 'enum_header_string', 'enum_query_string_array', 'enum_query_string', 'enum_query_integer', 'enum_query_double']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -462,7 +438,7 @@ class FakeApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),

--- a/samples/client/petstore/python/petstore_api/apis/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_classname_tags_123_api.py
@@ -39,22 +39,18 @@ class FakeClassnameTags123Api(object):
         """
         To test class name in snake case
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.test_classname(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_classname(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Client body: client model (required)
         :return: Client
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.test_classname_with_http_info(body, **kwargs)
         else:
             (data) = self.test_classname_with_http_info(body, **kwargs)
@@ -64,15 +60,11 @@ class FakeClassnameTags123Api(object):
         """
         To test class name in snake case
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.test_classname_with_http_info(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.test_classname_with_http_info(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Client body: client model (required)
         :return: Client
                  If the method is called asynchronously,
@@ -80,7 +72,7 @@ class FakeClassnameTags123Api(object):
         """
 
         all_params = ['body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -133,7 +125,7 @@ class FakeClassnameTags123Api(object):
                                         files=local_var_files,
                                         response_type='Client',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),

--- a/samples/client/petstore/python/petstore_api/apis/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/pet_api.py
@@ -40,22 +40,18 @@ class PetApi(object):
         Add a new pet to the store
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.add_pet(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.add_pet(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Pet body: Pet object that needs to be added to the store (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.add_pet_with_http_info(body, **kwargs)
         else:
             (data) = self.add_pet_with_http_info(body, **kwargs)
@@ -66,15 +62,11 @@ class PetApi(object):
         Add a new pet to the store
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.add_pet_with_http_info(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.add_pet_with_http_info(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Pet body: Pet object that needs to be added to the store (required)
         :return: None
                  If the method is called asynchronously,
@@ -82,7 +74,7 @@ class PetApi(object):
         """
 
         all_params = ['body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -135,7 +127,7 @@ class PetApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -146,15 +138,11 @@ class PetApi(object):
         Deletes a pet
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.delete_pet(pet_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.delete_pet(pet_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int pet_id: Pet id to delete (required)
         :param str api_key:
         :return: None
@@ -162,7 +150,7 @@ class PetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.delete_pet_with_http_info(pet_id, **kwargs)
         else:
             (data) = self.delete_pet_with_http_info(pet_id, **kwargs)
@@ -173,15 +161,11 @@ class PetApi(object):
         Deletes a pet
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.delete_pet_with_http_info(pet_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.delete_pet_with_http_info(pet_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int pet_id: Pet id to delete (required)
         :param str api_key:
         :return: None
@@ -190,7 +174,7 @@ class PetApi(object):
         """
 
         all_params = ['pet_id', 'api_key']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -241,7 +225,7 @@ class PetApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -252,22 +236,18 @@ class PetApi(object):
         Finds Pets by status
         Multiple status values can be provided with comma separated strings
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.find_pets_by_status(status, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.find_pets_by_status(status, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[str] status: Status values that need to be considered for filter (required)
         :return: list[Pet]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.find_pets_by_status_with_http_info(status, **kwargs)
         else:
             (data) = self.find_pets_by_status_with_http_info(status, **kwargs)
@@ -278,15 +258,11 @@ class PetApi(object):
         Finds Pets by status
         Multiple status values can be provided with comma separated strings
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.find_pets_by_status_with_http_info(status, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.find_pets_by_status_with_http_info(status, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[str] status: Status values that need to be considered for filter (required)
         :return: list[Pet]
                  If the method is called asynchronously,
@@ -294,7 +270,7 @@ class PetApi(object):
         """
 
         all_params = ['status']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -344,7 +320,7 @@ class PetApi(object):
                                         files=local_var_files,
                                         response_type='list[Pet]',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -355,22 +331,18 @@ class PetApi(object):
         Finds Pets by tags
         Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.find_pets_by_tags(tags, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.find_pets_by_tags(tags, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[str] tags: Tags to filter by (required)
         :return: list[Pet]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.find_pets_by_tags_with_http_info(tags, **kwargs)
         else:
             (data) = self.find_pets_by_tags_with_http_info(tags, **kwargs)
@@ -381,15 +353,11 @@ class PetApi(object):
         Finds Pets by tags
         Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.find_pets_by_tags_with_http_info(tags, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.find_pets_by_tags_with_http_info(tags, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[str] tags: Tags to filter by (required)
         :return: list[Pet]
                  If the method is called asynchronously,
@@ -397,7 +365,7 @@ class PetApi(object):
         """
 
         all_params = ['tags']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -447,7 +415,7 @@ class PetApi(object):
                                         files=local_var_files,
                                         response_type='list[Pet]',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -458,22 +426,18 @@ class PetApi(object):
         Find pet by ID
         Returns a single pet
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.get_pet_by_id(pet_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_pet_by_id(pet_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int pet_id: ID of pet to return (required)
         :return: Pet
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.get_pet_by_id_with_http_info(pet_id, **kwargs)
         else:
             (data) = self.get_pet_by_id_with_http_info(pet_id, **kwargs)
@@ -484,15 +448,11 @@ class PetApi(object):
         Find pet by ID
         Returns a single pet
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.get_pet_by_id_with_http_info(pet_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_pet_by_id_with_http_info(pet_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int pet_id: ID of pet to return (required)
         :return: Pet
                  If the method is called asynchronously,
@@ -500,7 +460,7 @@ class PetApi(object):
         """
 
         all_params = ['pet_id']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -549,7 +509,7 @@ class PetApi(object):
                                         files=local_var_files,
                                         response_type='Pet',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -560,22 +520,18 @@ class PetApi(object):
         Update an existing pet
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.update_pet(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.update_pet(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Pet body: Pet object that needs to be added to the store (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.update_pet_with_http_info(body, **kwargs)
         else:
             (data) = self.update_pet_with_http_info(body, **kwargs)
@@ -586,15 +542,11 @@ class PetApi(object):
         Update an existing pet
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.update_pet_with_http_info(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.update_pet_with_http_info(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Pet body: Pet object that needs to be added to the store (required)
         :return: None
                  If the method is called asynchronously,
@@ -602,7 +554,7 @@ class PetApi(object):
         """
 
         all_params = ['body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -655,7 +607,7 @@ class PetApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -666,15 +618,11 @@ class PetApi(object):
         Updates a pet in the store with form data
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.update_pet_with_form(pet_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.update_pet_with_form(pet_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int pet_id: ID of pet that needs to be updated (required)
         :param str name: Updated name of the pet
         :param str status: Updated status of the pet
@@ -683,7 +631,7 @@ class PetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.update_pet_with_form_with_http_info(pet_id, **kwargs)
         else:
             (data) = self.update_pet_with_form_with_http_info(pet_id, **kwargs)
@@ -694,15 +642,11 @@ class PetApi(object):
         Updates a pet in the store with form data
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.update_pet_with_form_with_http_info(pet_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.update_pet_with_form_with_http_info(pet_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int pet_id: ID of pet that needs to be updated (required)
         :param str name: Updated name of the pet
         :param str status: Updated status of the pet
@@ -712,7 +656,7 @@ class PetApi(object):
         """
 
         all_params = ['pet_id', 'name', 'status']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -769,7 +713,7 @@ class PetApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -780,15 +724,11 @@ class PetApi(object):
         uploads an image
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.upload_file(pet_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.upload_file(pet_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int pet_id: ID of pet to update (required)
         :param str additional_metadata: Additional data to pass to server
         :param file file: file to upload
@@ -797,7 +737,7 @@ class PetApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.upload_file_with_http_info(pet_id, **kwargs)
         else:
             (data) = self.upload_file_with_http_info(pet_id, **kwargs)
@@ -808,15 +748,11 @@ class PetApi(object):
         uploads an image
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.upload_file_with_http_info(pet_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.upload_file_with_http_info(pet_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int pet_id: ID of pet to update (required)
         :param str additional_metadata: Additional data to pass to server
         :param file file: file to upload
@@ -826,7 +762,7 @@ class PetApi(object):
         """
 
         all_params = ['pet_id', 'additional_metadata', 'file']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -883,7 +819,7 @@ class PetApi(object):
                                         files=local_var_files,
                                         response_type='ApiResponse',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),

--- a/samples/client/petstore/python/petstore_api/apis/store_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/store_api.py
@@ -40,22 +40,18 @@ class StoreApi(object):
         Delete purchase order by ID
         For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.delete_order(order_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.delete_order(order_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str order_id: ID of the order that needs to be deleted (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.delete_order_with_http_info(order_id, **kwargs)
         else:
             (data) = self.delete_order_with_http_info(order_id, **kwargs)
@@ -66,15 +62,11 @@ class StoreApi(object):
         Delete purchase order by ID
         For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.delete_order_with_http_info(order_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.delete_order_with_http_info(order_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str order_id: ID of the order that needs to be deleted (required)
         :return: None
                  If the method is called asynchronously,
@@ -82,7 +74,7 @@ class StoreApi(object):
         """
 
         all_params = ['order_id']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -131,7 +123,7 @@ class StoreApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -142,21 +134,17 @@ class StoreApi(object):
         Returns pet inventories by status
         Returns a map of status codes to quantities
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.get_inventory(callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_inventory(async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :return: dict(str, int)
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.get_inventory_with_http_info(**kwargs)
         else:
             (data) = self.get_inventory_with_http_info(**kwargs)
@@ -167,22 +155,18 @@ class StoreApi(object):
         Returns pet inventories by status
         Returns a map of status codes to quantities
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.get_inventory_with_http_info(callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_inventory_with_http_info(async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :return: dict(str, int)
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -225,7 +209,7 @@ class StoreApi(object):
                                         files=local_var_files,
                                         response_type='dict(str, int)',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -236,22 +220,18 @@ class StoreApi(object):
         Find purchase order by ID
         For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.get_order_by_id(order_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_order_by_id(order_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int order_id: ID of pet that needs to be fetched (required)
         :return: Order
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.get_order_by_id_with_http_info(order_id, **kwargs)
         else:
             (data) = self.get_order_by_id_with_http_info(order_id, **kwargs)
@@ -262,15 +242,11 @@ class StoreApi(object):
         Find purchase order by ID
         For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.get_order_by_id_with_http_info(order_id, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_order_by_id_with_http_info(order_id, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param int order_id: ID of pet that needs to be fetched (required)
         :return: Order
                  If the method is called asynchronously,
@@ -278,7 +254,7 @@ class StoreApi(object):
         """
 
         all_params = ['order_id']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -331,7 +307,7 @@ class StoreApi(object):
                                         files=local_var_files,
                                         response_type='Order',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -342,22 +318,18 @@ class StoreApi(object):
         Place an order for a pet
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.place_order(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.place_order(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Order body: order placed for purchasing the pet (required)
         :return: Order
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.place_order_with_http_info(body, **kwargs)
         else:
             (data) = self.place_order_with_http_info(body, **kwargs)
@@ -368,15 +340,11 @@ class StoreApi(object):
         Place an order for a pet
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.place_order_with_http_info(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.place_order_with_http_info(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param Order body: order placed for purchasing the pet (required)
         :return: Order
                  If the method is called asynchronously,
@@ -384,7 +352,7 @@ class StoreApi(object):
         """
 
         all_params = ['body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -433,7 +401,7 @@ class StoreApi(object):
                                         files=local_var_files,
                                         response_type='Order',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),

--- a/samples/client/petstore/python/petstore_api/apis/user_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/user_api.py
@@ -40,22 +40,18 @@ class UserApi(object):
         Create user
         This can only be done by the logged in user.
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.create_user(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.create_user(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param User body: Created user object (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.create_user_with_http_info(body, **kwargs)
         else:
             (data) = self.create_user_with_http_info(body, **kwargs)
@@ -66,15 +62,11 @@ class UserApi(object):
         Create user
         This can only be done by the logged in user.
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.create_user_with_http_info(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.create_user_with_http_info(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param User body: Created user object (required)
         :return: None
                  If the method is called asynchronously,
@@ -82,7 +74,7 @@ class UserApi(object):
         """
 
         all_params = ['body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -131,7 +123,7 @@ class UserApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -142,22 +134,18 @@ class UserApi(object):
         Creates list of users with given input array
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.create_users_with_array_input(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.create_users_with_array_input(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[User] body: List of user object (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.create_users_with_array_input_with_http_info(body, **kwargs)
         else:
             (data) = self.create_users_with_array_input_with_http_info(body, **kwargs)
@@ -168,15 +156,11 @@ class UserApi(object):
         Creates list of users with given input array
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.create_users_with_array_input_with_http_info(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.create_users_with_array_input_with_http_info(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[User] body: List of user object (required)
         :return: None
                  If the method is called asynchronously,
@@ -184,7 +168,7 @@ class UserApi(object):
         """
 
         all_params = ['body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -233,7 +217,7 @@ class UserApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -244,22 +228,18 @@ class UserApi(object):
         Creates list of users with given input array
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.create_users_with_list_input(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.create_users_with_list_input(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[User] body: List of user object (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.create_users_with_list_input_with_http_info(body, **kwargs)
         else:
             (data) = self.create_users_with_list_input_with_http_info(body, **kwargs)
@@ -270,15 +250,11 @@ class UserApi(object):
         Creates list of users with given input array
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.create_users_with_list_input_with_http_info(body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.create_users_with_list_input_with_http_info(body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param list[User] body: List of user object (required)
         :return: None
                  If the method is called asynchronously,
@@ -286,7 +262,7 @@ class UserApi(object):
         """
 
         all_params = ['body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -335,7 +311,7 @@ class UserApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -346,22 +322,18 @@ class UserApi(object):
         Delete user
         This can only be done by the logged in user.
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.delete_user(username, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.delete_user(username, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str username: The name that needs to be deleted (required)
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.delete_user_with_http_info(username, **kwargs)
         else:
             (data) = self.delete_user_with_http_info(username, **kwargs)
@@ -372,15 +344,11 @@ class UserApi(object):
         Delete user
         This can only be done by the logged in user.
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.delete_user_with_http_info(username, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.delete_user_with_http_info(username, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str username: The name that needs to be deleted (required)
         :return: None
                  If the method is called asynchronously,
@@ -388,7 +356,7 @@ class UserApi(object):
         """
 
         all_params = ['username']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -437,7 +405,7 @@ class UserApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -448,22 +416,18 @@ class UserApi(object):
         Get user by user name
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.get_user_by_name(username, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_user_by_name(username, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str username: The name that needs to be fetched. Use user1 for testing.  (required)
         :return: User
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.get_user_by_name_with_http_info(username, **kwargs)
         else:
             (data) = self.get_user_by_name_with_http_info(username, **kwargs)
@@ -474,15 +438,11 @@ class UserApi(object):
         Get user by user name
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.get_user_by_name_with_http_info(username, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.get_user_by_name_with_http_info(username, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str username: The name that needs to be fetched. Use user1 for testing.  (required)
         :return: User
                  If the method is called asynchronously,
@@ -490,7 +450,7 @@ class UserApi(object):
         """
 
         all_params = ['username']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -539,7 +499,7 @@ class UserApi(object):
                                         files=local_var_files,
                                         response_type='User',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -550,15 +510,11 @@ class UserApi(object):
         Logs user into the system
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.login_user(username, password, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.login_user(username, password, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str username: The user name for login (required)
         :param str password: The password for login in clear text (required)
         :return: str
@@ -566,7 +522,7 @@ class UserApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.login_user_with_http_info(username, password, **kwargs)
         else:
             (data) = self.login_user_with_http_info(username, password, **kwargs)
@@ -577,15 +533,11 @@ class UserApi(object):
         Logs user into the system
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.login_user_with_http_info(username, password, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.login_user_with_http_info(username, password, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str username: The user name for login (required)
         :param str password: The password for login in clear text (required)
         :return: str
@@ -594,7 +546,7 @@ class UserApi(object):
         """
 
         all_params = ['username', 'password']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -648,7 +600,7 @@ class UserApi(object):
                                         files=local_var_files,
                                         response_type='str',
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -659,21 +611,17 @@ class UserApi(object):
         Logs out current logged in user session
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.logout_user(callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.logout_user(async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.logout_user_with_http_info(**kwargs)
         else:
             (data) = self.logout_user_with_http_info(**kwargs)
@@ -684,22 +632,18 @@ class UserApi(object):
         Logs out current logged in user session
         
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.logout_user_with_http_info(callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.logout_user_with_http_info(async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
         all_params = []
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -742,7 +686,7 @@ class UserApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),
@@ -753,15 +697,11 @@ class UserApi(object):
         Updated user
         This can only be done by the logged in user.
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.update_user(username, body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.update_user(username, body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str username: name that need to be deleted (required)
         :param User body: Updated user object (required)
         :return: None
@@ -769,7 +709,7 @@ class UserApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        if kwargs.get('callback'):
+        if kwargs.get('async'):
             return self.update_user_with_http_info(username, body, **kwargs)
         else:
             (data) = self.update_user_with_http_info(username, body, **kwargs)
@@ -780,15 +720,11 @@ class UserApi(object):
         Updated user
         This can only be done by the logged in user.
         This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.update_user_with_http_info(username, body, callback=callback_function)
+        asynchronous HTTP request, please pass async=True
+        >>> thread = api.update_user_with_http_info(username, body, async=True)
+        >>> result = thread.get()
 
-        :param callback function: The callback function
-            for asynchronous request. (optional)
+        :param async bool
         :param str username: name that need to be deleted (required)
         :param User body: Updated user object (required)
         :return: None
@@ -797,7 +733,7 @@ class UserApi(object):
         """
 
         all_params = ['username', 'body']
-        all_params.append('callback')
+        all_params.append('async')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -851,7 +787,7 @@ class UserApi(object):
                                         files=local_var_files,
                                         response_type=None,
                                         auth_settings=auth_settings,
-                                        callback=params.get('callback'),
+                                        async=params.get('async'),
                                         _return_http_data_only=params.get('_return_http_data_only'),
                                         _preload_content=params.get('_preload_content', True),
                                         _request_timeout=params.get('_request_timeout'),


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Fixes issue https://github.com/swagger-api/swagger-codegen/issues/4235. Implementation of solution suggested here: https://github.com/swagger-api/swagger-codegen/issues/4235#issuecomment-291086921. See test cases for examples: https://github.com/swagger-api/swagger-codegen/pull/5308/files#diff-c5c849b26d5134175812cdb46ddbe39cR143

In next iteration implementation can be improved by adding separate methods for async stuff like `api.get_pet_by_id_async()` and `api.get_pet_by_id_async_with_http_info()`.