### PR TITLE
ensuring that swagger dates are treated as strings for all typescript clients

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -84,6 +84,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         typeMapping.put("object", "any");
         typeMapping.put("integer", "number");
         typeMapping.put("Map", "any");
+        typeMapping.put("date", "string");
         typeMapping.put("DateTime", "Date");
         //TODO binary should be mapped to byte array
         // mapped to String as a workaround

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -42,7 +42,6 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
         modelTemplateFiles.put("model.mustache", ".ts");
         apiTemplateFiles.put("api.service.mustache", ".ts");
         languageSpecificPrimitives.add("Blob");
-        typeMapping.put("date","string");
         typeMapping.put("file","Blob");
         apiPackage = "api";
         modelPackage = "model";

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -2,6 +2,7 @@ package io.swagger.codegen.typescript.fetch;
 
 import com.google.common.collect.Sets;
 
+import io.swagger.models.properties.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,12 +13,6 @@ import io.swagger.codegen.languages.TypeScriptFetchClientCodegen;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.DateTimeProperty;
-import io.swagger.models.properties.LongProperty;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 
@@ -34,6 +29,7 @@ public class TypeScriptFetchModelTest {
                 .property("id", new LongProperty())
                 .property("name", new StringProperty())
                 .property("createdAt", new DateTimeProperty())
+                .property("birthDate", new DateProperty())
                 .required("id")
                 .required("name");
         final DefaultCodegen codegen = new TypeScriptFetchClientCodegen();
@@ -42,7 +38,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 3);
+        Assert.assertEquals(cm.vars.size(), 4);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -70,9 +66,19 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
-        Assert.assertFalse(property3.hasMore);
+        Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.complexType, null);
+        Assert.assertEquals(property4.datatype, "string");
+        Assert.assertEquals(property4.name, "birthDate");
+        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertFalse(property4.hasMore);
+        Assert.assertFalse(property4.required);
+        Assert.assertTrue(property4.isNotContainer);
     }
 
     @Test(description = "convert a model with list property")

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
@@ -7,11 +7,7 @@ import io.swagger.codegen.languages.TypeScriptAngularClientCodegen;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.DateTimeProperty;
-import io.swagger.models.properties.LongProperty;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.*;
 
 import com.google.common.collect.Sets;
 import org.testng.Assert;
@@ -27,6 +23,7 @@ public class TypeScriptAngularModelTest {
                 .property("id", new LongProperty())
                 .property("name", new StringProperty())
                 .property("createdAt", new DateTimeProperty())
+                .property("birthDate", new DateProperty())
                 .required("id")
                 .required("name");
         final DefaultCodegen codegen = new TypeScriptAngularClientCodegen();
@@ -35,7 +32,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 3);
+        Assert.assertEquals(cm.vars.size(), 4);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -63,9 +60,19 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
-        Assert.assertFalse(property3.hasMore);
+        Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.complexType, null);
+        Assert.assertEquals(property4.datatype, "string");
+        Assert.assertEquals(property4.name, "birthDate");
+        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertFalse(property4.hasMore);
+        Assert.assertFalse(property4.required);
+        Assert.assertTrue(property4.isNotContainer);
     }
 
     @Test(description = "convert a model with list property")

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
@@ -7,11 +7,7 @@ import io.swagger.codegen.languages.TypeScriptNodeClientCodegen;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.DateTimeProperty;
-import io.swagger.models.properties.LongProperty;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.*;
 
 import com.google.common.collect.Sets;
 import org.testng.Assert;
@@ -27,6 +23,7 @@ public class TypeScriptNodeModelTest {
                 .property("id", new LongProperty())
                 .property("name", new StringProperty())
                 .property("createdAt", new DateTimeProperty())
+                .property("birthDate", new DateProperty())
                 .required("id")
                 .required("name");
         final DefaultCodegen codegen = new TypeScriptNodeClientCodegen();
@@ -35,7 +32,7 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 3);
+        Assert.assertEquals(cm.vars.size(), 4);
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
@@ -63,9 +60,19 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(property3.datatype, "Date");
         Assert.assertEquals(property3.name, "createdAt");
         Assert.assertEquals(property3.defaultValue, "null");
-        Assert.assertFalse(property3.hasMore);
+        Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isNotContainer);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "birthDate");
+        Assert.assertEquals(property4.complexType, null);
+        Assert.assertEquals(property4.datatype, "string");
+        Assert.assertEquals(property4.name, "birthDate");
+        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertFalse(property4.hasMore);
+        Assert.assertFalse(property4.required);
+        Assert.assertTrue(property4.isNotContainer);
     }
 
     @Test(description = "convert a model with list property")


### PR DESCRIPTION

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The 2.3.0 typescript clients all treat Swagger dates as Javascript Date types. This would be appropriate for date-times, but for dates, which lack times, this leads to meaningless times being passed to an API which expects only dates, in violation of the Swagger spec.

A better datetype for Swagger dates, since Javascript does not have a native concept of dates, is simply ISO strings (e.g `2017-04-30`). The generated clients should therefore use strings for dates, while continuing to use Dates for datetimes.

In #5417 I submitted a change that fixed this issue for the typescript-angular2 client. @wing328 merged it but suggested that we fix this for the other Typescript clients as well, to ensure consistency. Therefore, I'm submitting this PR, which moves the typing to the `AbstractTypeScriptClientCodegen` superclass and therefore makes all of the Typescript clients share the same consistent behavior.

Happy to answer any questions or assist in moving this forward.