### PR TITLE
Fix hasMore field and order consistency of authMethods

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -48,6 +48,7 @@ import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import io.swagger.models.properties.UUIDProperty;
 import io.swagger.util.Json;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -2689,9 +2690,23 @@ public class DefaultCodegen {
                 }
             }
 
-            sec.hasMore = it.hasNext();
             secs.add(sec);
         }
+
+        // sort auth methods to maintain the same order
+        Collections.sort(secs, new Comparator<CodegenSecurity>() {
+            @Override
+            public int compare(CodegenSecurity one, CodegenSecurity another) {
+                return ObjectUtils.compare(one.name, another.name);
+            }
+        });
+        // set 'hasMore'
+        Iterator<CodegenSecurity> it = secs.iterator();
+        while (it.hasNext()) {
+            final CodegenSecurity security = it.next();
+            security.hasMore = it.hasNext();
+        }
+
         return secs;
     }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -625,13 +625,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         bundle.put("modelPackage", config.modelPackage());
         List<CodegenSecurity> authMethods = config.fromSecurity(swagger.getSecurityDefinitions());
         if (authMethods != null && !authMethods.isEmpty()) {
-            // sort auth methods to maintain the same order
-            Collections.sort(authMethods, new Comparator<CodegenSecurity>() {
-                @Override
-                public int compare(CodegenSecurity one, CodegenSecurity another) {
-                    return ObjectUtils.compare(one.name, another.name);
-                }
-            });
             bundle.put("authMethods", authMethods);
             bundle.put("hasAuthMethods", true);
         }


### PR DESCRIPTION
The hasMore field of the global authMethods was broken due to sorting after
setting that field. The sort order for per-operation authMethods was not
guaranteed to be consistent across runs because it didn't do sorting. This
change fixes those issues by always sorting and setting the hasMore field
post-sort.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Adopted code from DefaultGenerator and AkkaScalaClientCodegen to consistently sort the authMethods dictionaries and set the hasMore field.

Fix for #5515 

