### PR TITLE
[csharp2] Extend generator from AbstractCSharpCodegen

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CsharpDotNet2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CsharpDotNet2ClientCodegen.java
@@ -17,15 +17,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 
-public class CsharpDotNet2ClientCodegen extends DefaultCodegen implements CodegenConfig {
+public class CsharpDotNet2ClientCodegen extends AbstractCSharpCodegen {
     public static final String CLIENT_PACKAGE = "clientPackage";
-    protected String packageName = "IO.Swagger";
-    protected String packageVersion = "1.0.0";
     protected String clientPackage = "IO.Swagger.Client";
-    protected String sourceFolder = "src" + File.separator + "main" + File.separator + "CsharpDotNet2";
     protected String apiDocPath = "docs/"; 
     protected String modelDocPath = "docs/";
-
 
     public CsharpDotNet2ClientCodegen() {
         super();
@@ -34,126 +30,72 @@ public class CsharpDotNet2ClientCodegen extends DefaultCodegen implements Codege
         // at the moment
         importMapping.clear();
 
-        outputFolder = "generated-code" + File.separator + "CsharpDotNet2";
         modelTemplateFiles.put("model.mustache", ".cs");
         apiTemplateFiles.put("api.mustache", ".cs");
-        embeddedTemplateDir = templateDir = "CsharpDotNet2";
-        apiPackage = "IO.Swagger.Api";
-        modelPackage = "IO.Swagger.Model";
+
+        setApiPackage("IO.Swagger.Api");
+        setModelPackage("IO.Swagger.Model");
+        setSourceFolder("src" + File.separator + "main" + File.separator + this.getName());
+
         modelDocTemplateFiles.put("model_doc.mustache", ".md");
         apiDocTemplateFiles.put("api_doc.mustache", ".md");
 
-        setReservedWordsLowerCase(
-                Arrays.asList(
-                    // local variable names in API methods (endpoints)
-                    "path", "queryParams", "headerParams", "formParams", "fileParams", "postBody",
-                    "authSettings", "response", "StatusCode",
-                    // C# reserved word
-                    "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while")
-        );
-
-
-        languageSpecificPrimitives = new HashSet<String>(
-                Arrays.asList(
-                        "String",
-                        "string",
-                        "bool?",
-                        "double?",
-                        "int?",
-                        "long?",
-                        "float?",
-                        "byte[]",
-                        "List",
-                        "Dictionary",
-                        "DateTime?",
-                        "String",
-                        "Boolean",
-                        "Double",
-                        "Integer",
-                        "Long",
-                        "Float",
-                        "Guid?",
-                        "System.IO.Stream", // not really a primitive, we include it to avoid model import
-                        "Object")
-        );
-        instantiationTypes.put("array", "List");
-        instantiationTypes.put("map", "Dictionary");
-
-        typeMapping = new HashMap<String, String>();
-        typeMapping.put("string", "string");
-        typeMapping.put("boolean", "bool?");
-        typeMapping.put("integer", "int?");
-        typeMapping.put("float", "float?");
-        typeMapping.put("long", "long?");
-        typeMapping.put("double", "double?");
-        typeMapping.put("number", "double?");
-        typeMapping.put("datetime", "DateTime?");
-        typeMapping.put("date", "DateTime?");
-        typeMapping.put("file", "System.IO.Stream");
-        typeMapping.put("array", "List");
-        typeMapping.put("list", "List");
-        typeMapping.put("map", "Dictionary");
-        typeMapping.put("object", "Object");
-        typeMapping.put("uuid", "Guid?");
-
         cliOptions.clear();
-        cliOptions.add(new CliOption(CodegenConstants.PACKAGE_NAME, "C# package name (convention: Camel.Case).")
-                .defaultValue("IO.Swagger"));
-        cliOptions.add(new CliOption(CodegenConstants.PACKAGE_VERSION, "C# package version.").defaultValue("1.0.0"));
-        cliOptions.add(new CliOption(CLIENT_PACKAGE, "C# client package name (convention: Camel.Case).")
-                .defaultValue("IO.Swagger.Client"));
+        cliOptions.add(new CliOption(CodegenConstants.PACKAGE_NAME,
+                "C# package name (convention: Camel.Case).")
+                .defaultValue(packageName));
+        cliOptions.add(new CliOption(CodegenConstants.PACKAGE_VERSION,
+                "C# package version.")
+                .defaultValue(packageVersion));
+        cliOptions.add(new CliOption(CLIENT_PACKAGE,
+                "C# client package name (convention: Camel.Case).")
+                .defaultValue(clientPackage));
     }
 
     @Override
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_VERSION)) {
-            setPackageVersion((String) additionalProperties.get(CodegenConstants.PACKAGE_VERSION));
-        } else {
-            additionalProperties.put(CodegenConstants.PACKAGE_VERSION, packageVersion);
-        }
-
-        if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
-            setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
-            apiPackage = packageName + ".Api";
-            modelPackage = packageName + ".Model";
-            clientPackage = packageName + ".Client";
-        } else {
-            additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
-        }
-
         if (additionalProperties.containsKey(CLIENT_PACKAGE)) {
             this.setClientPackage((String) additionalProperties.get(CLIENT_PACKAGE));
         } else {
-            additionalProperties.put(CLIENT_PACKAGE, clientPackage);
+            additionalProperties.put(CLIENT_PACKAGE, getClientPackage());
         }
