### PR TITLE
Modifying resty dependency to use stable release instead of HEAD

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/api_client.mustache
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"net/url"
 	"io/ioutil"
-	"github.com/go-resty/resty"
+	"gopkg.in/go-resty/resty.v0"
 )
 
 type APIClient struct {

--- a/samples/client/petstore-security-test/go/api_client.go
+++ b/samples/client/petstore-security-test/go/api_client.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"net/url"
 	"io/ioutil"
-	"github.com/go-resty/resty"
+	"gopkg.in/go-resty/resty.v0"
 )
 
 type APIClient struct {

--- a/samples/client/petstore/go/go-petstore/api_client.go
+++ b/samples/client/petstore/go/go-petstore/api_client.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"net/url"
 	"io/ioutil"
-	"github.com/go-resty/resty"
+	"gopkg.in/go-resty/resty.v0"
 )
 
 type APIClient struct {

--- a/samples/client/petstore/go/pom.xml
+++ b/samples/client/petstore/go/pom.xml
@@ -50,7 +50,7 @@
                             <executable>go</executable>
                             <arguments>
                                 <argument>get</argument>
-                                <argument>github.com/go-resty/resty</argument>
+                                <argument>gopkg.in/go-resty/resty.v0</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Fixes #5578
Users will have to run `go get ./...` again after generating the golang client, as the dependency now tracks the `resty` stable release instead of the HEAD of resty's repository master.
