### PR TITLE
Disable Jackson FAIL_ON_INVALID_SUBTYPE in feign

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -68,6 +68,7 @@ public class ApiClient {
     objectMapper = new ObjectMapper();
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -146,6 +146,7 @@ public class ApiClient {
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    objectMapper.disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE);
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.setDateFormat(new RFC3339DateFormat());
     {{^java8}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/JSON.mustache
@@ -21,6 +21,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/JSON.mustache
@@ -21,6 +21,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/ApiClient.java
@@ -132,6 +132,7 @@ public class ApiClient {
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    objectMapper.disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE);
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.setDateFormat(new RFC3339DateFormat());
     objectMapper.registerModule(new JodaModule());

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
@@ -74,6 +74,7 @@ public class ApiClient {
     objectMapper = new ObjectMapper();
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/JSON.java
@@ -16,6 +16,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/JSON.java
@@ -16,6 +16,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/samples/client/petstore/java/jersey2-java8/src/test/java/io/swagger/client/ConfigurationTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/test/java/io/swagger/client/ConfigurationTest.java
@@ -9,7 +9,7 @@ public class ConfigurationTest {
     public void testDefaultApiClient() {
         ApiClient apiClient = Configuration.getDefaultApiClient();
         assertNotNull(apiClient);
-        assertEquals("http://petstore.swagger.io/v2", apiClient.getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", apiClient.getBasePath());
         assertFalse(apiClient.isDebugging());
     }
 }

--- a/samples/client/petstore/java/jersey2-java8/src/test/java/io/swagger/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/test/java/io/swagger/client/api/PetApiTest.java
@@ -36,7 +36,7 @@ public class PetApiTest {
         // the default api client is used
         assertEquals(Configuration.getDefaultApiClient(), api.getApiClient());
         assertNotNull(api.getApiClient());
-        assertEquals("http://petstore.swagger.io/v2", api.getApiClient().getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", api.getApiClient().getBasePath());
         assertFalse(api.getApiClient().isDebugging());
 
         ApiClient oldClient = api.getApiClient();
@@ -54,7 +54,7 @@ public class PetApiTest {
         // set api client via setter method
         api.setApiClient(oldClient);
         assertNotNull(api.getApiClient());
-        assertEquals("http://petstore.swagger.io/v2", api.getApiClient().getBasePath());
+        assertEquals("http://petstore.swagger.io:80/v2", api.getApiClient().getBasePath());
         assertFalse(api.getApiClient().isDebugging());
     }
 

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/JSON.java
@@ -16,6 +16,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/JSON.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/JSON.java
@@ -16,6 +16,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);


### PR DESCRIPTION
With this change, Jackson does not fail even if it doesn't recognize a
discriminator type name. This is helpful when upgrading a microservice with
a new subtype while keeping compatibility with its old clients. The instance
is returned as null instead of throwing an exception deep in the feign
framework, allowing clients to gracefully degrade.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This is a fix for #5596. It disables the Jackson FAIL_ON_INVALID_SUBTYPE deserialization feature so that unknown discriminator subtypes return null instead of throwing an exception.

