### PR TITLE
fix(swift3): decoders call parents decoders too

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/AlamofireImplementations.mustache
@@ -197,7 +197,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     return
                 }
                 if let json: Any = response.result.value {
-                    let body = Decoders.decode(clazz: T.self, source: json as AnyObject)
+                    let body = Decoders.decode(clazz: T.self, source: json as AnyObject, instance: nil)
                     completion(Response(response: response.response!, body: body), nil)
                     return
                 } else if "" is T {

--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -37,17 +37,17 @@ open class Response<T> {
 
 private var once = Int()
 class Decoders {
-    static fileprivate var decoders = Dictionary<String, ((AnyObject) -> AnyObject)>()
+    static fileprivate var decoders = Dictionary<String, ((AnyObject, AnyObject?) -> AnyObject)>()
 
-    static func addDecoder<T>(clazz: T.Type, decoder: @escaping ((AnyObject) -> T)) {
+    static func addDecoder<T>(clazz: T.Type, decoder: @escaping ((AnyObject, AnyObject?) -> T)) {
         let key = "\(T.self)"
-        decoders[key] = { decoder($0) as AnyObject }
+        decoders[key] = { decoder($0, $1) as AnyObject }
     }
 
     static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> T {
         let key = discriminator;
         if let decoder = decoders[key] {
-            return decoder(source) as! T
+            return decoder(source, nil) as! T
         } else {
             fatalError("Source \(source) is not convertible to type \(clazz): Maybe swagger file is insufficient")
         }
@@ -55,19 +55,19 @@ class Decoders {
 
     static func decode<T>(clazz: [T].Type, source: AnyObject) -> [T] {
         let array = source as! [AnyObject]
-        return array.map { Decoders.decode(clazz: T.self, source: $0) }
+        return array.map { Decoders.decode(clazz: T.self, source: $0, instance: nil) }
     }
 
     static func decode<T, Key: Hashable>(clazz: [Key:T].Type, source: AnyObject) -> [Key:T] {
         let sourceDictionary = source as! [Key: AnyObject]
         var dictionary = [Key:T]()
         for (key, value) in sourceDictionary {
-            dictionary[key] = Decoders.decode(clazz: T.self, source: value)
+            dictionary[key] = Decoders.decode(clazz: T.self, source: value, instance: nil)
         }
         return dictionary
     }
 
-    static func decode<T>(clazz: T.Type, source: AnyObject) -> T {
+    static func decode<T>(clazz: T.Type, source: AnyObject, instance: AnyObject?) -> T {
         initialize()
         if T.self is Int32.Type && source is NSNumber {
             return source.int32Value as! T;
@@ -87,7 +87,7 @@ class Decoders {
 
         let key = "\(T.self)"
         if let decoder = decoders[key] {
-           return decoder(source) as! T
+           return decoder(source, instance) as! T
         } else {
             fatalError("Source \(source) is not convertible to type \(clazz): Maybe swagger file is insufficient")
         }
@@ -98,7 +98,7 @@ class Decoders {
             return nil
         }
         return source.map { (source: AnyObject) -> T in
-            Decoders.decode(clazz: clazz, source: source)
+            Decoders.decode(clazz: clazz, source: source, instance: nil)
         }
     }
 
@@ -134,7 +134,7 @@ class Decoders {
             return formatter
         }
         // Decoder for Date
-        Decoders.addDecoder(clazz: Date.self) { (source: AnyObject) -> Date in
+        Decoders.addDecoder(clazz: Date.self) { (source: AnyObject, instance: AnyObject?) -> Date in
            if let sourceString = source as? String {
                 for formatter in formatters {
                     if let date = formatter.date(from: sourceString) {
@@ -150,14 +150,14 @@ class Decoders {
         } {{#models}}{{#model}}
 
         // Decoder for [{{{classname}}}]
-        Decoders.addDecoder(clazz: [{{{classname}}}].self) { (source: AnyObject) -> [{{{classname}}}] in
+        Decoders.addDecoder(clazz: [{{{classname}}}].self) { (source: AnyObject, instance: AnyObject?) -> [{{{classname}}}] in
             return Decoders.decode(clazz: [{{{classname}}}].self, source: source)
         }
         // Decoder for {{{classname}}}
-        Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject) -> {{{classname}}} in
+        Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject, instance: AnyObject?) -> {{{classname}}} in
 {{#isArrayModel}}
             let sourceArray = source as! [AnyObject]
-            return sourceArray.map({ Decoders.decode(clazz: {{{arrayModelType}}}.self, source: $0) })
+            return sourceArray.map({ Decoders.decode(clazz: {{{arrayModelType}}}.self, source: $0, instance: nil) })
 {{/isArrayModel}}
 {{^isArrayModel}}
 {{#isEnum}}
@@ -185,24 +185,28 @@ class Decoders {
             {{/discriminator}}
 
             {{#unwrapRequired}}
-            let instance = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{#isEnum}}{{name}}: {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{baseName}}"] as! {{datatype}}))! {{/isEnum}}{{^isEnum}}{{name}}: Decoders.decode(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"]! as AnyObject){{/isEnum}}{{/requiredVars}})
+            let result = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{#isEnum}}{{name}}: {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{baseName}}"] as! {{datatype}}))! {{/isEnum}}{{^isEnum}}{{name}}: Decoders.decode(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"]! as AnyObject, instance: nil){{/isEnum}}{{/requiredVars}})
             {{#optionalVars}}{{#isEnum}}
             if let {{name}} = sourceDictionary["{{baseName}}"] as? {{datatype}} { {{^isContainer}}
-                instance.{{name}} = {{classname}}.{{datatypeWithEnum}}(rawValue: ({{name}})){{/isContainer}}{{#isListContainer}}
-                instance.{{name}}  = {{name}}.map ({ {{classname}}.{{enumName}}(rawValue: $0)! }){{/isListContainer}}
+                result.{{name}} = {{classname}}.{{datatypeWithEnum}}(rawValue: ({{name}})){{/isContainer}}{{#isListContainer}}
+                result.{{name}}  = {{name}}.map ({ {{classname}}.{{enumName}}(rawValue: $0)! }){{/isListContainer}}
             }{{/isEnum}}{{^isEnum}}
-            instance.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}
+            result.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}
             {{/optionalVars}}
             {{/unwrapRequired}}
             {{^unwrapRequired}}
-            let instance = {{classname}}(){{#allVars}}{{#isEnum}}
+            let result = instance == nil ? {{classname}}() : instance as! {{classname}}
+            {{#parent}}
+            _ = Decoders.decode(clazz: {{parent}}.self, source: source, instance: result)
+            {{/parent}}
+            {{#allVars}}{{#isEnum}}
             if let {{name}} = sourceDictionary["{{baseName}}"] as? {{datatype}} { {{^isContainer}}
-                instance.{{name}} = {{classname}}.{{datatypeWithEnum}}(rawValue: ({{name}})){{/isContainer}}{{#isListContainer}}
-                instance.{{name}}  = {{name}}.map ({ {{classname}}.{{enumName}}(rawValue: $0)! }){{/isListContainer}}{{#isMapContainer}}//TODO: handle enum map scenario{{/isMapContainer}}
+                result.{{name}} = {{classname}}.{{datatypeWithEnum}}(rawValue: ({{name}})){{/isContainer}}{{#isListContainer}}
+                result.{{name}}  = {{name}}.map ({ {{classname}}.{{enumName}}(rawValue: $0)! }){{/isListContainer}}{{#isMapContainer}}//TODO: handle enum map scenario{{/isMapContainer}}
             }{{/isEnum}}
-            {{^isEnum}}instance.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}{{/allVars}}
+            {{^isEnum}}result.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}{{/allVars}}
             {{/unwrapRequired}}
-            return instance
+            return result
 {{/allVars.isEmpty}}
 {{/isEnum}}
 {{/isArrayModel}}

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -27,9 +27,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -122,7 +122,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -131,21 +131,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -154,20 +154,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -209,7 +209,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -218,21 +218,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -241,20 +241,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -296,7 +296,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -305,21 +305,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -328,20 +328,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -470,11 +470,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 0,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -65,9 +65,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 0
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -101,36 +101,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{order_id}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -167,36 +167,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -168,7 +168,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -177,17 +177,17 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -196,16 +196,16 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -245,8 +245,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -197,7 +197,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     return
                 }
                 if let json: Any = response.result.value {
-                    let body = Decoders.decode(clazz: T.self, source: json as AnyObject)
+                    let body = Decoders.decode(clazz: T.self, source: json as AnyObject, instance: nil)
                     completion(Response(response: response.response!, body: body), nil)
                     return
                 } else if "" is T {

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -45,9 +45,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -175,7 +175,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -184,21 +184,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -207,20 +207,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -279,7 +279,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -288,21 +288,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -311,20 +311,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -383,7 +383,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -392,21 +392,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -415,20 +415,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -612,11 +612,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 0,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -99,9 +99,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 0
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -152,36 +152,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{order_id}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -235,36 +235,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -254,7 +254,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -263,17 +263,17 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -282,16 +282,16 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -349,8 +349,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -197,7 +197,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     return
                 }
                 if let json: Any = response.result.value {
-                    let body = Decoders.decode(clazz: T.self, source: json as AnyObject)
+                    let body = Decoders.decode(clazz: T.self, source: json as AnyObject, instance: nil)
                     completion(Response(response: response.response!, body: body), nil)
                     return
                 } else if "" is T {

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -47,9 +47,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -181,7 +181,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -190,21 +190,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -213,20 +213,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -287,7 +287,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -296,21 +296,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -319,20 +319,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -393,7 +393,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -402,21 +402,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -425,20 +425,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -628,11 +628,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 0,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -103,9 +103,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 0
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -158,36 +158,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{order_id}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -243,36 +243,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -264,7 +264,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -273,17 +273,17 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -292,16 +292,16 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -361,8 +361,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -197,7 +197,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     return
                 }
                 if let json: Any = response.result.value {
-                    let body = Decoders.decode(clazz: T.self, source: json as AnyObject)
+                    let body = Decoders.decode(clazz: T.self, source: json as AnyObject, instance: nil)
                     completion(Response(response: response.response!, body: body), nil)
                     return
                 } else if "" is T {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

I was having problems with classes inheriting from other classes, fields defined in parent classes were `nil`. I fixed it by calling the parent's decoder in the child's decoder and passing the child's instance.