### PR TITLE
[typescript-angular2] change OpaqueToken to InjectionToken<string> (Issue #5565)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -26,10 +26,13 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
     public static final String NPM_VERSION = "npmVersion";
     public static final String NPM_REPOSITORY = "npmRepository";
     public static final String SNAPSHOT = "snapshot";
+    public static final String USE_OPAQUE_TOKEN = "useOpaqueToken";
+    public static final String INJECTION_TOKEN = "injectionToken";
 
     protected String npmName = null;
     protected String npmVersion = "1.0.0";
     protected String npmRepository = null;
+    protected String injectionToken = "InjectionToken<string>";
 
     public TypeScriptAngular2ClientCodegen() {
         super();
@@ -47,6 +50,7 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
         this.cliOptions.add(new CliOption(NPM_VERSION, "The version of your npm package"));
         this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(SNAPSHOT, "When setting this property to true the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm", BooleanProperty.TYPE).defaultValue(Boolean.FALSE.toString()));
+        this.cliOptions.add(new CliOption(USE_OPAQUE_TOKEN, "When setting this property to true, OpaqueToken is used instead of InjectionToken", BooleanProperty.TYPE).defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override
@@ -79,6 +83,11 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
         if(additionalProperties.containsKey(NPM_NAME)) {
             addNpmPackageGeneration();
         }
+
+        if(additionalProperties.containsKey(USE_OPAQUE_TOKEN) && Boolean.valueOf(additionalProperties.get(USE_OPAQUE_TOKEN).toString())) {
+            this.setOpaqueToken();
+        }
+        additionalProperties.put(INJECTION_TOKEN, this.injectionToken);
     }
 
     private void addNpmPackageGeneration() {
@@ -233,5 +242,9 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
 
     public void setNpmRepository(String npmRepository) {
         this.npmRepository = npmRepository;
+    }
+
+    public void setOpaqueToken() {
+        this.injectionToken = "OpaqueToken";
     }
 }

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/variables.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/variables.mustache
@@ -1,6 +1,6 @@
-import { OpaqueToken } from '@angular/core';
+import { {{{injectionToken}}} } from '@angular/core';
 
-export const BASE_PATH = new OpaqueToken('basePath');
+export const BASE_PATH = new {{{injectionToken}}}('basePath');
 export const COLLECTION_FORMATS = {
     'csv': ',',
     'tsv': '   ',

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAngular2ClientOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/TypeScriptAngular2ClientOptionsProvider.java
@@ -35,6 +35,7 @@ public class TypeScriptAngular2ClientOptionsProvider implements OptionsProvider 
                 .put(TypeScriptAngular2ClientCodegen.SNAPSHOT, Boolean.FALSE.toString())
                 .put(TypeScriptAngular2ClientCodegen.NPM_REPOSITORY, NPM_REPOSITORY)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
+                .put(TypeScriptAngular2ClientCodegen.USE_OPAQUE_TOKEN, Boolean.FALSE.toString())
                 .build();
     }
 

--- a/samples/client/petstore-security-test/typescript-angular2/api/FakeApi.ts
+++ b/samples/client/petstore-security-test/typescript-angular2/api/FakeApi.ts
@@ -91,9 +91,9 @@ export class FakeApi {
             method: RequestMethod.Put,
             headers: headers,
             body: formParams.toString(),
-            search: queryParameters
+            search: queryParameters,
+            withCredentials:this.configuration.withCredentials
         });
-
         // https://github.com/swagger-api/swagger-codegen/issues/4037
         if (extraHttpRequestParams) {
             requestOptions = (<any>Object).assign(requestOptions, extraHttpRequestParams);

--- a/samples/client/petstore-security-test/typescript-angular2/configuration.ts
+++ b/samples/client/petstore-security-test/typescript-angular2/configuration.ts
@@ -3,4 +3,5 @@ export class Configuration {
     username: string;
     password: string;
     accessToken: string | (() => string);
+    withCredentials: boolean;
 }

--- a/samples/client/petstore-security-test/typescript-angular2/variables.ts
+++ b/samples/client/petstore-security-test/typescript-angular2/variables.ts
@@ -1,6 +1,6 @@
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken<string> } from '@angular/core';
 
