### PR TITLE
PHP: Reuse allowed Enum values

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -674,6 +674,11 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
             return varName;
         }
 
+        // for symbol, e.g. $, #
+        if (getSymbolName(name) != null) {
+            return getSymbolName(name).toUpperCase();
+        }
+
         // string
         String enumName = sanitizeName(underscore(name).toUpperCase());
         enumName = enumName.replaceFirst("^_", "");

--- a/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model_generic.mustache
@@ -132,9 +132,12 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}imple
         {{/required}}
         {{#isEnum}}
         {{^isContainer}}
-        $allowed_values = [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}];
+        $allowed_values = $this->{{getter}}AllowableValues();
         if (!in_array($this->container['{{name}}'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for '{{name}}', must be one of {{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}.";
+            $invalid_properties[] = sprintf(
+                "invalid value for '{{name}}', must be one of '%s'",
+                implode("', '", $allowed_values)
+            );
         }
 
         {{/isContainer}}
@@ -209,7 +212,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}imple
         {{/required}}
         {{#isEnum}}
         {{^isContainer}}
-        $allowed_values = [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}];
+        $allowed_values = $this->{{getter}}AllowableValues();
         if (!in_array($this->container['{{name}}'], $allowed_values)) {
             return false;
         }
@@ -275,15 +278,25 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}imple
     public function {{setter}}(${{name}})
     {
         {{#isEnum}}
-        $allowed_values = array({{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}});
+        $allowed_values = $this->{{getter}}AllowableValues();
         {{^isContainer}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(!in_array(${{{name}}}, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for '{{name}}', must be one of {{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}");
+        if ({{^required}}!is_null(${{name}}) && {{/required}}!in_array(${{{name}}}, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for '{{name}}', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         {{/isContainer}}
         {{#isContainer}}
-        if ({{^required}}!is_null(${{name}}) && {{/required}}(array_diff(${{{name}}}, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for '{{name}}', must be one of {{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}");
+        if ({{^required}}!is_null(${{name}}) && {{/required}}array_diff(${{{name}}}, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for '{{name}}', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         {{/isContainer}}
         {{/isEnum}}

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
@@ -107,8 +107,8 @@ class EnumArrays implements ArrayAccess
         return self::$getters;
     }
 
-    const JUST_SYMBOL_ = '>=';
-    const JUST_SYMBOL_ = '$';
+    const JUST_SYMBOL_GREATER_THAN_OR_EQUAL_TO = '>=';
+    const JUST_SYMBOL_DOLLAR = '$';
     const ARRAY_ENUM_FISH = 'fish';
     const ARRAY_ENUM_CRAB = 'crab';
     
@@ -121,8 +121,8 @@ class EnumArrays implements ArrayAccess
     public function getJustSymbolAllowableValues()
     {
         return [
-            self::JUST_SYMBOL_,
-            self::JUST_SYMBOL_,
+            self::JUST_SYMBOL_GREATER_THAN_OR_EQUAL_TO,
+            self::JUST_SYMBOL_DOLLAR,
         ];
     }
     
@@ -164,9 +164,12 @@ class EnumArrays implements ArrayAccess
     {
         $invalid_properties = [];
 
-        $allowed_values = [">=", "$"];
+        $allowed_values = $this->getJustSymbolAllowableValues();
         if (!in_array($this->container['just_symbol'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'just_symbol', must be one of '>=', '$'.";
+            $invalid_properties[] = sprintf(
+                "invalid value for 'just_symbol', must be one of '%s'",
+                implode("', '", $allowed_values)
+            );
         }
 
         return $invalid_properties;
@@ -181,7 +184,7 @@ class EnumArrays implements ArrayAccess
     public function valid()
     {
 
-        $allowed_values = [">=", "$"];
+        $allowed_values = $this->getJustSymbolAllowableValues();
         if (!in_array($this->container['just_symbol'], $allowed_values)) {
             return false;
         }
@@ -205,9 +208,14 @@ class EnumArrays implements ArrayAccess
      */
     public function setJustSymbol($just_symbol)
     {
-        $allowed_values = array('>=', '$');
-        if (!is_null($just_symbol) && (!in_array($just_symbol, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'just_symbol', must be one of '>=', '$'");
+        $allowed_values = $this->getJustSymbolAllowableValues();
+        if (!is_null($just_symbol) && !in_array($just_symbol, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'just_symbol', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         $this->container['just_symbol'] = $just_symbol;
 
@@ -230,9 +238,14 @@ class EnumArrays implements ArrayAccess
      */
     public function setArrayEnum($array_enum)
     {
-        $allowed_values = array('fish', 'crab');
-        if (!is_null($array_enum) && (array_diff($array_enum, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'array_enum', must be one of 'fish', 'crab'");
+        $allowed_values = $this->getArrayEnumAllowableValues();
+        if (!is_null($array_enum) && array_diff($array_enum, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'array_enum', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         $this->container['array_enum'] = $array_enum;
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
@@ -190,19 +190,28 @@ class EnumTest implements ArrayAccess
     {
         $invalid_properties = [];
 
-        $allowed_values = ["UPPER", "lower", ""];
+        $allowed_values = $this->getEnumStringAllowableValues();
         if (!in_array($this->container['enum_string'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'enum_string', must be one of 'UPPER', 'lower', ''.";
+            $invalid_properties[] = sprintf(
+                "invalid value for 'enum_string', must be one of '%s'",
+                implode("', '", $allowed_values)
+            );
         }
 
-        $allowed_values = ["1", "-1"];
+        $allowed_values = $this->getEnumIntegerAllowableValues();
         if (!in_array($this->container['enum_integer'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'enum_integer', must be one of '1', '-1'.";
+            $invalid_properties[] = sprintf(
+                "invalid value for 'enum_integer', must be one of '%s'",
+                implode("', '", $allowed_values)
+            );
         }
 
-        $allowed_values = ["1.1", "-1.2"];
+        $allowed_values = $this->getEnumNumberAllowableValues();
         if (!in_array($this->container['enum_number'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'enum_number', must be one of '1.1', '-1.2'.";
+            $invalid_properties[] = sprintf(
+                "invalid value for 'enum_number', must be one of '%s'",
+                implode("', '", $allowed_values)
+            );
         }
 
         return $invalid_properties;
@@ -217,15 +226,15 @@ class EnumTest implements ArrayAccess
     public function valid()
     {
 
-        $allowed_values = ["UPPER", "lower", ""];
+        $allowed_values = $this->getEnumStringAllowableValues();
         if (!in_array($this->container['enum_string'], $allowed_values)) {
             return false;
         }
-        $allowed_values = ["1", "-1"];
+        $allowed_values = $this->getEnumIntegerAllowableValues();
         if (!in_array($this->container['enum_integer'], $allowed_values)) {
             return false;
         }
-        $allowed_values = ["1.1", "-1.2"];
+        $allowed_values = $this->getEnumNumberAllowableValues();
         if (!in_array($this->container['enum_number'], $allowed_values)) {
             return false;
         }
@@ -249,9 +258,14 @@ class EnumTest implements ArrayAccess
      */
     public function setEnumString($enum_string)
     {
-        $allowed_values = array('UPPER', 'lower', '');
-        if (!is_null($enum_string) && (!in_array($enum_string, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'enum_string', must be one of 'UPPER', 'lower', ''");
+        $allowed_values = $this->getEnumStringAllowableValues();
+        if (!is_null($enum_string) && !in_array($enum_string, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'enum_string', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         $this->container['enum_string'] = $enum_string;
 
@@ -274,9 +288,14 @@ class EnumTest implements ArrayAccess
      */
     public function setEnumInteger($enum_integer)
     {
-        $allowed_values = array('1', '-1');
-        if (!is_null($enum_integer) && (!in_array($enum_integer, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'enum_integer', must be one of '1', '-1'");
+        $allowed_values = $this->getEnumIntegerAllowableValues();
+        if (!is_null($enum_integer) && !in_array($enum_integer, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'enum_integer', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         $this->container['enum_integer'] = $enum_integer;
 
@@ -299,9 +318,14 @@ class EnumTest implements ArrayAccess
      */
     public function setEnumNumber($enum_number)
     {
-        $allowed_values = array('1.1', '-1.2');
-        if (!is_null($enum_number) && (!in_array($enum_number, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'enum_number', must be one of '1.1', '-1.2'");
+        $allowed_values = $this->getEnumNumberAllowableValues();
+        if (!is_null($enum_number) && !in_array($enum_number, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'enum_number', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         $this->container['enum_number'] = $enum_number;
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/MapTest.php
@@ -203,9 +203,14 @@ class MapTest implements ArrayAccess
      */
     public function setMapOfEnumString($map_of_enum_string)
     {
-        $allowed_values = array('UPPER', 'lower');
-        if (!is_null($map_of_enum_string) && (array_diff($map_of_enum_string, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'map_of_enum_string', must be one of 'UPPER', 'lower'");
+        $allowed_values = $this->getMapOfEnumStringAllowableValues();
+        if (!is_null($map_of_enum_string) && array_diff($map_of_enum_string, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'map_of_enum_string', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         $this->container['map_of_enum_string'] = $map_of_enum_string;
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
@@ -172,9 +172,12 @@ class Order implements ArrayAccess
     {
         $invalid_properties = [];
 
-        $allowed_values = ["placed", "approved", "delivered"];
+        $allowed_values = $this->getStatusAllowableValues();
         if (!in_array($this->container['status'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'status', must be one of 'placed', 'approved', 'delivered'.";
+            $invalid_properties[] = sprintf(
+                "invalid value for 'status', must be one of '%s'",
+                implode("', '", $allowed_values)
+            );
         }
 
         return $invalid_properties;
@@ -189,7 +192,7 @@ class Order implements ArrayAccess
     public function valid()
     {
 
-        $allowed_values = ["placed", "approved", "delivered"];
+        $allowed_values = $this->getStatusAllowableValues();
         if (!in_array($this->container['status'], $allowed_values)) {
             return false;
         }
@@ -297,9 +300,14 @@ class Order implements ArrayAccess
      */
     public function setStatus($status)
     {
-        $allowed_values = array('placed', 'approved', 'delivered');
-        if (!is_null($status) && (!in_array($status, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'status', must be one of 'placed', 'approved', 'delivered'");
+        $allowed_values = $this->getStatusAllowableValues();
+        if (!is_null($status) && !in_array($status, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'status', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         $this->container['status'] = $status;
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
@@ -178,9 +178,12 @@ class Pet implements ArrayAccess
         if ($this->container['photo_urls'] === null) {
             $invalid_properties[] = "'photo_urls' can't be null";
         }
-        $allowed_values = ["available", "pending", "sold"];
+        $allowed_values = $this->getStatusAllowableValues();
         if (!in_array($this->container['status'], $allowed_values)) {
-            $invalid_properties[] = "invalid value for 'status', must be one of 'available', 'pending', 'sold'.";
+            $invalid_properties[] = sprintf(
+                "invalid value for 'status', must be one of '%s'",
+                implode("', '", $allowed_values)
+            );
         }
 
         return $invalid_properties;
@@ -201,7 +204,7 @@ class Pet implements ArrayAccess
         if ($this->container['photo_urls'] === null) {
             return false;
         }
-        $allowed_values = ["available", "pending", "sold"];
+        $allowed_values = $this->getStatusAllowableValues();
         if (!in_array($this->container['status'], $allowed_values)) {
             return false;
         }
@@ -330,9 +333,14 @@ class Pet implements ArrayAccess
      */
     public function setStatus($status)
     {
-        $allowed_values = array('available', 'pending', 'sold');
-        if (!is_null($status) && (!in_array($status, $allowed_values))) {
-            throw new \InvalidArgumentException("Invalid value for 'status', must be one of 'available', 'pending', 'sold'");
+        $allowed_values = $this->getStatusAllowableValues();
+        if (!is_null($status) && !in_array($status, $allowed_values)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'status', must be one of '%s'",
+                    implode("', '", $allowed_values)
+                )
+            );
         }
         $this->container['status'] = $status;
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- Fix a bug for repeating `JUST_SYMBOL_` constants (reuse `getSymbolName()`)
- Reuse `get...AllowableValues()` for enum values
- Remove extra brackets around `array_diff` and `!in_array`