### PR TITLE
issue #3365 adding accept encoding for PHP

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/ApiClient.mustache
@@ -157,7 +157,7 @@ class ApiClient
         if ($this->config->getCurlConnectTimeout() != 0) {
             curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->config->getCurlConnectTimeout());
         }
-        
+
         // return the result on success, rather than just true
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 
@@ -187,6 +187,10 @@ class ApiClient
 
         if (!empty($queryParams)) {
             $url = ($url . '?' . http_build_query($queryParams));
+        }
+
+        if ($this->config->getAllowEncoding()) {
+            curl_setopt($curl, CURLOPT_ENCODING, '');
         }
 
         if ($method === self::$POST) {

--- a/modules/swagger-codegen/src/main/resources/php/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/configuration.mustache
@@ -168,6 +168,13 @@ class Configuration
     protected $proxyPassword;
 
     /**
+     * Allow Curl encoding header
+     *
+     * @var bool
+     */
+    protected $allowEncoding = false;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -436,6 +443,16 @@ class Configuration
     }
 
     /**
+     * Set whether to accept encoding
+     * @param bool $allowEncoding
+     */
+    public function setAllowEncoding($allowEncoding)
+    {
+        $this->allowEncoding = $allowEncoding;
+        return $this;
+    }
+
+    /**
      * Gets the HTTP connect timeout value
      *
      * @return string HTTP connect timeout value
@@ -445,6 +462,15 @@ class Configuration
         return $this->curlConnectTimeout;
     }
 
+    /**
+     * Get whether to allow encoding
+     *
+     * @return bool
+     */
+    public function getAllowEncoding()
+    {
+        return $this->allowEncoding;
+    }
 
     /**
      * Sets the HTTP Proxy Host

--- a/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/ApiClient.php
@@ -167,7 +167,7 @@ class ApiClient
         if ($this->config->getCurlConnectTimeout() != 0) {
             curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->config->getCurlConnectTimeout());
         }
-        
+
         // return the result on success, rather than just true
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 
@@ -197,6 +197,10 @@ class ApiClient
 
         if (!empty($queryParams)) {
             $url = ($url . '?' . http_build_query($queryParams));
+        }
+
+        if ($this->config->getAllowEncoding()) {
+            curl_setopt($curl, CURLOPT_ENCODING, '');
         }
 
         if ($method === self::$POST) {

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Configuration.php
@@ -178,6 +178,13 @@ class Configuration
     protected $proxyPassword;
 
     /**
+     * Allow Curl encoding header
+     *
+     * @var bool
+     */
+    protected $allowEncoding = false;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -446,6 +453,16 @@ class Configuration
     }
 
     /**
+     * Set whether to accept encoding
+     * @param bool $allowEncoding
+     */
+    public function setAllowEncoding($allowEncoding)
+    {
+        $this->allowEncoding = $allowEncoding;
+        return $this;
+    }
+
+    /**
      * Gets the HTTP connect timeout value
      *
      * @return string HTTP connect timeout value
@@ -455,6 +472,15 @@ class Configuration
         return $this->curlConnectTimeout;
     }
 
+    /**
+     * Get whether to allow encoding
+     *
+     * @return bool
+     */
+    public function getAllowEncoding()
+    {
+        return $this->allowEncoding;
+    }
 
     /**
      * Sets the HTTP Proxy Host


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This change is to implement PHP client for allowing encoding headers.
https://github.com/swagger-api/swagger-codegen/issues/3365


