### PR TITLE
swagger-codegen-maven-plugin: hint added how to generate server code

### DIFF
--- a/modules/swagger-codegen-maven-plugin/examples/java-client.xml
+++ b/modules/swagger-codegen-maven-plugin/examples/java-client.xml
@@ -22,8 +22,11 @@
                             <!-- specify the swagger yaml -->
                             <inputSpec>swagger.yaml</inputSpec>
 
-                            <!-- target to generate -->
+                            <!-- target to generate java client code -->
                             <language>java</language>
+
+                            <!-- hint: if you want to generate java server code, e.g. based on Spring Boot,
+                                 you can use the following target: <language>spring</language> -->
 
                             <!-- pass any necessary config options -->
                             <configOptions>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR addresses issue #5332. I was looking for a way to use swagger-codegen-maven-plugin in order to generate server code (based on Spring Boot). The current example generates client code only. Therefore, I added a hint to the example to make it easier for other people to find out how to generate server code.
