### PR TITLE
Add switch in mustache templates to determine Java8 or Java7

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -32,8 +32,14 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#java8}}
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+            {{/java8}}
+            {{^java8}}
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
+            {{/java8}}
         }
 
         // Rename the aar correctly

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -32,8 +32,14 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#java8}}
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+            {{/java8}}
+            {{^java8}}
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
+            {{/java8}}
         }
 
         // Rename the aar correctly

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -32,8 +32,14 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#java8}}
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+            {{/java8}}
+            {{^java8}}
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
+            {{/java8}}
         }
 
         // Rename the aar correctly

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -119,8 +119,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</source>
+          <target>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</target>
         </configuration>
       </plugin>
       <plugin>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -32,8 +32,14 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#java8}}
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+            {{/java8}}
+            {{^java8}}
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
+            {{/java8}}
         }
 
         // Rename the aar correctly

--- a/modules/swagger-codegen/src/main/resources/android/build.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/build.mustache
@@ -36,8 +36,14 @@ android {
         targetSdkVersion 25
     }
     compileOptions {
+        {{#java8}}
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+        {{/java8}}
+        {{^java8}}
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
+        {{/java8}}
     }
 
     // Rename the aar correctly

--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/build.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/build.mustache
@@ -35,8 +35,14 @@ android {
         targetSdkVersion 25
     }
     compileOptions {
+        {{#java8}}
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+        {{/java8}}
+        {{^java8}}
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
+        {{/java8}}
     }
 
     // Rename the aar correctly

--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/pom.mustache
@@ -49,8 +49,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</source>
+          <target>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</target>
         </configuration>
       </plugin>
     </plugins>

--- a/modules/swagger-codegen/src/main/resources/android/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/pom.mustache
@@ -100,8 +100,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</source>
+          <target>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/client/petstore/android/volley/pom.xml
+++ b/samples/client/petstore/android/volley/pom.xml
@@ -49,8 +49,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Use `java8` mustache tag to determine Java version in the output.
