### PR TITLE
[JavaScript] Fix for issue #5358: Regression in 2.3 using `multi` parameters (Cannot read property 'buildCollectionParam' of undefined)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -391,7 +391,7 @@
           }
         } else {
           // All other collection query parameters should be treated as ordinary query parameters.
-          queryParams[key] = this.apiClient.buildCollectionParam(param.value, param.collectionFormat);
+          queryParams[key] = this.buildCollectionParam(param.value, param.collectionFormat);
         }
       }
     }

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -385,7 +385,7 @@
           }
         } else {
           // All other collection query parameters should be treated as ordinary query parameters.
-          queryParams[key] = this.apiClient.buildCollectionParam(param.value, param.collectionFormat);
+          queryParams[key] = this.buildCollectionParam(param.value, param.collectionFormat);
         }
       }
     }

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -394,7 +394,7 @@
           }
         } else {
           // All other collection query parameters should be treated as ordinary query parameters.
-          queryParams[key] = this.apiClient.buildCollectionParam(param.value, param.collectionFormat);
+          queryParams[key] = this.buildCollectionParam(param.value, param.collectionFormat);
         }
       }
     }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

See #5358.