### PR TITLE
[Python]: correct query_params type.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api.mustache
@@ -168,10 +168,10 @@ class {{classname}}(object):
             collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
 {{/pathParams}}
 
-        query_params = {}
+        query_params = []
 {{#queryParams}}
         if '{{paramName}}' in params:
-            query_params['{{baseName}}'] = params['{{paramName}}']{{#isListContainer}}
+            query_params.append(('{{baseName}}', params['{{paramName}}'])){{#isListContainer}}
             collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}
 {{/queryParams}}
 

--- a/samples/client/petstore-security-test/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore-security-test/python/petstore_api/apis/fake_api.py
@@ -105,7 +105,7 @@ class FakeApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 

--- a/samples/client/petstore/python/petstore_api/apis/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/fake_api.py
@@ -110,7 +110,7 @@ class FakeApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -277,7 +277,7 @@ class FakeApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -420,14 +420,14 @@ class FakeApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
         if 'enum_query_string_array' in params:
-            query_params['enum_query_string_array'] = params['enum_query_string_array']
+            query_params.append(('enum_query_string_array', params['enum_query_string_array']))
             collection_formats['enum_query_string_array'] = 'csv'
         if 'enum_query_string' in params:
-            query_params['enum_query_string'] = params['enum_query_string']
+            query_params.append(('enum_query_string', params['enum_query_string']))
         if 'enum_query_integer' in params:
-            query_params['enum_query_integer'] = params['enum_query_integer']
+            query_params.append(('enum_query_integer', params['enum_query_integer']))
 
         header_params = {}
         if 'enum_header_string_array' in params:

--- a/samples/client/petstore/python/petstore_api/apis/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/pet_api.py
@@ -110,7 +110,7 @@ class PetApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -220,7 +220,7 @@ class PetApi(object):
         if 'pet_id' in params:
             path_params['petId'] = params['pet_id']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
         if 'api_key' in params:
@@ -322,9 +322,9 @@ class PetApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
         if 'status' in params:
-            query_params['status'] = params['status']
+            query_params.append(('status', params['status']))
             collection_formats['status'] = 'csv'
 
         header_params = {}
@@ -425,9 +425,9 @@ class PetApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
         if 'tags' in params:
-            query_params['tags'] = params['tags']
+            query_params.append(('tags', params['tags']))
             collection_formats['tags'] = 'csv'
 
         header_params = {}
@@ -530,7 +530,7 @@ class PetApi(object):
         if 'pet_id' in params:
             path_params['petId'] = params['pet_id']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -630,7 +630,7 @@ class PetApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -742,7 +742,7 @@ class PetApi(object):
         if 'pet_id' in params:
             path_params['petId'] = params['pet_id']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -856,7 +856,7 @@ class PetApi(object):
         if 'pet_id' in params:
             path_params['petId'] = params['pet_id']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 

--- a/samples/client/petstore/python/petstore_api/apis/store_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/store_api.py
@@ -112,7 +112,7 @@ class StoreApi(object):
         if 'order_id' in params:
             path_params['order_id'] = params['order_id']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -206,7 +206,7 @@ class StoreApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -312,7 +312,7 @@ class StoreApi(object):
         if 'order_id' in params:
             path_params['order_id'] = params['order_id']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -412,7 +412,7 @@ class StoreApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 

--- a/samples/client/petstore/python/petstore_api/apis/user_api.py
+++ b/samples/client/petstore/python/petstore_api/apis/user_api.py
@@ -110,7 +110,7 @@ class UserApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -212,7 +212,7 @@ class UserApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -314,7 +314,7 @@ class UserApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -418,7 +418,7 @@ class UserApi(object):
         if 'username' in params:
             path_params['username'] = params['username']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -520,7 +520,7 @@ class UserApi(object):
         if 'username' in params:
             path_params['username'] = params['username']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -625,11 +625,11 @@ class UserApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
         if 'username' in params:
-            query_params['username'] = params['username']
+            query_params.append(('username', params['username']))
         if 'password' in params:
-            query_params['password'] = params['password']
+            query_params.append(('password', params['password']))
 
         header_params = {}
 
@@ -723,7 +723,7 @@ class UserApi(object):
 
         path_params = {}
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 
@@ -830,7 +830,7 @@ class UserApi(object):
         if 'username' in params:
             path_params['username'] = params['username']
 
-        query_params = {}
+        query_params = []
 
         header_params = {}
 


### PR DESCRIPTION
query_params is a list of tuple, so defined it as a list by
default instead of a dict.

This fix below issue on the client side.

Traceback (most recent call last):
  File "test.py", line 13, in <module>
    api_response = api_instance.seek("the")
  File "python-client/swagger_client/apis/seek_api.py", line 168, in seek
    (data) = self.seek_with_http_info(recherche, **kwargs)
  File "python-client/swagger_client/apis/seek_api.py", line 245, in seek_with_http_info
    collection_formats=collection_formats)
  File "python-client/swagger_client/api_client.py", line 323, in call_api
    _return_http_data_only, collection_formats, _preload_content, _request_timeout)
  File "python-client/swagger_client/api_client.py", line 135, in __call_api
    self.update_params_for_auth(header_params, query_params, auth_settings)
  File "python-client/swagger_client/api_client.py", line 512, in update_params_for_auth
    querys.append((auth_setting['key'], auth_setting['value']))
AttributeError: 'dict' object has no attribute 'append'

Signed-off-by: Gregory Herrero <gregory.herrero@gmail.com>

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This patch fix #5502 
I regenerated client API and ensured no exception. 

