### PR TITLE
[Spring] Adds serialVersionUID to serializable model POJO's

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/pojo.mustache
@@ -4,6 +4,10 @@
 @ApiModel(description = "{{{description}}}"){{/description}}
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+{{#serializableModel}}
+  private static final long serialVersionUID = 1L;
+
+{{/serializableModel}}
   {{#vars}}
     {{#isEnum}}
     {{^isContainer}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Added serialVersionUID to the mustache template for Spring POJO's to resolve a Java compiler warning.
Link to issue: https://github.com/swagger-api/swagger-codegen/issues/5346
