### PR TITLE
[2.3.0] fix(swift3): decoders call parents decoders too

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/AlamofireImplementations.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/AlamofireImplementations.mustache
@@ -197,7 +197,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     return
                 }
                 if let json: Any = response.result.value {
-                    let decoded = Decoders.decode(clazz: T.self, source: json as AnyObject)
+                    let decoded = Decoders.decode(clazz: T.self, source: json as AnyObject, instance: nil)
                     switch decoded {
                     case let .success(object): completion(Response(response: response.response!, body: object), nil)
                     case let .failure(error): completion(nil, ErrorResponse.DecodeError(response: response.data, decodeError: error))

--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -60,17 +60,16 @@ public enum DecodeError {
 
 private var once = Int()
 class Decoders {
-    static fileprivate var decoders = Dictionary<String, ((AnyObject) -> AnyObject)>()
+    static fileprivate var decoders = Dictionary<String, ((AnyObject, AnyObject?) -> AnyObject)>()
 
-
-    static func addDecoder<T>(clazz: T.Type, decoder: @escaping ((AnyObject) -> Decoded<T>)) {
+    static func addDecoder<T>(clazz: T.Type, decoder: @escaping ((AnyObject, AnyObject?) -> Decoded<T>)) {
         let key = "\(T.self)"
-        decoders[key] = { decoder($0) as AnyObject }
+        decoders[key] = { decoder($0, $1) as AnyObject }
     }
 
     static func decode<T>(clazz: T.Type, discriminator: String, source: AnyObject) -> Decoded<T> {
         let key = discriminator
-        if let decoder = decoders[key], let value = decoder(source) as? Decoded<T> {
+        if let decoder = decoders[key], let value = decoder(source, nil) as? Decoded<T> {
             return value
         } else {
             return .failure(.typeMismatch(expected: String(describing: clazz), actual: String(describing: source)))
@@ -81,7 +80,7 @@ class Decoders {
         if let sourceArray = source as? [AnyObject] {
             var values = [T]()
             for sourceValue in sourceArray {
-                switch Decoders.decode(clazz: T.self, source: sourceValue) {
+                switch Decoders.decode(clazz: T.self, source: sourceValue, instance: nil) {
                 case let .success(value):
                     values.append(value)
                 case let .failure(error):
@@ -98,7 +97,7 @@ class Decoders {
         if let sourceDictionary = source as? [Key: AnyObject] {
             var dictionary = [Key:T]()
             for (key, value) in sourceDictionary {
-                switch Decoders.decode(clazz: T.self, source: value) {
+                switch Decoders.decode(clazz: T.self, source: value, instance: nil) {
                 case let .success(value):
                     dictionary[key] = value
                 case let .failure(error):
@@ -124,7 +123,7 @@ class Decoders {
         }
     }
 
-    static func decode<T>(clazz: T.Type, source: AnyObject) -> Decoded<T> {
+    static func decode<T>(clazz: T.Type, source: AnyObject, instance: AnyObject?) -> Decoded<T> {
         initialize()
         if let value = source.int32Value as? T, source is NSNumber, T.self is Int32.Type {
             return .success(value)
@@ -143,7 +142,7 @@ class Decoders {
         }
 
         let key = "\(T.self)"
-        if let decoder = decoders[key], let value = decoder(source) as? Decoded<T> {
+        if let decoder = decoders[key], let value = decoder(source, instance) as? Decoded<T> {
            return value
         } else {
             return .failure(.typeMismatch(expected: String(describing: clazz), actual: String(describing: source)))
@@ -157,7 +156,7 @@ class Decoders {
 
     static func decodeOptional<T>(clazz: T.Type, source: AnyObject?) -> Decoded<T?> {
         if let source = source, !(source is NSNull) {
-            switch Decoders.decode(clazz: clazz, source: source) {
+            switch Decoders.decode(clazz: clazz, source: source, instance: nil) {
             case let .success(value): return .success(value)
             case let .failure(error): return .failure(error)
             }
@@ -170,7 +169,7 @@ class Decoders {
         if let source = source as? [AnyObject] {
             var values = [T]()
             for sourceValue in source {
-                switch Decoders.decode(clazz: T.self, source: sourceValue) {
+                switch Decoders.decode(clazz: T.self, source: sourceValue, instance: nil) {
                 case let .success(value): values.append(value)
                 case let .failure(error): return .failure(error)
                 }
@@ -185,7 +184,7 @@ class Decoders {
         if let sourceDictionary = source as? [Key: AnyObject] {
             var dictionary = [Key:T]()
             for (key, value) in sourceDictionary {
-                switch Decoders.decode(clazz: T.self, source: value) {
+                switch Decoders.decode(clazz: T.self, source: value, instance: nil) {
                 case let .success(value): dictionary[key] = value
                 case let .failure(error): return .failure(error)
                 }
@@ -223,7 +222,7 @@ class Decoders {
             return formatter
         }
         // Decoder for Date
-        Decoders.addDecoder(clazz: Date.self) { (source: AnyObject) -> Decoded<Date> in
+        Decoders.addDecoder(clazz: Date.self) { (source: AnyObject, instance: AnyObject?) -> Decoded<Date> in
            if let sourceString = source as? String {
                 for formatter in formatters {
                     if let date = formatter.date(from: sourceString) {
@@ -243,7 +242,7 @@ class Decoders {
         }
 
         // Decoder for ISOFullDate
-        Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject) -> Decoded<ISOFullDate> in
+        Decoders.addDecoder(clazz: ISOFullDate.self) { (source: AnyObject, instance: AnyObject?) -> Decoded<ISOFullDate> in
             if let string = source as? String,
                let isoDate = ISOFullDate.from(string: string) {
                 return .success(isoDate)
@@ -254,14 +253,14 @@ class Decoders {
 
 {{^isArrayModel}}
         // Decoder for [{{{classname}}}]
-        Decoders.addDecoder(clazz: [{{{classname}}}].self) { (source: AnyObject) -> Decoded<[{{{classname}}}]> in
-            return Decoders.decode(clazz: [{{{classname}}}].self, source: source)
+        Decoders.addDecoder(clazz: [{{{classname}}}].self) { (source: AnyObject, instance: AnyObject?) -> Decoded<[{{{classname}}}]> in
+            return Decoders.decode(clazz: [{{{classname}}}].self, source: source, instance: instance)
         }
         // Decoder for {{{classname}}}
-        Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject) -> Decoded<{{{classname}}}> in
+        Decoders.addDecoder(clazz: {{{classname}}}.self) { (source: AnyObject, instance: AnyObject?) -> Decoded<{{{classname}}}> in
 {{#isEnum}}
             //TODO: I don't think we need this anymore
-            return Decoders.decode(clazz: {{{classname}}}.self, source: source)
+            return Decoders.decode(clazz: {{{classname}}}.self, source: source, instance: instance)
 {{/isEnum}}
 {{^isEnum}}
 {{#allVars.isEmpty}}
@@ -275,7 +274,7 @@ class Decoders {
             if let sourceDictionary = source as? [AnyHashable: Any] {
             {{#discriminator}}
                 // Check discriminator to support inheritance
-                if let discriminator = sourceDictionary["{{discriminator}}"] as? String, discriminator != "{{classname}}"{
+                if let discriminator = sourceDictionary["{{discriminator}}"] as? String, instance == nil && discriminator != "{{classname}}"{
                     return Decoders.decode(clazz: {{classname}}.self, discriminator: discriminator, source: source)
                 }
             {{/discriminator}}
@@ -289,7 +288,7 @@ class Decoders {
                     return .failure(.typeMismatch(expected: "{{classname}}", actual: "\({{name}}Source)"))
                 }
                 {{/requiredVars}}
-                let instance = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{name}}: {{name}}{{/requiredVars}})
+                let result = {{classname}}({{#requiredVars}}{{^-first}}, {{/-first}}{{name}}: {{name}}{{/requiredVars}})
             {{#optionalVars}}
                 switch Decoders.decodeOptional(clazz: {{#isEnum}}{{^isListContainer}}{{classname}}.{{enumName}}.self{{/isListContainer}}{{#isListContainer}}Array<{{classname}}.{{enumName}}>.self{{/isListContainer}}{{/isEnum}}{{^isEnum}}{{{datatype}}}.self{{/isEnum}}, source: sourceDictionary["{{baseName}}"] as AnyObject?) {
                 case let .success(value): instance.{{name}} = value
@@ -298,16 +297,22 @@ class Decoders {
             {{/optionalVars}}
             {{/unwrapRequired}}
             {{^unwrapRequired}}
-                let instance = {{classname}}(){{#allVars}}
+                let result = instance == nil ? {{classname}}() : instance as! {{classname}}
+                {{#parent}}
+                if decoders["\({{parent}}.self)"] != nil {
+                  _ = Decoders.decode(clazz: {{parent}}.self, source: source, instance: result)
+                }
+                {{/parent}}
+                {{#allVars}}
                 switch Decoders.decodeOptional(clazz: {{#isEnum}}{{^isListContainer}}{{classname}}.{{enumName}}.self{{/isListContainer}}{{#isListContainer}}Array<{{classname}}.{{enumName}}>.self{{/isListContainer}}{{/isEnum}}{{^isEnum}}{{{datatype}}}.self{{/isEnum}}, source: sourceDictionary["{{baseName}}"] as AnyObject?) {
                 {{#isEnum}}{{#isMapContainer}}/*{{/isMapContainer}}{{/isEnum}}
-                case let .success(value): instance.{{name}} = value
+                case let .success(value): result.{{name}} = value
                 case let .failure(error): return .failure(error)
                 {{#isEnum}}{{#isMapContainer}}*/ default: break //TODO: handle enum map scenario{{/isMapContainer}}{{/isEnum}}
                 }
             {{/allVars}}
             {{/unwrapRequired}}
-                return .success(instance)
+                return .success(result)
             } else {
                 return .failure(.typeMismatch(expected: "{{classname}}", actual: "\(source)"))
             }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -27,9 +27,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
@@ -26,9 +26,9 @@ open class Fake_classname_tags123API: APIBase {
     /**
      To test class name in snake case
      - PATCH /fake_classname_test
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -122,7 +122,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -131,21 +131,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -154,20 +154,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -209,7 +209,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -218,21 +218,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -241,20 +241,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -296,7 +296,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -305,21 +305,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -328,20 +328,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -470,11 +470,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 0,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -65,9 +65,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 0
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -101,36 +101,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{order_id}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -167,36 +167,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -168,7 +168,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -177,17 +177,17 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -196,16 +196,16 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -245,8 +245,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -197,7 +197,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     return
                 }
                 if let json: Any = response.result.value {
-                    let decoded = Decoders.decode(clazz: T.self, source: json as AnyObject)
+                    let decoded = Decoders.decode(clazz: T.self, source: json as AnyObject, instance: nil)
                     switch decoded {
                     case let .success(object): completion(Response(response: response.response!, body: object), nil)
                     case let .failure(error): completion(nil, ErrorResponse.DecodeError(response: response.data, decodeError: error))

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -45,9 +45,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
@@ -44,9 +44,9 @@ open class Fake_classname_tags123API: APIBase {
     /**
      To test class name in snake case
      - PATCH /fake_classname_test
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -175,7 +175,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -184,21 +184,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -207,20 +207,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -279,7 +279,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -288,21 +288,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -311,20 +311,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -383,7 +383,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -392,21 +392,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -415,20 +415,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -612,11 +612,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 0,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -99,9 +99,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 0
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -152,36 +152,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{order_id}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -235,36 +235,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -254,7 +254,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -263,17 +263,17 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -282,16 +282,16 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -349,8 +349,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -197,7 +197,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     return
                 }
                 if let json: Any = response.result.value {
-                    let decoded = Decoders.decode(clazz: T.self, source: json as AnyObject)
+                    let decoded = Decoders.decode(clazz: T.self, source: json as AnyObject, instance: nil)
                     switch decoded {
                     case let .success(object): completion(Response(response: response.response!, body: object), nil)
                     case let .failure(error): completion(nil, ErrorResponse.DecodeError(response: response.data, decodeError: error))

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/FakeAPI.swift
@@ -47,9 +47,9 @@ open class FakeAPI: APIBase {
      To test \"client\" model
      - PATCH /fake
      - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/Fake_classname_tags123API.swift
@@ -46,9 +46,9 @@ open class Fake_classname_tags123API: APIBase {
     /**
      To test class name in snake case
      - PATCH /fake_classname_test
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "client" : "aeiou"
-}}]
+}, contentType=application/json}]
      
      - parameter body: (body) client model 
 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/PetAPI.swift
@@ -181,7 +181,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -190,21 +190,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -213,20 +213,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter status: (query) Status values that need to be considered for filter 
 
@@ -287,7 +287,7 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -296,21 +296,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -319,20 +319,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example=[ {
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example=[ {
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-} ]}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+} ], contentType=application/json}]
      
      - parameter tags: (query) Tags to filter by 
 
@@ -393,7 +393,7 @@ open class PetAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/xml, example=<Pet>
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -402,21 +402,21 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
-     - examples: [{contentType=application/xml, example=<Pet>
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
+     - examples: [{example=<Pet>
   <id>123456789</id>
   <name>doggie</name>
   <photoUrls>
@@ -425,20 +425,20 @@ open class PetAPI: APIBase {
   <tags>
   </tags>
   <status>aeiou</status>
-</Pet>}, {contentType=application/json, example={
-  "photoUrls" : [ "aeiou" ],
-  "name" : "doggie",
+</Pet>, contentType=application/xml}, {example={
+  "tags" : [ {
+    "id" : 1,
+    "name" : "aeiou"
+  } ],
   "id" : 0,
   "category" : {
-    "name" : "aeiou",
-    "id" : 6
+    "id" : 6,
+    "name" : "aeiou"
   },
-  "tags" : [ {
-    "name" : "aeiou",
-    "id" : 1
-  } ],
-  "status" : "available"
-}}]
+  "status" : "available",
+  "name" : "doggie",
+  "photoUrls" : [ "aeiou" ]
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to return 
 
@@ -628,11 +628,11 @@ open class PetAPI: APIBase {
      - OAuth:
        - type: oauth2
        - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
+  "message" : "aeiou",
   "code" : 0,
-  "type" : "aeiou",
-  "message" : "aeiou"
-}}]
+  "type" : "aeiou"
+}, contentType=application/json}]
      
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/StoreAPI.swift
@@ -103,9 +103,9 @@ open class StoreAPI: APIBase {
      - API Key:
        - type: apiKey api_key 
        - name: api_key
-     - examples: [{contentType=application/json, example={
+     - examples: [{example={
   "key" : 0
-}}]
+}, contentType=application/json}]
 
      - returns: RequestBuilder<[String:Int32]> 
      */
@@ -158,36 +158,36 @@ open class StoreAPI: APIBase {
      Find purchase order by ID
      - GET /store/order/{order_id}
      - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
 
@@ -243,36 +243,36 @@ open class StoreAPI: APIBase {
      Place an order for a pet
      - POST /store/order
      - 
-     - examples: [{contentType=application/xml, example=<Order>
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
-     - examples: [{contentType=application/xml, example=<Order>
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
+     - examples: [{example=<Order>
   <id>123456789</id>
   <petId>123456789</petId>
   <quantity>123</quantity>
   <shipDate>2000-01-23T04:56:07.000Z</shipDate>
   <status>aeiou</status>
   <complete>true</complete>
-</Order>}, {contentType=application/json, example={
-  "petId" : 6,
-  "quantity" : 1,
+</Order>, contentType=application/xml}, {example={
   "id" : 0,
-  "shipDate" : "2000-01-23T04:56:07.000+00:00",
+  "petId" : 6,
   "complete" : false,
-  "status" : "placed"
-}}]
+  "status" : "placed",
+  "quantity" : 1,
+  "shipDate" : "2000-01-23T04:56:07.000+00:00"
+}, contentType=application/json}]
      
      - parameter body: (body) order placed for purchasing the pet 
 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIs/UserAPI.swift
@@ -264,7 +264,7 @@ open class UserAPI: APIBase {
      Get user by user name
      - GET /user/{username}
      - 
-     - examples: [{contentType=application/xml, example=<User>
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -273,17 +273,17 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
-     - examples: [{contentType=application/xml, example=<User>
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
+     - examples: [{example=<User>
   <id>123456789</id>
   <username>aeiou</username>
   <firstName>aeiou</firstName>
@@ -292,16 +292,16 @@ open class UserAPI: APIBase {
   <password>aeiou</password>
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
-</User>}, {contentType=application/json, example={
-  "firstName" : "aeiou",
-  "lastName" : "aeiou",
-  "password" : "aeiou",
-  "userStatus" : 6,
-  "phone" : "aeiou",
+</User>, contentType=application/xml}, {example={
   "id" : 0,
+  "lastName" : "aeiou",
+  "phone" : "aeiou",
+  "username" : "aeiou",
   "email" : "aeiou",
-  "username" : "aeiou"
-}}]
+  "userStatus" : 6,
+  "firstName" : "aeiou",
+  "password" : "aeiou"
+}, contentType=application/json}]
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
 
@@ -361,8 +361,8 @@ open class UserAPI: APIBase {
      - 
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
      - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
-     - examples: [{contentType=application/xml, example=aeiou}, {contentType=application/json, example="aeiou"}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
+     - examples: [{example=aeiou, contentType=application/xml}, {example="aeiou", contentType=application/json}]
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/AlamofireImplementations.swift
@@ -197,7 +197,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
                     return
                 }
                 if let json: Any = response.result.value {
-                    let decoded = Decoders.decode(clazz: T.self, source: json as AnyObject)
+                    let decoded = Decoders.decode(clazz: T.self, source: json as AnyObject, instance: nil)
                     switch decoded {
                     case let .success(object): completion(Response(response: response.response!, body: object), nil)
                     case let .failure(error): completion(nil, ErrorResponse.DecodeError(response: response.data, decodeError: error))


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This is the same than https://github.com/swagger-api/swagger-codegen/pull/5369 and https://github.com/swagger-api/swagger-codegen/pull/5416, but against branch `2.3.0`.