### PR TITLE
[PHP] Eescape reserved words in enum variables names

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -315,7 +315,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    public String escapeReservedWord(String name) {           
+    public String escapeReservedWord(String name) {
         if(this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
         }
@@ -679,8 +679,8 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");
 
-        if (enumName.matches("\\d.*")) { // starts with number
-            return "_" + enumName;
+        if (isReservedWord(enumName) || enumName.matches("\\d.*")) { // reserved word or starts with number
+            return escapeReservedWord(enumName);
         } else {
             return enumName;
         }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
@@ -334,7 +334,15 @@ public class PhpModelTest {
 
     }
 
-
+    @Test(description = "test enum variable names for reserved words")
+    public void testReservedWord() throws Exception {
+        final DefaultCodegen codegen = new PhpClientCodegen();
+        Assert.assertEquals(codegen.toEnumVarName("public", null), "_PUBLIC");
+        Assert.assertEquals(codegen.toEnumVarName("Private", null), "_PRIVATE");
+        Assert.assertEquals(codegen.toEnumVarName("IF", null), "_IF");
+        // should not escape non-reserved
+        Assert.assertEquals(codegen.toEnumVarName("hello", null), "HELLO");
+    }
 
 
 }


### PR DESCRIPTION
Signed-off-by: Vincent Giersch <vincent@giersch.fr>

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Similar to #4201 / #4357 but in PHP: escape the enum variables names + use standard escape function.