### PR TITLE
Fix class name in discriminator subtypes

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/typeInfoAnnotation.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/typeInfoAnnotation.mustache
@@ -2,6 +2,6 @@
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{discriminator}}", visible = true )
 @JsonSubTypes({
   {{#children}}
-  @JsonSubTypes.Type(value = {{name}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),
+  @JsonSubTypes.Type(value = {{classname}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),
   {{/children}}
 }){{/jackson}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This fixes a typo in the mustache file for discriminator types. It is generating a class name, so it should use the {{classname}} field, not the {{name}} field. Most of the time, these two are the same, but in cases where the model name in the spec file is lower cased, they are different. This edge case doesn't show up in the existing testing endpoint, so the samples are unaffected.