### PR TITLE
[csharp] Fix project glob pattern

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/Project.mustache
@@ -88,10 +88,8 @@
     {{/netStandard}}
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Api\**\*.cs"/>
-    <Compile Include="Client\**\*.cs"/>
-    <Compile Include="Model\**\*.cs"/>
-    <Compile Include="Properties\**\*.cs"/>
+    <Compile Include="**\*.cs"
+             Exclude="obj\**" />
   </ItemGroup>
   {{^netStandard}}
   <ItemGroup>

--- a/modules/swagger-codegen/src/main/resources/csharp/TestProject.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/TestProject.mustache
@@ -78,7 +78,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs"/>
+    <Compile Include="**\*.cs"
+             Exclude="obj\**"/>
   </ItemGroup>
   <ItemGroup>
       <None Include="packages.config" />


### PR DESCRIPTION
This fixes the glob pattern to remove hard-coded namespaces, and exclude the obj folder.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Introduced in #5590, the following change to the project file was made:

```diff
-     <Compile Include="**\*.cs"/>
+     <Compile Include="Api\**\*.cs"/>
+     <Compile Include="Client\**\*.cs"/>
+     <Compile Include="Model\**\*.cs"/>
+     <Compile Include="Properties\**\*.cs"/>
```

This change was made to account for Xamarin also including `obj\*.cs`. See #5590 for more discussion.

The change causes apiPackage and modelPackage additional properties to generated code, but be excluded when code is loaded in an IDE.

To compare with master:
* run `\rm -rf samples/client/petstore/csharp/SwaggerClient/`. This is necessary, otherwise Api and Model folders from previous sample generation will remain.
* run:
```
java -jar ./modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
 -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml \
 -l csharp -o samples/client/petstore/csharp/SwaggerClient \
--additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C},apiPackage=PublicApi,modelPackage=Stuff
```
(note apiPackage and modelPackage above)
* Load `samples/client/petstore/csharp/SwaggerClient/IO.Swagger.sln` in Rider or Visual Studio