### PR TITLE
Fix#5510

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -180,14 +180,8 @@ void
     {{/returnType}}
     worker->deleteLater();
 
-    {{#returnType}}
-    emit {{nickname}}Signal(output);
-    emit {{nickname}}Signal(output,error_type,error_str);
-    {{/returnType}}
-    {{^returnType}}
-    emit {{nickname}}Signal();
-    emit {{nickname}}Signal(error_type,error_str);
-    {{/returnType}}
+    emit {{nickname}}Signal({{#returnType}}output{{/returnType}});
+    emit {{nickname}}SignalE({{#returnType}}output, {{/returnType}}error_type, error_str);
 }
 
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -90,7 +90,8 @@ void
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "{{httpMethod}}");
 
-    {{#formParams}}if ({{paramName}} != nullptr) {
+    {{#formParams}}
+    if ({{paramName}} != nullptr) {
         {{^isFile}}input.add_var("{{baseName}}", *{{paramName}});{{/isFile}}{{#isFile}}input.add_file("{{baseName}}", (*{{paramName}}).local_filename, (*{{paramName}}).request_filename, (*{{paramName}}).mime_type);{{/isFile}}
     }
     {{/formParams}}
@@ -128,7 +129,6 @@ void
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -136,7 +136,8 @@ void
         msg = "Error: " + worker->error_str;
     }
 
-    {{#returnType}}{{#isListContainer}}
+    {{#returnType}}
+    {{#isListContainer}}
     {{{returnType}}} output = {{{defaultResponse}}};
     QString json(worker->response);
     QByteArray array (json.toStdString().c_str());
@@ -152,12 +153,12 @@ void
     }
     {{/isListContainer}}
 
-    {{^isListContainer}}{{#returnTypeIsPrimitive}}
+    {{^isListContainer}}
+    {{#returnTypeIsPrimitive}}
     {{{returnType}}} output;  // TODO add primitive output support
     {{/returnTypeIsPrimitive}}
     {{#isMapContainer}} 
     {{{returnType}}} output = {{{defaultResponse}}};
-
     QString json(worker->response);
     QByteArray array (json.toStdString().c_str());
     QJsonDocument doc = QJsonDocument::fromJson(array);
@@ -168,14 +169,15 @@ void
         setValue(&val, obj[key], "{{returnBaseType}}", "");
         output->insert(key, *val);
     }
-
     {{/isMapContainer}}
     {{^isMapContainer}}
-    {{^returnTypeIsPrimitive}}QString json(worker->response);
+    {{^returnTypeIsPrimitive}}
+    QString json(worker->response);
     {{{returnType}}} output = static_cast<{{{returnType}}}>(create(json, QString("{{{returnBaseType}}}")));
     {{/returnTypeIsPrimitive}}
     {{/isMapContainer}}
-    {{/isListContainer}}{{/returnType}}
+    {{/isListContainer}}
+    {{/returnType}}
     worker->deleteLater();
 
     {{#returnType}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-body.mustache
@@ -125,6 +125,10 @@ void
 void
 {{classname}}::{{nickname}}Callback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -165,7 +169,6 @@ void
         output->insert(key, *val);
     }
 
-
     {{/isMapContainer}}
     {{^isMapContainer}}
     {{^returnTypeIsPrimitive}}QString json(worker->response);
@@ -173,12 +176,18 @@ void
     {{/returnTypeIsPrimitive}}
     {{/isMapContainer}}
     {{/isListContainer}}{{/returnType}}
-
     worker->deleteLater();
 
-    {{#returnType}}emit {{nickname}}Signal(output);{{/returnType}}
-    {{^returnType}}emit {{nickname}}Signal();{{/returnType}}
+    {{#returnType}}
+    emit {{nickname}}Signal(output);
+    emit {{nickname}}Signal(output,error_type,error_str);
+    {{/returnType}}
+    {{^returnType}}
+    emit {{nickname}}Signal();
+    emit {{nickname}}Signal(error_type,error_str);
+    {{/returnType}}
 }
+
 {{/operation}}
 {{/operations}}
 

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-header.mustache
@@ -30,8 +30,18 @@ private:
     {{#operations}}{{#operation}}void {{nickname}}Callback (HttpRequestWorker * worker);
     {{/operation}}{{/operations}}
 signals:
-    {{#operations}}{{#operation}}void {{nickname}}Signal({{#returnType}}{{{returnType}}} summary{{/returnType}});
-    {{/operation}}{{/operations}}
+    {{#operations}}
+    {{#operation}}
+    {{#returnType}}
+    void {{nickname}}Signal({{{returnType}}} summary);
+    void {{nickname}}Signal({{{returnType}}} summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    {{/returnType}}
+    {{^returnType}}
+    void {{nickname}}Signal();
+    void {{nickname}}Signal(QNetworkReply::NetworkError error_type, QString& error_str);
+    {{/returnType}}
+    {{/operation}}
+    {{/operations}}
 };
 
 {{#cppNamespaceDeclarations}}

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/api-header.mustache
@@ -30,18 +30,10 @@ private:
     {{#operations}}{{#operation}}void {{nickname}}Callback (HttpRequestWorker * worker);
     {{/operation}}{{/operations}}
 signals:
-    {{#operations}}
-    {{#operation}}
-    {{#returnType}}
-    void {{nickname}}Signal({{{returnType}}} summary);
-    void {{nickname}}Signal({{{returnType}}} summary, QNetworkReply::NetworkError error_type, QString& error_str);
-    {{/returnType}}
-    {{^returnType}}
-    void {{nickname}}Signal();
-    void {{nickname}}Signal(QNetworkReply::NetworkError error_type, QString& error_str);
-    {{/returnType}}
-    {{/operation}}
-    {{/operations}}
+    {{#operations}}{{#operation}}void {{nickname}}Signal({{#returnType}}{{{returnType}}} summary{{/returnType}});
+    {{/operation}}{{/operations}}
+    {{#operations}}{{#operation}}void {{nickname}}SignalE({{#returnType}}{{{returnType}}} summary, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str);
+    {{/operation}}{{/operations}}
 };
 
 {{#cppNamespaceDeclarations}}

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGFakeApi.cpp
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGFakeApi.cpp
@@ -56,6 +56,9 @@ SWGFakeApi::testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \r(QString* test_c
 void
 SWGFakeApi::testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -63,12 +66,11 @@ SWGFakeApi::testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rCallback(HttpReq
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rSignal();
+    emit testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rSignalE(error_type, error_str);
 }
+
 
 }

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGFakeApi.h
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGFakeApi.h
@@ -40,6 +40,8 @@ private:
 signals:
     void testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rSignal();
     
+    void testCodeInject */ &#39; &quot; &#x3D;end  \r\n \n \rSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    
 };
 
 }

--- a/samples/client/petstore/qt5cpp/client/SWGPetApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGPetApi.cpp
@@ -38,7 +38,7 @@ SWGPetApi::addPet(SWGPet body) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "POST");
 
-    
+
     QString output = body.asJson();
     input.request_body.append(output);
     
@@ -55,6 +55,9 @@ SWGPetApi::addPet(SWGPet body) {
 void
 SWGPetApi::addPetCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -62,13 +65,12 @@ SWGPetApi::addPetCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit addPetSignal();
+    emit addPetSignalE(error_type, error_str);
 }
+
 void
 SWGPetApi::deletePet(qint64 pet_id, QString* api_key) {
     QString fullPath;
@@ -81,7 +83,7 @@ SWGPetApi::deletePet(qint64 pet_id, QString* api_key) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "DELETE");
 
-    
+
 
 
     // TODO: add header support
@@ -97,6 +99,9 @@ SWGPetApi::deletePet(qint64 pet_id, QString* api_key) {
 void
 SWGPetApi::deletePetCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -104,13 +109,12 @@ SWGPetApi::deletePetCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit deletePetSignal();
+    emit deletePetSignalE(error_type, error_str);
 }
+
 void
 SWGPetApi::findPetsByStatus(QList<QString*>* status) {
     QString fullPath;
@@ -163,7 +167,7 @@ SWGPetApi::findPetsByStatus(QList<QString*>* status) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "GET");
 
-    
+
 
 
 
@@ -178,6 +182,9 @@ SWGPetApi::findPetsByStatus(QList<QString*>* status) {
 void
 SWGPetApi::findPetsByStatusCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -185,7 +192,6 @@ SWGPetApi::findPetsByStatusCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
     QList<SWGPet*>* output = new QList<SWGPet*>();
     QString json(worker->response);
     QByteArray array (json.toStdString().c_str());
@@ -200,13 +206,12 @@ SWGPetApi::findPetsByStatusCallback(HttpRequestWorker * worker) {
         output->append(o);
     }
 
-    
-
     worker->deleteLater();
 
     emit findPetsByStatusSignal(output);
-    
+    emit findPetsByStatusSignalE(output, error_type, error_str);
 }
+
 void
 SWGPetApi::findPetsByTags(QList<QString*>* tags) {
     QString fullPath;
@@ -259,7 +264,7 @@ SWGPetApi::findPetsByTags(QList<QString*>* tags) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "GET");
 
-    
+
 
 
 
@@ -274,6 +279,9 @@ SWGPetApi::findPetsByTags(QList<QString*>* tags) {
 void
 SWGPetApi::findPetsByTagsCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -281,7 +289,6 @@ SWGPetApi::findPetsByTagsCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
     QList<SWGPet*>* output = new QList<SWGPet*>();
     QString json(worker->response);
     QByteArray array (json.toStdString().c_str());
@@ -296,13 +303,12 @@ SWGPetApi::findPetsByTagsCallback(HttpRequestWorker * worker) {
         output->append(o);
     }
 
-    
-
     worker->deleteLater();
 
     emit findPetsByTagsSignal(output);
-    
+    emit findPetsByTagsSignalE(output, error_type, error_str);
 }
+
 void
 SWGPetApi::getPetById(qint64 pet_id) {
     QString fullPath;
@@ -315,7 +321,7 @@ SWGPetApi::getPetById(qint64 pet_id) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "GET");
 
-    
+
 
 
 
@@ -330,6 +336,9 @@ SWGPetApi::getPetById(qint64 pet_id) {
 void
 SWGPetApi::getPetByIdCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -337,16 +346,15 @@ SWGPetApi::getPetByIdCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-        QString json(worker->response);
-    SWGPet* output = static_cast<SWGPet*>(create(json, QString("SWGPet")));
-    
 
+    QString json(worker->response);
+    SWGPet* output = static_cast<SWGPet*>(create(json, QString("SWGPet")));
     worker->deleteLater();
 
     emit getPetByIdSignal(output);
-    
+    emit getPetByIdSignalE(output, error_type, error_str);
 }
+
 void
 SWGPetApi::updatePet(SWGPet body) {
     QString fullPath;
@@ -357,7 +365,7 @@ SWGPetApi::updatePet(SWGPet body) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "PUT");
 
-    
+
     QString output = body.asJson();
     input.request_body.append(output);
     
@@ -374,6 +382,9 @@ SWGPetApi::updatePet(SWGPet body) {
 void
 SWGPetApi::updatePetCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -381,13 +392,12 @@ SWGPetApi::updatePetCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit updatePetSignal();
+    emit updatePetSignalE(error_type, error_str);
 }
+
 void
 SWGPetApi::updatePetWithForm(qint64 pet_id, QString* name, QString* status) {
     QString fullPath;
@@ -403,7 +413,7 @@ SWGPetApi::updatePetWithForm(qint64 pet_id, QString* name, QString* status) {
     if (name != nullptr) {
         input.add_var("name", *name);
     }
-if (status != nullptr) {
+    if (status != nullptr) {
         input.add_var("status", *status);
     }
 
@@ -421,6 +431,9 @@ if (status != nullptr) {
 void
 SWGPetApi::updatePetWithFormCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -428,13 +441,12 @@ SWGPetApi::updatePetWithFormCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit updatePetWithFormSignal();
+    emit updatePetWithFormSignalE(error_type, error_str);
 }
+
 void
 SWGPetApi::uploadFile(qint64 pet_id, QString* additional_metadata, SWGHttpRequestInputFileElement* file) {
     QString fullPath;
@@ -450,7 +462,7 @@ SWGPetApi::uploadFile(qint64 pet_id, QString* additional_metadata, SWGHttpReques
     if (additional_metadata != nullptr) {
         input.add_var("additionalMetadata", *additional_metadata);
     }
-if (file != nullptr) {
+    if (file != nullptr) {
         input.add_file("file", (*file).local_filename, (*file).request_filename, (*file).mime_type);
     }
 
@@ -468,6 +480,9 @@ if (file != nullptr) {
 void
 SWGPetApi::uploadFileCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -475,15 +490,14 @@ SWGPetApi::uploadFileCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-        QString json(worker->response);
-    SWGApiResponse* output = static_cast<SWGApiResponse*>(create(json, QString("SWGApiResponse")));
-    
 
+    QString json(worker->response);
+    SWGApiResponse* output = static_cast<SWGApiResponse*>(create(json, QString("SWGApiResponse")));
     worker->deleteLater();
 
     emit uploadFileSignal(output);
-    
+    emit uploadFileSignalE(output, error_type, error_str);
 }
+
 
 }

--- a/samples/client/petstore/qt5cpp/client/SWGPetApi.h
+++ b/samples/client/petstore/qt5cpp/client/SWGPetApi.h
@@ -64,6 +64,15 @@ signals:
     void updatePetWithFormSignal();
     void uploadFileSignal(SWGApiResponse* summary);
     
+    void addPetSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void deletePetSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void findPetsByStatusSignalE(QList<SWGPet*>* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    void findPetsByTagsSignalE(QList<SWGPet*>* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    void getPetByIdSignalE(SWGPet* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    void updatePetSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void updatePetWithFormSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void uploadFileSignalE(SWGApiResponse* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    
 };
 
 }

--- a/samples/client/petstore/qt5cpp/client/SWGStoreApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGStoreApi.cpp
@@ -40,7 +40,7 @@ SWGStoreApi::deleteOrder(QString* order_id) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "DELETE");
 
-    
+
 
 
 
@@ -55,6 +55,9 @@ SWGStoreApi::deleteOrder(QString* order_id) {
 void
 SWGStoreApi::deleteOrderCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -62,13 +65,12 @@ SWGStoreApi::deleteOrderCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit deleteOrderSignal();
+    emit deleteOrderSignalE(error_type, error_str);
 }
+
 void
 SWGStoreApi::getInventory() {
     QString fullPath;
@@ -79,7 +81,7 @@ SWGStoreApi::getInventory() {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "GET");
 
-    
+
 
 
 
@@ -94,6 +96,9 @@ SWGStoreApi::getInventory() {
 void
 SWGStoreApi::getInventoryCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -101,9 +106,8 @@ SWGStoreApi::getInventoryCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-        QMap<QString, qint32>* output = new QMap<QString, qint32>();
 
+    QMap<QString, qint32>* output = new QMap<QString, qint32>();
     QString json(worker->response);
     QByteArray array (json.toStdString().c_str());
     QJsonDocument doc = QJsonDocument::fromJson(array);
@@ -114,15 +118,12 @@ SWGStoreApi::getInventoryCallback(HttpRequestWorker * worker) {
         setValue(&val, obj[key], "QMap", "");
         output->insert(key, *val);
     }
-
-
-    
-
     worker->deleteLater();
 
     emit getInventorySignal(output);
-    
+    emit getInventorySignalE(output, error_type, error_str);
 }
+
 void
 SWGStoreApi::getOrderById(qint64 order_id) {
     QString fullPath;
@@ -135,7 +136,7 @@ SWGStoreApi::getOrderById(qint64 order_id) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "GET");
 
-    
+
 
 
 
@@ -150,6 +151,9 @@ SWGStoreApi::getOrderById(qint64 order_id) {
 void
 SWGStoreApi::getOrderByIdCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -157,16 +161,15 @@ SWGStoreApi::getOrderByIdCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-        QString json(worker->response);
-    SWGOrder* output = static_cast<SWGOrder*>(create(json, QString("SWGOrder")));
-    
 
+    QString json(worker->response);
+    SWGOrder* output = static_cast<SWGOrder*>(create(json, QString("SWGOrder")));
     worker->deleteLater();
 
     emit getOrderByIdSignal(output);
-    
+    emit getOrderByIdSignalE(output, error_type, error_str);
 }
+
 void
 SWGStoreApi::placeOrder(SWGOrder body) {
     QString fullPath;
@@ -177,7 +180,7 @@ SWGStoreApi::placeOrder(SWGOrder body) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "POST");
 
-    
+
     QString output = body.asJson();
     input.request_body.append(output);
     
@@ -194,6 +197,9 @@ SWGStoreApi::placeOrder(SWGOrder body) {
 void
 SWGStoreApi::placeOrderCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -201,15 +207,14 @@ SWGStoreApi::placeOrderCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-        QString json(worker->response);
-    SWGOrder* output = static_cast<SWGOrder*>(create(json, QString("SWGOrder")));
-    
 
+    QString json(worker->response);
+    SWGOrder* output = static_cast<SWGOrder*>(create(json, QString("SWGOrder")));
     worker->deleteLater();
 
     emit placeOrderSignal(output);
-    
+    emit placeOrderSignalE(output, error_type, error_str);
 }
+
 
 }

--- a/samples/client/petstore/qt5cpp/client/SWGStoreApi.h
+++ b/samples/client/petstore/qt5cpp/client/SWGStoreApi.h
@@ -51,6 +51,11 @@ signals:
     void getOrderByIdSignal(SWGOrder* summary);
     void placeOrderSignal(SWGOrder* summary);
     
+    void deleteOrderSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void getInventorySignalE(QMap<QString, qint32>* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    void getOrderByIdSignalE(SWGOrder* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    void placeOrderSignalE(SWGOrder* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    
 };
 
 }

--- a/samples/client/petstore/qt5cpp/client/SWGUserApi.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGUserApi.cpp
@@ -38,7 +38,7 @@ SWGUserApi::createUser(SWGUser body) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "POST");
 
-    
+
     QString output = body.asJson();
     input.request_body.append(output);
     
@@ -55,6 +55,9 @@ SWGUserApi::createUser(SWGUser body) {
 void
 SWGUserApi::createUserCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -62,13 +65,12 @@ SWGUserApi::createUserCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit createUserSignal();
+    emit createUserSignalE(error_type, error_str);
 }
+
 void
 SWGUserApi::createUsersWithArrayInput(QList<SWGUser*>* body) {
     QString fullPath;
@@ -79,7 +81,7 @@ SWGUserApi::createUsersWithArrayInput(QList<SWGUser*>* body) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "POST");
 
-    
+
     QJsonArray* bodyArray = new QJsonArray();
     toJsonArray((QList<void*>*)body, bodyArray, QString("body"), QString("SWGUser*"));
 
@@ -101,6 +103,9 @@ SWGUserApi::createUsersWithArrayInput(QList<SWGUser*>* body) {
 void
 SWGUserApi::createUsersWithArrayInputCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -108,13 +113,12 @@ SWGUserApi::createUsersWithArrayInputCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit createUsersWithArrayInputSignal();
+    emit createUsersWithArrayInputSignalE(error_type, error_str);
 }
+
 void
 SWGUserApi::createUsersWithListInput(QList<SWGUser*>* body) {
     QString fullPath;
@@ -125,7 +129,7 @@ SWGUserApi::createUsersWithListInput(QList<SWGUser*>* body) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "POST");
 
-    
+
     QJsonArray* bodyArray = new QJsonArray();
     toJsonArray((QList<void*>*)body, bodyArray, QString("body"), QString("SWGUser*"));
 
@@ -147,6 +151,9 @@ SWGUserApi::createUsersWithListInput(QList<SWGUser*>* body) {
 void
 SWGUserApi::createUsersWithListInputCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -154,13 +161,12 @@ SWGUserApi::createUsersWithListInputCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit createUsersWithListInputSignal();
+    emit createUsersWithListInputSignalE(error_type, error_str);
 }
+
 void
 SWGUserApi::deleteUser(QString* username) {
     QString fullPath;
@@ -173,7 +179,7 @@ SWGUserApi::deleteUser(QString* username) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "DELETE");
 
-    
+
 
 
 
@@ -188,6 +194,9 @@ SWGUserApi::deleteUser(QString* username) {
 void
 SWGUserApi::deleteUserCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -195,13 +204,12 @@ SWGUserApi::deleteUserCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit deleteUserSignal();
+    emit deleteUserSignalE(error_type, error_str);
 }
+
 void
 SWGUserApi::getUserByName(QString* username) {
     QString fullPath;
@@ -214,7 +222,7 @@ SWGUserApi::getUserByName(QString* username) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "GET");
 
-    
+
 
 
 
@@ -229,6 +237,9 @@ SWGUserApi::getUserByName(QString* username) {
 void
 SWGUserApi::getUserByNameCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -236,16 +247,15 @@ SWGUserApi::getUserByNameCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-        QString json(worker->response);
-    SWGUser* output = static_cast<SWGUser*>(create(json, QString("SWGUser")));
-    
 
+    QString json(worker->response);
+    SWGUser* output = static_cast<SWGUser*>(create(json, QString("SWGUser")));
     worker->deleteLater();
 
     emit getUserByNameSignal(output);
-    
+    emit getUserByNameSignalE(output, error_type, error_str);
 }
+
 void
 SWGUserApi::loginUser(QString* username, QString* password) {
     QString fullPath;
@@ -272,7 +282,7 @@ SWGUserApi::loginUser(QString* username, QString* password) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "GET");
 
-    
+
 
 
 
@@ -287,6 +297,9 @@ SWGUserApi::loginUser(QString* username, QString* password) {
 void
 SWGUserApi::loginUserCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -294,16 +307,15 @@ SWGUserApi::loginUserCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-        QString json(worker->response);
-    QString* output = static_cast<QString*>(create(json, QString("QString")));
-    
 
+    QString json(worker->response);
+    QString* output = static_cast<QString*>(create(json, QString("QString")));
     worker->deleteLater();
 
     emit loginUserSignal(output);
-    
+    emit loginUserSignalE(output, error_type, error_str);
 }
+
 void
 SWGUserApi::logoutUser() {
     QString fullPath;
@@ -314,7 +326,7 @@ SWGUserApi::logoutUser() {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "GET");
 
-    
+
 
 
 
@@ -329,6 +341,9 @@ SWGUserApi::logoutUser() {
 void
 SWGUserApi::logoutUserCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -336,13 +351,12 @@ SWGUserApi::logoutUserCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit logoutUserSignal();
+    emit logoutUserSignalE(error_type, error_str);
 }
+
 void
 SWGUserApi::updateUser(QString* username, SWGUser body) {
     QString fullPath;
@@ -355,7 +369,7 @@ SWGUserApi::updateUser(QString* username, SWGUser body) {
     HttpRequestWorker *worker = new HttpRequestWorker();
     HttpRequestInput input(fullPath, "PUT");
 
-    
+
     QString output = body.asJson();
     input.request_body.append(output);
     
@@ -372,6 +386,9 @@ SWGUserApi::updateUser(QString* username, SWGUser body) {
 void
 SWGUserApi::updateUserCallback(HttpRequestWorker * worker) {
     QString msg;
+    QString error_str = worker->error_str;
+    QNetworkReply::NetworkError error_type = worker->error_type;
+
     if (worker->error_type == QNetworkReply::NoError) {
         msg = QString("Success! %1 bytes").arg(worker->response.length());
     }
@@ -379,12 +396,11 @@ SWGUserApi::updateUserCallback(HttpRequestWorker * worker) {
         msg = "Error: " + worker->error_str;
     }
 
-    
-
     worker->deleteLater();
 
-    
     emit updateUserSignal();
+    emit updateUserSignalE(error_type, error_str);
 }
+
 
 }

--- a/samples/client/petstore/qt5cpp/client/SWGUserApi.h
+++ b/samples/client/petstore/qt5cpp/client/SWGUserApi.h
@@ -63,6 +63,15 @@ signals:
     void logoutUserSignal();
     void updateUserSignal();
     
+    void createUserSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void createUsersWithArrayInputSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void createUsersWithListInputSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void deleteUserSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void getUserByNameSignalE(SWGUser* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    void loginUserSignalE(QString* summary, QNetworkReply::NetworkError error_type, QString& error_str);
+    void logoutUserSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    void updateUserSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
+    
 };
 
 }


### PR DESCRIPTION
### Description of the PR

fix #5510 

Add signals that support error information in addition to previous signal.
The new signal has the same name as previous message with a 'E' suffix. Eg:
```
void addPetSignal();
void getPetByIdSignal(SWGPet* summary);

void addPetSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
void getPetByIdSignalE(SWGPet* summary, QNetworkReply::NetworkError error_type, QString& error_str);
```
This is because signal overloading usage is cumbersome for consumer code and it breaks compatibility.

The patch will not break compatibility with client of the previously generated code.  The new error management system is an addition and it is then optional to use it.