### PR TITLE
Cpprest json body for application/json content-type

### DIFF
--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
@@ -113,12 +113,24 @@ pplx::task<web::http::http_response> ApiClient::callApi(
         }
         else
         {
-            web::http::uri_builder formData;
-            for (auto& kvp : formParams)
+            if (contentType == U("application/json"))
             {
-                formData.append_query(kvp.first, kvp.second);
+                web::json::value body_data = web::json::value::object();
+                for (auto& kvp : formParams)
+                {
+                    body_data[U(kvp.first)] = ModelBase::toJson(kvp.second);
+                }
+                request.set_body(body_data);
             }
-            request.set_body(formData.query(), U("application/x-www-form-urlencoded"));
+            else
+            {
+                web::http::uri_builder formData;
+                for (auto& kvp : formParams)
+                {
+                    formData.append_query(kvp.first, kvp.second);
+                }
+                request.set_body(formData.query(), U("application/x-www-form-urlencoded"));
+            }
         }
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

My rails server try to parse a json body because content-type was application/json in the header but the cpprest client generate build a formdata body.
I corrected this by adding the generation of a body in json in case the content type is "application / json".