### PR TITLE
Add validate option to swagger-codegen-cli (Issue #5466)

### DIFF
--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/SwaggerCodegen.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/SwaggerCodegen.java
@@ -6,6 +6,7 @@ import io.swagger.codegen.cmd.ConfigHelp;
 import io.swagger.codegen.cmd.Generate;
 import io.swagger.codegen.cmd.Langs;
 import io.swagger.codegen.cmd.Meta;
+import io.swagger.codegen.cmd.Validate;
 import io.swagger.codegen.cmd.Version;
 
 /**
@@ -35,6 +36,7 @@ public class SwaggerCodegen {
                         Langs.class,
                         Help.class,
                         ConfigHelp.class,
+                        Validate.class,
                         Version.class
                 );
 

--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Validate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Validate.java
@@ -1,0 +1,37 @@
+package io.swagger.codegen.cmd;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+import io.swagger.parser.SwaggerParser;
+import io.swagger.parser.util.SwaggerDeserializationResult;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Command(name = "validate", description = "Validate specification")
+public class Validate implements Runnable {
+
+    @Option(name = {"-i", "--input-spec"}, title = "spec file", required = true,
+            description = "location of the swagger spec, as URL or file (required)")
+    private String spec;
+
+    @Override
+    public void run() {
+        System.out.println("Validating spec file (" + spec + ")");
+
+        SwaggerParser parser = new SwaggerParser();
+        SwaggerDeserializationResult result = parser.readWithInfo(spec, null, true);
+        List<String> messageList = result.getMessages();
+        Set<String> messages = new HashSet<String>(messageList);
+
+        for (String message: messages) {
+            System.out.println(message);
+        }
+
+        if (messages.size() > 0) {
+            throw new ValidateException();
+        }
+    }
+}

--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/ValidateException.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/ValidateException.java
@@ -1,0 +1,7 @@
+package io.swagger.codegen.cmd;
+
+/**
+ * Created by takuro on 2017/05/02.
+ */
+public class ValidateException extends RuntimeException {
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
- Issue #5466 
- Enhancement to add `validate` option to swagger-codegen-cli
- Using swagger-parser's `SwaggerDeserializationResult` according to @wing328 advice
- If this basic concept is OK, I will add some tests for this enhancement, so please let me know.

### Command result
#### Against valid spec
```shell
$ java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar validate -i valid.json
Validating spec file (valid.json)
```

#### Against invalid spec (example: `info` attribute is changed to `infa`)
```shell
$ java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar validate -i invalid.json
Validating spec file (invalid.json)
attribute infa is unexpected
attribute info is missing
Exception in thread "main" io.swagger.codegen.cmd.ValidateException
        at io.swagger.codegen.cmd.Validate.run(Validate.java:60)
        at io.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:43)
```

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

