### PR TITLE
Adding enum generation support for golang client

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
@@ -151,7 +151,7 @@ public class GoClientCodegen extends DefaultCodegen implements CodegenConfig {
 
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         additionalProperties.put(CodegenConstants.PACKAGE_VERSION, packageVersion);
-        
+
         additionalProperties.put("apiDocPath", apiDocPath);
         additionalProperties.put("modelDocPath", modelDocPath);
 
@@ -180,10 +180,10 @@ public class GoClientCodegen extends DefaultCodegen implements CodegenConfig {
         // - XName
         // - X_Name
         // ... or maybe a suffix?
-        // - Name_ ... think this will work. 
+        // - Name_ ... think this will work.
         if(this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
-        }        
+        }
         return camelize(name) + '_';
     }
 
@@ -465,7 +465,7 @@ public class GoClientCodegen extends DefaultCodegen implements CodegenConfig {
             }
         }
 
-        return objs;
+        return postProcessModelsEnum(objs);
     }
 
     @Override
@@ -498,5 +498,66 @@ public class GoClientCodegen extends DefaultCodegen implements CodegenConfig {
         customImport.put(key, value);
 
         return customImport;
+    }
+
+
+    @Override
+    public String toEnumValue(String value, String datatype) {
+        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
+            return value;
+        } else {
+            return escapeText(value);
+        }
+    }
+
+    @Override
+    public String toEnumDefaultValue(String value, String datatype) {
+        return datatype + "_" + value;
+    }
+
+    @Override
+    public String toEnumVarName(String name, String datatype) {
+        if (name.length() == 0) {
+            return "EMPTY";
+        }
+
+        // number
+        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
+            String varName = name;
+            varName = varName.replaceAll("-", "MINUS_");
+            varName = varName.replaceAll("\\+", "PLUS_");
+            varName = varName.replaceAll("\\.", "_DOT_");
+            return varName;
+        }
+
+        // for symbol, e.g. $, #
+        if (getSymbolName(name) != null) {
+            return getSymbolName(name).toUpperCase();
+        }
+
+        // string
+        String enumName = sanitizeName(underscore(name).toUpperCase());
+        enumName = enumName.replaceFirst("^_", "");
+        enumName = enumName.replaceFirst("_$", "");
+
+        if (isReservedWord(enumName) || enumName.matches("\\d.*")) { // reserved word or starts with number
+            return escapeReservedWord(enumName);
+        } else {
+            return enumName;
+        }
+    }
+
+    @Override
+    public String toEnumName(CodegenProperty property) {
+        String enumName = underscore(toModelName(property.name)).toUpperCase();
+
+        // remove [] for array or map of enum
+        enumName = enumName.replace("[]", "");
+
+        if (enumName.matches("\\d.*")) { // starts with number
+            return "_" + enumName;
+        } else {
+            return enumName;
+        }
     }
 }

--- a/modules/swagger-codegen/src/main/resources/go/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/model.mustache
@@ -4,12 +4,21 @@ package {{packageName}}
 import ({{/imports}}{{#imports}}
 	"{{import}}"{{/imports}}{{#imports}}
 )
-{{/imports}}{{#model}}{{#description}}
+{{/imports}}{{#model}}{{#isEnum}}{{#description}}// {{{classname}}} : {{{description}}}{{/description}}
+type {{{name}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
+
+// List of {{{name}}}
+const (
+	{{#allowableValues}}
+		{{#enumVars}}
+		{{name}} {{{classname}}} = "{{{value}}}"
+		{{/enumVars}}
+	{{/allowableValues}}
+){{/isEnum}}{{^isEnum}}{{#description}}
 // {{{description}}}{{/description}}
 type {{classname}} struct {
 {{#vars}}{{#description}}
 	// {{{description}}}{{/description}}
-	{{name}} {{^isPrimitiveType}}{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{/isPrimitiveType}}{{{datatype}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"`
+	{{name}} {{^isEnum}}{{^isPrimitiveType}}{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{/isPrimitiveType}}{{/isEnum}}{{{datatype}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"`
 {{/vars}}
-}
-{{/model}}{{/models}}
+}{{/isEnum}}{{/model}}{{/models}}

--- a/modules/swagger-codegen/src/main/resources/go/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/model.mustache
@@ -10,9 +10,9 @@ type {{{name}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/form
 // List of {{{name}}}
 const (
 	{{#allowableValues}}
-		{{#enumVars}}
-		{{name}} {{{classname}}} = "{{{value}}}"
-		{{/enumVars}}
+	{{#enumVars}}
+	{{name}} {{{classname}}} = "{{{value}}}"
+	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}
 // {{{description}}}{{/description}}

--- a/samples/client/petstore/go/go-petstore/enum_class.go
+++ b/samples/client/petstore/go/go-petstore/enum_class.go
@@ -1,4 +1,4 @@
-/*
+/* 
  * Swagger Petstore
  *
  * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\

--- a/samples/client/petstore/go/go-petstore/enum_class.go
+++ b/samples/client/petstore/go/go-petstore/enum_class.go
@@ -1,4 +1,4 @@
-/* 
+/*
  * Swagger Petstore
  *
  * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
@@ -10,5 +10,11 @@
 
 package petstore
 
-type EnumClass struct {
-}
+type EnumClass string
+
+// List of EnumClass
+const (
+	ABC EnumClass = "_abc"
+	EFG EnumClass = "-efg"
+	XYZ EnumClass = "(xyz)"
+)

--- a/samples/client/petstore/go/go-petstore/outer_enum.go
+++ b/samples/client/petstore/go/go-petstore/outer_enum.go
@@ -14,7 +14,7 @@ type OuterEnum string
 
 // List of OuterEnum
 const (
-		PLACED OuterEnum = "placed"
-		APPROVED OuterEnum = "approved"
-		DELIVERED OuterEnum = "delivered"
+	PLACED OuterEnum = "placed"
+	APPROVED OuterEnum = "approved"
+	DELIVERED OuterEnum = "delivered"
 )

--- a/samples/client/petstore/go/go-petstore/outer_enum.go
+++ b/samples/client/petstore/go/go-petstore/outer_enum.go
@@ -10,5 +10,11 @@
 
 package petstore
 
-type OuterEnum struct {
-}
+type OuterEnum string
+
+// List of OuterEnum
+const (
+		PLACED OuterEnum = "placed"
+		APPROVED OuterEnum = "approved"
+		DELIVERED OuterEnum = "delivered"
+)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Fixes #4459
Adding enum generation support for golang. After some investigation, it turns out the missing key to actually getting the enum value support for the mustache fields was to call `postProcessModelsEnum()` before returning the `objs` result in the client-generator's `postProcessModels()` function.

Derived from #5631.
@wing328 
@antihax 