### PR TITLE
Fixing import-mappings and using it when generating API stub. #2248

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -504,6 +504,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toModelName(final String name) {
+        // We need to check if import-mapping has a different model for this class, so we use it
+        // instead of the auto-generated one.
+        if (importMapping.containsKey(name)) {
+            return importMapping.get(name);
+        }
+
         final String sanitizedName = sanitizeName(name);
 
         String nameWithPrefixSuffix = sanitizedName;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/AbstractJavaCodegenTest.java
@@ -39,4 +39,14 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals("propertyClass", fakeJavaCodegen.toVarName("__class"));
     }
 
+    @Test
+    public void toModelNameShouldUseProvidedMapping() throws Exception {
+        fakeJavaCodegen.importMapping().put("json_myclass", "com.test.MyClass");
+        Assert.assertEquals("com.test.MyClass", fakeJavaCodegen.toModelName("json_myclass"));
+    }
+
+    @Test
+    public void toModelNameUsesPascalCase() throws Exception {
+        Assert.assertEquals("JsonAnotherclass", fakeJavaCodegen.toModelName("json_anotherclass"));
+    }
 }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixing the issue that the Java generator was using the auto-generated model classes when generating the client API stub, ignoring the `--import-mappings` parameters. Added two unit tests to ensure it is fixed and it won't regress.

Seems related to #2502, despite being related to the client generation.