### PR TITLE
[swift3] Swift3 code generator & templates fixed to support additiona…

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import io.swagger.codegen.*;
 import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.HeaderParameter;
@@ -60,6 +61,16 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
     @Override
     public String getHelp() {
         return "Generates a swift client library.";
+    }
+
+    @Override
+    protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, ModelImpl swaggerModel) {
+
+        final Property additionalProperties = swaggerModel.getAdditionalProperties();
+
+        if(additionalProperties != null) {
+            codegenModel.additionalPropertiesType = getSwaggerType(additionalProperties);
+        }
     }
 
     public Swift3Codegen() {
@@ -349,7 +360,7 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
         if (p instanceof MapProperty) {
             MapProperty ap = (MapProperty) p;
             String inner = getSwaggerType(ap.getAdditionalProperties());
-            return "[String:" + inner + "]";
+            return inner;
         } else if (p instanceof ArrayProperty) {
             ArrayProperty ap = (ArrayProperty) p;
             String inner = getSwaggerType(ap.getItems());

--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -183,7 +183,10 @@ class Decoders {
                 return Decoders.decode(clazz: {{classname}}.self, discriminator: discriminator, source: source)
             }
             {{/discriminator}}
-
+            {{#additionalPropertiesType}}
+            var propsDictionary = sourceDictionary
+            let keys : [AnyHashable] = [{{#allVars}}{{^-last}}"{{baseName}}", {{/-last}}{{#-last}}"{{baseName}}"{{/-last}}{{/allVars}}]
+            {{/additionalPropertiesType}}
             {{#unwrapRequired}}
             let result = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{#isEnum}}{{name}}: {{classname}}.{{datatypeWithEnum}}(rawValue: (sourceDictionary["{{baseName}}"] as! {{datatype}}))! {{/isEnum}}{{^isEnum}}{{name}}: Decoders.decode(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"]! as AnyObject, instance: nil){{/isEnum}}{{/requiredVars}})
             {{#optionalVars}}{{#isEnum}}
@@ -208,6 +211,18 @@ class Decoders {
             }{{/isEnum}}
             {{^isEnum}}result.{{name}} = Decoders.decodeOptional(clazz: {{{baseType}}}.self, source: sourceDictionary["{{baseName}}"] as AnyObject?){{/isEnum}}{{/allVars}}
             {{/unwrapRequired}}
+            {{#additionalPropertiesType}}
+
+            for key in keys {
+                propsDictionary.removeValue(forKey: key)
+            }
+
+            for key in propsDictionary.keys {
+                if let decodedValue = Decoders.decodeOptional(clazz: String.self, source: propsDictionary[key] as AnyObject?) {
+                    result[key] = decodedValue
+                }
+            }
+            {{/additionalPropertiesType}}
             return result
 {{/allVars.isEmpty}}
 {{/isEnum}}

--- a/modules/swagger-codegen/src/main/resources/swift3/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/model.mustache
@@ -27,6 +27,7 @@ public typealias {{classname}} = {{dataType}}
 {{/vars.isEmpty}}
 {{^vars.isEmpty}}
 open class {{classname}}: {{#parent}}{{{parent}}}{{/parent}}{{^parent}}JSONEncodable{{/parent}} {
+
 {{#vars}}
 {{#isEnum}}
     public enum {{enumName}}: {{^isContainer}}{{datatype}}{{/isContainer}}{{#isContainer}}String{{/isContainer}} { {{#allowableValues}}{{#enumVars}}
@@ -45,18 +46,32 @@ open class {{classname}}: {{#parent}}{{{parent}}}{{/parent}}{{^parent}}JSONEncod
 {{/isEnum}}
 {{/vars}}
 
+{{#additionalPropertiesType}}
+    public var additionalProperties: [AnyHashable:{{{additionalPropertiesType}}}] = [:]
+
+{{/additionalPropertiesType}}
 {{^unwrapRequired}}
-    {{^parent}}public init() {}{{/parent}}
-{{/unwrapRequired}}
+    {{^parent}}public init() {}{{/parent}}{{/unwrapRequired}}
 {{#unwrapRequired}}
     public init({{#allVars}}{{^-first}}, {{/-first}}{{name}}: {{#isEnum}}{{datatypeWithEnum}}{{/isEnum}}{{^isEnum}}{{datatype}}{{/isEnum}}{{^required}}?=nil{{/required}}{{/allVars}}) {
         {{#vars}}
         self.{{name}} = {{name}}
         {{/vars}}
-        {{#parent}}super.init({{#parentVars}}{{^-first}}, {{/-first}}{{name}}: {{name}}{{/parentVars}}){{/parent}}
-    }
-{{/unwrapRequired}}
+    }{{/unwrapRequired}}
+{{#additionalPropertiesType}}
+    public subscript(key: AnyHashable) -> {{{additionalPropertiesType}}}? {
+        get {
+            if let value = additionalProperties[key] {
+                return value
+            }
+            return nil
+        }
 
+        set {
+            additionalProperties[key] = newValue
+        }
+    }
+{{/additionalPropertiesType}}
     // MARK: JSONEncodable
     {{#parent}}override {{/parent}}open func encodeToJSON() -> Any {
         var nillableDictionary = {{#parent}}super.encodeToJSON() as? [String:Any?] ?? {{/parent}}[String:Any?](){{#vars}}{{#isNotContainer}}{{#isPrimitiveType}}{{^isEnum}}{{#isInteger}}
@@ -67,6 +82,15 @@ open class {{classname}}: {{#parent}}{{{parent}}}{{/parent}}{{^parent}}JSONEncod
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isPrimitiveType}}{{/isNotContainer}}{{#isContainer}}{{^isEnum}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isEnum}}{{#isEnum}}{{#isListContainer}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.map({$0.rawValue}).encodeToJSON(){{/isListContainer}}{{#isMapContainer}}//TODO: handle enum map scenario{{/isMapContainer}}{{/isEnum}}{{/isContainer}}{{/vars}}
+
+        {{#additionalPropertiesType}}
+        for (key, value) in additionalProperties {
+            if let key = key as? String {
+               nillableDictionary[key] = value
+            }
+        }
+
+        {{/additionalPropertiesType}}
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -156,7 +156,6 @@ class Decoders {
         // Decoder for AdditionalPropertiesClass
         Decoders.addDecoder(clazz: AdditionalPropertiesClass.self) { (source: AnyObject, instance: AnyObject?) -> AdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? AdditionalPropertiesClass() : instance as! AdditionalPropertiesClass
             
             result.mapProperty = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_property"] as AnyObject?)
@@ -176,7 +175,6 @@ class Decoders {
             if let discriminator = sourceDictionary["className"] as? String, instance == nil && discriminator != "Animal" {
                 return Decoders.decode(clazz: Animal.self, discriminator: discriminator, source: source)
             }
-
             let result = instance == nil ? Animal() : instance as! Animal
             
             result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
@@ -203,7 +201,6 @@ class Decoders {
         // Decoder for ApiResponse
         Decoders.addDecoder(clazz: ApiResponse.self) { (source: AnyObject, instance: AnyObject?) -> ApiResponse in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? ApiResponse() : instance as! ApiResponse
             
             result.code = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["code"] as AnyObject?)
@@ -220,7 +217,6 @@ class Decoders {
         // Decoder for ArrayOfArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfArrayOfNumberOnly.self) { (source: AnyObject, instance: AnyObject?) -> ArrayOfArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? ArrayOfArrayOfNumberOnly() : instance as! ArrayOfArrayOfNumberOnly
             
             result.arrayArrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayArrayNumber"] as AnyObject?)
@@ -235,7 +231,6 @@ class Decoders {
         // Decoder for ArrayOfNumberOnly
         Decoders.addDecoder(clazz: ArrayOfNumberOnly.self) { (source: AnyObject, instance: AnyObject?) -> ArrayOfNumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? ArrayOfNumberOnly() : instance as! ArrayOfNumberOnly
             
             result.arrayNumber = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["ArrayNumber"] as AnyObject?)
@@ -250,7 +245,6 @@ class Decoders {
         // Decoder for ArrayTest
         Decoders.addDecoder(clazz: ArrayTest.self) { (source: AnyObject, instance: AnyObject?) -> ArrayTest in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? ArrayTest() : instance as! ArrayTest
             
             result.arrayOfString = Decoders.decodeOptional(clazz: Array.self, source: sourceDictionary["array_of_string"] as AnyObject?)
@@ -267,7 +261,6 @@ class Decoders {
         // Decoder for Capitalization
         Decoders.addDecoder(clazz: Capitalization.self) { (source: AnyObject, instance: AnyObject?) -> Capitalization in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Capitalization() : instance as! Capitalization
             
             result.smallCamel = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["smallCamel"] as AnyObject?)
@@ -287,7 +280,6 @@ class Decoders {
         // Decoder for Cat
         Decoders.addDecoder(clazz: Cat.self) { (source: AnyObject, instance: AnyObject?) -> Cat in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Cat() : instance as! Cat
             if decoders["\(Animal.self)"] != nil {
               _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
@@ -307,7 +299,6 @@ class Decoders {
         // Decoder for Category
         Decoders.addDecoder(clazz: Category.self) { (source: AnyObject, instance: AnyObject?) -> Category in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Category() : instance as! Category
             
             result.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
@@ -323,7 +314,6 @@ class Decoders {
         // Decoder for ClassModel
         Decoders.addDecoder(clazz: ClassModel.self) { (source: AnyObject, instance: AnyObject?) -> ClassModel in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? ClassModel() : instance as! ClassModel
             
             result._class = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["_class"] as AnyObject?)
@@ -338,7 +328,6 @@ class Decoders {
         // Decoder for Client
         Decoders.addDecoder(clazz: Client.self) { (source: AnyObject, instance: AnyObject?) -> Client in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Client() : instance as! Client
             
             result.client = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["client"] as AnyObject?)
@@ -353,7 +342,6 @@ class Decoders {
         // Decoder for Dog
         Decoders.addDecoder(clazz: Dog.self) { (source: AnyObject, instance: AnyObject?) -> Dog in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Dog() : instance as! Dog
             if decoders["\(Animal.self)"] != nil {
               _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
@@ -373,7 +361,6 @@ class Decoders {
         // Decoder for EnumArrays
         Decoders.addDecoder(clazz: EnumArrays.self) { (source: AnyObject, instance: AnyObject?) -> EnumArrays in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? EnumArrays() : instance as! EnumArrays
             
             if let justSymbol = sourceDictionary["just_symbol"] as? String { 
@@ -410,7 +397,6 @@ class Decoders {
         // Decoder for EnumTest
         Decoders.addDecoder(clazz: EnumTest.self) { (source: AnyObject, instance: AnyObject?) -> EnumTest in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? EnumTest() : instance as! EnumTest
             
             if let enumString = sourceDictionary["enum_string"] as? String { 
@@ -437,7 +423,6 @@ class Decoders {
         // Decoder for FormatTest
         Decoders.addDecoder(clazz: FormatTest.self) { (source: AnyObject, instance: AnyObject?) -> FormatTest in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? FormatTest() : instance as! FormatTest
             
             result.integer = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["integer"] as AnyObject?)
@@ -464,7 +449,6 @@ class Decoders {
         // Decoder for HasOnlyReadOnly
         Decoders.addDecoder(clazz: HasOnlyReadOnly.self) { (source: AnyObject, instance: AnyObject?) -> HasOnlyReadOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? HasOnlyReadOnly() : instance as! HasOnlyReadOnly
             
             result.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
@@ -480,7 +464,6 @@ class Decoders {
         // Decoder for List
         Decoders.addDecoder(clazz: List.self) { (source: AnyObject, instance: AnyObject?) -> List in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? List() : instance as! List
             
             result._123List = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["123-list"] as AnyObject?)
@@ -495,7 +478,6 @@ class Decoders {
         // Decoder for MapTest
         Decoders.addDecoder(clazz: MapTest.self) { (source: AnyObject, instance: AnyObject?) -> MapTest in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? MapTest() : instance as! MapTest
             
             result.mapMapOfString = Decoders.decodeOptional(clazz: Dictionary.self, source: sourceDictionary["map_map_of_string"] as AnyObject?)
@@ -513,7 +495,6 @@ class Decoders {
         // Decoder for MixedPropertiesAndAdditionalPropertiesClass
         Decoders.addDecoder(clazz: MixedPropertiesAndAdditionalPropertiesClass.self) { (source: AnyObject, instance: AnyObject?) -> MixedPropertiesAndAdditionalPropertiesClass in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? MixedPropertiesAndAdditionalPropertiesClass() : instance as! MixedPropertiesAndAdditionalPropertiesClass
             
             result.uuid = Decoders.decodeOptional(clazz: UUID.self, source: sourceDictionary["uuid"] as AnyObject?)
@@ -530,7 +511,6 @@ class Decoders {
         // Decoder for Model200Response
         Decoders.addDecoder(clazz: Model200Response.self) { (source: AnyObject, instance: AnyObject?) -> Model200Response in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Model200Response() : instance as! Model200Response
             
             result.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
@@ -546,7 +526,6 @@ class Decoders {
         // Decoder for Name
         Decoders.addDecoder(clazz: Name.self) { (source: AnyObject, instance: AnyObject?) -> Name in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Name() : instance as! Name
             
             result.name = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["name"] as AnyObject?)
@@ -564,7 +543,6 @@ class Decoders {
         // Decoder for NumberOnly
         Decoders.addDecoder(clazz: NumberOnly.self) { (source: AnyObject, instance: AnyObject?) -> NumberOnly in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? NumberOnly() : instance as! NumberOnly
             
             result.justNumber = Decoders.decodeOptional(clazz: Double.self, source: sourceDictionary["JustNumber"] as AnyObject?)
@@ -579,7 +557,6 @@ class Decoders {
         // Decoder for Order
         Decoders.addDecoder(clazz: Order.self) { (source: AnyObject, instance: AnyObject?) -> Order in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Order() : instance as! Order
             
             result.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
@@ -617,7 +594,6 @@ class Decoders {
         // Decoder for Pet
         Decoders.addDecoder(clazz: Pet.self) { (source: AnyObject, instance: AnyObject?) -> Pet in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Pet() : instance as! Pet
             
             result.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
@@ -640,7 +616,6 @@ class Decoders {
         // Decoder for ReadOnlyFirst
         Decoders.addDecoder(clazz: ReadOnlyFirst.self) { (source: AnyObject, instance: AnyObject?) -> ReadOnlyFirst in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? ReadOnlyFirst() : instance as! ReadOnlyFirst
             
             result.bar = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["bar"] as AnyObject?)
@@ -656,7 +631,6 @@ class Decoders {
         // Decoder for Return
         Decoders.addDecoder(clazz: Return.self) { (source: AnyObject, instance: AnyObject?) -> Return in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Return() : instance as! Return
             
             result._return = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["return"] as AnyObject?)
@@ -671,7 +645,6 @@ class Decoders {
         // Decoder for SpecialModelName
         Decoders.addDecoder(clazz: SpecialModelName.self) { (source: AnyObject, instance: AnyObject?) -> SpecialModelName in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? SpecialModelName() : instance as! SpecialModelName
             
             result.specialPropertyName = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["$special[property.name]"] as AnyObject?)
@@ -686,7 +659,6 @@ class Decoders {
         // Decoder for Tag
         Decoders.addDecoder(clazz: Tag.self) { (source: AnyObject, instance: AnyObject?) -> Tag in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? Tag() : instance as! Tag
             
             result.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)
@@ -702,7 +674,6 @@ class Decoders {
         // Decoder for User
         Decoders.addDecoder(clazz: User.self) { (source: AnyObject, instance: AnyObject?) -> User in
             let sourceDictionary = source as! [AnyHashable: Any]
-
             let result = instance == nil ? User() : instance as! User
             
             result.id = Decoders.decodeOptional(clazz: Int64.self, source: sourceDictionary["id"] as AnyObject?)

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/AdditionalPropertiesClass.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class AdditionalPropertiesClass: JSONEncodable {
+
     public var mapProperty: [String:String]?
     public var mapOfMapProperty: [String:[String:String]]?
 
@@ -19,6 +20,7 @@ open class AdditionalPropertiesClass: JSONEncodable {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_property"] = self.mapProperty?.encodeToJSON()
         nillableDictionary["map_of_map_property"] = self.mapOfMapProperty?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Animal.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Animal.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Animal: JSONEncodable {
+
     public var className: String?
     public var color: String?
 
@@ -19,6 +20,7 @@ open class Animal: JSONEncodable {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["className"] = self.className
         nillableDictionary["color"] = self.color
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ApiResponse.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class ApiResponse: JSONEncodable {
+
     public var code: Int32?
     public var type: String?
     public var message: String?
@@ -21,6 +22,7 @@ open class ApiResponse: JSONEncodable {
         nillableDictionary["code"] = self.code?.encodeToJSON()
         nillableDictionary["type"] = self.type
         nillableDictionary["message"] = self.message
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ArrayOfArrayOfNumberOnly.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class ArrayOfArrayOfNumberOnly: JSONEncodable {
+
     public var arrayArrayNumber: [[Double]]?
 
     public init() {}
@@ -17,6 +18,7 @@ open class ArrayOfArrayOfNumberOnly: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayArrayNumber"] = self.arrayArrayNumber?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ArrayOfNumberOnly.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class ArrayOfNumberOnly: JSONEncodable {
+
     public var arrayNumber: [Double]?
 
     public init() {}
@@ -17,6 +18,7 @@ open class ArrayOfNumberOnly: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["ArrayNumber"] = self.arrayNumber?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ArrayTest.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class ArrayTest: JSONEncodable {
+
     public var arrayOfString: [String]?
     public var arrayArrayOfInteger: [[Int64]]?
     public var arrayArrayOfModel: [[ReadOnlyFirst]]?
@@ -21,6 +22,7 @@ open class ArrayTest: JSONEncodable {
         nillableDictionary["array_of_string"] = self.arrayOfString?.encodeToJSON()
         nillableDictionary["array_array_of_integer"] = self.arrayArrayOfInteger?.encodeToJSON()
         nillableDictionary["array_array_of_model"] = self.arrayArrayOfModel?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Capitalization.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Capitalization: JSONEncodable {
+
     public var smallCamel: String?
     public var capitalCamel: String?
     public var smallSnake: String?
@@ -28,6 +29,7 @@ open class Capitalization: JSONEncodable {
         nillableDictionary["Capital_Snake"] = self.capitalSnake
         nillableDictionary["SCA_ETH_Flow_Points"] = self.sCAETHFlowPoints
         nillableDictionary["ATT_NAME"] = self.ATT_NAME
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Cat.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Cat.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Cat: Animal {
+
     public var declawed: Bool?
 
     
@@ -17,6 +18,7 @@ open class Cat: Animal {
     override open func encodeToJSON() -> Any {
         var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["declawed"] = self.declawed
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Category.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Category.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Category: JSONEncodable {
+
     public var id: Int64?
     public var name: String?
 
@@ -19,6 +20,7 @@ open class Category: JSONEncodable {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ClassModel.swift
@@ -10,6 +10,7 @@ import Foundation
 
 /** Model for testing model with \&quot;_class\&quot; property */
 open class ClassModel: JSONEncodable {
+
     public var _class: String?
 
     public init() {}
@@ -18,6 +19,7 @@ open class ClassModel: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["_class"] = self._class
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Client.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Client.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Client: JSONEncodable {
+
     public var client: String?
 
     public init() {}
@@ -17,6 +18,7 @@ open class Client: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["client"] = self.client
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Dog.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Dog.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Dog: Animal {
+
     public var breed: String?
 
     
@@ -17,6 +18,7 @@ open class Dog: Animal {
     override open func encodeToJSON() -> Any {
         var nillableDictionary = super.encodeToJSON() as? [String:Any?] ?? [String:Any?]()
         nillableDictionary["breed"] = self.breed
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/EnumArrays.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class EnumArrays: JSONEncodable {
+
     public enum JustSymbol: String { 
         case greaterThanOrEqualTo = ">="
         case dollar = "$"
@@ -27,6 +28,7 @@ open class EnumArrays: JSONEncodable {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["just_symbol"] = self.justSymbol?.rawValue
         nillableDictionary["array_enum"] = self.arrayEnum?.map({$0.rawValue}).encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/EnumTest.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class EnumTest: JSONEncodable {
+
     public enum EnumString: String { 
         case upper = "UPPER"
         case lower = "lower"
@@ -36,6 +37,7 @@ open class EnumTest: JSONEncodable {
         nillableDictionary["enum_integer"] = self.enumInteger?.rawValue
         nillableDictionary["enum_number"] = self.enumNumber?.rawValue
         nillableDictionary["outerEnum"] = self.outerEnum?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/FormatTest.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class FormatTest: JSONEncodable {
+
     public var integer: Int32?
     public var int32: Int32?
     public var int64: Int64?
@@ -41,6 +42,7 @@ open class FormatTest: JSONEncodable {
         nillableDictionary["dateTime"] = self.dateTime?.encodeToJSON()
         nillableDictionary["uuid"] = self.uuid?.encodeToJSON()
         nillableDictionary["password"] = self.password
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/HasOnlyReadOnly.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class HasOnlyReadOnly: JSONEncodable {
+
     public var bar: String?
     public var foo: String?
 
@@ -19,6 +20,7 @@ open class HasOnlyReadOnly: JSONEncodable {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["foo"] = self.foo
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/List.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/List.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class List: JSONEncodable {
+
     public var _123List: String?
 
     public init() {}
@@ -17,6 +18,7 @@ open class List: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["123-list"] = self._123List
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/MapTest.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class MapTest: JSONEncodable {
+
     public enum MapOfEnumString: String { 
         case upper = "UPPER"
         case lower = "lower"
@@ -22,6 +23,7 @@ open class MapTest: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["map_map_of_string"] = self.mapMapOfString?.encodeToJSON()//TODO: handle enum map scenario
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class MixedPropertiesAndAdditionalPropertiesClass: JSONEncodable {
+
     public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String:Animal]?
@@ -21,6 +22,7 @@ open class MixedPropertiesAndAdditionalPropertiesClass: JSONEncodable {
         nillableDictionary["uuid"] = self.uuid?.encodeToJSON()
         nillableDictionary["dateTime"] = self.dateTime?.encodeToJSON()
         nillableDictionary["map"] = self.map?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Model200Response.swift
@@ -10,6 +10,7 @@ import Foundation
 
 /** Model for testing model name starting with number */
 open class Model200Response: JSONEncodable {
+
     public var name: Int32?
     public var _class: String?
 
@@ -20,6 +21,7 @@ open class Model200Response: JSONEncodable {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["name"] = self.name?.encodeToJSON()
         nillableDictionary["class"] = self._class
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Name.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Name.swift
@@ -10,6 +10,7 @@ import Foundation
 
 /** Model for testing model name same as property name */
 open class Name: JSONEncodable {
+
     public var name: Int32?
     public var snakeCase: Int32?
     public var property: String?
@@ -24,6 +25,7 @@ open class Name: JSONEncodable {
         nillableDictionary["snake_case"] = self.snakeCase?.encodeToJSON()
         nillableDictionary["property"] = self.property
         nillableDictionary["123Number"] = self._123Number?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/NumberOnly.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class NumberOnly: JSONEncodable {
+
     public var justNumber: Double?
 
     public init() {}
@@ -17,6 +18,7 @@ open class NumberOnly: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["JustNumber"] = self.justNumber
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Order.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Order.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Order: JSONEncodable {
+
     public enum Status: String { 
         case placed = "placed"
         case approved = "approved"
@@ -33,6 +34,7 @@ open class Order: JSONEncodable {
         nillableDictionary["shipDate"] = self.shipDate?.encodeToJSON()
         nillableDictionary["status"] = self.status?.rawValue
         nillableDictionary["complete"] = self.complete
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Pet.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Pet.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Pet: JSONEncodable {
+
     public enum Status: String { 
         case available = "available"
         case pending = "pending"
@@ -33,6 +34,7 @@ open class Pet: JSONEncodable {
         nillableDictionary["photoUrls"] = self.photoUrls?.encodeToJSON()
         nillableDictionary["tags"] = self.tags?.encodeToJSON()
         nillableDictionary["status"] = self.status?.rawValue
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/ReadOnlyFirst.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class ReadOnlyFirst: JSONEncodable {
+
     public var bar: String?
     public var baz: String?
 
@@ -19,6 +20,7 @@ open class ReadOnlyFirst: JSONEncodable {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["bar"] = self.bar
         nillableDictionary["baz"] = self.baz
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Return.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Return.swift
@@ -10,6 +10,7 @@ import Foundation
 
 /** Model for testing reserved words */
 open class Return: JSONEncodable {
+
     public var _return: Int32?
 
     public init() {}
@@ -18,6 +19,7 @@ open class Return: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["return"] = self._return?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/SpecialModelName.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class SpecialModelName: JSONEncodable {
+
     public var specialPropertyName: Int64?
 
     public init() {}
@@ -17,6 +18,7 @@ open class SpecialModelName: JSONEncodable {
     open func encodeToJSON() -> Any {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["$special[property.name]"] = self.specialPropertyName?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Tag.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/Tag.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class Tag: JSONEncodable {
+
     public var id: Int64?
     public var name: String?
 
@@ -19,6 +20,7 @@ open class Tag: JSONEncodable {
         var nillableDictionary = [String:Any?]()
         nillableDictionary["id"] = self.id?.encodeToJSON()
         nillableDictionary["name"] = self.name
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/User.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models/User.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 open class User: JSONEncodable {
+
     public var id: Int64?
     public var username: String?
     public var firstName: String?
@@ -32,6 +33,7 @@ open class User: JSONEncodable {
         nillableDictionary["password"] = self.password
         nillableDictionary["phone"] = self.phone
         nillableDictionary["userStatus"] = self.userStatus?.encodeToJSON()
+
         let dictionary: [String:Any] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary
     }


### PR DESCRIPTION
…l properties

Fix for issue #4907 

Correct swift3 code generation when handling additional properties.  

### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Modified templates
Fixed swift3 code generator
Added support for additional properties 
