### PR TITLE
Run all the CLI commands in the Docker environment

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ JAVA_OPTS=${JAVA_OPTS:-"-Xmx1024M -DloggerPath=conf/log4j.properties"}
 codegen="${GEN_DIR}/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"
 
 case "$1" in
-    generate|help|langs|meta|config-help)
+    generate|help|langs|meta|config-help|validate|version)
         # If ${GEN_DIR} has been mapped elsewhere from default, and that location has not been built
         if [[ ! -f "${codegen}" ]]; then
             (cd ${GEN_DIR} && exec mvn -am -pl "modules/swagger-codegen-cli" package)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,11 +14,11 @@ pattern="@Command(name = \"$1\""
 if expr "x$1" : 'x[a-z][a-z-]*$' > /dev/null && fgrep -qe "$pattern" "$cmdsrc"/*.java; then
     # If ${GEN_DIR} has been mapped elsewhere from default, and that location has not been built
     if [[ ! -f "${codegen}" ]]; then
-        (cd ${GEN_DIR} && exec mvn -am -pl "modules/swagger-codegen-cli" package)
+        (cd "${GEN_DIR}" && exec mvn -am -pl "modules/swagger-codegen-cli" package)
     fi
     command=$1
     shift
-    exec java ${JAVA_OPTS} -jar ${codegen} ${command} "$@"
+    exec java ${JAVA_OPTS} -jar "${codegen}" "${command}" "$@"
 else
     exec "$@"
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,19 +6,19 @@ set -euo pipefail
 GEN_DIR=${GEN_DIR:-/opt/swagger-codegen}
 JAVA_OPTS=${JAVA_OPTS:-"-Xmx1024M -DloggerPath=conf/log4j.properties"}
 
-codegen="${GEN_DIR}/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"
+cli="${GEN_DIR}/modules/swagger-codegen-cli"
+codegen="${cli}/target/swagger-codegen-cli.jar"
+cmdsrc="${cli}/src/main/java/io/swagger/codegen/cmd"
 
-case "$1" in
-    generate|help|langs|meta|config-help|validate|version)
-        # If ${GEN_DIR} has been mapped elsewhere from default, and that location has not been built
-        if [[ ! -f "${codegen}" ]]; then
-            (cd ${GEN_DIR} && exec mvn -am -pl "modules/swagger-codegen-cli" package)
-        fi
-        command=$1
-        shift
-        exec java ${JAVA_OPTS} -jar ${codegen} ${command} "$@"
-        ;;
-    *)  # Any other commands, e.g. docker run imagename ls -la or docker run -it imagename /bin/bash
-        exec "$@"
-        ;;
-esac
+pattern="@Command(name = \"$1\""
+if expr "x$1" : 'x[a-z][a-z-]*$' > /dev/null && fgrep -qe "$pattern" "$cmdsrc"/*.java; then
+    # If ${GEN_DIR} has been mapped elsewhere from default, and that location has not been built
+    if [[ ! -f "${codegen}" ]]; then
+        (cd ${GEN_DIR} && exec mvn -am -pl "modules/swagger-codegen-cli" package)
+    fi
+    command=$1
+    shift
+    exec java ${JAVA_OPTS} -jar ${codegen} ${command} "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Hi,

Thanks for developing and maintaining Swagger!

Yesterday I found that I could not run "validate" in Docker, so I made a trivial change to allow the "validate" and "version" commands in the docker-environment shell script.  Then it occured to me that it would not be so hard to check if the CLI can handle an arbitrary command, and then a couple of unquoted shell variables caught my eye.

Thanks in advance, and keep up the great work!

G'luck,
Peter