+
+        final String clientPackage = getClientPackage();
+        final String clientPackagePath = clientPackage.replace(".", java.io.File.separator);
 
         additionalProperties.put("apiDocPath", apiDocPath);
         additionalProperties.put("modelDocPath", modelDocPath);
 
         supportingFiles.add(new SupportingFile("Configuration.mustache",
-                sourceFolder + File.separator + clientPackage.replace(".", java.io.File.separator), "Configuration.cs"));
+                sourceFolder + File.separator + clientPackagePath, "Configuration.cs"));
         supportingFiles.add(new SupportingFile("ApiClient.mustache",
-                sourceFolder + File.separator + clientPackage.replace(".", java.io.File.separator), "ApiClient.cs"));
+                sourceFolder + File.separator + clientPackagePath, "ApiClient.cs"));
         supportingFiles.add(new SupportingFile("ApiException.mustache",
-                sourceFolder + File.separator + clientPackage.replace(".", java.io.File.separator), "ApiException.cs"));
+                sourceFolder + File.separator + clientPackagePath, "ApiException.cs"));
         supportingFiles.add(new SupportingFile("packages.config.mustache", "vendor", "packages.config"));
         supportingFiles.add(new SupportingFile("compile-mono.sh.mustache", "", "compile-mono.sh"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
 
     }
 
+    @Override
+    public String apiPackage() {
+        return packageName + ".Api";
+    }
+
+    @Override
+    public String modelPackage() {
+        return packageName + ".Model";
+    }
+
+    public String getClientPackage(){
+        return packageName + ".Client";
+    }
+
     public void setClientPackage(String clientPackage) {
         this.clientPackage = clientPackage;
-    }
-
-    public void setPackageName(String packageName) {
-        this.packageName = packageName;
-    }
-
-    public void setPackageVersion(String packageVersion) {
-        this.packageVersion = packageVersion;
     }
 
     @Override
@@ -172,14 +114,6 @@ public class CsharpDotNet2ClientCodegen extends DefaultCodegen implements Codege
     }
 
     @Override
-    public String escapeReservedWord(String name) {           
-        if(this.reservedWordsMappings().containsKey(name)) {
-            return this.reservedWordsMappings().get(name);
-        }
-        return "_" + name;
-    }
-
-    @Override
     public String apiFileFolder() {
         return outputFolder + File.separator + sourceFolder + File.separator + apiPackage().replace('.', File.separatorChar);
     }
