### PR TITLE
Add float conversion for cpprest client api template.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-header.mustache
@@ -38,6 +38,7 @@ public:
     static utility::string_t parameterToString(utility::string_t value);
     static utility::string_t parameterToString(int32_t value);
     static utility::string_t parameterToString(int64_t value);
+    static utility::string_t parameterToString(float value);
     static utility::string_t parameterToString(const utility::datetime &value);
 
     template<class T>

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
@@ -40,6 +40,11 @@ utility::string_t ApiClient::parameterToString(int32_t value)
     return utility::conversions::to_string_t(std::to_string(value));
 }
 
+utility::string_t ApiClient::parameterToString(float value)
+{
+    return utility::conversions::to_string_t(std::to_string(value));
+}
+
 utility::string_t ApiClient::parameterToString(const utility::datetime &value)
 {
     return utility::conversions::to_string_t(value.to_string(utility::datetime::ISO_8601));

--- a/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/modelbase-header.mustache
@@ -43,6 +43,7 @@ public:
 
     static int64_t int64_tFromJson(web::json::value& val);
     static int32_t int32_tFromJson(web::json::value& val);
+    static float floatFromJson(web::json::value& val);
     static utility::string_t stringFromJson(web::json::value& val);
     static utility::datetime dateFromJson(web::json::value& val);
     static double doubleFromJson(web::json::value& val);
@@ -59,6 +60,7 @@ public:
 
     static int64_t int64_tFromHttpContent(std::shared_ptr<HttpContent> val);
     static int32_t int32_tFromHttpContent(std::shared_ptr<HttpContent> val);
+    static float floatFromHttpContent(std::shared_ptr<HttpContent> val);
     static utility::string_t stringFromHttpContent(std::shared_ptr<HttpContent> val);
     static utility::datetime dateFromHttpContent(std::shared_ptr<HttpContent> val);
     static bool boolFromHttpContent(std::shared_ptr<HttpContent> val);

--- a/modules/swagger-codegen/src/main/resources/cpprest/modelbase-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/modelbase-source.mustache
@@ -262,6 +262,10 @@ int32_t ModelBase::int32_tFromJson(web::json::value& val)
 {
     return val.as_integer();
 }
+float ModelBase::floatFromJson(web::json::value& val)
+{
+    return val.as_double();
+}
 utility::string_t ModelBase::stringFromJson(web::json::value& val)
 {
     return val.is_string() ? val.as_string() : U("");
@@ -295,6 +299,15 @@ int32_t ModelBase::int32_tFromHttpContent(std::shared_ptr<HttpContent> val)
 
     utility::stringstream_t ss(str);
     int32_t result = 0;
+    ss >> result;
+    return result;
+}
+float ModelBase::floatFromHttpContent(std::shared_ptr<HttpContent> val)
+{
+    utility::string_t str = ModelBase::stringFromHttpContent(val);
+
+    utility::stringstream_t ss(str);
+    float result = 0;
     ss >> result;
     return result;
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

I had the float conversion for cpprest client API template.