### PR TITLE
Fix for issue #5349.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.module.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.module.mustache
@@ -16,10 +16,10 @@ import { {{classname}} } from './{{importPath}}';
   providers:    [ {{#apiInfo}}{{#apis}}{{classname}}{{#hasMore}}, {{/hasMore}}{{/apis}}{{/apiInfo}} ]
 })
 export class ApiModule {
-    public static forConfig(configuration: Configuration): ModuleWithProviders {
+    public static forConfig(configurationFactory: () => Configuration): ModuleWithProviders {
         return {
             ngModule: ApiModule,
-            providers: [ {provide: Configuration, useValue: configuration}]
+            providers: [ {provide: Configuration, useFactory: configurationFactory}]
         }
     }
 }

--- a/samples/client/petstore/typescript-angular2/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular2/default/api.module.ts
@@ -14,10 +14,10 @@ import { UserService } from './api/user.service';
   providers:    [ PetService, StoreService, UserService ]
 })
 export class ApiModule {
-    public static forConfig(configuration: Configuration): ModuleWithProviders {
+    public static forConfig(configurationFactory: () => Configuration): ModuleWithProviders {
         return {
             ngModule: ApiModule,
-            providers: [ {provide: Configuration, useValue: configuration}]
+            providers: [ {provide: Configuration, useFactory: configurationFactory}]
         }
     }
 }

--- a/samples/client/petstore/typescript-angular2/npm/api.module.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api.module.ts
@@ -14,10 +14,10 @@ import { UserService } from './api/user.service';
   providers:    [ PetService, StoreService, UserService ]
 })
 export class ApiModule {
-    public static forConfig(configuration: Configuration): ModuleWithProviders {
+    public static forConfig(configurationFactory: () => Configuration): ModuleWithProviders {
         return {
             ngModule: ApiModule,
-            providers: [ {provide: Configuration, useValue: configuration}]
+            providers: [ {provide: Configuration, useFactory: configurationFactory}]
         }
     }
 }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

With this change, users providing custom configuration must provide an exported Configuration factory, rather than just an object. This is needed to be Angular AoT compatible.

Example use:
```
import * as api from '../api';

/** Configuration settings for the backend API */
export function backendConfigurationFactory(): api.Configuration {
    return new api.Configuration({basePath: '/api'});
}

@NgModule({
    imports: [api.ApiModule.forConfig(backendConfigurationFactory)],
```