@@ -187,143 +121,6 @@ public class CsharpDotNet2ClientCodegen extends DefaultCodegen implements Codege
     @Override
     public String modelFileFolder() {
         return outputFolder + File.separator + sourceFolder + File.separator + modelPackage().replace('.', File.separatorChar);
-    }
-
-    @Override
-    public String toVarName(String name) {
-        // replace - with _ e.g. created-at => created_at
-        name = name.replaceAll("-", "_"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
-
-        // if it's all uppper case, do nothing
-        if (name.matches("^[A-Z_]*$")) {
-            return name;
-        }
-
-        // camelize the variable name
-        // pet_id => PetId
-        name = camelize(name);
-
-        // for reserved word or word starting with number, append _
-        if (isReservedWord(name) || name.matches("^\\d.*")) {
-            name = escapeReservedWord(name);
-        }
-
-        return name;
-    }
-
-    @Override
-    public String toParamName(String name) {
-        // replace - with _ e.g. created-at => created_at
-        name = name.replaceAll("-", "_");
-
-        // if it's all uppper case, do nothing
-        if (name.matches("^[A-Z_]*$")) {
-            return name;
-        }
-
-        // camelize(lower) the variable name
-        // pet_id => petId
-        name = camelize(name, true);
-
-        // for reserved word or word starting with number, append _
-        if (isReservedWord(name) || name.matches("^\\d.*")) {
-            name = escapeReservedWord(name);
-        }
-
-        return name;
-    }
-
-    @Override
-    public String toModelName(String name) {
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
-            name = modelNamePrefix + "_" + name;
-        }
-
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
-            name = name + "_" + modelNameSuffix;
-        }
-
-        name = sanitizeName(name);
-
-        // model name cannot use reserved keyword, e.g. return
-        if (isReservedWord(name)) {
-            LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to " + camelize("model_" + name));
-            name = "model_" + name; // e.g. return => ModelReturn (after camelize)
-        }
-
-        // model name starts with number
-        if (name.matches("^\\d.*")) {
-            LOGGER.warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + camelize("model_" + name));
-            name = "model_" + name; // e.g. 200Response => Model200Response (after camelize)
-        }
-
-        // camelize the model name
-        // phone_number => PhoneNumber
-        return camelize(name);
-    }
-
-    @Override
-    public String toModelFilename(String name) {
-        // should be the same as the model name
-        return toModelName(name);
-    }
-
-
-    @Override
-    public String getTypeDeclaration(Property p) {
-        if (p instanceof ArrayProperty) {
-            ArrayProperty ap = (ArrayProperty) p;
-            Property inner = ap.getItems();
-            return getSwaggerType(p) + "<" + getTypeDeclaration(inner) + ">";
-        } else if (p instanceof MapProperty) {
-            MapProperty mp = (MapProperty) p;
-            Property inner = mp.getAdditionalProperties();
-
-            return getSwaggerType(p) + "<String, " + getTypeDeclaration(inner) + ">";
-        }
-        return super.getTypeDeclaration(p);
-    }
-
-    @Override
-    public String getSwaggerType(Property p) {
-        String swaggerType = super.getSwaggerType(p);
-        String type = null;
-        if (typeMapping.containsKey(swaggerType.toLowerCase())) {
-            type = typeMapping.get(swaggerType.toLowerCase());
-            if (languageSpecificPrimitives.contains(type)) {
-                return type;
-            }
-        } else {
-            type = swaggerType;
-        }
-        return toModelName(type);
-    }
-
-    @Override
-    public String toOperationId(String operationId) {
-        // throw exception if method name is empty (should not occur as an auto-generated method name will be used)
-        if (StringUtils.isEmpty(operationId)) {
-            throw new RuntimeException("Empty method name (operationId) not allowed");
-        }
-
-        // method name cannot use reserved keyword, e.g. return
-        if (isReservedWord(operationId)) {
-            LOGGER.warn(operationId + " (reserved word) cannot be used as method name. Renamed to " + camelize(sanitizeName("call_" + operationId)));
-            operationId = "call_" + operationId;
-        }
-
-        return camelize(sanitizeName(operationId));
-    }
-
-    @Override
-    public String escapeQuotationMark(String input) {
-        // remove " to avoid code injection
-        return input.replace("\"", "");
-    }
-
-    @Override
-    public String escapeUnsafeCharacters(String input) {
-        return input.replace("*/", "*_/").replace("/*", "/_*");
     }
 
     @Override

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/ApiResponse.md
@@ -3,9 +3,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int?** |  | [optional] [default to null]
-**Type** | **string** |  | [optional] [default to null]
-**Message** | **string** |  | [optional] [default to null]
+**Code** | **int?** |  | [optional] 
+**Type** | **string** |  | [optional] 
+**Message** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/Category.md
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/Category.md
@@ -3,8 +3,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] [default to null]
-**Name** | **string** |  | [optional] [default to null]
+**Id** | **long?** |  | [optional] 
+**Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/Order.md
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/Order.md
@@ -3,12 +3,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] [default to null]
-**PetId** | **long?** |  | [optional] [default to null]
-**Quantity** | **int?** |  | [optional] [default to null]
-**ShipDate** | **DateTime?** |  | [optional] [default to null]
-**Status** | **string** | Order Status | [optional] [default to null]
-**Complete** | **bool?** |  | [optional] [default to null]
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
+**Status** | **string** | Order Status | [optional] 
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/Pet.md
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/Pet.md
@@ -3,12 +3,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] [default to null]
-**Category** | [**Category**](Category.md) |  | [optional] [default to null]
-**Name** | **string** |  | [default to null]
-**PhotoUrls** | **List&lt;string&gt;** |  | [default to null]
-**Tags** | [**List&lt;Tag&gt;**](Tag.md) |  | [optional] [default to null]
-**Status** | **string** | pet status in the store | [optional] [default to null]
+**Id** | **long?** |  | [optional] 
+**Category** | [**Category**](Category.md) |  | [optional] 
+**Name** | **string** |  | 
+**PhotoUrls** | **List&lt;string&gt;** |  | 
+**Tags** | [**List&lt;Tag&gt;**](Tag.md) |  | [optional] 
+**Status** | **string** | pet status in the store | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/StoreApi.md
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/StoreApi.md
@@ -73,7 +73,7 @@ No authorization required
 
 <a name="getinventory"></a>
 # **GetInventory**
