### PR TITLE
Set name for item property from 'x-item-name' annotation if present.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1736,7 +1736,11 @@ public class DefaultCodegen {
             ArrayProperty ap = (ArrayProperty) p;
             property.maxItems = ap.getMaxItems();
             property.minItems = ap.getMinItems();
-            CodegenProperty cp = fromProperty(property.name, ap.getItems());
+            String itemName = (String) p.getVendorExtensions().get("x-item-name");
+            if (itemName == null) {
+                itemName = property.name;
+            }
+            CodegenProperty cp = fromProperty(itemName, ap.getItems());
             updatePropertyForArray(property, cp);
           } else if (p instanceof MapProperty) {
             MapProperty ap = (MapProperty) p;

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -274,6 +274,42 @@ public class JavaModelTest {
 
     }
 
+    @Test(description = "convert a model with an array property with item name")
+    public void arrayModelWithItemNameTest() {
+        final Model model = new ModelImpl()
+            .description("a sample model")
+            .property("children", new ArrayProperty()
+                .description("an array property")
+                .items(new RefProperty("#/definitions/Child"))
+                .vendorExtension("x-item-name", "child"));
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 1);
+        Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("List", "Child")).size(), 2);
+
+        final CodegenProperty property = cm.vars.get(0);
+        Assert.assertEquals(property.baseName, "children");
+        Assert.assertEquals(property.complexType, "Child");
+        Assert.assertEquals(property.getter, "getChildren");
+        Assert.assertEquals(property.setter, "setChildren");
+        Assert.assertEquals(property.datatype, "List<Child>");
+        Assert.assertEquals(property.name, "children");
+        Assert.assertEquals(property.defaultValue, "new ArrayList<Child>()");
+        Assert.assertEquals(property.baseType, "List");
+        Assert.assertEquals(property.containerType, "array");
+        Assert.assertFalse(property.required);
+        Assert.assertTrue(property.isContainer);
+        Assert.assertFalse(property.isNotContainer);
+
+        final CodegenProperty itemsProperty = property.items;
+        Assert.assertEquals(itemsProperty.baseName,"child");
+        Assert.assertEquals(itemsProperty.name,"child");
+    }
+
     @Test(description = "convert an array model")
     public void arrayModelTest() {
         final Model model = new ArrayModel()


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The Swagger/OpenAPI spec (2.0 at least) does not have a way to give a "name" to an element in an array property.  Currently, the generator confers the name of the array property onto the property for an array item.  This can lead to awkward/unnatural method names for adding or removing an item from an array property.

Consider:
```
properties:
  children:
    type: array
    items:
      $ref: "#/definitions/Child"
```

Currently, the CodegenProperty describing an item in the `children` array will also have the name `children`.  For some languages it is common to provide methods to access individual elements of an array property, like add<element>.  For the `children` property above, the natural signature (in Java) for such a method would be:
```
  public void addChild(Child child) {
```
But since the item name is actually `children`, the method produced would have the signature:
```
  public void addChildren(Child children) {
```
This is awkward and unnatural and potentially misleading.

This PR adds support for an `x-item-name` vendor extension on array properties that specifies the name for an item of the array.  Using this extension, the swagger above would be modified as follows:
```
properties:
  children:
    type: array
    items:
      $ref: "#/definitions/Child"
    x-item-name: child
```
This will set the `name` and `basename` in the CodegenProperty describing the array item to `child` so that element accessors can be generated with the desired signatures.


