### PR TITLE
Minor fixes to sample generation scripts

### DIFF
--- a/bin/csharp-petstore-net-standard.sh
+++ b/bin/csharp-petstore-net-standard.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClientNetStanard --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-standard.json"
+ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClientNetStandard --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-standard.json"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-netcore-project.sh
+++ b/bin/csharp-petstore-netcore-project.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClientNetCoreProject --additional-properties packageGuid={67035b31-f8e5-41a4-9673-954035084f7d},netCoreProjectFile=true -c ./bin/csharp-petstore-v5.json"
+ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClientNetCoreProject --additional-properties packageGuid={67035b31-f8e5-41a4-9673-954035084f7d},netCoreProjectFile=true -c ./bin/csharp-petstore-net-standard.json"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/ruby-petstore.sh
+++ b/bin/ruby-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/ruby -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l ruby -c bin/ruby-petstore.yaml -o samples/client/petstore/ruby"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/ruby -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l ruby -c bin/ruby-petstore.json -o samples/client/petstore/ruby"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-petstore-npm.json
+++ b/bin/typescript-petstore-npm.json
@@ -2,5 +2,5 @@
   "npmName": "@swagger/angular2-typescript-petstore",
   "npmVersion": "0.0.1",
   "npmRepository" : "https://skimdb.npmjs.com/registry",
-  "snapshot" : true
+  "snapshot" : false
 }


### PR DESCRIPTION
- typo in csharp-petstore-net-standard.sh (Stanard -> Standard)
- non-existent config file name name in csharp-petstore-netcore-project.sh
- non-existing config file name in ruby-petstore.sh
- snapshot versioning in typescript-petstore-npm.json causes
  non-deterministic output

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

In trying to recreate some of the samples, I ran into a few issues with the scripts that produced incorrect output. Mostly these were typos or references to non-existent (probably old) config files.

I'm working on re-generating the samples with new testing endpoints, so these fixes will help make that process go more smoothly.