### PR TITLE
[Perl] remove singleton

### DIFF
--- a/modules/swagger-codegen/src/main/resources/perl/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/ApiClient.mustache
@@ -26,21 +26,24 @@ use Module::Runtime qw(use_module);
 
 use {{moduleName}}::Configuration;
 
-use base 'Class::Singleton';
 
-sub _new_instance
-{
+sub new {
     my $class = shift;
+
+    my $config;
+    if ( $_[0] && ref $_[0] && ref $_[0] eq '{{moduleName}}::Configuration' ) {
+        $config = $_[0];
+    } else {
+        $config = {{moduleName}}::Configuration->new(@_);
+    }
+
     my (%args) = (
         'ua' => LWP::UserAgent->new,
-        'base_url' => '{{{basePath}}}',
-        @_
+        'config' => $config,
     );
   
     return bless \%args, $class;
 }
-
-sub _cfg {'{{moduleName}}::Configuration'}
 
 # Set the user agent of the API client
 #
@@ -78,7 +81,7 @@ sub call_api {
     $self->update_params_for_auth($header_params, $query_params, $auth_settings); 
   
   
-    my $_url = $self->{base_url} . $resource_path;
+    my $_url = $self->{config}{base_url} . $resource_path;
   
     # build query 
     if (%$query_params) {
@@ -125,8 +128,8 @@ sub call_api {
     else {
     }
    
-    $self->{ua}->timeout($self->{http_timeout} || ${{moduleName}}::Configuration::http_timeout); 
-    $self->{ua}->agent($self->{http_user_agent} || ${{moduleName}}::Configuration::http_user_agent);
+    $self->{ua}->timeout($self->{http_timeout} || $self->{config}{http_timeout});
+    $self->{ua}->agent($self->{http_user_agent} || $self->{config}{http_user_agent});
     
     $log->debugf("REQUEST: %s", $_request->as_string);
     my $_response = $self->{ua}->request($_request);
@@ -300,11 +303,11 @@ sub get_api_key_with_prefix
 {
 	my ($self, $key_name) = @_;
 
-	my $api_key = ${{moduleName}}::Configuration::api_key->{$key_name};
+	my $api_key = $self->{config}{api_key}{$key_name};
 	
 	return unless $api_key;
 	
-	my $prefix = ${{moduleName}}::Configuration::api_key_prefix->{$key_name};
+	my $prefix = $self->{config}{api_key_prefix}{$key_name};
 	return $prefix ? "$prefix $api_key" : $api_key;
 }	
 
@@ -335,11 +338,11 @@ sub update_params_for_auth {
             if ($api_key) {
                 $query_params->{'{{keyParamName}}'} = $api_key;
             }{{/isKeyInQuery}}{{/isApiKey}}{{#isBasic}}
-            if (${{moduleName}}::Configuration::username || ${{moduleName}}::Configuration::password) {
-                $header_params->{'Authorization'} = 'Basic ' . encode_base64(${{moduleName}}::Configuration::username . ":" . ${{moduleName}}::Configuration::password);
+            if ($self->{config}{username} || $self->{config}{password}) {
+                $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password});
             }{{/isBasic}}{{#isOAuth}}
-            if (${{moduleName}}::Configuration::access_token) {
-                $header_params->{'Authorization'} = 'Bearer ' . ${{moduleName}}::Configuration::access_token;
+            if ($self->{config}{access_token}) {
+                $header_params->{'Authorization'} = 'Bearer ' . $self->{config}{access_token};
             }{{/isOAuth}}
         }
         {{/authMethods}}
@@ -356,7 +359,7 @@ sub update_params_for_auth {
 sub _global_auth_setup {
 	my ($self, $header_params, $query_params) = @_; 
 	
-	my $tokens = $self->_cfg->get_tokens;
+	my $tokens = $self->{config}->get_tokens;
 	return unless keys %$tokens;
 	
 	# basic

--- a/modules/swagger-codegen/src/main/resources/perl/ApiFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/ApiFactory.mustache
@@ -49,19 +49,28 @@ my %_apis = map { $_ =~ /^{{moduleName}}::(.*)$/; $1 => $_ }
 			grep {$_ =~ /Api$/} 
 			usesub '{{moduleName}}';
 
-=head1 new()
+=head1 new($api_client)
 	
-	Any parameters are optional, and are passed to and stored on the api_client object. 
+	create a new {{moduleName}}::ApiFactory instance with the given {{moduleName}}::ApiClient instance.
+
+=head1 new(%paramters)
+
+	Any parameters are optional, and are passed to and stored on the api_client object.
 	
-	base_url: (optional)
-		supply this to change the default base URL taken from the Swagger definition.
-	
+	See L<{{moduleName}}::ApiClient> and L<{{moduleName}}::Configuration> for valid paramters
+
 =cut	
 
 sub new {
-    my ($class, %p) = (shift, @_);
-	$p{api_client} = {{moduleName}}::ApiClient->instance(%p);			
-	return bless \%p, $class;
+    my ($class) = shift;
+
+    my $api_client;
+    if ($_[0] && ref $_[0] && ref $_[0] eq '{{moduleName}}::ApiClient' ) {
+        $api_client = $_[0];
+    } else {
+        $api_client = {{moduleName}}::ApiClient->new(@_);
+    }
+    bless { api_client => $api_client }, $class;
 }
 
 =head1 get_api($which)
@@ -78,7 +87,7 @@ sub get_api {
 	my ($self, $which) = @_;
 	croak "API not specified" unless $which;
 	my $api_class = $_apis{"${which}Api"} || croak "No known API for '$which'";
-	return $api_class->new(api_client => $self->api_client); 
+	return $api_class->new($self->api_client); 
 }
 
 =head1 api_client()

--- a/modules/swagger-codegen/src/main/resources/perl/Configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/Configuration.mustache
@@ -15,71 +15,142 @@ use Carp;
 
 use constant VERSION => '{{moduleVersion}}';
 
-# class/static variables
-our $http_timeout = 180;
-our $http_user_agent = '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{{moduleVersion}}}/perl{{/httpUserAgent}}';
+=head1 Name
 
-# authentication setting
-our $api_key = {};
-our $api_key_prefix = {};
-our $api_key_in = {};
+        {{moduleName}}::Configuration - holds the configuration for all {{moduleName}} Modules
 
-# username and password for HTTP basic authentication
-our $username = '';
-our $password = '';
+=head1 new(%paramters)
 
-# access token for OAuth
-our $access_token = '';
+=over 4
+
+=item http_timeout: (optional)
+
+Integer. timeout for HTTP requests in seconds
+
+default: 180
+
+=item http_user_agent: (optional)
+
+String. custom UserAgent header
+
+default: {{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{{moduleVersion}}}/perl{{/httpUserAgent}}
+
+=item api_key: (optional)
+
+Hashref. Keyed on the name of each key (there can be multiple tokens).
+
+    api_key => {
+	secretKey => 'aaaabbbbccccdddd',
+	anotherKey => '1111222233334444',
+    };
+
+=item api_key_prefix: (optional)
+
+Hashref. Keyed on the name of each key (there can be multiple tokens). Note not all api keys require a prefix.
+
+    api_key_prefix => {
+        secretKey => 'string',
+	anotherKey => 'same or some other string',
+    };
+ 
+=item api_key_in: (optional)
+
+=item username: (optional)
+
+String. The username for basic auth.
+
+=item password: (optional)
+
+String. The password for basic auth.
+
+=item access_token: (optional)
+
+String. The OAuth access token.
+
+=item base_url: (optional)
+
+String. The base URL of the API
+
+default: {{{basePath}}}
+
+=back
+
+=cut
+
+sub new {
+	my ($self, %p) = (shift,@_);
+
+	# class/static variables
+	$p{http_timeout} //= 180;
+	$p{http_user_agent} //= '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{{moduleVersion}}}/perl{{/httpUserAgent}}';
+
+	# authentication setting
+	$p{api_key} //= {};
+	$p{api_key_prefix} //= {};
+	$p{api_key_in} //= {};
+
+	# username and password for HTTP basic authentication
+	$p{username} //= '';
+	$p{password} //= '';
+
+	# access token for OAuth
+	$p{access_token} //= '';
+
+	# base_url
+        $p{base_url} //= '{{{basePath}}}';
+
+	return bless \%p => $self;
+}
+
 
 sub get_tokens {
-	my $class = shift;
+	my $self = shift;
 	
 	my $tokens = {};
-	$tokens->{username} = $username if $username;
-	$tokens->{password} = $password if $password;
-	$tokens->{access_token} = $access_token if $access_token;
+	$tokens->{username} = $self->{username} if $self->{username};
+	$tokens->{password} = $self->{password} if $self->{password};
+	$tokens->{access_token} = $self->{access_token} if $self->{access_token};
 	
-	foreach my $token_name (keys %{ $api_key }) {
-		$tokens->{$token_name}->{token} = $api_key->{$token_name};
-		$tokens->{$token_name}->{prefix} = $api_key_prefix->{$token_name};
-		$tokens->{$token_name}->{in} = $api_key_in->{$token_name};
+	foreach my $token_name (keys %{ $self->{api_key} }) {
+		$tokens->{$token_name}->{token} = $self->{api_key}{$token_name};
+		$tokens->{$token_name}->{prefix} = $self->{api_key_prefix}{$token_name};
+		$tokens->{$token_name}->{in} = $self->{api_key_in}{$token_name};
 	}
 
 	return $tokens;
 }
 
 sub clear_tokens {
-	my $class = shift;
-	my %tokens = %{$class->get_tokens}; # copy
+	my $self = shift;
+	my %tokens = %{$self->get_tokens}; # copy
 	
-	$username = undef;
-	$password = undef;
-	$access_token = undef;
+	$self->{username} = '';
+	$self->{password} = '';
+	$self->{access_token} = '';
 
-	$api_key = {};
-	$api_key_prefix = {};
-	$api_key_in = {};
+	$self->{api_key} = {};
+	$self->{api_key_prefix} = {};
+	$self->{api_key_in} = {};
 	
 	return \%tokens;
 }
 
 sub accept_tokens {
-	my ($class, $tokens) = @_;
+	my ($self, $tokens) = @_;
 	
 	foreach my $known_name (qw(username password access_token)) {
 		next unless $tokens->{$known_name};
-		eval "\$$known_name = delete \$tokens->{\$known_name}";
-		die $@ if $@;
+		$self->{$known_name} = delete $tokens->{$known_name};
 	}
 	
 	foreach my $token_name (keys %$tokens) {
-		$api_key->{$token_name} = $tokens->{$token_name}->{token};
-		if ($tokens->{$token_name}->{prefix}) {
-			$api_key_prefix->{$token_name} = $tokens->{$token_name}->{prefix};
+		$self->{api_key}{$token_name} = $tokens->{$token_name}{token};
+		if ($tokens->{$token_name}{prefix}) {
+			$self->{api_key_prefix}{$token_name} = $tokens->{$token_name}{prefix};
 		}
 		my $in = $tokens->{$token_name}->{in} || 'head';
 		croak "Tokens can only go in 'head' or 'query' (not in '$in')" unless $in =~ /^(?:head|query)$/;
-		$api_key_in->{$token_name} = $in;
+		$self->{api_key_in}{$token_name} = $in;
 	}
 }	
 

--- a/modules/swagger-codegen/src/main/resources/perl/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/README.mustache
@@ -94,37 +94,37 @@ you are accessing. Usually `prefix` and `in` will be determined by the code gene
 the spec and you will not need to set them at run time. If not, `in` will
 default to 'head' and `prefix` to the empty string.
 
-The tokens will be placed in the `{{moduleName}}::Configuration` namespace
+The tokens will be placed in a L<{{moduleName}}::Configuration> instance
 as follows, but you don't need to know about this.
 
-- `${{moduleName}}::Configuration::username`
+- `$cfg->{username}`
 
     String. The username for basic auth.
 
-- `${{moduleName}}::Configuration::password`
+- `$cfg->{password}`
 
     String. The password for basic auth.
 
-- `${{moduleName}}::Configuration::api_key`
+- `$cfg->{api_key}`
 
     Hashref. Keyed on the name of each key (there can be multiple tokens).
 
-            ${{moduleName}}::Configuration::api_key = {
+            $cfg->{api_key} = {
                     secretKey => 'aaaabbbbccccdddd',
                     anotherKey => '1111222233334444',
                     };
 
-- `${{moduleName}}::Configuration::api_key_prefix`
+- `$cfg->{api_key_prefix}`
 
     Hashref. Keyed on the name of each key (there can be multiple tokens). Note not
     all api keys require a prefix.
 
-            ${{moduleName}}::Configuration::api_key_prefix = {
+            $cfg->{api_key_prefix} = {
                     secretKey => 'string',
                     anotherKey => 'same or some other string',
                     };
 
-- `${{moduleName}}::Configuration::access_token`
+- `$cfg->{access_token}`
 
     String. The OAuth access token.
 
@@ -133,8 +133,7 @@ as follows, but you don't need to know about this.
 ## `base_url`
 
 The generated code has the `base_url` already set as a default value. This method
-returns (and optionally sets, but only if the API client has not been
-created yet) the current value of `base_url`.
+returns the current value of `base_url`.
 
 ## `api_factory`
 
@@ -253,21 +252,22 @@ use warnings;
 {{/model}}{{/models}}
 # for displaying the API response data
 use Data::Dumper;
-use {{{moduleName}}}::Configuration;
 use {{moduleName}}::{{classname}};
-{{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}{{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
-# Configure HTTP basic authorization: {{{name}}}
-${{{moduleName}}}::Configuration::username = 'YOUR_USERNAME';
-${{{moduleName}}}::Configuration::password = 'YOUR_PASSWORD';{{/isBasic}}{{#isApiKey}}
-# Configure API key authorization: {{{name}}}
-${{{moduleName}}}::Configuration::api_key->{'{{{keyParamName}}}'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-#${{{moduleName}}}::Configuration::api_key_prefix->{'{{{keyParamName}}}'} = 'Bearer';{{/isApiKey}}{{#isOAuth}}
-# Configure OAuth2 access token for authorization: {{{name}}}
-${{{moduleName}}}::Configuration::access_token = 'YOUR_ACCESS_TOKEN';{{/isOAuth}}{{/authMethods}}
-{{/hasAuthMethods}}
 
-my $api_instance = {{moduleName}}::{{classname}}->new();
+my $api_instance = {{moduleName}}::{{classname}}->new(
+{{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}{{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
+    # Configure HTTP basic authorization: {{{name}}}
+    username => 'YOUR_USERNAME',
+    password => 'YOUR_PASSWORD',{{/isBasic}}{{#isApiKey}}
+    # Configure API key authorization: {{{name}}}
+    api_key => {'{{{keyParamName}}}' => 'YOUR_API_KEY'},
+    # uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    #api_key_prefix => {'{{{keyParamName}}}' => 'Bearer'},{{/isApiKey}}{{#isOAuth}}
+    # Configure OAuth2 access token for authorization: {{{name}}}
+    access_token => 'YOUR_ACCESS_TOKEN',{{/isOAuth}}{{/authMethods}}
+{{/hasAuthMethods}}
+);
+
 {{#allParams}}my ${{paramName}} = {{#isListContainer}}[{{/isListContainer}}{{#isBodyParam}}{{{moduleName}}}::Object::{{dataType}}->new(){{/isBodyParam}}{{^isBodyParam}}{{{example}}}{{/isBodyParam}}{{#isListContainer}}]{{/isListContainer}}; # {{{dataType}}} | {{{description}}}
 {{/allParams}}
 

--- a/modules/swagger-codegen/src/main/resources/perl/Role.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/Role.mustache
@@ -34,8 +34,8 @@ has tokens => ( is => 'ro',
                 );
 
 has _cfg => ( is => 'ro',
-              isa => 'Str',
-              default => '{{moduleName}}::Configuration',
+              isa => '{{moduleName}}::Configuration',
+              default => sub { {{moduleName}}::Configuration->new() },
               );
 
 has version_info => ( is => 'ro',
@@ -196,39 +196,39 @@ you are accessing. Usually C<prefix> and C<in> will be determined by the code ge
 the spec and you will not need to set them at run time. If not, C<in> will
 default to 'head' and C<prefix> to the empty string.
 
-The tokens will be placed in the C<{{moduleName}}::Configuration> namespace
+The tokens will be placed in a L<{{moduleName}}::Configuration> instance
 as follows, but you don't need to know about this.
 
 =over 4
 
-=item C<${{moduleName}}::Configuration::username>
+=item C<$cfg-\>{username}>
 
 String. The username for basic auth.
 
-=item C<${{moduleName}}::Configuration::password>
+=item C<$cfg-\>{password}>
 
 String. The password for basic auth.
 
-=item C<${{moduleName}}::Configuration::api_key>
+=item C<$cfg-\>{api_key}>
 
 Hashref. Keyed on the name of each key (there can be multiple tokens).
 
-	${{moduleName}}::Configuration::api_key = {
+	$cfg->{api_key} = {
 		secretKey => 'aaaabbbbccccdddd',
 		anotherKey => '1111222233334444',
 		};
 
-=item C<${{moduleName}}::Configuration::api_key_prefix>
+=item C<$cfg->{api_key_prefix}>
 
 Hashref. Keyed on the name of each key (there can be multiple tokens). Note not
 all api keys require a prefix.
 
-	${{moduleName}}::Configuration::api_key_prefix = {
+	$cfg->{api_key_prefix} = {
 		secretKey => 'string',
 		anotherKey => 'same or some other string',
 		};
 
-=item C<${{moduleName}}::Configuration::access_token>
+=item C<$config-\>{access_token}>
 
 String. The OAuth access token.
 
@@ -239,8 +239,7 @@ String. The OAuth access token.
 =head2 C<base_url>
 
 The generated code has the C<base_url> already set as a default value. This method
-returns (and optionally sets, but only if the API client has not been
-created yet) the current value of C<base_url>.
+returns the current value of C<base_url>.
 
 =head2 C<api_factory>
 

--- a/modules/swagger-codegen/src/main/resources/perl/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/api.mustache
@@ -15,25 +15,22 @@ use Carp qw( croak );
 use Log::Any qw($log);
 
 use {{moduleName}}::ApiClient;
-use {{moduleName}}::Configuration;
 
 use base "Class::Data::Inheritable";
 
 __PACKAGE__->mk_classdata('method_documentation' => {});
 
 sub new {
-    my $class   = shift;
-    my (%self) = (
-        'api_client' => {{moduleName}}::ApiClient->instance,
-        @_
-    );
+    my $class = shift;
+    my $api_client;
 
-    #my $self = {
-    #    #api_client => $options->{api_client}
-    #    api_client => $default_api_client
-    #}; 
+    if ($_[0] && ref $_[0] && ref $_[0] eq '{{moduleName}}::ApiClient' ) {
+        $api_client = $_[0];
+    } else {
+        $api_client = {{moduleName}}::ApiClient->new(@_);
+    }
 
-    bless \%self, $class;
+    bless { api_client => $api_client }, $class;
 
 }
 {{#operations}}

--- a/modules/swagger-codegen/src/main/resources/perl/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/perl/api_doc.mustache
@@ -25,21 +25,21 @@ Method | HTTP request | Description
 ### Example 
 ```perl
 use Data::Dumper;
-use {{{moduleName}}}::Configuration;
 use {{moduleName}}::{{classname}};
+my $api_instance = {{moduleName}}::{{classname}}->new(
 {{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
-# Configure HTTP basic authorization: {{{name}}}
-${{{moduleName}}}::Configuration::username = 'YOUR_USERNAME';
-${{{moduleName}}}::Configuration::password = 'YOUR_PASSWORD';{{/isBasic}}{{#isApiKey}}
-# Configure API key authorization: {{{name}}}
-${{{moduleName}}}::Configuration::api_key->{'{{{keyParamName}}}'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-#${{{moduleName}}}::Configuration::api_key_prefix->{'{{{keyParamName}}}'} = "Bearer";{{/isApiKey}}{{#isOAuth}}
-# Configure OAuth2 access token for authorization: {{{name}}}
-${{{moduleName}}}::Configuration::access_token = 'YOUR_ACCESS_TOKEN';{{/isOAuth}}{{/authMethods}}
+    # Configure HTTP basic authorization: {{{name}}}
+    username => 'YOUR_USERNAME',
+    password => 'YOUR_PASSWORD',{{/isBasic}}{{#isApiKey}}
+    # Configure API key authorization: {{{name}}}
+    api_key => {'{{{keyParamName}}}' => 'YOUR_API_KEY'},
+    # uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    #api_key_prefix => {'{{{keyParamName}}}' => 'Bearer'},{{/isApiKey}}{{#isOAuth}}
+    # Configure OAuth2 access token for authorization: {{{name}}}
+    access_token => 'YOUR_ACCESS_TOKEN',{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}
+);
 
-my $api_instance = {{moduleName}}::{{classname}}->new();
 {{#allParams}}my ${{paramName}} = {{#isListContainer}}[{{/isListContainer}}{{#isBodyParam}}{{{moduleName}}}::Object::{{dataType}}->new(){{/isBodyParam}}{{^isBodyParam}}{{{example}}}{{/isBodyParam}}{{#isListContainer}}]{{/isListContainer}}; # {{{dataType}}} | {{{description}}}
 {{/allParams}}
 

--- a/samples/client/petstore/perl/README.md
+++ b/samples/client/petstore/perl/README.md
@@ -88,37 +88,37 @@ you are accessing. Usually `prefix` and `in` will be determined by the code gene
 the spec and you will not need to set them at run time. If not, `in` will
 default to 'head' and `prefix` to the empty string.
 
-The tokens will be placed in the `WWW::SwaggerClient::Configuration` namespace
+The tokens will be placed in a L<WWW::SwaggerClient::Configuration> instance
 as follows, but you don't need to know about this.
 
-- `$WWW::SwaggerClient::Configuration::username`
+- `$cfg->{username}`
 
     String. The username for basic auth.
 
-- `$WWW::SwaggerClient::Configuration::password`
+- `$cfg->{password}`
 
     String. The password for basic auth.
 
-- `$WWW::SwaggerClient::Configuration::api_key`
+- `$cfg->{api_key}`
 
     Hashref. Keyed on the name of each key (there can be multiple tokens).
 
-            $WWW::SwaggerClient::Configuration::api_key = {
+            $cfg->{api_key} = {
                     secretKey => 'aaaabbbbccccdddd',
                     anotherKey => '1111222233334444',
                     };
 
-- `$WWW::SwaggerClient::Configuration::api_key_prefix`
+- `$cfg->{api_key_prefix}`
 
     Hashref. Keyed on the name of each key (there can be multiple tokens). Note not
     all api keys require a prefix.
 
-            $WWW::SwaggerClient::Configuration::api_key_prefix = {
+            $cfg->{api_key_prefix} = {
                     secretKey => 'string',
                     anotherKey => 'same or some other string',
                     };
 
-- `$WWW::SwaggerClient::Configuration::access_token`
+- `$cfg->{access_token}`
 
     String. The OAuth access token.
 
@@ -127,8 +127,7 @@ as follows, but you don't need to know about this.
 ## `base_url`
 
 The generated code has the `base_url` already set as a default value. This method
-returns (and optionally sets, but only if the API client has not been
-created yet) the current value of `base_url`.
+returns the current value of `base_url`.
 
 ## `api_factory`
 
@@ -317,10 +316,11 @@ use WWW::SwaggerClient::Object::User;
 
 # for displaying the API response data
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::;
 
-my $api_instance = WWW::SwaggerClient::FakeApi->new();
+my $api_instance = WWW::SwaggerClient::->new(
+);
+
 my $body = WWW::SwaggerClient::Object::Client->new(); # Client | client model
 
 eval {

--- a/samples/client/petstore/perl/docs/FakeApi.md
+++ b/samples/client/petstore/perl/docs/FakeApi.md
@@ -24,10 +24,10 @@ To test \"client\" model
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::FakeApi;
+my $api_instance = WWW::SwaggerClient::FakeApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::FakeApi->new();
 my $body = WWW::SwaggerClient::Object::Client->new(); # Client | client model
 
 eval { 
@@ -70,14 +70,14 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::FakeApi;
+my $api_instance = WWW::SwaggerClient::FakeApi->new(
 
-# Configure HTTP basic authorization: http_basic_test
-$WWW::SwaggerClient::Configuration::username = 'YOUR_USERNAME';
-$WWW::SwaggerClient::Configuration::password = 'YOUR_PASSWORD';
+    # Configure HTTP basic authorization: http_basic_test
+    username => 'YOUR_USERNAME',
+    password => 'YOUR_PASSWORD',
+);
 
-my $api_instance = WWW::SwaggerClient::FakeApi->new();
 my $number = 3.4; # Number | None
 my $double = 1.2; # double | None
 my $pattern_without_delimiter = 'pattern_without_delimiter_example'; # string | None
@@ -145,10 +145,10 @@ To test enum parameters
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::FakeApi;
+my $api_instance = WWW::SwaggerClient::FakeApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::FakeApi->new();
 my $enum_form_string_array = []; # ARRAY[string] | Form parameter enum test (string array)
 my $enum_form_string = 'enum_form_string_example'; # string | Form parameter enum test (string)
 my $enum_header_string_array = []; # ARRAY[string] | Header parameter enum test (string array)

--- a/samples/client/petstore/perl/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/perl/docs/FakeClassnameTags123Api.md
@@ -5,7 +5,7 @@
 use WWW::SwaggerClient::Object::FakeClassnameTags123Api;
 ```
 
-All URIs are relative to *http://petstore.swagger.io/v2*
+All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -20,10 +20,10 @@ To test class name in snake case
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::FakeClassnameTags123Api;
+my $api_instance = WWW::SwaggerClient::FakeClassnameTags123Api->new(
+);
 
-my $api_instance = WWW::SwaggerClient::FakeClassnameTags123Api->new();
 my $body = WWW::SwaggerClient::Object::Client->new(); # Client | client model
 
 eval { 

--- a/samples/client/petstore/perl/docs/PetApi.md
+++ b/samples/client/petstore/perl/docs/PetApi.md
@@ -29,13 +29,13 @@ Add a new pet to the store
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::PetApi;
+my $api_instance = WWW::SwaggerClient::PetApi->new(
 
-# Configure OAuth2 access token for authorization: petstore_auth
-$WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
+    # Configure OAuth2 access token for authorization: petstore_auth
+    access_token => 'YOUR_ACCESS_TOKEN',
+);
 
-my $api_instance = WWW::SwaggerClient::PetApi->new();
 my $body = WWW::SwaggerClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
 
 eval { 
@@ -77,13 +77,13 @@ Deletes a pet
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::PetApi;
+my $api_instance = WWW::SwaggerClient::PetApi->new(
 
-# Configure OAuth2 access token for authorization: petstore_auth
-$WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
+    # Configure OAuth2 access token for authorization: petstore_auth
+    access_token => 'YOUR_ACCESS_TOKEN',
+);
 
-my $api_instance = WWW::SwaggerClient::PetApi->new();
 my $pet_id = 789; # int | Pet id to delete
 my $api_key = 'api_key_example'; # string | 
 
@@ -127,13 +127,13 @@ Multiple status values can be provided with comma separated strings
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::PetApi;
+my $api_instance = WWW::SwaggerClient::PetApi->new(
 
-# Configure OAuth2 access token for authorization: petstore_auth
-$WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
+    # Configure OAuth2 access token for authorization: petstore_auth
+    access_token => 'YOUR_ACCESS_TOKEN',
+);
 
-my $api_instance = WWW::SwaggerClient::PetApi->new();
 my $status = []; # ARRAY[string] | Status values that need to be considered for filter
 
 eval { 
@@ -176,13 +176,13 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::PetApi;
+my $api_instance = WWW::SwaggerClient::PetApi->new(
 
-# Configure OAuth2 access token for authorization: petstore_auth
-$WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
+    # Configure OAuth2 access token for authorization: petstore_auth
+    access_token => 'YOUR_ACCESS_TOKEN',
+);
 
-my $api_instance = WWW::SwaggerClient::PetApi->new();
 my $tags = []; # ARRAY[string] | Tags to filter by
 
 eval { 
@@ -225,15 +225,15 @@ Returns a single pet
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::PetApi;
+my $api_instance = WWW::SwaggerClient::PetApi->new(
 
-# Configure API key authorization: api_key
-$WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "Bearer";
+    # Configure API key authorization: api_key
+    api_key => {'api_key' => 'YOUR_API_KEY'},
+    # uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    #api_key_prefix => {'api_key' => 'Bearer'},
+);
 
-my $api_instance = WWW::SwaggerClient::PetApi->new();
 my $pet_id = 789; # int | ID of pet to return
 
 eval { 
@@ -276,13 +276,13 @@ Update an existing pet
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::PetApi;
+my $api_instance = WWW::SwaggerClient::PetApi->new(
 
-# Configure OAuth2 access token for authorization: petstore_auth
-$WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
+    # Configure OAuth2 access token for authorization: petstore_auth
+    access_token => 'YOUR_ACCESS_TOKEN',
+);
 
-my $api_instance = WWW::SwaggerClient::PetApi->new();
 my $body = WWW::SwaggerClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
 
 eval { 
@@ -324,13 +324,13 @@ Updates a pet in the store with form data
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::PetApi;
+my $api_instance = WWW::SwaggerClient::PetApi->new(
 
-# Configure OAuth2 access token for authorization: petstore_auth
-$WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
+    # Configure OAuth2 access token for authorization: petstore_auth
+    access_token => 'YOUR_ACCESS_TOKEN',
+);
 
-my $api_instance = WWW::SwaggerClient::PetApi->new();
 my $pet_id = 789; # int | ID of pet that needs to be updated
 my $name = 'name_example'; # string | Updated name of the pet
 my $status = 'status_example'; # string | Updated status of the pet
@@ -376,13 +376,13 @@ uploads an image
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::PetApi;
+my $api_instance = WWW::SwaggerClient::PetApi->new(
 
-# Configure OAuth2 access token for authorization: petstore_auth
-$WWW::SwaggerClient::Configuration::access_token = 'YOUR_ACCESS_TOKEN';
+    # Configure OAuth2 access token for authorization: petstore_auth
+    access_token => 'YOUR_ACCESS_TOKEN',
+);
 
-my $api_instance = WWW::SwaggerClient::PetApi->new();
 my $pet_id = 789; # int | ID of pet to update
 my $additional_metadata = 'additional_metadata_example'; # string | Additional data to pass to server
 my $file = '/path/to/file.txt'; # File | file to upload

--- a/samples/client/petstore/perl/docs/StoreApi.md
+++ b/samples/client/petstore/perl/docs/StoreApi.md
@@ -25,10 +25,10 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::StoreApi;
+my $api_instance = WWW::SwaggerClient::StoreApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::StoreApi->new();
 my $order_id = 'order_id_example'; # string | ID of the order that needs to be deleted
 
 eval { 
@@ -70,15 +70,15 @@ Returns a map of status codes to quantities
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::StoreApi;
+my $api_instance = WWW::SwaggerClient::StoreApi->new(
 
-# Configure API key authorization: api_key
-$WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-#$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = "Bearer";
+    # Configure API key authorization: api_key
+    api_key => {'api_key' => 'YOUR_API_KEY'},
+    # uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+    #api_key_prefix => {'api_key' => 'Bearer'},
+);
 
-my $api_instance = WWW::SwaggerClient::StoreApi->new();
 
 eval { 
     my $result = $api_instance->get_inventory();
@@ -117,10 +117,10 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::StoreApi;
+my $api_instance = WWW::SwaggerClient::StoreApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::StoreApi->new();
 my $order_id = 789; # int | ID of pet that needs to be fetched
 
 eval { 
@@ -163,10 +163,10 @@ Place an order for a pet
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::StoreApi;
+my $api_instance = WWW::SwaggerClient::StoreApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::StoreApi->new();
 my $body = WWW::SwaggerClient::Object::Order->new(); # Order | order placed for purchasing the pet
 
 eval { 

--- a/samples/client/petstore/perl/docs/UserApi.md
+++ b/samples/client/petstore/perl/docs/UserApi.md
@@ -29,10 +29,10 @@ This can only be done by the logged in user.
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::UserApi;
+my $api_instance = WWW::SwaggerClient::UserApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::UserApi->new();
 my $body = WWW::SwaggerClient::Object::User->new(); # User | Created user object
 
 eval { 
@@ -74,10 +74,10 @@ Creates list of users with given input array
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::UserApi;
+my $api_instance = WWW::SwaggerClient::UserApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::UserApi->new();
 my $body = [WWW::SwaggerClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
 
 eval { 
@@ -119,10 +119,10 @@ Creates list of users with given input array
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::UserApi;
+my $api_instance = WWW::SwaggerClient::UserApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::UserApi->new();
 my $body = [WWW::SwaggerClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
 
 eval { 
@@ -164,10 +164,10 @@ This can only be done by the logged in user.
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::UserApi;
+my $api_instance = WWW::SwaggerClient::UserApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::UserApi->new();
 my $username = 'username_example'; # string | The name that needs to be deleted
 
 eval { 
@@ -209,10 +209,10 @@ Get user by user name
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::UserApi;
+my $api_instance = WWW::SwaggerClient::UserApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::UserApi->new();
 my $username = 'username_example'; # string | The name that needs to be fetched. Use user1 for testing. 
 
 eval { 
@@ -255,10 +255,10 @@ Logs user into the system
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::UserApi;
+my $api_instance = WWW::SwaggerClient::UserApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::UserApi->new();
 my $username = 'username_example'; # string | The user name for login
 my $password = 'password_example'; # string | The password for login in clear text
 
@@ -303,10 +303,10 @@ Logs out current logged in user session
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::UserApi;
+my $api_instance = WWW::SwaggerClient::UserApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::UserApi->new();
 
 eval { 
     $api_instance->logout_user();
@@ -344,10 +344,10 @@ This can only be done by the logged in user.
 ### Example 
 ```perl
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
 use WWW::SwaggerClient::UserApi;
+my $api_instance = WWW::SwaggerClient::UserApi->new(
+);
 
-my $api_instance = WWW::SwaggerClient::UserApi->new();
 my $username = 'username_example'; # string | name that need to be deleted
 my $body = WWW::SwaggerClient::Object::User->new(); # User | Updated user object
 

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/ApiClient.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/ApiClient.pm
@@ -39,21 +39,24 @@ use Module::Runtime qw(use_module);
 
 use WWW::SwaggerClient::Configuration;
 
-use base 'Class::Singleton';
 
-sub _new_instance
-{
+sub new {
     my $class = shift;
+
+    my $config;
+    if ( $_[0] && ref $_[0] && ref $_[0] eq 'WWW::SwaggerClient::Configuration' ) {
+        $config = $_[0];
+    } else {
+        $config = WWW::SwaggerClient::Configuration->new(@_);
+    }
+
     my (%args) = (
         'ua' => LWP::UserAgent->new,
-        'base_url' => 'http://petstore.swagger.io:80/v2',
-        @_
+        'config' => $config,
     );
   
     return bless \%args, $class;
 }
-
-sub _cfg {'WWW::SwaggerClient::Configuration'}
 
 # Set the user agent of the API client
 #
@@ -91,7 +94,7 @@ sub call_api {
     $self->update_params_for_auth($header_params, $query_params, $auth_settings); 
   
   
-    my $_url = $self->{base_url} . $resource_path;
+    my $_url = $self->{config}{base_url} . $resource_path;
   
     # build query 
     if (%$query_params) {
@@ -138,8 +141,8 @@ sub call_api {
     else {
     }
    
-    $self->{ua}->timeout($self->{http_timeout} || $WWW::SwaggerClient::Configuration::http_timeout); 
-    $self->{ua}->agent($self->{http_user_agent} || $WWW::SwaggerClient::Configuration::http_user_agent);
+    $self->{ua}->timeout($self->{http_timeout} || $self->{config}{http_timeout});
+    $self->{ua}->agent($self->{http_user_agent} || $self->{config}{http_user_agent});
     
     $log->debugf("REQUEST: %s", $_request->as_string);
     my $_response = $self->{ua}->request($_request);
@@ -313,11 +316,11 @@ sub get_api_key_with_prefix
 {
 	my ($self, $key_name) = @_;
 
-	my $api_key = $WWW::SwaggerClient::Configuration::api_key->{$key_name};
+	my $api_key = $self->{config}{api_key}{$key_name};
 	
 	return unless $api_key;
 	
-	my $prefix = $WWW::SwaggerClient::Configuration::api_key_prefix->{$key_name};
+	my $prefix = $self->{config}{api_key_prefix}{$key_name};
 	return $prefix ? "$prefix $api_key" : $api_key;
 }	
 
@@ -347,14 +350,14 @@ sub update_params_for_auth {
         }
 elsif ($auth eq 'http_basic_test') {
             
-            if ($WWW::SwaggerClient::Configuration::username || $WWW::SwaggerClient::Configuration::password) {
-                $header_params->{'Authorization'} = 'Basic ' . encode_base64($WWW::SwaggerClient::Configuration::username . ":" . $WWW::SwaggerClient::Configuration::password);
+            if ($self->{config}{username} || $self->{config}{password}) {
+                $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password});
             }
         }
 elsif ($auth eq 'petstore_auth') {
             
-            if ($WWW::SwaggerClient::Configuration::access_token) {
-                $header_params->{'Authorization'} = 'Bearer ' . $WWW::SwaggerClient::Configuration::access_token;
+            if ($self->{config}{access_token}) {
+                $header_params->{'Authorization'} = 'Bearer ' . $self->{config}{access_token};
             }
         }
         else {
@@ -370,7 +373,7 @@ elsif ($auth eq 'petstore_auth') {
 sub _global_auth_setup {
 	my ($self, $header_params, $query_params) = @_; 
 	
-	my $tokens = $self->_cfg->get_tokens;
+	my $tokens = $self->{config}->get_tokens;
 	return unless keys %$tokens;
 	
 	# basic

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/ApiFactory.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/ApiFactory.pm
@@ -62,19 +62,28 @@ my %_apis = map { $_ =~ /^WWW::SwaggerClient::(.*)$/; $1 => $_ }
 			grep {$_ =~ /Api$/} 
 			usesub 'WWW::SwaggerClient';
 
-=head1 new()
+=head1 new($api_client)
 	
-	Any parameters are optional, and are passed to and stored on the api_client object. 
+	create a new WWW::SwaggerClient::ApiFactory instance with the given WWW::SwaggerClient::ApiClient instance.
+
+=head1 new(%paramters)
+
+	Any parameters are optional, and are passed to and stored on the api_client object.
 	
-	base_url: (optional)
-		supply this to change the default base URL taken from the Swagger definition.
-	
+	See L<WWW::SwaggerClient::ApiClient> and L<WWW::SwaggerClient::Configuration> for valid paramters
+
 =cut	
 
 sub new {
-    my ($class, %p) = (shift, @_);
-	$p{api_client} = WWW::SwaggerClient::ApiClient->instance(%p);			
-	return bless \%p, $class;
+    my ($class) = shift;
+
+    my $api_client;
+    if ($_[0] && ref $_[0] && ref $_[0] eq 'WWW::SwaggerClient::ApiClient' ) {
+        $api_client = $_[0];
+    } else {
+        $api_client = WWW::SwaggerClient::ApiClient->new(@_);
+    }
+    bless { api_client => $api_client }, $class;
 }
 
 =head1 get_api($which)
@@ -91,7 +100,7 @@ sub get_api {
 	my ($self, $which) = @_;
 	croak "API not specified" unless $which;
 	my $api_class = $_apis{"${which}Api"} || croak "No known API for '$which'";
-	return $api_class->new(api_client => $self->api_client); 
+	return $api_class->new($self->api_client); 
 }
 
 =head1 api_client()

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/Configuration.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/Configuration.pm
@@ -28,71 +28,142 @@ use Carp;
 
 use constant VERSION => '1.0.0';
 
-# class/static variables
-our $http_timeout = 180;
-our $http_user_agent = 'Swagger-Codegen/1.0.0/perl';
+=head1 Name
 
-# authentication setting
-our $api_key = {};
-our $api_key_prefix = {};
-our $api_key_in = {};
+        WWW::SwaggerClient::Configuration - holds the configuration for all WWW::SwaggerClient Modules
 
-# username and password for HTTP basic authentication
-our $username = '';
-our $password = '';
+=head1 new(%paramters)
 
-# access token for OAuth
-our $access_token = '';
+=over 4
+
+=item http_timeout: (optional)
+
+Integer. timeout for HTTP requests in seconds
+
+default: 180
+
+=item http_user_agent: (optional)
+
+String. custom UserAgent header
+
+default: Swagger-Codegen/1.0.0/perl
+
+=item api_key: (optional)
+
+Hashref. Keyed on the name of each key (there can be multiple tokens).
+
+    api_key => {
+	secretKey => 'aaaabbbbccccdddd',
+	anotherKey => '1111222233334444',
+    };
+
+=item api_key_prefix: (optional)
+
+Hashref. Keyed on the name of each key (there can be multiple tokens). Note not all api keys require a prefix.
+
+    api_key_prefix => {
+        secretKey => 'string',
+	anotherKey => 'same or some other string',
+    };
+ 
+=item api_key_in: (optional)
+
+=item username: (optional)
+
+String. The username for basic auth.
+
+=item password: (optional)
+
+String. The password for basic auth.
+
+=item access_token: (optional)
+
+String. The OAuth access token.
+
+=item base_url: (optional)
+
+String. The base URL of the API
+
+default: http://petstore.swagger.io:80/v2
+
+=back
+
+=cut
+
+sub new {
+	my ($self, %p) = (shift,@_);
+
+	# class/static variables
+	$p{http_timeout} //= 180;
+	$p{http_user_agent} //= 'Swagger-Codegen/1.0.0/perl';
+
+	# authentication setting
+	$p{api_key} //= {};
+	$p{api_key_prefix} //= {};
+	$p{api_key_in} //= {};
+
+	# username and password for HTTP basic authentication
+	$p{username} //= '';
+	$p{password} //= '';
+
+	# access token for OAuth
+	$p{access_token} //= '';
+
+	# base_url
+        $p{base_url} //= 'http://petstore.swagger.io:80/v2';
+
+	return bless \%p => $self;
+}
+
 
 sub get_tokens {
-	my $class = shift;
+	my $self = shift;
 	
 	my $tokens = {};
-	$tokens->{username} = $username if $username;
-	$tokens->{password} = $password if $password;
-	$tokens->{access_token} = $access_token if $access_token;
+	$tokens->{username} = $self->{username} if $self->{username};
+	$tokens->{password} = $self->{password} if $self->{password};
+	$tokens->{access_token} = $self->{access_token} if $self->{access_token};
 	
-	foreach my $token_name (keys %{ $api_key }) {
-		$tokens->{$token_name}->{token} = $api_key->{$token_name};
-		$tokens->{$token_name}->{prefix} = $api_key_prefix->{$token_name};
-		$tokens->{$token_name}->{in} = $api_key_in->{$token_name};
+	foreach my $token_name (keys %{ $self->{api_key} }) {
+		$tokens->{$token_name}->{token} = $self->{api_key}{$token_name};
+		$tokens->{$token_name}->{prefix} = $self->{api_key_prefix}{$token_name};
+		$tokens->{$token_name}->{in} = $self->{api_key_in}{$token_name};
 	}
 
 	return $tokens;
 }
 
 sub clear_tokens {
-	my $class = shift;
-	my %tokens = %{$class->get_tokens}; # copy
+	my $self = shift;
+	my %tokens = %{$self->get_tokens}; # copy
 	
-	$username = undef;
-	$password = undef;
-	$access_token = undef;
+	$self->{username} = '';
+	$self->{password} = '';
+	$self->{access_token} = '';
 
-	$api_key = {};
-	$api_key_prefix = {};
-	$api_key_in = {};
+	$self->{api_key} = {};
+	$self->{api_key_prefix} = {};
+	$self->{api_key_in} = {};
 	
 	return \%tokens;
 }
 
 sub accept_tokens {
-	my ($class, $tokens) = @_;
+	my ($self, $tokens) = @_;
 	
 	foreach my $known_name (qw(username password access_token)) {
 		next unless $tokens->{$known_name};
-		eval "\$$known_name = delete \$tokens->{\$known_name}";
-		die $@ if $@;
+		$self->{$known_name} = delete $tokens->{$known_name};
 	}
 	
 	foreach my $token_name (keys %$tokens) {
-		$api_key->{$token_name} = $tokens->{$token_name}->{token};
-		if ($tokens->{$token_name}->{prefix}) {
-			$api_key_prefix->{$token_name} = $tokens->{$token_name}->{prefix};
+		$self->{api_key}{$token_name} = $tokens->{$token_name}{token};
+		if ($tokens->{$token_name}{prefix}) {
+			$self->{api_key_prefix}{$token_name} = $tokens->{$token_name}{prefix};
 		}
 		my $in = $tokens->{$token_name}->{in} || 'head';
 		croak "Tokens can only go in 'head' or 'query' (not in '$in')" unless $in =~ /^(?:head|query)$/;
-		$api_key_in->{$token_name} = $in;
+		$self->{api_key_in}{$token_name} = $in;
 	}
 }	
 

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/FakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/FakeApi.pm
@@ -28,25 +28,22 @@ use Carp qw( croak );
 use Log::Any qw($log);
 
 use WWW::SwaggerClient::ApiClient;
-use WWW::SwaggerClient::Configuration;
 
 use base "Class::Data::Inheritable";
 
 __PACKAGE__->mk_classdata('method_documentation' => {});
 
 sub new {
-    my $class   = shift;
-    my (%self) = (
-        'api_client' => WWW::SwaggerClient::ApiClient->instance,
-        @_
-    );
+    my $class = shift;
+    my $api_client;
 
-    #my $self = {
-    #    #api_client => $options->{api_client}
-    #    api_client => $default_api_client
-    #}; 
+    if ($_[0] && ref $_[0] && ref $_[0] eq 'WWW::SwaggerClient::ApiClient' ) {
+        $api_client = $_[0];
+    } else {
+        $api_client = WWW::SwaggerClient::ApiClient->new(@_);
+    }
 
-    bless \%self, $class;
+    bless { api_client => $api_client }, $class;
 
 }
 

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/FakeClassnameTags123Api.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/FakeClassnameTags123Api.pm
@@ -28,25 +28,22 @@ use Carp qw( croak );
 use Log::Any qw($log);
 
 use WWW::SwaggerClient::ApiClient;
-use WWW::SwaggerClient::Configuration;
 
 use base "Class::Data::Inheritable";
 
 __PACKAGE__->mk_classdata('method_documentation' => {});
 
 sub new {
-    my $class   = shift;
-    my (%self) = (
-        'api_client' => WWW::SwaggerClient::ApiClient->instance,
-        @_
-    );
+    my $class = shift;
+    my $api_client;
 
-    #my $self = {
-    #    #api_client => $options->{api_client}
-    #    api_client => $default_api_client
-    #}; 
+    if ($_[0] && ref $_[0] && ref $_[0] eq 'WWW::SwaggerClient::ApiClient' ) {
+        $api_client = $_[0];
+    } else {
+        $api_client = WWW::SwaggerClient::ApiClient->new(@_);
+    }
 
-    bless \%self, $class;
+    bless { api_client => $api_client }, $class;
 
 }
 

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/PetApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/PetApi.pm
@@ -28,25 +28,22 @@ use Carp qw( croak );
 use Log::Any qw($log);
 
 use WWW::SwaggerClient::ApiClient;
-use WWW::SwaggerClient::Configuration;
 
 use base "Class::Data::Inheritable";
 
 __PACKAGE__->mk_classdata('method_documentation' => {});
 
 sub new {
-    my $class   = shift;
-    my (%self) = (
-        'api_client' => WWW::SwaggerClient::ApiClient->instance,
-        @_
-    );
+    my $class = shift;
+    my $api_client;
 
-    #my $self = {
-    #    #api_client => $options->{api_client}
-    #    api_client => $default_api_client
-    #}; 
+    if ($_[0] && ref $_[0] && ref $_[0] eq 'WWW::SwaggerClient::ApiClient' ) {
+        $api_client = $_[0];
+    } else {
+        $api_client = WWW::SwaggerClient::ApiClient->new(@_);
+    }
 
-    bless \%self, $class;
+    bless { api_client => $api_client }, $class;
 
 }
 

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/Role.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/Role.pm
@@ -47,8 +47,8 @@ has tokens => ( is => 'ro',
                 );
 
 has _cfg => ( is => 'ro',
-              isa => 'Str',
-              default => 'WWW::SwaggerClient::Configuration',
+              isa => 'WWW::SwaggerClient::Configuration',
+              default => sub { WWW::SwaggerClient::Configuration->new() },
               );
 
 has version_info => ( is => 'ro',
@@ -201,39 +201,39 @@ you are accessing. Usually C<prefix> and C<in> will be determined by the code ge
 the spec and you will not need to set them at run time. If not, C<in> will
 default to 'head' and C<prefix> to the empty string.
 
-The tokens will be placed in the C<WWW::SwaggerClient::Configuration> namespace
+The tokens will be placed in a L<WWW::SwaggerClient::Configuration> instance
 as follows, but you don't need to know about this.
 
 =over 4
 
-=item C<$WWW::SwaggerClient::Configuration::username>
+=item C<$cfg-\>{username}>
 
 String. The username for basic auth.
 
-=item C<$WWW::SwaggerClient::Configuration::password>
+=item C<$cfg-\>{password}>
 
 String. The password for basic auth.
 
-=item C<$WWW::SwaggerClient::Configuration::api_key>
+=item C<$cfg-\>{api_key}>
 
 Hashref. Keyed on the name of each key (there can be multiple tokens).
 
-	$WWW::SwaggerClient::Configuration::api_key = {
+	$cfg->{api_key} = {
 		secretKey => 'aaaabbbbccccdddd',
 		anotherKey => '1111222233334444',
 		};
 
-=item C<$WWW::SwaggerClient::Configuration::api_key_prefix>
+=item C<$cfg->{api_key_prefix}>
 
 Hashref. Keyed on the name of each key (there can be multiple tokens). Note not
 all api keys require a prefix.
 
-	$WWW::SwaggerClient::Configuration::api_key_prefix = {
+	$cfg->{api_key_prefix} = {
 		secretKey => 'string',
 		anotherKey => 'same or some other string',
 		};
 
-=item C<$WWW::SwaggerClient::Configuration::access_token>
+=item C<$config-\>{access_token}>
 
 String. The OAuth access token.
 
@@ -244,8 +244,7 @@ String. The OAuth access token.
 =head2 C<base_url>
 
 The generated code has the C<base_url> already set as a default value. This method
-returns (and optionally sets, but only if the API client has not been
-created yet) the current value of C<base_url>.
+returns the current value of C<base_url>.
 
 =head2 C<api_factory>
 

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/StoreApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/StoreApi.pm
@@ -28,25 +28,22 @@ use Carp qw( croak );
 use Log::Any qw($log);
 
 use WWW::SwaggerClient::ApiClient;
-use WWW::SwaggerClient::Configuration;
 
 use base "Class::Data::Inheritable";
 
 __PACKAGE__->mk_classdata('method_documentation' => {});
 
 sub new {
-    my $class   = shift;
-    my (%self) = (
-        'api_client' => WWW::SwaggerClient::ApiClient->instance,
-        @_
-    );
+    my $class = shift;
+    my $api_client;
 
-    #my $self = {
-    #    #api_client => $options->{api_client}
-    #    api_client => $default_api_client
-    #}; 
+    if ($_[0] && ref $_[0] && ref $_[0] eq 'WWW::SwaggerClient::ApiClient' ) {
+        $api_client = $_[0];
+    } else {
+        $api_client = WWW::SwaggerClient::ApiClient->new(@_);
+    }
 
-    bless \%self, $class;
+    bless { api_client => $api_client }, $class;
 
 }
 

--- a/samples/client/petstore/perl/lib/WWW/SwaggerClient/UserApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/SwaggerClient/UserApi.pm
@@ -28,25 +28,22 @@ use Carp qw( croak );
 use Log::Any qw($log);
 
 use WWW::SwaggerClient::ApiClient;
-use WWW::SwaggerClient::Configuration;
 
 use base "Class::Data::Inheritable";
 
 __PACKAGE__->mk_classdata('method_documentation' => {});
 
 sub new {
-    my $class   = shift;
-    my (%self) = (
-        'api_client' => WWW::SwaggerClient::ApiClient->instance,
-        @_
-    );
+    my $class = shift;
+    my $api_client;
 
-    #my $self = {
-    #    #api_client => $options->{api_client}
-    #    api_client => $default_api_client
-    #}; 
+    if ($_[0] && ref $_[0] && ref $_[0] eq 'WWW::SwaggerClient::ApiClient' ) {
+        $api_client = $_[0];
+    } else {
+        $api_client = WWW::SwaggerClient::ApiClient->new(@_);
+    }
 
-    bless \%self, $class;
+    bless { api_client => $api_client }, $class;
 
 }
 

--- a/samples/client/petstore/perl/test.pl
+++ b/samples/client/petstore/perl/test.pl
@@ -15,15 +15,14 @@ use JSON;
 use Data::Dumper;
 use DateTime;
 
-$WWW::SwaggerClient::Configuration::http_user_agent = 'Perl-Swagger-Test';
-$WWW::SwaggerClient::Configuration::api_key->{'api_key'} = 'ZZZZZZZZZZZZZZ';
-$WWW::SwaggerClient::Configuration::api_key_prefix->{'api_key'} = 'Bearer';
+my $api = WWW::SwaggerClient::PetApi->new(
+    http_user_agent => 'Perl-Swagger-Test',
+    api_key => { api_key => 'ZZZZZZZZZZZZZZ' },
+    api_key_prefix => { api_key => 'Bearer' },
 
-$WWW::SwaggerClient::Configuration::username = 'username';
-$WWW::SwaggerClient::Configuration::password = 'password';
-
-
-my $api = WWW::SwaggerClient::PetApi->new();
+    username => 'username',
+    password => 'password',
+);
 
 # exception handling
 #eval {

--- a/samples/client/petstore/perl/tests/01_pet_api.t
+++ b/samples/client/petstore/perl/tests/01_pet_api.t
@@ -1,4 +1,4 @@
-use Test::More tests => 38;
+use Test::More tests => 37;
 use Test::Exception;
 
 use lib 'lib';
@@ -11,19 +11,15 @@ use_ok('WWW::SwaggerClient::Object::Pet');
 use_ok('WWW::SwaggerClient::Object::Tag');
 use_ok('WWW::SwaggerClient::Object::Category');
 
-my $api_client = WWW::SwaggerClient::ApiClient->instance('base_url' => 'http://testing');
-my $pet_api = WWW::SwaggerClient::PetApi->new('api_client' => $api_client);
-is $pet_api->{api_client}->{base_url}, 'http://testing', 'get the proper base URL from api client';
-
-my $api = WWW::SwaggerClient::PetApi->new();
-
-is $api->{api_client}->{base_url}, 'http://testing', 'we still get the original base URL from api client, because it\'s a singleton';
+my $api_client = WWW::SwaggerClient::ApiClient->new('base_url' => 'http://testing');
+my $api = WWW::SwaggerClient::PetApi->new($api_client);
+is $api->{api_client}{config}{base_url}, 'http://testing', 'get the proper base URL from api client';
 
 # reset the base_url - no direct access because an application shouldn't be changing 
 # its base URL halfway through
-$api->{api_client}->{base_url} = 'http://petstore.swagger.io/v2';
+$api->{api_client}{config}{base_url} = 'http://petstore.swagger.io/v2';
 
-is $api->{api_client}->{base_url}, 'http://petstore.swagger.io/v2', 'get the default base URL from api client';
+is $api->{api_client}{config}{base_url}, 'http://petstore.swagger.io/v2', 'get the default base URL from api client';
 
 # test select_header_content_type
 is $api->{api_client}->select_header_content_type('application/xml', 'Application/JSON'), 'application/json', 'get the proper content type application/json but not application/xml';

--- a/samples/client/petstore/perl/tests/02_store_api.t
+++ b/samples/client/petstore/perl/tests/02_store_api.t
@@ -15,10 +15,10 @@ use_ok('WWW::SwaggerClient::Object::Category');
 use_ok('WWW::SwaggerClient::Object::User');
 
 
-my $api_client = WWW::SwaggerClient::ApiClient->instance();
-my $store_api = WWW::SwaggerClient::StoreApi->new('api_client' => $api_client);
+my $api_client = WWW::SwaggerClient::ApiClient->new();
+my $store_api = WWW::SwaggerClient::StoreApi->new($api_client);
 
-is $store_api->{api_client}->{base_url}, 'http://petstore.swagger.io/v2', 'get the default base URL from api client';
+is $store_api->{api_client}{config}{base_url}, 'http://petstore.swagger.io:80/v2', 'get the default base URL from api client';
 
 my $get_inventory_response = $store_api->get_inventory();
 

--- a/samples/client/petstore/perl/tests/03_api_factory.t
+++ b/samples/client/petstore/perl/tests/03_api_factory.t
@@ -10,15 +10,15 @@ use_ok('WWW::SwaggerClient::ApiFactory');
 my $api_factory = WWW::SwaggerClient::ApiFactory->new('base_url' => 'http://testing');
 my $pet_api = $api_factory->get_api('Pet');
 isa_ok($pet_api, 'WWW::SwaggerClient::PetApi');
-is $pet_api->{api_client}->{base_url}, 'http://testing', 'get the proper base URL from api client';
+is $pet_api->{api_client}{config}{base_url}, 'http://testing', 'get the proper base URL from api client';
 
 $api_factory = WWW::SwaggerClient::ApiFactory->new;
 $pet_api = $api_factory->get_api('Pet');
 
 # reset the base_url - no direct access because an application shouldn't be changing 
 # its base URL halfway through
-$pet_api->{api_client}->{base_url} = 'http://petstore.swagger.io/v2';
-is $pet_api->{api_client}->{base_url}, 'http://petstore.swagger.io/v2', 'get the default base URL from api client';
+$pet_api->{api_client}{config}{base_url} = 'http://petstore.swagger.io/v2';
+is $pet_api->{api_client}{config}{base_url}, 'http://petstore.swagger.io/v2', 'get the default base URL from api client';
 
 # test accessor methods
 my $pet_id = 10008;

--- a/samples/client/petstore/perl/tests/04_role.t
+++ b/samples/client/petstore/perl/tests/04_role.t
@@ -95,26 +95,26 @@ my $tokens = {
 
 $api->_cfg->accept_tokens({%$tokens}); # pass a copy
 no warnings 'once';
-is $WWW::SwaggerClient::Configuration::username, 'UserName', 'accept_tokens() correctly set the username';
-is $WWW::SwaggerClient::Configuration::password, 'PassWord', 'accept_tokens() correctly set the password';
-is $WWW::SwaggerClient::Configuration::access_token, 'OAuth_token', 'accept_tokens() correctly set the oauth';
+is $api->_cfg->{username}, 'UserName', 'accept_tokens() correctly set the username';
+is $api->_cfg->{password}, 'PassWord', 'accept_tokens() correctly set the password';
+is $api->_cfg->{access_token}, 'OAuth_token', 'accept_tokens() correctly set the oauth';
 
 my $api_key_href = {
           'anotherKey' => 'another_key_token',
           'someKey' => 'some_key_token'
         };
-cmp_deeply( $WWW::SwaggerClient::Configuration::api_key, $api_key_href, 'accept_tokens() correctly set api_key' );
+cmp_deeply( $api->_cfg->{api_key}, $api_key_href, 'accept_tokens() correctly set api_key' );
 
 my $api_key_prefix_href = {
           'someKey' => 'some_key_prefix'
         };
-cmp_deeply( $WWW::SwaggerClient::Configuration::api_key_prefix, $api_key_prefix_href, 'accept_tokens() correctly set api_key_prefix' );
+cmp_deeply( $api->_cfg->{api_key_prefix}, $api_key_prefix_href, 'accept_tokens() correctly set api_key_prefix' );
 
 my $api_key_in = {
           'someKey' => 'query',
           'anotherKey' => 'head'
         };
-cmp_deeply( $WWW::SwaggerClient::Configuration::api_key_in, $api_key_in, 'accept_tokens() correctly set api_key_in' );
+cmp_deeply( $api->_cfg->{api_key_in}, $api_key_in, 'accept_tokens() correctly set api_key_in' );
 
 use warnings 'once';
 


### PR DESCRIPTION
- removed Singleton from ApiClient

fixes #5336

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The perl singleton was removed and the documentation updated ( at least i hope i found all relevant parts )
