### PR TITLE
Fix environment variable support in successive Maven plugin executions

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -435,6 +435,8 @@ public class CodeGenMojo extends AbstractMojo {
             project.addCompileSourceRoot(sourceJavaFolder);
         }
 
+        // Reset all environment variables to their original value. This prevents unexpected behaviour
+        // when running the plugin multiple consecutive times with different configurations.
         for(Map.Entry<String, String> entry : originalEnvironmentVariables.entrySet()) {
             if(entry.getValue() == null) {
                 System.clearProperty(entry.getKey());

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -381,9 +381,12 @@ public class CodeGenMojo extends AbstractMojo {
             }
         }
 
+        Map<String, String> originalEnvironmentVariables = new HashMap<>();
+
         if (environmentVariables != null) {
 
             for(String key : environmentVariables.keySet()) {
+                originalEnvironmentVariables.put(key, System.getProperty(key));
                 String value = environmentVariables.get(key);
                 if(value == null) {
                     // don't put null values
@@ -430,6 +433,14 @@ public class CodeGenMojo extends AbstractMojo {
 
             String sourceJavaFolder = output.toString() + "/" + sourceFolder;
             project.addCompileSourceRoot(sourceJavaFolder);
+        }
+
+        for(Map.Entry<String, String> entry : originalEnvironmentVariables.entrySet()) {
+            if(entry.getValue() == null) {
+                System.clearProperty(entry.getKey());
+            } else {
+                System.setProperty(entry.getKey(), entry.getValue());
+            }
         }
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

System properties were retained across multiple successive executions,
resulting in unpredictable behavior. Property values are now properly reset
to their original value after plugin execution.

See #5350