### PR TITLE
[TypeScript][Angular2] Add "toString()" to form parameters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
@@ -241,7 +241,7 @@ export class {{classname}} {
             body: {{paramName}} == null ? '' : JSON.stringify({{paramName}}), // https://github.com/angular/angular/issues/10612
 {{/bodyParam}}
 {{#hasFormParams}}
-            body: formParams,
+            body: formParams.toString(),
 {{/hasFormParams}}
 {{#isResponseFile}}
             responseType: ResponseContentType.Blob,

--- a/samples/client/petstore/typescript-angular2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/pet.service.ts
@@ -554,7 +554,7 @@ export class PetService {
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
-            body: formParams,
+            body: formParams.toString(),
             search: queryParameters,
             withCredentials:true
         });
@@ -623,7 +623,7 @@ export class PetService {
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
-            body: formParams,
+            body: formParams.toString(),
             search: queryParameters,
             withCredentials:true
         });

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704231833
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704231845
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704231833 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704231845 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/pet.service.ts
@@ -554,7 +554,7 @@ export class PetService {
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
-            body: formParams,
+            body: formParams.toString(),
             search: queryParameters,
             withCredentials:true
         });
@@ -623,7 +623,7 @@ export class PetService {
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
-            body: formParams,
+            body: formParams.toString(),
             search: queryParameters,
             withCredentials:true
         });

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201704231833",
+  "version": "0.0.1-SNAPSHOT.201704231845",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

toString() seems to be removed when syncing changes from master to 2.3.0. Adding it back via this PR.