-export const BASE_PATH = new OpaqueToken('basePath');
+export const BASE_PATH = new InjectionToken<string>('basePath');
 export const COLLECTION_FORMATS = {
     'csv': ',',
     'tsv': '   ',

--- a/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/PetApi.ts
@@ -396,6 +396,11 @@ export class PetApi {
             'application/xml'
         ];
 
+        // authentication (api_key) required
+        if (this.configuration.apiKey) {
+            headers.set('api_key', this.configuration.apiKey);
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -403,11 +408,6 @@ export class PetApi {
                 ? this.configuration.accessToken()
                 : this.configuration.accessToken;
             headers.set('Authorization', 'Bearer ' + accessToken);
-        }
-
-        // authentication (api_key) required
-        if (this.configuration.apiKey) {
-            headers.set('api_key', this.configuration.apiKey);
         }
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({

--- a/samples/client/petstore/typescript-angular2/default/variables.ts
+++ b/samples/client/petstore/typescript-angular2/default/variables.ts
@@ -1,6 +1,6 @@
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken<string> } from '@angular/core';
 
-export const BASE_PATH = new OpaqueToken('basePath');
+export const BASE_PATH = new InjectionToken<string>('basePath');
 export const COLLECTION_FORMATS = {
     'csv': ',',
     'tsv': '   ',

--- a/samples/client/petstore/typescript-angular2/npm/README.md
+++ b/samples/client/petstore/typescript-angular2/npm/README.md
@@ -1,4 +1,4 @@
-## @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704272137
+## @swagger/angular2-typescript-petstore@0.0.1
 
 ### Building
 
@@ -19,7 +19,7 @@ navigate to the folder of your consuming project and run one of next commando's.
 _published:_
 
 ```
-npm install @swagger/angular2-typescript-petstore@0.0.1-SNAPSHOT.201704272137 --save
+npm install @swagger/angular2-typescript-petstore@0.0.1 --save
 ```
 
 _unPublished (not recommended):_

--- a/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/PetApi.ts
@@ -396,6 +396,11 @@ export class PetApi {
             'application/xml'
         ];
 
+        // authentication (api_key) required
+        if (this.configuration.apiKey) {
+            headers.set('api_key', this.configuration.apiKey);
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -403,11 +408,6 @@ export class PetApi {
                 ? this.configuration.accessToken()
                 : this.configuration.accessToken;
             headers.set('Authorization', 'Bearer ' + accessToken);
-        }
-
-        // authentication (api_key) required
-        if (this.configuration.apiKey) {
-            headers.set('api_key', this.configuration.apiKey);
         }
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swagger/angular2-typescript-petstore",
-  "version": "0.0.1-SNAPSHOT.201704272137",
+  "version": "0.0.1",
   "description": "swagger client for @swagger/angular2-typescript-petstore",
   "author": "Swagger Codegen Contributors",
   "keywords": [

--- a/samples/client/petstore/typescript-angular2/npm/variables.ts
+++ b/samples/client/petstore/typescript-angular2/npm/variables.ts
@@ -1,6 +1,6 @@
-import { OpaqueToken } from '@angular/core';
+import { InjectionToken<string> } from '@angular/core';
 
-export const BASE_PATH = new OpaqueToken('basePath');
+export const BASE_PATH = new InjectionToken<string>('basePath');
 export const COLLECTION_FORMATS = {
     'csv': ',',
     'tsv': '   ',


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- Issue #5565
- Change `OpaqueToken` to `InjectionToken<string>`
- Provide `useOpaqueToken` option for backward compatibility
