### PR TITLE
[Erlang] Plant CI for server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,10 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq bats
   - sudo apt-get install -qq curl
-  # Add rebar3 build tool for Erlang petstore server tests. Travis CI does not support rebar3 [yet](https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490).
+  # Add rebar3 build tool and recent Erlang/OTP for Erlang petstore server tests.
+  # - Travis CI does not support rebar3 [yet](https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490).
+  # - Rely on `kerl` for [pre-compiled versions available](https://docs.travis-ci.com/user/languages/erlang#Choosing-OTP-releases-to-test-against). Rely on installation path chosen by [`travis-erlang-builder`](https://github.com/travis-ci/travis-erlang-builder/blob/e6d016b1a91ca7ecac5a5a46395bde917ea13d36/bin/compile#L18).
+  - . ~/otp/18.2.1/activate && erl -version
   - curl -f -L -o ./rebar3 https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3 && ./rebar3 version && export PATH="${TRAVIS_BUILD_DIR}:$PATH"
 
   # show host table to confirm petstore.swagger.io is mapped to localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq bats
   - sudo apt-get install -qq curl
+  # Add rebar3 build tool for Erlang petstore server tests. Travis CI does not support rebar3 [yet](https://github.com/travis-ci/travis-ci/issues/6506#issuecomment-275189490).
+  - curl -f -L -o ./rebar3 https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3 && ./rebar3 version && export PATH="${TRAVIS_BUILD_DIR}:$PATH"
 
   # show host table to confirm petstore.swagger.io is mapped to localhost
   - cat /etc/hosts

--- a/modules/swagger-codegen/src/main/resources/erlang-server/rebar.config.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/rebar.config.mustache
@@ -1,4 +1,4 @@
 {deps, [
-    {jsx, {git, "https://github.com/talentdeficit/jsx.git", {branch, "v2.8.0"}}},
+    {jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.2"}}},
     {jesse, {git, "https://github.com/for-GET/jesse.git", {tag, "1.4.0"}}}
 ]}.

--- a/pom.xml
+++ b/pom.xml
@@ -839,7 +839,7 @@
                 <module>samples/server/petstore/jaxrs-cxf-cdi</module>
                 <module>samples/server/petstore/jaxrs-cxf-non-spring-app</module>
                 <!--<module>samples/server/petstore/java-msf4j</module> note: JDK8 only -->
-                <module>samples/server/petstore/erlang-server</module>
+                <!-- <module>samples/server/petstore/erlang-server</module> note: make sample compilation work -->
             </modules>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -839,6 +839,7 @@
                 <module>samples/server/petstore/jaxrs-cxf-cdi</module>
                 <module>samples/server/petstore/jaxrs-cxf-non-spring-app</module>
                 <!--<module>samples/server/petstore/java-msf4j</module> note: JDK8 only -->
+                <module>samples/server/petstore/erlang-server</module>
             </modules>
         </profile>
     </profiles>

--- a/samples/server/petstore/erlang-server/pom.xml
+++ b/samples/server/petstore/erlang-server/pom.xml
@@ -1,0 +1,46 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.swagger</groupId>
+    <artifactId>ErlangServerTests</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Erlang Petstore Server</name>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>Erlang Test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>rebar3</executable>
+                            <arguments>
+                                <argument>compile</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/samples/server/petstore/erlang-server/priv/swagger.json
+++ b/samples/server/petstore/erlang-server/priv/swagger.json
@@ -108,8 +108,8 @@
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "available", "pending", "sold" ],
-            "default" : "available"
+            "default" : "available",
+            "enum" : [ "available", "pending", "sold" ]
           },
           "collectionFormat" : "csv"
         } ],

--- a/samples/server/petstore/erlang-server/rebar.config
+++ b/samples/server/petstore/erlang-server/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-    {jsx, {git, "https://github.com/talentdeficit/jsx.git", {branch, "v2.8.0"}}},
+    {jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.2"}}},
     {jesse, {git, "https://github.com/for-GET/jesse.git", {tag, "1.4.0"}}}
 ]}.


### PR DESCRIPTION
This PR is not ready to be merged yet, and opened for receiving comments (RFC).

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
  - [x] `bin/erlang-petstore-server.sh`
  - (There is no erlang-server related script in `./bin/security/`)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR plants CI for erlang-server. A related issue seems to be #3762

This PR tests that the sample compiles, that can be considered a very basic test.

I see the current version of the code generation leaves functions syntactically invalid - i.e. no body at all rather than e.g. raising a runtime error - hence the code will not compile. I suggest - and I plan to implement if I find time - the way forward is populating the (generated) body with `error(unimplemented)` and the "correct" separator/terminator i.e. `;` or `.`. Any comments?