-> Dictionary<String, int?> GetInventory ()
+> Dictionary<string, int?> GetInventory ()
 
 Returns pet inventories by status
 
@@ -104,7 +104,7 @@ namespace Example
             try
             {
                 // Returns pet inventories by status
-                Dictionary&lt;String, int?&gt; result = apiInstance.GetInventory();
+                Dictionary&lt;string, int?&gt; result = apiInstance.GetInventory();
                 Debug.WriteLine(result);
             }
             catch (Exception e)
@@ -121,7 +121,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-**Dictionary<String, int?>**
+**Dictionary<string, int?>**
 
 ### Authorization
 

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/Tag.md
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/Tag.md
@@ -3,8 +3,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] [default to null]
-**Name** | **string** |  | [optional] [default to null]
+**Id** | **long?** |  | [optional] 
+**Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/User.md
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/docs/User.md
@@ -3,14 +3,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] [default to null]
-**Username** | **string** |  | [optional] [default to null]
-**FirstName** | **string** |  | [optional] [default to null]
-**LastName** | **string** |  | [optional] [default to null]
-**Email** | **string** |  | [optional] [default to null]
-**Password** | **string** |  | [optional] [default to null]
-**Phone** | **string** |  | [optional] [default to null]
-**UserStatus** | **int?** | User Status | [optional] [default to null]
+**Id** | **long?** |  | [optional] 
+**Username** | **string** |  | [optional] 
+**FirstName** | **string** |  | [optional] 
+**LastName** | **string** |  | [optional] 
+**Email** | **string** |  | [optional] 
+**Password** | **string** |  | [optional] 
+**Phone** | **string** |  | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-dotnet2/SwaggerClientTest/Lib/SwaggerClient/src/main/CsharpDotNet2/IO/Swagger/Api/StoreApi.cs
@@ -20,8 +20,8 @@ namespace IO.Swagger.Api
         /// <summary>
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
-        /// <returns>Dictionary&lt;String, int?&gt;</returns>
-        Dictionary<String, int?> GetInventory ();
+        /// <returns>Dictionary&lt;string, int?&gt;</returns>
+        Dictionary<string, int?> GetInventory ();
         /// <summary>
         /// Find purchase order by ID For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
         /// </summary>
@@ -129,8 +129,8 @@ namespace IO.Swagger.Api
         /// <summary>
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
-        /// <returns>Dictionary&lt;String, int?&gt;</returns>            
-        public Dictionary<String, int?> GetInventory ()
+        /// <returns>Dictionary&lt;string, int?&gt;</returns>            
+        public Dictionary<string, int?> GetInventory ()
         {
             
     
@@ -155,7 +155,7 @@ namespace IO.Swagger.Api
             else if (((int)response.StatusCode) == 0)
                 throw new ApiException ((int)response.StatusCode, "Error calling GetInventory: " + response.ErrorMessage, response.ErrorMessage);
     
-            return (Dictionary<String, int?>) ApiClient.Deserialize(response.Content, typeof(Dictionary<String, int?>), response.Headers);
+            return (Dictionary<string, int?>) ApiClient.Deserialize(response.Content, typeof(Dictionary<string, int?>), response.Headers);
         }
     
         /// <summary>


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.


see #5138

This is the start of consolidation efforts of C# 2.0 to the greater C# client generator code.

There is further discussion in the issue related to maintainability of combining C# 2.0 code into the newer code. For example, current users of both generators have the option to extend built-in templates to enhance the generator for their use case. This means users of `CsharpDotNet2` as well as `csharp` may have a file called `api.mustache`. The `CsharpDotNet2` version of the file is extremely basic because C# 2.0 doesn't support many of the advanced features that C# 3.0 and higher support. One option is to introduce extensive conditions into the logicless mustache template, which I think would reduce maintainability. Another option is to rename the file from `api.mustache` to `api_2_0.mustache` or something similar, which would be a breaking change. I don't feel that either option is a maintenance gain. This goes for all template files in the `CsharpDotNet2` generator.

For the above reason, this PR simply offloads some of the duplicated logic to the abstract generator class.