### PR TITLE
Fix spring generated annotations only generating first return type

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/SpringCodegen.java
@@ -362,40 +362,39 @@ public class SpringCodegen extends AbstractJavaCodegen implements BeanValidation
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         if (operations != null) {
             List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
-            for (CodegenOperation operation : ops) {
+            for (final CodegenOperation operation : ops) {
                 List<CodegenResponse> responses = operation.responses;
                 if (responses != null) {
-                    for (CodegenResponse resp : responses) {
+                    for (final CodegenResponse resp : responses) {
                         if ("0".equals(resp.code)) {
                             resp.code = "200";
                         }
+                        doDataTypeAssignment(resp.dataType, new DataTypeAssigner() {
+                            @Override
+                            public void setReturnType(final String returnType) {
+                                resp.dataType = returnType;
+                            }
+
+                            @Override
+                            public void setReturnContainer(final String returnContainer) {
+                                resp.containerType = returnContainer;
+                            }
+                        });
                     }
                 }
 
-                if (operation.returnType == null) {
-                    operation.returnType = "Void";
-                } else if (operation.returnType.startsWith("List")) {
-                    String rt = operation.returnType;
-                    int end = rt.lastIndexOf(">");
-                    if (end > 0) {
-                        operation.returnType = rt.substring("List<".length(), end).trim();
-                        operation.returnContainer = "List";
+                doDataTypeAssignment(operation.returnType, new DataTypeAssigner() {
+
+                    @Override
+                    public void setReturnType(final String returnType) {
+                        operation.returnType = returnType;
                     }
-                } else if (operation.returnType.startsWith("Map")) {
-                    String rt = operation.returnType;
-                    int end = rt.lastIndexOf(">");
-                    if (end > 0) {
-                        operation.returnType = rt.substring("Map<".length(), end).split(",")[1].trim();
-                        operation.returnContainer = "Map";
+
+                    @Override
+                    public void setReturnContainer(final String returnContainer) {
+                        operation.returnContainer = returnContainer;
                     }
-                } else if (operation.returnType.startsWith("Set")) {
-                    String rt = operation.returnType;
-                    int end = rt.lastIndexOf(">");
-                    if (end > 0) {
-                        operation.returnType = rt.substring("Set<".length(), end).trim();
-                        operation.returnContainer = "Set";
-                    }
-                }
+                });
 
                 if(implicitHeaders){
                     removeHeadersFromAllParams(operation.allParams);
@@ -404,6 +403,41 @@ public class SpringCodegen extends AbstractJavaCodegen implements BeanValidation
         }
 
         return objs;
+    }
+
+    private interface DataTypeAssigner {
+        void setReturnType(String returnType);
+        void setReturnContainer(String returnContainer);
+    }
+
+    /**
+     *
+     * @param returnType The return type that needs to be converted
+     * @param dataTypeAssigner An object that will assign the data to the respective fields in the model.
+     */
+    private void doDataTypeAssignment(String returnType, DataTypeAssigner dataTypeAssigner) {
+        final String rt = returnType;
+        if (rt == null) {
+            dataTypeAssigner.setReturnType("Void");
+        } else if (rt.startsWith("List")) {
+            int end = rt.lastIndexOf(">");
+            if (end > 0) {
+                dataTypeAssigner.setReturnType(rt.substring("List<".length(), end).trim());
+                dataTypeAssigner.setReturnContainer("List");
+            }
+        } else if (rt.startsWith("Map")) {
+            int end = rt.lastIndexOf(">");
+            if (end > 0) {
+                dataTypeAssigner.setReturnType(rt.substring("Map<".length(), end).split(",")[1].trim());
+                dataTypeAssigner.setReturnContainer("Map");
+            }
+        } else if (rt.startsWith("Set")) {
+            int end = rt.lastIndexOf(">");
+            if (end > 0) {
+                dataTypeAssigner.setReturnType(rt.substring("Set<".length(), end).trim());
+                dataTypeAssigner.setReturnContainer("Set");
+            }
+        }
     }
 
     /**

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/api.mustache
@@ -39,7 +39,7 @@ public interface {{classname}} {
         {{/hasMore}}{{/authMethods}}
     }{{/hasAuthMethods}}, tags={ {{#vendorExtensions.x-tags}}"{{tag}}",{{/vendorExtensions.x-tags}} })
     @ApiResponses(value = { {{#responses}}
-        @ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{returnType}}}.class){{#hasMore}},{{/hasMore}}{{/responses}} })
+        @ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{dataType}}}.class{{#containerType}}, responseContainer = "{{{containerType}}}"{{/containerType}}){{#hasMore}},{{/hasMore}}{{/responses}} })
     {{#implicitHeaders}}@ApiImplicitParams({
     {{#headerParams}}{{>implicitHeader}}{{/headerParams}}
     }){{/implicitHeaders}}

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/PetApi.java
@@ -61,8 +61,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByStatus",
         produces = "application/json",
@@ -78,8 +78,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByTags",
         produces = "application/json",
@@ -93,8 +93,8 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     
     @RequestMapping(value = "/pet/{petId}",
         produces = "application/json",

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/StoreApi.java
@@ -37,7 +37,7 @@ public interface StoreApi {
         @Authorization(value = "api_key")
     }, tags={ "store", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Integer.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     
     @RequestMapping(value = "/store/inventory",
         produces = "application/json",
@@ -49,8 +49,8 @@ public interface StoreApi {
     @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
-        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     
     @RequestMapping(value = "/store/order/{orderId}",
         produces = "application/json",
@@ -62,7 +62,7 @@ public interface StoreApi {
     @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     
     @RequestMapping(value = "/store/order",
         produces = "application/json",

--- a/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/io/swagger/api/UserApi.java
@@ -69,8 +69,8 @@ public interface UserApi {
     @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = User.class),
-        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
-        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "User not found", response = Void.class) })
     
     @RequestMapping(value = "/user/{username}",
         produces = "application/json",
@@ -82,7 +82,7 @@ public interface UserApi {
     @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = String.class),
-        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     
     @RequestMapping(value = "/user/login",
         produces = "application/json",

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/PetApi.java
@@ -61,8 +61,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByStatus",
         produces = "application/json",
@@ -78,8 +78,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByTags",
         produces = "application/json",
@@ -93,8 +93,8 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     
     @RequestMapping(value = "/pet/{petId}",
         produces = "application/json",

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/StoreApi.java
@@ -37,7 +37,7 @@ public interface StoreApi {
         @Authorization(value = "api_key")
     }, tags={ "store", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Integer.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     
     @RequestMapping(value = "/store/inventory",
         produces = "application/json",
@@ -49,8 +49,8 @@ public interface StoreApi {
     @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
-        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     
     @RequestMapping(value = "/store/order/{orderId}",
         produces = "application/json",
@@ -62,7 +62,7 @@ public interface StoreApi {
     @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     
     @RequestMapping(value = "/store/order",
         produces = "application/json",

--- a/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/io/swagger/api/UserApi.java
@@ -69,8 +69,8 @@ public interface UserApi {
     @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = User.class),
-        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
-        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "User not found", response = Void.class) })
     
     @RequestMapping(value = "/user/{username}",
         produces = "application/json",
@@ -82,7 +82,7 @@ public interface UserApi {
     @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = String.class),
-        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     
     @RequestMapping(value = "/user/login",
         produces = "application/json",

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/PetApi.java
@@ -68,8 +68,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
@@ -87,8 +87,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
@@ -104,8 +104,8 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/StoreApi.java
@@ -41,7 +41,7 @@ public interface StoreApi {
         @Authorization(value = "api_key")
     }, tags={ "store", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Integer.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
@@ -55,8 +55,8 @@ public interface StoreApi {
     @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
-        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
@@ -70,7 +70,7 @@ public interface StoreApi {
     @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/io/swagger/api/UserApi.java
@@ -79,8 +79,8 @@ public interface UserApi {
     @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = User.class),
-        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
-        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "User not found", response = Void.class) })
     
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
@@ -94,7 +94,7 @@ public interface UserApi {
     @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = String.class),
-        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/PetApi.java
@@ -60,8 +60,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
@@ -76,8 +76,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
@@ -90,8 +90,8 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/StoreApi.java
@@ -36,7 +36,7 @@ public interface StoreApi {
         @Authorization(value = "api_key")
     }, tags={ "store", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Integer.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
@@ -47,8 +47,8 @@ public interface StoreApi {
     @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
-        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
@@ -59,7 +59,7 @@ public interface StoreApi {
     @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/io/swagger/api/UserApi.java
@@ -65,8 +65,8 @@ public interface UserApi {
     @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = User.class),
-        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
-        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "User not found", response = Void.class) })
     
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
@@ -77,7 +77,7 @@ public interface UserApi {
     @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = String.class),
-        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-beanvalidation/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.swagger</groupId>
-    <artifactId>swagger-spring-beanvalidation</artifactId>
+    <artifactId>swagger-spring</artifactId>
     <packaging>jar</packaging>
     <name>swagger-spring</name>
     <version>1.0.0</version>

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/PetApi.java
@@ -60,8 +60,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
@@ -76,8 +76,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
@@ -90,8 +90,8 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/StoreApi.java
@@ -36,7 +36,7 @@ public interface StoreApi {
         @Authorization(value = "api_key")
     }, tags={ "store", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Integer.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
@@ -47,8 +47,8 @@ public interface StoreApi {
     @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
-        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
@@ -59,7 +59,7 @@ public interface StoreApi {
     @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/io/swagger/api/UserApi.java
@@ -65,8 +65,8 @@ public interface UserApi {
     @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = User.class),
-        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
-        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "User not found", response = Void.class) })
     
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
@@ -77,7 +77,7 @@ public interface UserApi {
     @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = String.class),
-        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/PetApi.java
@@ -67,8 +67,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
@@ -86,8 +86,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
@@ -103,8 +103,8 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/StoreApi.java
@@ -40,7 +40,7 @@ public interface StoreApi {
         @Authorization(value = "api_key")
     }, tags={ "store", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Integer.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
@@ -54,8 +54,8 @@ public interface StoreApi {
     @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
-        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
@@ -69,7 +69,7 @@ public interface StoreApi {
     @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/io/swagger/api/UserApi.java
@@ -78,8 +78,8 @@ public interface UserApi {
     @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = User.class),
-        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
-        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "User not found", response = Void.class) })
     
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
@@ -93,7 +93,7 @@ public interface UserApi {
     @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = String.class),
-        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/PetApi.java
@@ -60,8 +60,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
@@ -76,8 +76,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
@@ -90,8 +90,8 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/StoreApi.java
@@ -36,7 +36,7 @@ public interface StoreApi {
         @Authorization(value = "api_key")
     }, tags={ "store", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Integer.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
@@ -47,8 +47,8 @@ public interface StoreApi {
     @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
-        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
@@ -59,7 +59,7 @@ public interface StoreApi {
     @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/io/swagger/api/UserApi.java
@@ -65,8 +65,8 @@ public interface UserApi {
     @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = User.class),
-        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
-        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "User not found", response = Void.class) })
     
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
@@ -77,7 +77,7 @@ public interface UserApi {
     @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = String.class),
-        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/PetApi.java
@@ -60,8 +60,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid status value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
@@ -76,8 +76,8 @@ public interface PetApi {
             })
     }, tags={ "pet", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid tag value", response = Pet.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
@@ -90,8 +90,8 @@ public interface PetApi {
     }, tags={ "pet", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Pet.class),
-        @ApiResponse(code = 404, message = "Pet not found", response = Pet.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/StoreApi.java
@@ -36,7 +36,7 @@ public interface StoreApi {
         @Authorization(value = "api_key")
     }, tags={ "store", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation", response = Integer.class) })
+        @ApiResponse(code = 200, message = "successful operation", response = Integer.class, responseContainer = "Map") })
     
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
@@ -47,8 +47,8 @@ public interface StoreApi {
     @ApiOperation(value = "Find purchase order by ID", notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Order.class),
-        @ApiResponse(code = 404, message = "Order not found", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
@@ -59,7 +59,7 @@ public interface StoreApi {
     @ApiOperation(value = "Place an order for a pet", notes = "", response = Order.class, tags={ "store", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = Order.class),
-        @ApiResponse(code = 400, message = "Invalid Order", response = Order.class) })
+        @ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 

--- a/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/springboot/src/main/java/io/swagger/api/UserApi.java
@@ -65,8 +65,8 @@ public interface UserApi {
     @ApiOperation(value = "Get user by user name", notes = "", response = User.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = User.class),
-        @ApiResponse(code = 400, message = "Invalid username supplied", response = User.class),
-        @ApiResponse(code = 404, message = "User not found", response = User.class) })
+        @ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
+        @ApiResponse(code = 404, message = "User not found", response = Void.class) })
     
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
@@ -77,7 +77,7 @@ public interface UserApi {
     @ApiOperation(value = "Logs user into the system", notes = "", response = String.class, tags={ "user", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation", response = String.class),
-        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = String.class) })
+        @ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 


### PR DESCRIPTION
Fixes the spring java code generator so that the ApiResponse fields are populated correctly
on the controller.

Related to #4693

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

This yaml:
```yaml
      responses:
        '200':
          description: pet response
          schema:
            type: array
            items:
              $ref: '#/definitions/pet'
        '400':
          description: unexpected error
          schema:
            $ref: '#/definitions/errorModel'
```
Will now generate this java:
```java
@ApiOperation(value = "", notes = "Returns all pets from the system that the user has access to", response = Pet.class, responseContainer = "List", tags={  })
    @ApiResponses(value = { 
        @ApiResponse(code = 200, message = "pet response", response = Pet.class),
        @ApiResponse(code = 400, message = "unexpected error", response = ErrorModel.class) }) // This is the line that changed
    @RequestMapping(value = "/pets",
        produces = { "application/json", "application/xml", "text/xml", "text/html" }, 
        consumes = { "application/json" },
        method = RequestMethod.GET)
```