### PR TITLE
Moving import-mappings out of configOptions and converting it into a list, rather than being a comma-separated string.

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -381,6 +381,10 @@ public class CodeGenMojo extends AbstractMojo {
                 applyInstantiationTypesKvp(configOptions.get("instantiation-types").toString(), configurator);
             }
 
+            if(importMappings == null && configOptions.containsKey("import-mappings")) {
+                applyImportMappingsKvp(configOptions.get("import-mappings").toString(), configurator);
+            }
+
             if(configOptions.containsKey("type-mappings")) {
                 applyTypeMappingsKvp(configOptions.get("type-mappings").toString(), configurator);
             }
@@ -398,7 +402,7 @@ public class CodeGenMojo extends AbstractMojo {
             }
         }
 
-        if (importMappings != null) {
+        if (importMappings != null && !configOptions.containsKey("import-mappings")) {
             String importMappingsAsString = importMappings.toString();
             applyImportMappingsKvp(importMappingsAsString.substring(0, importMappingsAsString.length() - 1), configurator);
         }

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -26,6 +26,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -173,6 +174,9 @@ public class CodeGenMojo extends AbstractMojo {
      */
     @Parameter(name = "configOptions")
     private Map<?, ?> configOptions;
+
+    @Parameter(name = "importMappings")
+    private List<String> importMappings;
 
     /**
      * Generate the apis
@@ -377,10 +381,6 @@ public class CodeGenMojo extends AbstractMojo {
                 applyInstantiationTypesKvp(configOptions.get("instantiation-types").toString(), configurator);
             }
 
-            if(configOptions.containsKey("import-mappings")) {
-                applyImportMappingsKvp(configOptions.get("import-mappings").toString(), configurator);
-            }
-
             if(configOptions.containsKey("type-mappings")) {
                 applyTypeMappingsKvp(configOptions.get("type-mappings").toString(), configurator);
             }
@@ -392,10 +392,15 @@ public class CodeGenMojo extends AbstractMojo {
             if(configOptions.containsKey("additional-properties")) {
                 applyAdditionalPropertiesKvp(configOptions.get("additional-properties").toString(), configurator);
             }
-            
+
             if(configOptions.containsKey("reserved-words-mappings")) {
                 applyReservedWordsMappingsKvp(configOptions.get("reserved-words-mappings").toString(), configurator);
             }
+        }
+
+        if (importMappings != null) {
+            String importMappingsAsString = importMappings.toString();
+            applyImportMappingsKvp(importMappingsAsString.substring(0, importMappingsAsString.length() - 1), configurator);
         }
 
         if (environmentVariables != null) {


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Converting import-mappings to a list and moving it outside of `configOptions`, but still keeping it backwards compatible (and still as a comma-separated string). Fixes #5383 

This adds support to having configuration like this:
```xml
<configuration>
    <importMappings>
        <param>json_mymodel=com.mypackage.MyModel</param>
        <param>json_anothermodel=com.mypackage.AnotherModel</param>
    </importMappings>
</configuration>
```

