### PR TITLE
fix(swift3): fix infinite loop with inheritance and check if parent decoder exists

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -179,7 +179,7 @@ class Decoders {
             let sourceDictionary = source as! [AnyHashable: Any]
             {{#discriminator}}
             // Check discriminator to support inheritance
-            if let discriminator = sourceDictionary["{{discriminator}}"] as? String, discriminator != "{{classname}}"{
+            if let discriminator = sourceDictionary["{{discriminator}}"] as? String, instance == nil && discriminator != "{{classname}}" {
                 return Decoders.decode(clazz: {{classname}}.self, discriminator: discriminator, source: source)
             }
             {{/discriminator}}
@@ -197,7 +197,9 @@ class Decoders {
             {{^unwrapRequired}}
             let result = instance == nil ? {{classname}}() : instance as! {{classname}}
             {{#parent}}
-            _ = Decoders.decode(clazz: {{parent}}.self, source: source, instance: result)
+            if decoders["\({{parent}}.self)"] != nil {
+              _ = Decoders.decode(clazz: {{parent}}.self, source: source, instance: result)
+            }
             {{/parent}}
             {{#allVars}}{{#isEnum}}
             if let {{name}} = sourceDictionary["{{baseName}}"] as? {{datatype}} { {{^isContainer}}

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,7 +173,7 @@ class Decoders {
         Decoders.addDecoder(clazz: Animal.self) { (source: AnyObject, instance: AnyObject?) -> Animal in
             let sourceDictionary = source as! [AnyHashable: Any]
             // Check discriminator to support inheritance
-            if let discriminator = sourceDictionary["className"] as? String, discriminator != "Animal"{
+            if let discriminator = sourceDictionary["className"] as? String, instance == nil && discriminator != "Animal" {
                 return Decoders.decode(clazz: Animal.self, discriminator: discriminator, source: source)
             }
 
@@ -289,7 +289,9 @@ class Decoders {
             let sourceDictionary = source as! [AnyHashable: Any]
 
             let result = instance == nil ? Cat() : instance as! Cat
-            _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            if decoders["\(Animal.self)"] != nil {
+              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            }
             
             result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -353,7 +355,9 @@ class Decoders {
             let sourceDictionary = source as! [AnyHashable: Any]
 
             let result = instance == nil ? Dog() : instance as! Dog
-            _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            if decoders["\(Animal.self)"] != nil {
+              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            }
             
             result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,7 +173,7 @@ class Decoders {
         Decoders.addDecoder(clazz: Animal.self) { (source: AnyObject, instance: AnyObject?) -> Animal in
             let sourceDictionary = source as! [AnyHashable: Any]
             // Check discriminator to support inheritance
-            if let discriminator = sourceDictionary["className"] as? String, discriminator != "Animal"{
+            if let discriminator = sourceDictionary["className"] as? String, instance == nil && discriminator != "Animal" {
                 return Decoders.decode(clazz: Animal.self, discriminator: discriminator, source: source)
             }
 
@@ -289,7 +289,9 @@ class Decoders {
             let sourceDictionary = source as! [AnyHashable: Any]
 
             let result = instance == nil ? Cat() : instance as! Cat
-            _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            if decoders["\(Animal.self)"] != nil {
+              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            }
             
             result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -353,7 +355,9 @@ class Decoders {
             let sourceDictionary = source as! [AnyHashable: Any]
 
             let result = instance == nil ? Dog() : instance as! Dog
-            _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            if decoders["\(Animal.self)"] != nil {
+              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            }
             
             result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/Models.swift
@@ -173,7 +173,7 @@ class Decoders {
         Decoders.addDecoder(clazz: Animal.self) { (source: AnyObject, instance: AnyObject?) -> Animal in
             let sourceDictionary = source as! [AnyHashable: Any]
             // Check discriminator to support inheritance
-            if let discriminator = sourceDictionary["className"] as? String, discriminator != "Animal"{
+            if let discriminator = sourceDictionary["className"] as? String, instance == nil && discriminator != "Animal" {
                 return Decoders.decode(clazz: Animal.self, discriminator: discriminator, source: source)
             }
 
@@ -289,7 +289,9 @@ class Decoders {
             let sourceDictionary = source as! [AnyHashable: Any]
 
             let result = instance == nil ? Cat() : instance as! Cat
-            _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            if decoders["\(Animal.self)"] != nil {
+              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            }
             
             result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
@@ -353,7 +355,9 @@ class Decoders {
             let sourceDictionary = source as! [AnyHashable: Any]
 
             let result = instance == nil ? Dog() : instance as! Dog
-            _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            if decoders["\(Animal.self)"] != nil {
+              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            }
             
             result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
             result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
My last commit (https://github.com/swagger-api/swagger-codegen/commit/b1a39ac820fa1e3920b1ff826797f6fd354921fe) had introduced an infinite loop if you were using `discriminator` *and* returning a class that has a parent in one of your routes. By ensuring the instance is `nil` before "going down" in the tree, we ensure that we're not already "going up", thus removing the infinite loop.

#### Steps to reproduce

In the petstore, add a route `/cats` returning `Cat` elements only. It will first go through the `Cat` decoder, that will call the `Animal` decoder, which has a discriminator on `className` and thus will call the `Cat` decoder again...