### PR TITLE
Fix NullPointerException for info.version on Javascript client codegen

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -151,7 +151,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         }
         if (info.getVersion() != null) {
             config.additionalProperties().put("appVersion", config.escapeText(info.getVersion()));
+        } else {
+            LOGGER.error("Missing required field info version. Default appVersion set to 1.0.0")
+            config.additionalProperties().put("appVersion", "1.0.0");
         }
+        
         if (StringUtils.isEmpty(info.getDescription())) {
             // set a default description if none if provided
             config.additionalProperties().put("appDescription",
@@ -180,6 +184,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         }
         if (info.getVersion() != null) {
             config.additionalProperties().put("version", config.escapeText(info.getVersion()));
+        } else {
+            LOGGER.error("Missing required field info version. Default version set to 1.0.0")
+            config.additionalProperties().put("version", "1.0.0");
         }
         if (info.getTermsOfService() != null) {
             config.additionalProperties().put("termsOfService", config.escapeText(info.getTermsOfService()));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -152,7 +152,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if (info.getVersion() != null) {
             config.additionalProperties().put("appVersion", config.escapeText(info.getVersion()));
         } else {
-            LOGGER.error("Missing required field info version. Default appVersion set to 1.0.0")
+            LOGGER.error("Missing required field info version. Default appVersion set to 1.0.0");
             config.additionalProperties().put("appVersion", "1.0.0");
         }
         
@@ -185,7 +185,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if (info.getVersion() != null) {
             config.additionalProperties().put("version", config.escapeText(info.getVersion()));
         } else {
-            LOGGER.error("Missing required field info version. Default version set to 1.0.0")
+            LOGGER.error("Missing required field info version. Default version set to 1.0.0");
             config.additionalProperties().put("version", "1.0.0");
         }
         if (info.getTermsOfService() != null) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -1021,12 +1021,20 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     @Override
     public String escapeQuotationMark(String input) {
         // remove ', " to avoid code injection
-        return input.replace("\"", "").replace("'", "");
+        if (input != null) {
+            return input.replace("\"", "").replace("'", "");
+        }
+        
+        return "1.0.0";
     }
 
     @Override
     public String escapeUnsafeCharacters(String input) {
-        return input.replace("*/", "*_/").replace("/*", "/_*");
+        if (input != null) {
+            return input.replace("*/", "*_/").replace("/*", "/_*");
+        }
+        
+        return "1.0.0";
     }
 
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -1021,20 +1021,12 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     @Override
     public String escapeQuotationMark(String input) {
         // remove ', " to avoid code injection
-        if (input != null) {
-            return input.replace("\"", "").replace("'", "");
-        }
-        
-        return "1.0.0";
+        return input.replace("\"", "").replace("'", "");
     }
 
     @Override
     public String escapeUnsafeCharacters(String input) {
-        if (input != null) {
-            return input.replace("*/", "*_/").replace("/*", "/_*");
-        }
-        
-        return "1.0.0";
+        return input.replace("*/", "*_/").replace("/*", "/_*");
     }
 
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Issue reference #5467 

