### PR TITLE
[TypeScript] fix class filename in import/export

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/apis.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/apis.mustache
@@ -1,9 +1,9 @@
 {{#apiInfo}}
 {{#apis}}
 {{#operations}}
-export * from './{{ classname }}';
-import { {{ classname }} }  from './{{ classname }}';
+export * from './{{ classFilename }}';
+import { {{ classname }} } from './{{ classFilename }}';
 {{/operations}}
 {{/apis}}
-export const APIS = [ {{#apis}}{{#operations}}{{ classname }}, {{/operations}}{{/apis}}];
+export const APIS = [{{#apis}}{{#operations}}{{ classname }}, {{/operations}}{{/apis}}];
 {{/apiInfo}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/models.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/models.mustache
@@ -1,5 +1,5 @@
 {{#models}}
 {{#model}}
-export * from './{{{ classname }}}';
+export * from './{{{ classFilename }}}';
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/models.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/models.mustache
@@ -1,5 +1,5 @@
 {{#models}}
 {{#model}}
-export * from './{{{ classname }}}';
+export * from './{{{ classFilename }}}';
 {{/model}}
 {{/models}}

--- a/samples/client/petstore-security-test/typescript-angular/api/api.ts
+++ b/samples/client/petstore-security-test/typescript-angular/api/api.ts
@@ -1,3 +1,3 @@
 export * from './FakeApi';
-import { FakeApi }  from './FakeApi';
-export const APIS = [ FakeApi, ];
+import { FakeApi } from './FakeApi';
+export const APIS = [FakeApi, ];

--- a/samples/client/petstore/typescript-angular/api/api.ts
+++ b/samples/client/petstore/typescript-angular/api/api.ts
@@ -1,7 +1,7 @@
 export * from './PetApi';
-import { PetApi }  from './PetApi';
+import { PetApi } from './PetApi';
 export * from './StoreApi';
-import { StoreApi }  from './StoreApi';
+import { StoreApi } from './StoreApi';
 export * from './UserApi';
-import { UserApi }  from './UserApi';
-export const APIS = [ PetApi, StoreApi, UserApi, ];
+import { UserApi } from './UserApi';
+export const APIS = [PetApi, StoreApi, UserApi, ];

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201703211709
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704132011
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201703211709 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704132011 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201703211709",
+  "version": "0.0.1-SNAPSHOT.201704132011",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- Fixes #5136 
- Same changes as in #5131 but for ts-angular.
- Additionally: changed models.mustache of ts-angular2
- Recreated ts-angular & ts-angular2 samples