### PR TITLE
[csharp] fixes for netstandard (json serializing and project files)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/ApiClient.mustache
@@ -122,6 +122,10 @@ namespace {{packageName}}.Client
             String contentType)
         {
             var request = new RestRequest(path, method);
+            {{#netStandard}}
+            // disable ResetSharp.Portable built-in serialization
+            request.Serializer = null;
+            {{/netStandard}}
 
             // add path parameter, if any
             foreach(var param in pathParams)
@@ -161,11 +165,21 @@ namespace {{packageName}}.Client
             {
                 if (postBody.GetType() == typeof(String))
                 {
+                    {{#netStandard}}
+                    request.AddParameter(new Parameter { Value = postBody, Type = ParameterType.RequestBody, ContentType = "application/json" });
+                    {{/netStandard}}
+                    {{^netStandard}}
                     request.AddParameter("application/json", postBody, ParameterType.RequestBody);
+                    {{/netStandard}}
                 }
                 else if (postBody.GetType() == typeof(byte[]))
                 {
+                    {{#netStandard}}
+                    request.AddParameter(new Parameter { Value = postBody, Type = ParameterType.RequestBody, ContentType = contentType });
+                    {{/netStandard}}
+                    {{^netStandard}}
                     request.AddParameter(contentType, postBody, ParameterType.RequestBody);
+                    {{/netStandard}}
                 }
             }
 

--- a/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
@@ -88,7 +88,10 @@
     {{/netStandard}}
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs"/>
+    <Compile Include="Api\**\*.cs"/>
+    <Compile Include="Client\**\*.cs"/>
+    <Compile Include="Model\**\*.cs"/>
+    <Compile Include="Properties\**\*.cs"/>
   </ItemGroup>
   {{^netStandard}}
   <ItemGroup>

--- a/samples/client/petstore-security-test/csharp/SwaggerClient/src/IO.Swagger/Api/FakeApi.cs
+++ b/samples/client/petstore-security-test/csharp/SwaggerClient/src/IO.Swagger/Api/FakeApi.cs
@@ -216,7 +216,7 @@ namespace IO.Swagger.Api
 
             // to determine the Accept header
             String[] localVarHttpHeaderAccepts = new String[] {
-                "application/json", 
+                "application/json",
                 "*_/ '  =end - -       "
             };
             String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
@@ -239,7 +239,6 @@ namespace IO.Swagger.Api
                 if (exception != null) throw exception;
             }
 
-            
             return new ApiResponse<Object>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 null);
@@ -283,7 +282,7 @@ namespace IO.Swagger.Api
 
             // to determine the Accept header
             String[] localVarHttpHeaderAccepts = new String[] {
-                "application/json", 
+                "application/json",
                 "*_/ '  =end - -       "
             };
             String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
@@ -306,7 +305,6 @@ namespace IO.Swagger.Api
                 if (exception != null) throw exception;
             }
 
-            
             return new ApiResponse<Object>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 null);

--- a/samples/client/petstore-security-test/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore-security-test/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
@@ -62,7 +62,10 @@ Contact: apiteam@swagger.io *_/ ' \" =end - - \\r\\n \\n \\r
     
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs"/>
+    <Compile Include="Api\**\*.cs"/>
+    <Compile Include="Client\**\*.cs"/>
+    <Compile Include="Model\**\*.cs"/>
+    <Compile Include="Properties\**\*.cs"/>
   </ItemGroup>
   <ItemGroup>
       <None Include="packages.config" />

--- a/samples/client/petstore-security-test/csharp/SwaggerClient/src/IO.Swagger/Model/ModelReturn.cs
+++ b/samples/client/petstore-security-test/csharp/SwaggerClient/src/IO.Swagger/Model/ModelReturn.cs
@@ -119,7 +119,7 @@ namespace IO.Swagger.Model
         /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
-        { 
+        {
             yield break;
         }
     }

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/IO.Swagger.csproj
@@ -62,7 +62,10 @@ Contact: apiteam@swagger.io
     
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs"/>
+    <Compile Include="Api\**\*.cs"/>
+    <Compile Include="Client\**\*.cs"/>
+    <Compile Include="Model\**\*.cs"/>
+    <Compile Include="Properties\**\*.cs"/>
   </ItemGroup>
   <ItemGroup>
       <None Include="packages.config" />

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Client/ApiClient.cs
@@ -115,6 +115,8 @@ namespace IO.Swagger.Client
             String contentType)
         {
             var request = new RestRequest(path, method);
+            // disable ResetSharp.Portable built-in serialization
+            request.Serializer = null;
 
             // add path parameter, if any
             foreach(var param in pathParams)
@@ -142,11 +144,11 @@ namespace IO.Swagger.Client
             {
                 if (postBody.GetType() == typeof(String))
                 {
-                    request.AddParameter("application/json", postBody, ParameterType.RequestBody);
+                    request.AddParameter(new Parameter { Value = postBody, Type = ParameterType.RequestBody, ContentType = "application/json" });
                 }
                 else if (postBody.GetType() == typeof(byte[]))
                 {
-                    request.AddParameter(contentType, postBody, ParameterType.RequestBody);
+                    request.AddParameter(new Parameter { Value = postBody, Type = ParameterType.RequestBody, ContentType = contentType });
                 }
             }
 

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/IO.Swagger.csproj
@@ -43,7 +43,10 @@ Contact: apiteam@swagger.io
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs"/>
+    <Compile Include="Api\**\*.cs"/>
+    <Compile Include="Client\**\*.cs"/>
+    <Compile Include="Model\**\*.cs"/>
+    <Compile Include="Properties\**\*.cs"/>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/IO.Swagger.csproj
@@ -64,7 +64,10 @@ Contact: apiteam@swagger.io
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs"/>
+    <Compile Include="Api\**\*.cs"/>
+    <Compile Include="Client\**\*.cs"/>
+    <Compile Include="Model\**\*.cs"/>
+    <Compile Include="Properties\**\*.cs"/>
   </ItemGroup>
   <ItemGroup>
       <None Include="packages.config" />


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This is a non-breaking change.

see #5589 

As a side node: due to including `**/*.cs` as files to compile, there have always been some files of the `obj\` directory which where included.

This is fixed due to only include all files of the generated root directories, thus excluding the `obj\` directory.