### PR TITLE
Add option to skip Maven plugin execution

### DIFF
--- a/modules/swagger-codegen-maven-plugin/README.md
+++ b/modules/swagger-codegen-maven-plugin/README.md
@@ -59,6 +59,7 @@ mvn clean compile
 - `generateModelDocumentation` - generate the model documentation (`true` by default. Only available if `generateModels` is `true`)
 - `generateSupportingFiles` - generate the supporting files (`true` by default)
 - `supportingFilesToGenerate` - A comma separated list of supporting files to generate.  All files is the default.
+- `skip` - skip code generation (`false` by default. Can also be set globally through the `codegen.skip` property)
 
 ### Custom Generator
 

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -228,7 +228,11 @@ public class CodeGenMojo extends AbstractMojo {
     @Parameter(name = "generateApiDocumentation", required = false)
     private Boolean generateApiDocumentation = true;
 
-
+    /**
+     * Skip the execution.
+     */
+    @Parameter(name = "skip", property = "codegen.skip", required = false, defaultValue = "false")
+    private Boolean skip;
 
     /**
      * Add the output directory to the project as a source root, so that the
@@ -251,6 +255,14 @@ public class CodeGenMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+
+        if(skip) {
+            getLog().info("Code generation is skipped.");
+            // Even when no new sources are generated, the existing ones should
+            // still be compiled if needed.
+            addCompileSourceRootIfConfigured();
+            return;
+        }
 
         //attempt to read from config file
         CodegenConfigurator configurator = CodegenConfigurator.fromFile(configurationFile);
@@ -424,7 +436,11 @@ public class CodeGenMojo extends AbstractMojo {
             throw new MojoExecutionException("Code generation failed. See above for the full exception.");
         }
 
-        if (addCompileSourceRoot) {
+        addCompileSourceRootIfConfigured();
+    }
+
+    private void addCompileSourceRootIfConfigured() {
+        if(addCompileSourceRoot) {
             final Object sourceFolderObject = configOptions == null ? null : configOptions.get(CodegenConstants.SOURCE_FOLDER);
             final String sourceFolder =  sourceFolderObject == null ? "src/main/java" : sourceFolderObject.toString();
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The execution is skipped if either the `codegen.skip` property or the `<skip>`
configuration parameter is set. This is consistent with how many other Maven
plugins, such as maven-exec-plugin and maven-clean-plugin, handle this.
