### PR TITLE
Add option to set default model values to null (Like `List`, `Map`)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenConstants.java
@@ -186,4 +186,6 @@ public class CodegenConstants {
     public static final String IGNORE_FILE_OVERRIDE = "ignoreFileOverride";
     public static final String IGNORE_FILE_OVERRIDE_DESC = "Specifies an override location for the .swagger-codegen-ignore file. Most useful on initial generation.";
 
+    public static final String MODEL_DEFAULT_NULL = "modelDefaultNull";
+    public static final String MODEL_DEFAULT_NULL_DESC = "Generate models with null as default value";
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -570,6 +570,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toDefaultValue(Property p) {
+        if (!p.getRequired()) {
+            return "null";
+        }
         if (p instanceof ArrayProperty) {
             final ArrayProperty ap = (ArrayProperty) p;
             final String pattern;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -76,6 +76,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
     protected boolean supportJava6= false;
+    protected boolean modelDefaultNull = false;
 
     public AbstractJavaCodegen() {
         super();
@@ -292,6 +293,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         if(additionalProperties.containsKey(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING)) {
             this.setSerializeBigDecimalAsString(Boolean.valueOf(additionalProperties.get(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING).toString()));
+        }
+
+        if(additionalProperties.containsKey(CodegenConstants.MODEL_DEFAULT_NULL)) {
+            this.setModelDefaultNull(Boolean.valueOf(additionalProperties.get(CodegenConstants.MODEL_DEFAULT_NULL).toString()));
         }
 
         // need to put back serializableModel (boolean) into additionalProperties as value in additionalProperties is string
@@ -570,7 +575,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toDefaultValue(Property p) {
-        if (!p.getRequired()) {
+        if (this.modelDefaultNull) {
             return "null";
         }
         if (p instanceof ArrayProperty) {
@@ -1126,6 +1131,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     public void setSupportJava6(boolean value) {
         this.supportJava6 = value;
+    }
+
+    public void setModelDefaultNull(boolean value) {
+        this.modelDefaultNull = value;
     }
 
     public String toRegularExpression(String pattern) {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -115,6 +115,23 @@ public class JavaModelTest {
         Assert.assertTrue(property.isContainer);
     }
 
+    @Test(description = "convert a model when modelDefaultNull=true")
+    public void modelDefaultNullParamTest() {
+        final Model model = new ModelImpl()
+                .description("a sample model")
+                .property("urls", new ArrayProperty()
+                        .items(new StringProperty()));
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setModelDefaultNull(true);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty property = cm.vars.get(0);
+        Assert.assertEquals(property.datatype, "List<String>");
+        Assert.assertEquals(property.defaultValue, "null");
+    }
+
     @Test(description = "convert a model with a map property")
     public void mapPropertyTest() {
         final Model model = new ModelImpl()

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -108,10 +108,38 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setUrls");
         Assert.assertEquals(property.datatype, "List<String>");
         Assert.assertEquals(property.name, "urls");
-        Assert.assertEquals(property.defaultValue, "new ArrayList<String>()");
+        Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
         Assert.assertFalse(property.required);
+        Assert.assertTrue(property.isContainer);
+    }
+
+    @Test(description = "convert a model with required list property")
+    public void requiredListPropertyTest() {
+        final Model model = new ModelImpl()
+                .description("a sample model")
+                .property("urls", new ArrayProperty()
+                        .items(new StringProperty()))
+                .required("urls");
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty property = cm.vars.get(0);
+        Assert.assertEquals(property.baseName, "urls");
+        Assert.assertEquals(property.getter, "getUrls");
+        Assert.assertEquals(property.setter, "setUrls");
+        Assert.assertEquals(property.datatype, "List<String>");
+        Assert.assertEquals(property.name, "urls");
+        Assert.assertEquals(property.defaultValue, "new ArrayList<String>()");
+        Assert.assertEquals(property.baseType, "List");
+        Assert.assertEquals(property.containerType, "array");
+        Assert.assertTrue(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -136,7 +164,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setTranslations");
         Assert.assertEquals(property.datatype, "Map<String, String>");
         Assert.assertEquals(property.name, "translations");
-        Assert.assertEquals(property.defaultValue, "new HashMap<String, String>()");
+        Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
         Assert.assertFalse(property.required);
@@ -164,7 +192,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setTranslations");
         Assert.assertEquals(property.datatype, "Map<String, List<Pet>>");
         Assert.assertEquals(property.name, "translations");
-        Assert.assertEquals(property.defaultValue, "new HashMap<String, List<Pet>>()");
+        Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
         Assert.assertFalse(property.required);
@@ -186,7 +214,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setList2D");
         Assert.assertEquals(property.datatype, "List<List<Pet>>");
         Assert.assertEquals(property.name, "list2D");
-        Assert.assertEquals(property.defaultValue, "new ArrayList<List<Pet>>()");
+        Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
         Assert.assertFalse(property.required);
@@ -237,7 +265,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setChildren");
         Assert.assertEquals(property.datatype, "List<Children>");
         Assert.assertEquals(property.name, "children");
-        Assert.assertEquals(property.defaultValue, "new ArrayList<Children>()");
+        Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
         Assert.assertFalse(property.required);
@@ -265,7 +293,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setChildren");
         Assert.assertEquals(property.datatype, "Map<String, Children>");
         Assert.assertEquals(property.name, "children");
-        Assert.assertEquals(property.defaultValue, "new HashMap<String, Children>()");
+        Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
         Assert.assertFalse(property.required);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -108,38 +108,10 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setUrls");
         Assert.assertEquals(property.datatype, "List<String>");
         Assert.assertEquals(property.name, "urls");
-        Assert.assertEquals(property.defaultValue, "null");
-        Assert.assertEquals(property.baseType, "List");
-        Assert.assertEquals(property.containerType, "array");
-        Assert.assertFalse(property.required);
-        Assert.assertTrue(property.isContainer);
-    }
-
-    @Test(description = "convert a model with required list property")
-    public void requiredListPropertyTest() {
-        final Model model = new ModelImpl()
-                .description("a sample model")
-                .property("urls", new ArrayProperty()
-                        .items(new StringProperty()))
-                .required("urls");
-        final DefaultCodegen codegen = new JavaClientCodegen();
-        final CodegenModel cm = codegen.fromModel("sample", model);
-
-        Assert.assertEquals(cm.name, "sample");
-        Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 1);
-
-        final CodegenProperty property = cm.vars.get(0);
-        Assert.assertEquals(property.baseName, "urls");
-        Assert.assertEquals(property.getter, "getUrls");
-        Assert.assertEquals(property.setter, "setUrls");
-        Assert.assertEquals(property.datatype, "List<String>");
-        Assert.assertEquals(property.name, "urls");
         Assert.assertEquals(property.defaultValue, "new ArrayList<String>()");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
-        Assert.assertTrue(property.required);
+        Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
     }
 
@@ -164,7 +136,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setTranslations");
         Assert.assertEquals(property.datatype, "Map<String, String>");
         Assert.assertEquals(property.name, "translations");
-        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.defaultValue, "new HashMap<String, String>()");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
         Assert.assertFalse(property.required);
@@ -192,7 +164,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setTranslations");
         Assert.assertEquals(property.datatype, "Map<String, List<Pet>>");
         Assert.assertEquals(property.name, "translations");
-        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.defaultValue, "new HashMap<String, List<Pet>>()");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
         Assert.assertFalse(property.required);
@@ -214,7 +186,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setList2D");
         Assert.assertEquals(property.datatype, "List<List<Pet>>");
         Assert.assertEquals(property.name, "list2D");
-        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.defaultValue, "new ArrayList<List<Pet>>()");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
         Assert.assertFalse(property.required);
@@ -265,7 +237,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setChildren");
         Assert.assertEquals(property.datatype, "List<Children>");
         Assert.assertEquals(property.name, "children");
-        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.defaultValue, "new ArrayList<Children>()");
         Assert.assertEquals(property.baseType, "List");
         Assert.assertEquals(property.containerType, "array");
         Assert.assertFalse(property.required);
@@ -293,7 +265,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setChildren");
         Assert.assertEquals(property.datatype, "Map<String, Children>");
         Assert.assertEquals(property.name, "children");
-        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.defaultValue, "new HashMap<String, Children>()");
         Assert.assertEquals(property.baseType, "Map");
         Assert.assertEquals(property.containerType, "map");
         Assert.assertFalse(property.required);

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -116,20 +116,31 @@ public class JavaModelTest {
     }
 
     @Test(description = "convert a model when modelDefaultNull=true")
-    public void modelDefaultNullParamTest() {
+    public void modelDefaultNullTrueParamTest() {
         final Model model = new ModelImpl()
-                .description("a sample model")
                 .property("urls", new ArrayProperty()
                         .items(new StringProperty()));
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setModelDefaultNull(true);
         final CodegenModel cm = codegen.fromModel("sample", model);
 
-        Assert.assertEquals(cm.vars.size(), 1);
-
         final CodegenProperty property = cm.vars.get(0);
         Assert.assertEquals(property.datatype, "List<String>");
         Assert.assertEquals(property.defaultValue, "null");
+    }
+
+    @Test(description = "convert a model when modelDefaultNull=false")
+    public void modelDefaultNullFalseParamTest() {
+        final Model model = new ModelImpl()
+                .property("urls", new ArrayProperty()
+                        .items(new StringProperty()));
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setModelDefaultNull(false);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        final CodegenProperty property = cm.vars.get(0);
+        Assert.assertEquals(property.datatype, "List<String>");
+        Assert.assertEquals(property.defaultValue, "new ArrayList<String>()");
     }
 
     @Test(description = "convert a model with a map property")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Issue: #5240
I added new additional param for java client coden, it will allow us to set all Model fields to null. This change is important for us, because `null` List and empty list is two different things.

### Why it is important?

For example you have api with partial update support (our case). It means that if user send json with just one field from model, API will update just this field. But current version of codegen set List and Map default values to empty list and empty map, it means that when user will send update request to our api using SDK, it will override list options as well.
