### PR TITLE
add withCredentials to the configuration

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -195,6 +195,10 @@ export class {{classname}} {
         {{/isListContainer}}
 
 {{/formParams}}
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: {{httpMethod}},
             headers: headers,
@@ -205,8 +209,12 @@ export class {{classname}} {
             body: formParams.toString(),
 {{/hasFormParams}}
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('{{keyParamName}}', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.mustache
@@ -195,10 +195,6 @@ export class {{classname}} {
         {{/isListContainer}}
 
 {{/formParams}}
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: {{httpMethod}},
             headers: headers,
@@ -209,13 +205,8 @@ export class {{classname}} {
             body: formParams.toString(),
 {{/hasFormParams}}
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('{{keyParamName}}', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/configuration.mustache
@@ -3,4 +3,5 @@ export class Configuration {
     username: string;
     password: string;
     accessToken: string | (() => string);
+    withCredentials: boolean;
 }

--- a/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
@@ -207,13 +207,21 @@ export class PetApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -260,12 +268,20 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -310,12 +326,20 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -360,12 +384,20 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -414,12 +446,20 @@ export class PetApi {
             headers.set('api_key', this.configuration.apiKey);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -462,13 +502,21 @@ export class PetApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -527,13 +575,21 @@ export class PetApi {
             formParams.set('status', <any>status);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: formParams.toString(),
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -592,13 +648,21 @@ export class PetApi {
             formParams.set('file', <any>file);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: formParams.toString(),
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {

--- a/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
@@ -207,22 +207,13 @@ export class PetApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -268,21 +259,12 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -326,21 +308,12 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -384,21 +357,12 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -446,21 +410,12 @@ export class PetApi {
             headers.set('api_key', this.configuration.apiKey);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -502,22 +457,13 @@ export class PetApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -575,22 +521,13 @@ export class PetApi {
             formParams.set('status', <any>status);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: formParams.toString(),
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -648,22 +585,13 @@ export class PetApi {
             formParams.set('file', <any>file);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: formParams.toString(),
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);

--- a/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
@@ -129,21 +129,12 @@ export class StoreApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -176,21 +167,12 @@ export class StoreApi {
             headers.set('api_key', this.configuration.apiKey);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -224,21 +206,12 @@ export class StoreApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -269,22 +242,13 @@ export class StoreApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);

--- a/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/StoreApi.ts
@@ -129,12 +129,20 @@ export class StoreApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -168,12 +176,20 @@ export class StoreApi {
             headers.set('api_key', this.configuration.apiKey);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -208,12 +224,20 @@ export class StoreApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -245,13 +269,21 @@ export class StoreApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {

--- a/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
@@ -192,22 +192,13 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -238,22 +229,13 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -284,22 +266,13 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -333,21 +306,12 @@ export class UserApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -381,21 +345,12 @@ export class UserApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -433,21 +388,12 @@ export class UserApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -475,21 +421,12 @@ export class UserApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -526,22 +463,13 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);

--- a/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/UserApi.ts
@@ -192,13 +192,21 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -230,13 +238,21 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -268,13 +284,21 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -309,12 +333,20 @@ export class UserApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -349,12 +381,20 @@ export class UserApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -393,12 +433,20 @@ export class UserApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -427,12 +475,20 @@ export class UserApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -470,13 +526,21 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {

--- a/samples/client/petstore/typescript-angular2/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular2/default/configuration.ts
@@ -3,4 +3,5 @@ export class Configuration {
     username: string;
     password: string;
     accessToken: string | (() => string);
+    withCredentials: boolean;
 }

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704252321
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704272137
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704252321 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704272137 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704132011
+## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704252321
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704132011 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704252321 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
@@ -207,13 +207,21 @@ export class PetApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -260,12 +268,20 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -310,12 +326,20 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -360,12 +384,20 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -414,12 +446,20 @@ export class PetApi {
             headers.set('api_key', this.configuration.apiKey);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -462,13 +502,21 @@ export class PetApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -527,13 +575,21 @@ export class PetApi {
             formParams.set('status', <any>status);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: formParams.toString(),
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -592,13 +648,21 @@ export class PetApi {
             formParams.set('file', <any>file);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: formParams.toString(),
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {

--- a/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
@@ -207,22 +207,13 @@ export class PetApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -268,21 +259,12 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -326,21 +308,12 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -384,21 +357,12 @@ export class PetApi {
             headers.set('Authorization', 'Bearer ' + accessToken);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -446,21 +410,12 @@ export class PetApi {
             headers.set('api_key', this.configuration.apiKey);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -502,22 +457,13 @@ export class PetApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -575,22 +521,13 @@ export class PetApi {
             formParams.set('status', <any>status);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: formParams.toString(),
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -648,22 +585,13 @@ export class PetApi {
             formParams.set('file', <any>file);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: formParams.toString(),
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);

--- a/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
@@ -129,21 +129,12 @@ export class StoreApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -176,21 +167,12 @@ export class StoreApi {
             headers.set('api_key', this.configuration.apiKey);
         }
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -224,21 +206,12 @@ export class StoreApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -269,22 +242,13 @@ export class StoreApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);

--- a/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/StoreApi.ts
@@ -129,12 +129,20 @@ export class StoreApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -168,12 +176,20 @@ export class StoreApi {
             headers.set('api_key', this.configuration.apiKey);
         }
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -208,12 +224,20 @@ export class StoreApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -245,13 +269,21 @@ export class StoreApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {

--- a/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
@@ -192,22 +192,13 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -238,22 +229,13 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -284,22 +266,13 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -333,21 +306,12 @@ export class UserApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -381,21 +345,12 @@ export class UserApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -433,21 +388,12 @@ export class UserApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -475,21 +421,12 @@ export class UserApi {
             'application/xml'
         ];
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);
@@ -526,22 +463,13 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
-        let isWithCredentials: boolean = false;
-        if (this.configuration.withCredentials) {
-            isWithCredentials = this.configuration.withCredentials;
-        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:isWithCredentials
+            withCredentials:this.configuration.withCredentials
         });
-
-        if (this.configuration.apiKey) {
-        headers.set('', this.configuration.apiKey);
-        }
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);

--- a/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/UserApi.ts
@@ -192,13 +192,21 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -230,13 +238,21 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -268,13 +284,21 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Post,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -309,12 +333,20 @@ export class UserApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -349,12 +381,20 @@ export class UserApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -393,12 +433,20 @@ export class UserApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -427,12 +475,20 @@ export class UserApi {
             'application/xml'
         ];
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
             headers: headers,
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
@@ -470,13 +526,21 @@ export class UserApi {
 
         headers.set('Content-Type', 'application/json');
 
+        let isWithCredentials: boolean = false;
+        if (this.configuration.withCredentials) {
+            isWithCredentials = this.configuration.withCredentials;
+        }
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Put,
             headers: headers,
             body: body == null ? '' : JSON.stringify(body), // https://github.com/angular/angular/issues/10612
             search: queryParameters,
-            withCredentials:true
+            withCredentials:isWithCredentials
         });
+
+        if (this.configuration.apiKey) {
+        headers.set('', this.configuration.apiKey);
+        }
 
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {

--- a/samples/client/petstore/typescript-angular2/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular2/npm/configuration.ts
@@ -3,4 +3,5 @@ export class Configuration {
     username: string;
     password: string;
     accessToken: string | (() => string);
+    withCredentials: boolean;
 }

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201704252321",
+  "version": "0.0.1-SNAPSHOT.201704272137",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201704132011",
+  "version": "0.0.1-SNAPSHOT.201704252321",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [


### PR DESCRIPTION
#5374 
1. `withCredentials` in Request is `false` default
2. if want to set the `withCredentials` as `true` (for CORS request),
 instance `Configuration` object and set the `withCredentials` as `true`.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

