### PR TITLE
[generator] Adds a .swagger/VERSION file for all generators

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -3,6 +3,7 @@ package io.swagger.codegen;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import io.swagger.codegen.ignore.CodegenIgnoreProcessor;
+import io.swagger.codegen.utils.ImplementationVersion;
 import io.swagger.models.*;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
@@ -126,8 +127,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         }
         config.processOpts();
         config.preprocessSwagger(swagger);
-        // TODO need to obtain version from a file instead of hardcoding it
-        config.additionalProperties().put("generatorVersion", "2.2.3-SNAPSHOT");
+        config.additionalProperties().put("generatorVersion", ImplementationVersion.read());
         config.additionalProperties().put("generatedDate", DateTime.now().toString());
         config.additionalProperties().put("generatorClass", config.getClass().getName());
         config.additionalProperties().put("inputSpec", config.getInputSpec());
@@ -579,6 +579,15 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 throw new RuntimeException("Could not generate supporting file '" + swaggerCodegenIgnore + "'", e);
             }
             files.add(ignoreFile);
+        }
+
+        final String swaggerVersionMetadata = config.outputFolder() + File.separator + ".swagger" + File.separator + "VERSION";
+        File swaggerVersionMetadataFile = new File(swaggerVersionMetadata);
+        try {
+            writeToFile(swaggerVersionMetadata, ImplementationVersion.read());
+            files.add(swaggerVersionMetadataFile);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not generate supporting file '" + swaggerVersionMetadata + "'", e);
         }
 
         /*

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/ImplementationVersion.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/utils/ImplementationVersion.java
@@ -1,0 +1,13 @@
+package io.swagger.codegen.utils;
+
+public class ImplementationVersion {
+    public static String read() {
+        // Assumes this version is required at runtime. This could be modified to use a properties file like the CLI.
+        String compiledVersion = ImplementationVersion.class.getPackage().getImplementationVersion();
+        if(compiledVersion != null) {
+            return compiledVersion;
+        }
+
+        return "unset";
+    }
+}


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.


see #2183

This adds a new file at `.swagger/VERSION` which holds the swagger-codegen.jar's implementation version.