### PR TITLE
Fix#5481

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -1,9 +1,6 @@
 package io.swagger.codegen.languages;
 
-import io.swagger.codegen.CodegenConfig;
-import io.swagger.codegen.CodegenType;
-import io.swagger.codegen.DefaultCodegen;
-import io.swagger.codegen.SupportingFile;
+import io.swagger.codegen.*;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.BooleanProperty;
 import io.swagger.models.properties.DateProperty;
@@ -27,6 +24,9 @@ import java.util.Map;
 import java.util.Set;
 
 public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
+    public static final String CPP_NAMESPACE = "cppNamespace";
+    public static final String CPP_NAMESPACE_DESC = "C++ namespace (convention: name::space::for::api).";
+
     protected final String PREFIX = "SWG";
     protected Set<String> foundationClasses = new HashSet<String>();
     // source folder where to write the files
@@ -34,6 +34,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
     protected String apiVersion = "1.0.0";
     protected Map<String, String> namespaces = new HashMap<String, String>();
     protected Set<String> systemIncludes = new HashSet<String>();
+    protected String cppNamespace = "Swagger";
 
     public Qt5CPPGenerator() {
         super();
@@ -73,6 +74,9 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
          * will use the resource stream to attempt to read the templates.
          */
         embeddedTemplateDir = templateDir = "qt5cpp";
+
+        // CLI options
+        addOption(CPP_NAMESPACE, CPP_NAMESPACE_DESC, this.cppNamespace);
 
         /*
          * Reserved words.  Override this with reserved words specific to your language
@@ -148,6 +152,24 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
         systemIncludes.add("QByteArray");
     }
 
+    protected void addOption(String key, String description, String defaultValue) {
+        CliOption option = new CliOption(key, description);
+        if (defaultValue != null)
+            option.defaultValue(defaultValue);
+        cliOptions.add(option);
+    }
+
+    @Override
+    public void processOpts() {
+        super.processOpts();
+
+        if (additionalProperties.containsKey("cppNamespace")){
+            cppNamespace = (String) additionalProperties.get("cppNamespace");
+        }
+
+        additionalProperties.put("cppNamespaceDeclarations", cppNamespace.split("\\::"));
+    }
+
     /**
      * Configures the type of generator.
      *
@@ -203,7 +225,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
      * @return the escaped term
      */
     @Override
-    public String escapeReservedWord(String name) {           
+    public String escapeReservedWord(String name) {
         if(this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
         }
@@ -266,6 +288,7 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
         }
     }
 
+
     @Override
     public String toDefaultValue(Property p) {
         if (p instanceof StringProperty) {
@@ -309,7 +332,6 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
         }
         return "NULL";
     }
-
 
     /**
      * Optional - swagger type conversion.  This is used to map swagger types in a `Property` into

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Qt5CPPGenerator.java
@@ -94,6 +94,11 @@ public class Qt5CPPGenerator extends DefaultCodegen implements CodegenConfig {
         additionalProperties.put("apiVersion", apiVersion);
         additionalProperties().put("prefix", PREFIX);
 
+        // Write defaults namespace in properties so that it can be accessible in templates.
+        // At this point command line has not been parsed so if value is given
+        // in command line it will superseed this content
+        additionalProperties.put("cppNamespace",cppNamespace);
+
         /*
          * Language Specific Primitives.  These types will not trigger imports by
          * the client generator

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
@@ -6,6 +6,10 @@
 #include <QBuffer>
 
 
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
+
 HttpRequestInput::HttpRequestInput() {
     initialize();
 }
@@ -298,3 +302,7 @@ void HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
 
     emit on_execution_finished(this);
 }
+
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.h.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.h.mustache
@@ -16,6 +16,9 @@
 
 enum HttpRequestVarLayout {NOT_SET, ADDRESS, URL_ENCODED, MULTIPART};
 
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
 
 class SWGHttpRequestInputFileElement {
 
@@ -72,5 +75,9 @@ private slots:
     void on_manager_finished(QNetworkReply *reply);
 
 };
+
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}
 
 #endif // HTTPREQUESTWORKER_H

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -6,7 +6,10 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 
-namespace Swagger {
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
+
 {{classname}}::{{classname}}() {}
 
 {{classname}}::~{{classname}}() {}
@@ -178,4 +181,7 @@ void
 }
 {{/operation}}
 {{/operations}}
-} /* namespace Swagger */
+
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-header.mustache
@@ -9,7 +9,9 @@
 
 #include <QObject>
 
-namespace Swagger {
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
 
 class {{classname}}: public QObject {
     Q_OBJECT
@@ -31,5 +33,8 @@ signals:
     {{#operations}}{{#operation}}void {{nickname}}Signal({{#returnType}}{{{returnType}}} summary{{/returnType}});
     {{/operation}}{{/operations}}
 };
+
+{{#cppNamespaceDeclarations}}
 }
+{{/cppNamespaceDeclarations}}
 #endif

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -122,7 +122,7 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     else if(type.startsWith("SWG") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
-        SWGObject * so = (SWGObject*)Swagger::create(type);
+        SWGObject * so = (SWGObject*)::{{cppNamespace}}::create(type);
         if(so != nullptr) {
             so->fromJsonObject(jsonObj);
             SWGObject **val = static_cast<SWGObject**>(value);

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-body.mustache
@@ -7,7 +7,10 @@
 #include <QJsonValue>
 #include <QDateTime>
 
-namespace Swagger {
+
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
 
 void
 setValue(void* value, QJsonValue obj, QString type, QString complexType) {
@@ -279,4 +282,7 @@ QString
 stringValue(bool value) {
     return QString(value ? "true" : "false");
 }
-} /* namespace Swagger */
+
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/helpers-header.mustache
@@ -4,7 +4,10 @@
 
 #include <QJsonValue>
 
-namespace Swagger {
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
+
     void setValue(void* value, QJsonValue obj, QString type, QString complexType);
     void toJsonArray(QList<void*>* value, QJsonArray* output, QString innerName, QString innerType);
     void toJsonValue(QString name, void* value, QJsonObject* output, QString type);
@@ -13,6 +16,9 @@ namespace Swagger {
     QString stringValue(qint32 value);
     QString stringValue(qint64 value);
     QString stringValue(bool value);
+
+{{#cppNamespaceDeclarations}}
 }
+{{/cppNamespaceDeclarations}}
 
 #endif // SWGHELPERS_H

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -9,8 +9,9 @@
 #include <QObject>
 #include <QDebug>
 
-namespace Swagger {
-
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
 
 {{classname}}::{{classname}}(QString* json) {
     init();
@@ -107,8 +108,9 @@ void
 
 {{/vars}}
 
-
-} /* namespace Swagger */
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}
 
 {{/model}}
 {{/models}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-body.mustache
@@ -58,10 +58,10 @@ void
 void
 {{classname}}::fromJsonObject(QJsonObject &pJson) {
     {{#vars}}
-    {{^isContainer}}::Swagger::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}}
+    {{^isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}}
     {{#isContainer}}
-    {{#complexType}}::Swagger::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/complexType}}
-    {{^complexType}}::Swagger::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{items.baseType}}");{{/complexType}}
+    {{#complexType}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/complexType}}
+    {{^complexType}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{items.baseType}}");{{/complexType}}
     {{/isContainer}}
     {{/vars}}
 }

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model-header.mustache
@@ -17,7 +17,9 @@
 #include "SWGObject.h"
 
 {{#models}}{{#model}}
-namespace Swagger {
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
 
 class {{classname}}: public SWGObject {
 public:
@@ -44,7 +46,9 @@ private:
     {{/vars}}
 };
 
-} /* namespace Swagger */
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}
 
 #endif /* {{classname}}_H_ */
 {{/model}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/model.mustache
@@ -22,7 +22,10 @@ using namespace Tizen::Web::Json;
 {{/imports}}
 
 {{#models}}{{#model}}
-namespace Swagger {
+
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
 
 class {{classname}}: public {{prefix}}Object {
 public:
@@ -52,7 +55,9 @@ private:
     {{/vars}}
 };
 
-} /* namespace Swagger */
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}
 
 #endif /* {{classname}}_H_ */
 {{/model}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/modelFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/modelFactory.mustache
@@ -5,7 +5,10 @@
 {{#models}}{{#model}}
 #include "{{classname}}.h"{{/model}}{{/models}}
 
-namespace Swagger {
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
+
   inline void* create(QString type) {
     {{#models}}{{#model}}if(QString("{{classname}}").compare(type) == 0) {
       return new {{classname}}();
@@ -25,6 +28,9 @@ namespace Swagger {
     }
     return nullptr;
   }
-} /* namespace Swagger */
+
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}
 
 #endif /* ModelFactory_H_ */

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/object.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/object.mustache
@@ -4,6 +4,10 @@
 
 #include <QJsonValue>
 
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
+
 class {{prefix}}Object {
   public:
     virtual QJsonObject* asJsonObject() {
@@ -21,5 +25,9 @@ class {{prefix}}Object {
         return QString("");
     }
 };
+
+{{#cppNamespaceDeclarations}}
+}
+{{/cppNamespaceDeclarations}}
 
 #endif /* _{{prefix}}_OBJECT_H_ */

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Qt5CPPOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Qt5CPPOptionsProvider.java
@@ -3,6 +3,7 @@ package io.swagger.codegen.options;
 import io.swagger.codegen.CodegenConstants;
 
 import com.google.common.collect.ImmutableMap;
+import io.swagger.codegen.languages.Qt5CPPGenerator;
 
 import java.util.Map;
 
@@ -10,6 +11,7 @@ public class Qt5CPPOptionsProvider implements OptionsProvider {
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
+    public static final String CPP_NAMESPACE_VALUE = "Swagger";
 
 
     @Override
@@ -23,6 +25,7 @@ public class Qt5CPPOptionsProvider implements OptionsProvider {
         return builder.put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
+                .put(Qt5CPPGenerator.CPP_NAMESPACE, CPP_NAMESPACE_VALUE)
                 .build();
     }
 

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGFakeApi.cpp
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGFakeApi.cpp
@@ -18,6 +18,7 @@
 #include <QJsonDocument>
 
 namespace Swagger {
+
 SWGFakeApi::SWGFakeApi() {}
 
 SWGFakeApi::~SWGFakeApi() {}
@@ -69,4 +70,5 @@ SWGFakeApi::testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rCallback(HttpReq
     
     emit testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rSignal();
 }
-} /* namespace Swagger */
+
+}

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGFakeApi.h
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGFakeApi.h
@@ -41,5 +41,6 @@ signals:
     void testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rSignal();
     
 };
+
 }
 #endif

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGHelpers.cpp
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGHelpers.cpp
@@ -131,7 +131,7 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     else if(type.startsWith("SWG") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
-        SWGObject * so = (SWGObject*)Swagger::create(type);
+        SWGObject * so = (SWGObject*)::Swagger::create(type);
         if(so != nullptr) {
             so->fromJsonObject(jsonObj);
             SWGObject **val = static_cast<SWGObject**>(value);

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGHelpers.cpp
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGHelpers.cpp
@@ -18,6 +18,7 @@
 #include <QJsonValue>
 #include <QDateTime>
 
+
 namespace Swagger {
 
 void
@@ -290,4 +291,5 @@ QString
 stringValue(bool value) {
     return QString(value ? "true" : "false");
 }
-} /* namespace Swagger */
+
+}

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGHelpers.h
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGHelpers.h
@@ -16,6 +16,7 @@
 #include <QJsonValue>
 
 namespace Swagger {
+
     void setValue(void* value, QJsonValue obj, QString type, QString complexType);
     void toJsonArray(QList<void*>* value, QJsonArray* output, QString innerName, QString innerType);
     void toJsonValue(QString name, void* value, QJsonObject* output, QString type);
@@ -24,6 +25,7 @@ namespace Swagger {
     QString stringValue(qint32 value);
     QString stringValue(qint64 value);
     QString stringValue(bool value);
+
 }
 
 #endif // SWGHELPERS_H

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGHttpRequest.cpp
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGHttpRequest.cpp
@@ -17,6 +17,8 @@
 #include <QBuffer>
 
 
+namespace Swagger {
+
 HttpRequestInput::HttpRequestInput() {
     initialize();
 }
@@ -308,4 +310,6 @@ void HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
     reply->deleteLater();
 
     emit on_execution_finished(this);
+}
+
 }

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGHttpRequest.h
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGHttpRequest.h
@@ -27,6 +27,7 @@
 
 enum HttpRequestVarLayout {NOT_SET, ADDRESS, URL_ENCODED, MULTIPART};
 
+namespace Swagger {
 
 class SWGHttpRequestInputFileElement {
 
@@ -83,5 +84,7 @@ private slots:
     void on_manager_finished(QNetworkReply *reply);
 
 };
+
+}
 
 #endif // HTTPREQUESTWORKER_H

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGModelFactory.h
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGModelFactory.h
@@ -17,6 +17,7 @@
 #include "SWGReturn.h"
 
 namespace Swagger {
+
   inline void* create(QString type) {
     if(QString("SWGReturn").compare(type) == 0) {
       return new SWGReturn();
@@ -36,6 +37,7 @@ namespace Swagger {
     }
     return nullptr;
   }
-} /* namespace Swagger */
+
+}
 
 #endif /* ModelFactory_H_ */

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGObject.h
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGObject.h
@@ -15,6 +15,8 @@
 
 #include <QJsonValue>
 
+namespace Swagger {
+
 class SWGObject {
   public:
     virtual QJsonObject* asJsonObject() {
@@ -32,5 +34,7 @@ class SWGObject {
         return QString("");
     }
 };
+
+}
 
 #endif /* _SWG_OBJECT_H_ */

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGReturn.cpp
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGReturn.cpp
@@ -22,7 +22,6 @@
 
 namespace Swagger {
 
-
 SWGReturn::SWGReturn(QString* json) {
     init();
     this->fromJson(*json);
@@ -89,6 +88,5 @@ SWGReturn::setReturn(qint32 return) {
 }
 
 
-
-} /* namespace Swagger */
+}
 

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGReturn.h
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGReturn.h
@@ -49,6 +49,6 @@ private:
     qint32 return;
 };
 
-} /* namespace Swagger */
+}
 
 #endif /* SWGReturn_H_ */

--- a/samples/client/petstore/qt5cpp/client/SWGCategory.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGCategory.cpp
@@ -22,7 +22,6 @@
 
 namespace Swagger {
 
-
 SWGCategory::SWGCategory(QString* json) {
     init();
     this->fromJson(*json);
@@ -106,6 +105,5 @@ SWGCategory::setName(QString* name) {
 }
 
 
-
-} /* namespace Swagger */
+}
 

--- a/samples/client/petstore/qt5cpp/client/SWGCategory.h
+++ b/samples/client/petstore/qt5cpp/client/SWGCategory.h
@@ -54,6 +54,6 @@ private:
     QString* name;
 };
 
-} /* namespace Swagger */
+}
 
 #endif /* SWGCategory_H_ */

--- a/samples/client/petstore/qt5cpp/client/SWGHelpers.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGHelpers.cpp
@@ -131,7 +131,7 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     else if(type.startsWith("SWG") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
-        SWGObject * so = (SWGObject*)Swagger::create(type);
+        SWGObject * so = (SWGObject*)::Swagger::create(type);
         if(so != nullptr) {
             so->fromJsonObject(jsonObj);
             SWGObject **val = static_cast<SWGObject**>(value);

--- a/samples/client/petstore/qt5cpp/client/SWGHelpers.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGHelpers.cpp
@@ -18,6 +18,7 @@
 #include <QJsonValue>
 #include <QDateTime>
 
+
 namespace Swagger {
 
 void
@@ -290,4 +291,5 @@ QString
 stringValue(bool value) {
     return QString(value ? "true" : "false");
 }
-} /* namespace Swagger */
+
+}

--- a/samples/client/petstore/qt5cpp/client/SWGHelpers.h
+++ b/samples/client/petstore/qt5cpp/client/SWGHelpers.h
@@ -16,6 +16,7 @@
 #include <QJsonValue>
 
 namespace Swagger {
+
     void setValue(void* value, QJsonValue obj, QString type, QString complexType);
     void toJsonArray(QList<void*>* value, QJsonArray* output, QString innerName, QString innerType);
     void toJsonValue(QString name, void* value, QJsonObject* output, QString type);
@@ -24,6 +25,7 @@ namespace Swagger {
     QString stringValue(qint32 value);
     QString stringValue(qint64 value);
     QString stringValue(bool value);
+
 }
 
 #endif // SWGHELPERS_H

--- a/samples/client/petstore/qt5cpp/client/SWGHttpRequest.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGHttpRequest.cpp
@@ -17,6 +17,8 @@
 #include <QBuffer>
 
 
+namespace Swagger {
+
 HttpRequestInput::HttpRequestInput() {
     initialize();
 }
@@ -308,4 +310,6 @@ void HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
     reply->deleteLater();
 
     emit on_execution_finished(this);
+}
+
 }

--- a/samples/client/petstore/qt5cpp/client/SWGHttpRequest.h
+++ b/samples/client/petstore/qt5cpp/client/SWGHttpRequest.h
@@ -27,6 +27,7 @@
 
 enum HttpRequestVarLayout {NOT_SET, ADDRESS, URL_ENCODED, MULTIPART};
 
+namespace Swagger {
 
 class SWGHttpRequestInputFileElement {
 
@@ -83,5 +84,7 @@ private slots:
     void on_manager_finished(QNetworkReply *reply);
 
 };
+
+}
 
 #endif // HTTPREQUESTWORKER_H

--- a/samples/client/petstore/qt5cpp/client/SWGModelFactory.h
+++ b/samples/client/petstore/qt5cpp/client/SWGModelFactory.h
@@ -21,6 +21,7 @@
 #include "SWGUser.h"
 
 namespace Swagger {
+
   inline void* create(QString type) {
     if(QString("SWGCategory").compare(type) == 0) {
       return new SWGCategory();
@@ -52,6 +53,7 @@ namespace Swagger {
     }
     return nullptr;
   }
-} /* namespace Swagger */
+
+}
 
 #endif /* ModelFactory_H_ */

--- a/samples/client/petstore/qt5cpp/client/SWGObject.h
+++ b/samples/client/petstore/qt5cpp/client/SWGObject.h
@@ -15,6 +15,8 @@
 
 #include <QJsonValue>
 
+namespace Swagger {
+
 class SWGObject {
   public:
     virtual QJsonObject* asJsonObject() {
@@ -32,5 +34,7 @@ class SWGObject {
         return QString("");
     }
 };
+
+}
 
 #endif /* _SWG_OBJECT_H_ */

--- a/samples/client/petstore/qt5cpp/client/SWGOrder.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGOrder.cpp
@@ -22,7 +22,6 @@
 
 namespace Swagger {
 
-
 SWGOrder::SWGOrder(QString* json) {
     init();
     this->fromJson(*json);
@@ -165,6 +164,5 @@ SWGOrder::setComplete(bool complete) {
 }
 
 
-
-} /* namespace Swagger */
+}
 

--- a/samples/client/petstore/qt5cpp/client/SWGOrder.h
+++ b/samples/client/petstore/qt5cpp/client/SWGOrder.h
@@ -71,6 +71,6 @@ private:
     bool complete;
 };
 
-} /* namespace Swagger */
+}
 
 #endif /* SWGOrder_H_ */

--- a/samples/client/petstore/qt5cpp/client/SWGPet.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGPet.cpp
@@ -22,7 +22,6 @@
 
 namespace Swagger {
 
-
 SWGPet::SWGPet(QString* json) {
     init();
     this->fromJson(*json);
@@ -190,6 +189,5 @@ SWGPet::setStatus(QString* status) {
 }
 
 
-
-} /* namespace Swagger */
+}
 

--- a/samples/client/petstore/qt5cpp/client/SWGPet.h
+++ b/samples/client/petstore/qt5cpp/client/SWGPet.h
@@ -73,6 +73,6 @@ private:
     QString* status;
 };
 
-} /* namespace Swagger */
+}
 
 #endif /* SWGPet_H_ */

--- a/samples/client/petstore/qt5cpp/client/SWGPetApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGPetApi.cpp
@@ -18,6 +18,7 @@
 #include <QJsonDocument>
 
 namespace Swagger {
+
 SWGPetApi::SWGPetApi() {}
 
 SWGPetApi::~SWGPetApi() {}
@@ -481,4 +482,5 @@ SWGPetApi::uploadFileCallback(HttpRequestWorker * worker) {
     
     emit uploadFileSignal();
 }
-} /* namespace Swagger */
+
+}

--- a/samples/client/petstore/qt5cpp/client/SWGPetApi.h
+++ b/samples/client/petstore/qt5cpp/client/SWGPetApi.h
@@ -64,5 +64,6 @@ signals:
     void uploadFileSignal();
     
 };
+
 }
 #endif

--- a/samples/client/petstore/qt5cpp/client/SWGStoreApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGStoreApi.cpp
@@ -18,6 +18,7 @@
 #include <QJsonDocument>
 
 namespace Swagger {
+
 SWGStoreApi::SWGStoreApi() {}
 
 SWGStoreApi::~SWGStoreApi() {}
@@ -210,4 +211,5 @@ SWGStoreApi::placeOrderCallback(HttpRequestWorker * worker) {
     emit placeOrderSignal(output);
     
 }
-} /* namespace Swagger */
+
+}

--- a/samples/client/petstore/qt5cpp/client/SWGStoreApi.h
+++ b/samples/client/petstore/qt5cpp/client/SWGStoreApi.h
@@ -52,5 +52,6 @@ signals:
     void placeOrderSignal(SWGOrder* summary);
     
 };
+
 }
 #endif

--- a/samples/client/petstore/qt5cpp/client/SWGTag.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGTag.cpp
@@ -22,7 +22,6 @@
 
 namespace Swagger {
 
-
 SWGTag::SWGTag(QString* json) {
     init();
     this->fromJson(*json);
@@ -106,6 +105,5 @@ SWGTag::setName(QString* name) {
 }
 
 
-
-} /* namespace Swagger */
+}
 

--- a/samples/client/petstore/qt5cpp/client/SWGTag.h
+++ b/samples/client/petstore/qt5cpp/client/SWGTag.h
@@ -54,6 +54,6 @@ private:
     QString* name;
 };
 
-} /* namespace Swagger */
+}
 
 #endif /* SWGTag_H_ */

--- a/samples/client/petstore/qt5cpp/client/SWGUser.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGUser.cpp
@@ -22,7 +22,6 @@
 
 namespace Swagger {
 
-
 SWGUser::SWGUser(QString* json) {
     init();
     this->fromJson(*json);
@@ -205,6 +204,5 @@ SWGUser::setUserStatus(qint32 user_status) {
 }
 
 
-
-} /* namespace Swagger */
+}
 

--- a/samples/client/petstore/qt5cpp/client/SWGUser.h
+++ b/samples/client/petstore/qt5cpp/client/SWGUser.h
@@ -78,6 +78,6 @@ private:
     qint32 user_status;
 };
 
-} /* namespace Swagger */
+}
 
 #endif /* SWGUser_H_ */

--- a/samples/client/petstore/qt5cpp/client/SWGUserApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGUserApi.cpp
@@ -18,6 +18,7 @@
 #include <QJsonDocument>
 
 namespace Swagger {
+
 SWGUserApi::SWGUserApi() {}
 
 SWGUserApi::~SWGUserApi() {}
@@ -385,4 +386,5 @@ SWGUserApi::updateUserCallback(HttpRequestWorker * worker) {
     
     emit updateUserSignal();
 }
-} /* namespace Swagger */
+
+}

--- a/samples/client/petstore/qt5cpp/client/SWGUserApi.h
+++ b/samples/client/petstore/qt5cpp/client/SWGUserApi.h
@@ -64,5 +64,6 @@ signals:
     void updateUserSignal();
     
 };
+
 }
 #endif


### PR DESCRIPTION
### Description of the PR
fix #5481 

Add _ccpNamespace_ option to allow configurationof the namespace in which generated classes/methods reside in. 
Default is Swagger to stay compatible with previously hardcoded value.

CONFIG OPTIONS
    cppNamespace
	    C++ namespace (convention: name::space::for::api). (Default: Swagger)

