### PR TITLE
typescript-angular2: treating dates as strings (datetimes are still Dates)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -42,7 +42,7 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
         modelTemplateFiles.put("model.mustache", ".ts");
         apiTemplateFiles.put("api.service.mustache", ".ts");
         languageSpecificPrimitives.add("Blob");
-        typeMapping.put("Date","Date");
+        typeMapping.put("date","string");
         typeMapping.put("file","Blob");
         apiPackage = "api";
         modelPackage = "model";

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
@@ -132,12 +132,7 @@ export class {{classname}} {
             queryParameters.set('{{baseName}}', <any>{{paramName}}.toISOString());
         {{/isDateTime}}
         {{^isDateTime}}
-            {{#isDate}}
-            queryParameters.set('{{baseName}}', <any>{{paramName}}.toISOString());
-            {{/isDate}}
-            {{^isDate}}
             queryParameters.set('{{baseName}}', <any>{{paramName}});
-            {{/isDate}}
         {{/isDateTime}}
         }
         {{/isListContainer}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular2/TypeScriptAngular2ModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular2/TypeScriptAngular2ModelTest.java
@@ -14,6 +14,7 @@ import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.DateProperty;
 import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
@@ -28,6 +29,7 @@ public class TypeScriptAngular2ModelTest {
                 .property("id", new LongProperty())
                 .property("name", new StringProperty())
                 .property("createdAt", new DateTimeProperty())
+                .property("birthDate", new DateProperty())
                 .required("id")
                 .required("name");
         final DefaultCodegen codegen = new TypeScriptAngular2ClientCodegen();
@@ -36,7 +38,7 @@ public class TypeScriptAngular2ModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 3);
+        Assert.assertEquals(cm.vars.size(), 4);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -63,10 +65,22 @@ public class TypeScriptAngular2ModelTest {
         Assert.assertEquals(property3.complexType, null);
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
+        Assert.assertEquals(property3.baseType, "Date");
         Assert.assertEquals(property3.defaultValue, "null");
-        Assert.assertFalse(property3.hasMore);
+        Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.complexType, null);
+        Assert.assertEquals(property4.datatype, "string");
+        Assert.assertEquals(property4.name, "birthDate");
+        Assert.assertEquals(property4.baseType, "string");
+        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertFalse(property4.hasMore);
+        Assert.assertFalse(property4.required);
+        Assert.assertTrue(property4.isNotContainer);
     }
 
     @Test(description = "convert a model with list property")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The current 2.3.0 typescript-angular2 treats both Swagger dates and datetimes as Javascript `Date`s and sends their `toISOString()` over the wire. This is reasonable behavior for datetimes, but for dates, which don't contain times, the generated client will send across meaningless times, in violation of the Swagger spec and breaking APIs that are expecting to receive dates.

Javascript/TypeScript does not have a native way to store dates (the native `Date` object only stores datetimes), so an ISO string (e.g. `"2017-04-19"` is the best way to represent this data.

This PR changes the type to `string` for dates, but leaves datetimes as `Date`s.

Feedback welcome and let me know if there's anything I can do to help.