### PR TITLE
add option to skip client side validation in ruby client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -38,11 +38,13 @@ module {{moduleName}}
       {{#allParams}}
       {{#required}}
       # verify the required parameter '{{paramName}}' is set
-      fail ArgumentError, "Missing the required parameter '{{paramName}}' when calling {{classname}}.{{operationId}}" if {{{paramName}}}.nil?
+      if @api_client.config.client_side_validation && {{{paramName}}}.nil?
+        fail ArgumentError, "Missing the required parameter '{{paramName}}' when calling {{classname}}.{{operationId}}"
+      end
       {{#isEnum}}
       {{^isContainer}}
       # verify enum value
-      unless [{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?({{{paramName}}})
+      if @api_client.config.client_side_validation && ![{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?({{{paramName}}})
         fail ArgumentError, "invalid value for '{{{paramName}}}', must be one of {{#allowableValues}}{{#values}}{{{this}}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}"
       end
       {{/isContainer}}
@@ -51,12 +53,12 @@ module {{moduleName}}
       {{^required}}
       {{#isEnum}}
       {{#collectionFormat}}
-      if opts[:'{{{paramName}}}'] && !opts[:'{{{paramName}}}'].all?{|item| [{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?(item)}
+      if @api_client.config.client_side_validation && opts[:'{{{paramName}}}'] && !opts[:'{{{paramName}}}'].all?{|item| [{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?(item)}
         fail ArgumentError, 'invalid value for "{{{paramName}}}", must include one of {{#allowableValues}}{{#values}}{{{this}}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}'
       end
       {{/collectionFormat}}
       {{^collectionFormat}}
-      if opts[:'{{{paramName}}}'] && ![{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?(opts[:'{{{paramName}}}'])
+      if @api_client.config.client_side_validation && opts[:'{{{paramName}}}'] && ![{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?(opts[:'{{{paramName}}}'])
         fail ArgumentError, 'invalid value for "{{{paramName}}}", must be one of {{#allowableValues}}{{#values}}{{{this}}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}'
       end
       {{/collectionFormat}}
@@ -64,43 +66,43 @@ module {{moduleName}}
       {{/required}}
       {{#hasValidation}}
       {{#maxLength}}
-      if {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}.to_s.length > {{{maxLength}}}
+      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}.to_s.length > {{{maxLength}}}
         fail ArgumentError, 'invalid value for "{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:"{{{paramName}}}"]{{/required}}" when calling {{classname}}.{{operationId}}, the character length must be smaller than or equal to {{{maxLength}}}.'
       end
 
       {{/maxLength}}
       {{#minLength}}
-      if {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}.to_s.length < {{{minLength}}}
+      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}.to_s.length < {{{minLength}}}
         fail ArgumentError, 'invalid value for "{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:"{{{paramName}}}"]{{/required}}" when calling {{classname}}.{{operationId}}, the character length must be great than or equal to {{{minLength}}}.'
       end
 
       {{/minLength}}
       {{#maximum}}
-      if {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{{maximum}}}
+      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{{maximum}}}
         fail ArgumentError, 'invalid value for "{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:"{{{paramName}}}"]{{/required}}" when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{{maximum}}}.'
       end
 
       {{/maximum}}
       {{#minimum}}
-      if {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}} <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{{minimum}}}
+      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}} <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{{minimum}}}
         fail ArgumentError, 'invalid value for "{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:"{{{paramName}}}"]{{/required}}" when calling {{classname}}.{{operationId}}, must be greater than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{{minimum}}}.'
       end
 
       {{/minimum}}
       {{#pattern}}
-      if {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}} !~ Regexp.new({{{pattern}}})
+      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}} !~ Regexp.new({{{pattern}}})
         fail ArgumentError, "invalid value for '{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:\"{{{paramName}}}\"]{{/required}}' when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}."
       end
 
       {{/pattern}}
       {{#maxItems}}
-      if {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}.length > {{{maxItems}}}
+      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}.length > {{{maxItems}}}
         fail ArgumentError, 'invalid value for "{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:"{{{paramName}}}"]{{/required}}" when calling {{classname}}.{{operationId}}, number of items must be less than or equal to {{{maxItems}}}.'
       end
 
       {{/maxItems}}
       {{#minItems}}
-      if {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}.length < {{{minItems}}}
+      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}.length < {{{minItems}}}
         fail ArgumentError, 'invalid value for "{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:"{{{paramName}}}"]{{/required}}" when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{{minItems}}}.'
       end
 

--- a/modules/swagger-codegen/src/main/resources/ruby/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/configuration.mustache
@@ -68,6 +68,11 @@ module {{moduleName}}
     # Default to 0 (never times out).
     attr_accessor :timeout
 
+    # Set this to false to skip client side validation in the operation.
+    # Default to true.
+    # @return [true, false]
+    attr_accessor :client_side_validation
+
     ### TLS/SSL setting
     # Set this to false to skip verifying SSL certificate when calling API from https server.
     # Default to true.
@@ -121,6 +126,7 @@ module {{moduleName}}
       @api_key = {}
       @api_key_prefix = {}
       @timeout = 0
+      @client_side_validation = true
       @verify_ssl = true
       @verify_ssl_host = true
       @params_encoding = nil

--- a/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest', '~> 4.4', '>= 4.4.6'
   s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
   s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'
-  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.11'
+  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
 
   s.files         = `find *`.split("\n").uniq.sort.select{|f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")

--- a/samples/client/petstore/ruby/Gemfile.lock
+++ b/samples/client/petstore/ruby/Gemfile.lock
@@ -6,13 +6,13 @@ PATH
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     ZenTest (4.11.0)
     addressable (2.3.8)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
-    autotest-fsevent (0.2.11)
+    autotest-fsevent (0.2.12)
       sys-uname
     autotest-growl (0.2.16)
     autotest-rails-pure (4.1.2)
@@ -24,6 +24,7 @@ GEM
     ffi (1.9.8)
     hashdiff (0.3.0)
     json (1.8.3)
+    rake (12.0.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -38,7 +39,7 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     safe_yaml (1.0.4)
-    sys-uname (0.9.2)
+    sys-uname (1.0.3)
       ffi (>= 1.0.0)
     typhoeus (1.0.1)
       ethon (>= 0.8.0)
@@ -53,10 +54,14 @@ PLATFORMS
 
 DEPENDENCIES
   autotest (~> 4.4, >= 4.4.6)
-  autotest-fsevent (~> 0.2, >= 0.2.11)
+  autotest-fsevent (~> 0.2, >= 0.2.12)
   autotest-growl (~> 0.2, >= 0.2.16)
   autotest-rails-pure (~> 4.1, >= 4.1.2)
   petstore!
+  rake (~> 12.0.0)
   rspec (~> 3.4, >= 3.4.0)
   vcr (~> 3.0, >= 3.0.1)
   webmock (~> 1.24, >= 1.24.3)
+
+BUNDLED WITH
+   1.12.3

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -40,7 +40,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: FakeApi.test_client_model ..."
       end
       # verify the required parameter 'body' is set
-      fail ArgumentError, "Missing the required parameter 'body' when calling FakeApi.test_client_model" if body.nil?
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling FakeApi.test_client_model"
+      end
       # resource path
       local_var_path = "/fake"
 
@@ -119,62 +121,70 @@ module Petstore
         @api_client.config.logger.debug "Calling API: FakeApi.test_endpoint_parameters ..."
       end
       # verify the required parameter 'number' is set
-      fail ArgumentError, "Missing the required parameter 'number' when calling FakeApi.test_endpoint_parameters" if number.nil?
-      if number > 543.2
+      if @api_client.config.client_side_validation && number.nil?
+        fail ArgumentError, "Missing the required parameter 'number' when calling FakeApi.test_endpoint_parameters"
+      end
+      if @api_client.config.client_side_validation && number > 543.2
         fail ArgumentError, 'invalid value for "number" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 543.2.'
       end
 
-      if number < 32.1
+      if @api_client.config.client_side_validation && number < 32.1
         fail ArgumentError, 'invalid value for "number" when calling FakeApi.test_endpoint_parameters, must be greater than or equal to 32.1.'
       end
 
       # verify the required parameter 'double' is set
-      fail ArgumentError, "Missing the required parameter 'double' when calling FakeApi.test_endpoint_parameters" if double.nil?
-      if double > 123.4
+      if @api_client.config.client_side_validation && double.nil?
+        fail ArgumentError, "Missing the required parameter 'double' when calling FakeApi.test_endpoint_parameters"
+      end
+      if @api_client.config.client_side_validation && double > 123.4
         fail ArgumentError, 'invalid value for "double" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 123.4.'
       end
 
-      if double < 67.8
+      if @api_client.config.client_side_validation && double < 67.8
         fail ArgumentError, 'invalid value for "double" when calling FakeApi.test_endpoint_parameters, must be greater than or equal to 67.8.'
       end
 
       # verify the required parameter 'pattern_without_delimiter' is set
-      fail ArgumentError, "Missing the required parameter 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters" if pattern_without_delimiter.nil?
-      if pattern_without_delimiter !~ Regexp.new(/^[A-Z].*/)
+      if @api_client.config.client_side_validation && pattern_without_delimiter.nil?
+        fail ArgumentError, "Missing the required parameter 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters"
+      end
+      if @api_client.config.client_side_validation && pattern_without_delimiter !~ Regexp.new(/^[A-Z].*/)
         fail ArgumentError, "invalid value for 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters, must conform to the pattern /^[A-Z].*/."
       end
 
       # verify the required parameter 'byte' is set
-      fail ArgumentError, "Missing the required parameter 'byte' when calling FakeApi.test_endpoint_parameters" if byte.nil?
-      if !opts[:'integer'].nil? && opts[:'integer'] > 100
+      if @api_client.config.client_side_validation && byte.nil?
+        fail ArgumentError, "Missing the required parameter 'byte' when calling FakeApi.test_endpoint_parameters"
+      end
+      if @api_client.config.client_side_validation && !opts[:'integer'].nil? && opts[:'integer'] > 100
         fail ArgumentError, 'invalid value for "opts[:"integer"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 100.'
       end
 
-      if !opts[:'integer'].nil? && opts[:'integer'] < 10
+      if @api_client.config.client_side_validation && !opts[:'integer'].nil? && opts[:'integer'] < 10
         fail ArgumentError, 'invalid value for "opts[:"integer"]" when calling FakeApi.test_endpoint_parameters, must be greater than or equal to 10.'
       end
 
-      if !opts[:'int32'].nil? && opts[:'int32'] > 200
+      if @api_client.config.client_side_validation && !opts[:'int32'].nil? && opts[:'int32'] > 200
         fail ArgumentError, 'invalid value for "opts[:"int32"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 200.'
       end
 
-      if !opts[:'int32'].nil? && opts[:'int32'] < 20
+      if @api_client.config.client_side_validation && !opts[:'int32'].nil? && opts[:'int32'] < 20
         fail ArgumentError, 'invalid value for "opts[:"int32"]" when calling FakeApi.test_endpoint_parameters, must be greater than or equal to 20.'
       end
 
-      if !opts[:'float'].nil? && opts[:'float'] > 987.6
+      if @api_client.config.client_side_validation && !opts[:'float'].nil? && opts[:'float'] > 987.6
         fail ArgumentError, 'invalid value for "opts[:"float"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 987.6.'
       end
 
-      if !opts[:'string'].nil? && opts[:'string'] !~ Regexp.new(/[a-z]/i)
+      if @api_client.config.client_side_validation && !opts[:'string'].nil? && opts[:'string'] !~ Regexp.new(/[a-z]/i)
         fail ArgumentError, "invalid value for 'opts[:\"string\"]' when calling FakeApi.test_endpoint_parameters, must conform to the pattern /[a-z]/i."
       end
 
-      if !opts[:'password'].nil? && opts[:'password'].to_s.length > 64
+      if @api_client.config.client_side_validation && !opts[:'password'].nil? && opts[:'password'].to_s.length > 64
         fail ArgumentError, 'invalid value for "opts[:"password"]" when calling FakeApi.test_endpoint_parameters, the character length must be smaller than or equal to 64.'
       end
 
-      if !opts[:'password'].nil? && opts[:'password'].to_s.length < 10
+      if @api_client.config.client_side_validation && !opts[:'password'].nil? && opts[:'password'].to_s.length < 10
         fail ArgumentError, 'invalid value for "opts[:"password"]" when calling FakeApi.test_endpoint_parameters, the character length must be great than or equal to 10.'
       end
 
@@ -256,28 +266,28 @@ module Petstore
       if @api_client.config.debugging
         @api_client.config.logger.debug "Calling API: FakeApi.test_enum_parameters ..."
       end
-      if opts[:'enum_form_string_array'] && !opts[:'enum_form_string_array'].all?{|item| ['>', '$'].include?(item)}
+      if @api_client.config.client_side_validation && opts[:'enum_form_string_array'] && !opts[:'enum_form_string_array'].all?{|item| ['>', '$'].include?(item)}
         fail ArgumentError, 'invalid value for "enum_form_string_array", must include one of >, $'
       end
-      if opts[:'enum_form_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_form_string'])
+      if @api_client.config.client_side_validation && opts[:'enum_form_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_form_string'])
         fail ArgumentError, 'invalid value for "enum_form_string", must be one of _abc, -efg, (xyz)'
       end
-      if opts[:'enum_header_string_array'] && !opts[:'enum_header_string_array'].all?{|item| ['>', '$'].include?(item)}
+      if @api_client.config.client_side_validation && opts[:'enum_header_string_array'] && !opts[:'enum_header_string_array'].all?{|item| ['>', '$'].include?(item)}
         fail ArgumentError, 'invalid value for "enum_header_string_array", must include one of >, $'
       end
-      if opts[:'enum_header_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_header_string'])
+      if @api_client.config.client_side_validation && opts[:'enum_header_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_header_string'])
         fail ArgumentError, 'invalid value for "enum_header_string", must be one of _abc, -efg, (xyz)'
       end
-      if opts[:'enum_query_string_array'] && !opts[:'enum_query_string_array'].all?{|item| ['>', '$'].include?(item)}
+      if @api_client.config.client_side_validation && opts[:'enum_query_string_array'] && !opts[:'enum_query_string_array'].all?{|item| ['>', '$'].include?(item)}
         fail ArgumentError, 'invalid value for "enum_query_string_array", must include one of >, $'
       end
-      if opts[:'enum_query_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_query_string'])
+      if @api_client.config.client_side_validation && opts[:'enum_query_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_query_string'])
         fail ArgumentError, 'invalid value for "enum_query_string", must be one of _abc, -efg, (xyz)'
       end
-      if opts[:'enum_query_integer'] && !['1', '-2'].include?(opts[:'enum_query_integer'])
+      if @api_client.config.client_side_validation && opts[:'enum_query_integer'] && !['1', '-2'].include?(opts[:'enum_query_integer'])
         fail ArgumentError, 'invalid value for "enum_query_integer", must be one of 1, -2'
       end
-      if opts[:'enum_query_double'] && !['1.1', '-1.2'].include?(opts[:'enum_query_double'])
+      if @api_client.config.client_side_validation && opts[:'enum_query_double'] && !['1.1', '-1.2'].include?(opts[:'enum_query_double'])
         fail ArgumentError, 'invalid value for "enum_query_double", must be one of 1.1, -1.2'
       end
       # resource path

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -40,7 +40,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: PetApi.add_pet ..."
       end
       # verify the required parameter 'body' is set
-      fail ArgumentError, "Missing the required parameter 'body' when calling PetApi.add_pet" if body.nil?
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling PetApi.add_pet"
+      end
       # resource path
       local_var_path = "/pet"
 
@@ -94,7 +96,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: PetApi.delete_pet ..."
       end
       # verify the required parameter 'pet_id' is set
-      fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.delete_pet" if pet_id.nil?
+      if @api_client.config.client_side_validation && pet_id.nil?
+        fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.delete_pet"
+      end
       # resource path
       local_var_path = "/pet/{petId}".sub('{' + 'petId' + '}', pet_id.to_s)
 
@@ -145,7 +149,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: PetApi.find_pets_by_status ..."
       end
       # verify the required parameter 'status' is set
-      fail ArgumentError, "Missing the required parameter 'status' when calling PetApi.find_pets_by_status" if status.nil?
+      if @api_client.config.client_side_validation && status.nil?
+        fail ArgumentError, "Missing the required parameter 'status' when calling PetApi.find_pets_by_status"
+      end
       # resource path
       local_var_path = "/pet/findByStatus"
 
@@ -197,7 +203,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: PetApi.find_pets_by_tags ..."
       end
       # verify the required parameter 'tags' is set
-      fail ArgumentError, "Missing the required parameter 'tags' when calling PetApi.find_pets_by_tags" if tags.nil?
+      if @api_client.config.client_side_validation && tags.nil?
+        fail ArgumentError, "Missing the required parameter 'tags' when calling PetApi.find_pets_by_tags"
+      end
       # resource path
       local_var_path = "/pet/findByTags"
 
@@ -249,7 +257,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: PetApi.get_pet_by_id ..."
       end
       # verify the required parameter 'pet_id' is set
-      fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.get_pet_by_id" if pet_id.nil?
+      if @api_client.config.client_side_validation && pet_id.nil?
+        fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.get_pet_by_id"
+      end
       # resource path
       local_var_path = "/pet/{petId}".sub('{' + 'petId' + '}', pet_id.to_s)
 
@@ -300,7 +310,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: PetApi.update_pet ..."
       end
       # verify the required parameter 'body' is set
-      fail ArgumentError, "Missing the required parameter 'body' when calling PetApi.update_pet" if body.nil?
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling PetApi.update_pet"
+      end
       # resource path
       local_var_path = "/pet"
 
@@ -356,7 +368,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: PetApi.update_pet_with_form ..."
       end
       # verify the required parameter 'pet_id' is set
-      fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.update_pet_with_form" if pet_id.nil?
+      if @api_client.config.client_side_validation && pet_id.nil?
+        fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.update_pet_with_form"
+      end
       # resource path
       local_var_path = "/pet/{petId}".sub('{' + 'petId' + '}', pet_id.to_s)
 
@@ -414,7 +428,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: PetApi.upload_file ..."
       end
       # verify the required parameter 'pet_id' is set
-      fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.upload_file" if pet_id.nil?
+      if @api_client.config.client_side_validation && pet_id.nil?
+        fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.upload_file"
+      end
       # resource path
       local_var_path = "/pet/{petId}/uploadImage".sub('{' + 'petId' + '}', pet_id.to_s)
 

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -40,7 +40,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: StoreApi.delete_order ..."
       end
       # verify the required parameter 'order_id' is set
-      fail ArgumentError, "Missing the required parameter 'order_id' when calling StoreApi.delete_order" if order_id.nil?
+      if @api_client.config.client_side_validation && order_id.nil?
+        fail ArgumentError, "Missing the required parameter 'order_id' when calling StoreApi.delete_order"
+      end
       # resource path
       local_var_path = "/store/order/{order_id}".sub('{' + 'order_id' + '}', order_id.to_s)
 
@@ -137,12 +139,14 @@ module Petstore
         @api_client.config.logger.debug "Calling API: StoreApi.get_order_by_id ..."
       end
       # verify the required parameter 'order_id' is set
-      fail ArgumentError, "Missing the required parameter 'order_id' when calling StoreApi.get_order_by_id" if order_id.nil?
-      if order_id > 5
+      if @api_client.config.client_side_validation && order_id.nil?
+        fail ArgumentError, "Missing the required parameter 'order_id' when calling StoreApi.get_order_by_id"
+      end
+      if @api_client.config.client_side_validation && order_id > 5
         fail ArgumentError, 'invalid value for "order_id" when calling StoreApi.get_order_by_id, must be smaller than or equal to 5.'
       end
 
-      if order_id < 1
+      if @api_client.config.client_side_validation && order_id < 1
         fail ArgumentError, 'invalid value for "order_id" when calling StoreApi.get_order_by_id, must be greater than or equal to 1.'
       end
 
@@ -196,7 +200,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: StoreApi.place_order ..."
       end
       # verify the required parameter 'body' is set
-      fail ArgumentError, "Missing the required parameter 'body' when calling StoreApi.place_order" if body.nil?
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling StoreApi.place_order"
+      end
       # resource path
       local_var_path = "/store/order"
 

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -40,7 +40,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: UserApi.create_user ..."
       end
       # verify the required parameter 'body' is set
-      fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_user" if body.nil?
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_user"
+      end
       # resource path
       local_var_path = "/user"
 
@@ -90,7 +92,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: UserApi.create_users_with_array_input ..."
       end
       # verify the required parameter 'body' is set
-      fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_users_with_array_input" if body.nil?
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_users_with_array_input"
+      end
       # resource path
       local_var_path = "/user/createWithArray"
 
@@ -140,7 +144,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: UserApi.create_users_with_list_input ..."
       end
       # verify the required parameter 'body' is set
-      fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_users_with_list_input" if body.nil?
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.create_users_with_list_input"
+      end
       # resource path
       local_var_path = "/user/createWithList"
 
@@ -190,7 +196,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: UserApi.delete_user ..."
       end
       # verify the required parameter 'username' is set
-      fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.delete_user" if username.nil?
+      if @api_client.config.client_side_validation && username.nil?
+        fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.delete_user"
+      end
       # resource path
       local_var_path = "/user/{username}".sub('{' + 'username' + '}', username.to_s)
 
@@ -240,7 +248,9 @@ module Petstore
         @api_client.config.logger.debug "Calling API: UserApi.get_user_by_name ..."
       end
       # verify the required parameter 'username' is set
-      fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.get_user_by_name" if username.nil?
+      if @api_client.config.client_side_validation && username.nil?
+        fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.get_user_by_name"
+      end
       # resource path
       local_var_path = "/user/{username}".sub('{' + 'username' + '}', username.to_s)
 
@@ -293,9 +303,13 @@ module Petstore
         @api_client.config.logger.debug "Calling API: UserApi.login_user ..."
       end
       # verify the required parameter 'username' is set
-      fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.login_user" if username.nil?
+      if @api_client.config.client_side_validation && username.nil?
+        fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.login_user"
+      end
       # verify the required parameter 'password' is set
-      fail ArgumentError, "Missing the required parameter 'password' when calling UserApi.login_user" if password.nil?
+      if @api_client.config.client_side_validation && password.nil?
+        fail ArgumentError, "Missing the required parameter 'password' when calling UserApi.login_user"
+      end
       # resource path
       local_var_path = "/user/login"
 
@@ -396,9 +410,13 @@ module Petstore
         @api_client.config.logger.debug "Calling API: UserApi.update_user ..."
       end
       # verify the required parameter 'username' is set
-      fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.update_user" if username.nil?
+      if @api_client.config.client_side_validation && username.nil?
+        fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.update_user"
+      end
       # verify the required parameter 'body' is set
-      fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.update_user" if body.nil?
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.update_user"
+      end
       # resource path
       local_var_path = "/user/{username}".sub('{' + 'username' + '}', username.to_s)
 

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -76,6 +76,11 @@ module Petstore
     # Default to 0 (never times out).
     attr_accessor :timeout
 
+    # Set this to false to skip client side validation in the operation.
+    # Default to true.
+    # @return [true, false]
+    attr_accessor :client_side_validation
+
     ### TLS/SSL setting
     # Set this to false to skip verifying SSL certificate when calling API from https server.
     # Default to true.
@@ -129,6 +134,7 @@ module Petstore
       @api_key = {}
       @api_key_prefix = {}
       @timeout = 0
+      @client_side_validation = true
       @verify_ssl = true
       @verify_ssl_host = true
       @params_encoding = nil

--- a/samples/client/petstore/ruby/petstore.gemspec
+++ b/samples/client/petstore/ruby/petstore.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest', '~> 4.4', '>= 4.4.6'
   s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
   s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'
-  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.11'
+  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
 
   s.files         = `find *`.split("\n").uniq.sort.select{|f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- Add an option in configuration object to skip client validation so that the Ruby API client can be used to perform integration tests with the RESTful backend.
- update dependency "autotest-fsevent" to 0.2.12 to resolve an issue in Mac OS
