### PR TITLE
[JavaSpring] add support for map minProperties and maxProperties bean…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1739,12 +1739,16 @@ public class DefaultCodegen {
             CodegenProperty cp = fromProperty(property.name, ap.getItems());
             updatePropertyForArray(property, cp);
           } else if (p instanceof MapProperty) {
+            MapProperty ap = (MapProperty) p;
+
             property.isContainer = true;
             property.isMapContainer = true;
             property.containerType = "map";
             property.baseType = getSwaggerType(p);
+            property.minItems = ap.getMinProperties();
+            property.maxItems = ap.getMaxProperties();
+
             // handle inner property
-            MapProperty ap = (MapProperty) p;
             CodegenProperty cp = fromProperty("inner", ap.getAdditionalProperties());
             updatePropertyForMap(property, cp);
         } else {


### PR DESCRIPTION
#4307

Add support for minProperties and maxProperties.  The change is deliberately re-using the minItems and maxItems of CodegenProperty so that all templates using those properties requires no changes.  This is considering JavaSpring only where bean validation is the same annotation.