### PR TITLE
#5619 added getValue() method for generated Enum classes in Java

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/modelEnum.mustache
@@ -25,6 +25,10 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     this.value = value;
   }
 
+  public {{{dataType}}} getValue() {
+    return value;
+  }
+
   @Override
 {{#jackson}}
   @JsonValue

--- a/modules/swagger-codegen/src/main/resources/Java/modelInnerEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/modelInnerEnum.mustache
@@ -26,6 +26,10 @@
       this.value = value;
     }
 
+    public {{{datatype}}} getValue() {
+      return value;
+    }
+
     @Override
 {{#jackson}}
     @JsonValue

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -73,6 +77,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumClass.java
@@ -35,6 +35,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/EnumTest.java
@@ -42,6 +42,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -76,6 +80,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -108,6 +116,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Order.java
@@ -54,6 +54,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -35,6 +35,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/model/Pet.java
@@ -60,6 +60,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -73,6 +77,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumClass.java
@@ -35,6 +35,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/EnumTest.java
@@ -42,6 +42,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -76,6 +80,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -108,6 +116,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Order.java
@@ -54,6 +54,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -35,6 +35,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/model/Pet.java
@@ -60,6 +60,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -73,6 +77,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/EnumClass.java
@@ -35,6 +35,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/EnumTest.java
@@ -42,6 +42,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -76,6 +80,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -108,6 +116,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/Order.java
@@ -54,6 +54,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -35,6 +35,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/model/Pet.java
@@ -60,6 +60,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -73,6 +77,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumClass.java
@@ -35,6 +35,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/EnumTest.java
@@ -42,6 +42,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -76,6 +80,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -108,6 +116,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Order.java
@@ -54,6 +54,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -35,6 +35,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/model/Pet.java
@@ -60,6 +60,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -73,6 +77,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumClass.java
@@ -35,6 +35,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/EnumTest.java
@@ -42,6 +42,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -76,6 +80,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -108,6 +116,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Order.java
@@ -54,6 +54,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -35,6 +35,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/model/Pet.java
@@ -60,6 +60,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -43,6 +43,10 @@ public class EnumArrays implements Parcelable {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -66,6 +70,10 @@ public class EnumArrays implements Parcelable {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/EnumClass.java
@@ -39,6 +39,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/EnumTest.java
@@ -45,6 +45,10 @@ public class EnumTest implements Parcelable {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -70,6 +74,10 @@ public class EnumTest implements Parcelable {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -93,6 +101,10 @@ public class EnumTest implements Parcelable {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/MapTest.java
@@ -47,6 +47,10 @@ public class MapTest implements Parcelable {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/Order.java
@@ -57,6 +57,10 @@ public class Order implements Parcelable {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -39,6 +39,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/model/Pet.java
@@ -63,6 +63,10 @@ public class Pet implements Parcelable {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -64,6 +68,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumClass.java
@@ -37,6 +37,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/EnumTest.java
@@ -43,6 +43,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -68,6 +72,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -91,6 +99,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Order.java
@@ -55,6 +55,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -37,6 +37,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/model/Pet.java
@@ -61,6 +61,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -73,6 +77,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/EnumClass.java
@@ -35,6 +35,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/EnumTest.java
@@ -42,6 +42,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -76,6 +80,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -108,6 +116,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/Order.java
@@ -54,6 +54,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -35,6 +35,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/io/swagger/client/model/Pet.java
@@ -60,6 +60,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -73,6 +77,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/EnumClass.java
@@ -35,6 +35,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/EnumTest.java
@@ -42,6 +42,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -76,6 +80,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -108,6 +116,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/Order.java
@@ -54,6 +54,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -35,6 +35,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/io/swagger/client/model/Pet.java
@@ -60,6 +60,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -64,6 +68,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumClass.java
@@ -37,6 +37,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/EnumTest.java
@@ -43,6 +43,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -68,6 +72,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -91,6 +99,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Order.java
@@ -55,6 +55,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -37,6 +37,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/model/Pet.java
@@ -61,6 +61,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -43,6 +43,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -75,6 +79,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumClass.java
@@ -37,6 +37,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/EnumTest.java
@@ -44,6 +44,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -78,6 +82,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {
@@ -110,6 +118,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/MapTest.java
@@ -47,6 +47,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Order.java
@@ -56,6 +56,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -37,6 +37,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/Pet.java
@@ -62,6 +62,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     @JsonValue
     public String toString() {

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -64,6 +68,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumClass.java
@@ -37,6 +37,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/EnumTest.java
@@ -43,6 +43,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -68,6 +72,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -91,6 +99,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Order.java
@@ -55,6 +55,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -37,6 +37,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/model/Pet.java
@@ -61,6 +61,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -64,6 +68,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumClass.java
@@ -37,6 +37,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/EnumTest.java
@@ -43,6 +43,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -68,6 +72,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -91,6 +99,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/Order.java
@@ -55,6 +55,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -37,6 +37,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/model/Pet.java
@@ -61,6 +61,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -41,6 +41,10 @@ public class EnumArrays {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -64,6 +68,10 @@ public class EnumArrays {
 
     ArrayEnumEnum(String value) {
       this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/EnumClass.java
@@ -37,6 +37,10 @@ public enum EnumClass {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/EnumTest.java
@@ -43,6 +43,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -68,6 +72,10 @@ public class EnumTest {
       this.value = value;
     }
 
+    public Integer getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);
@@ -91,6 +99,10 @@ public class EnumTest {
 
     EnumNumberEnum(Double value) {
       this.value = value;
+    }
+
+    public Double getValue() {
+      return value;
     }
 
     @Override

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/MapTest.java
@@ -45,6 +45,10 @@ public class MapTest {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/Order.java
@@ -55,6 +55,10 @@ public class Order {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/OuterEnum.java
@@ -37,6 +37,10 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  public String getValue() {
+    return value;
+  }
+
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/model/Pet.java
@@ -61,6 +61,10 @@ public class Pet {
       this.value = value;
     }
 
+    public String getValue() {
+      return value;
+    }
+
     @Override
     public String toString() {
       return String.valueOf(value);


### PR DESCRIPTION
## PR checklist

- [x] Read the contribution guidelines.
- [x] Ran the shell/batch script under ./bin/ to update Petstore sample so that CIs can verify the change.  
To be more specific: I run ./bin/java-petstore-all.sh and ./bin/security/java-petstore-okhttp-gson.sh because I changed Java client's mustache templates.
- [x] Filed the PR against the correct branch: master for non-breaking changes
- [x] Triggered the unstable Travis build until it build successfully, because of that erratically npm error causing the instability

## Description

After creating the issue #5619 I had the privilege to create a pull request for that feature.

With this change for every enum generated for Java will contain a `getValue()` method returning the value for that enum.
This value wasn't accessible in a good way by now – see issue.

There is no much change. Only two mustache files had to be changed.

Additionally the sample files for all java projects have been updated with this change. All enumeration now contain the added method.
All java samples still compiling.