### PR TITLE
5626 Upgraded connexion to 1.1.9 - required change to encoder as connexion…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/flaskConnexion/encoder.mustache
+++ b/modules/swagger-codegen/src/main/resources/flaskConnexion/encoder.mustache
@@ -1,9 +1,8 @@
-from connexion.decorators import produces
 from six import iteritems
 from {{modelPackage}}.base_model_ import Model
+from connexion.apps.flask_app import FlaskJSONEncoder
 
-
-class JSONEncoder(produces.JSONEncoder):
+class JSONEncoder(FlaskJSONEncoder):
     include_nulls = False
 
     def default(self, o):
@@ -16,4 +15,4 @@ class JSONEncoder(produces.JSONEncoder):
                 attr = o.attribute_map[attr]
                 dikt[attr] = value
             return dikt
-        return produces.JSONEncoder.default(self, o)
+        return FlaskJSONEncoder.default(self, o)

--- a/modules/swagger-codegen/src/main/resources/flaskConnexion/requirements.mustache
+++ b/modules/swagger-codegen/src/main/resources/flaskConnexion/requirements.mustache
@@ -1,4 +1,4 @@
-connexion == 1.0.129
+connexion == 1.1.9
 python_dateutil == 2.6.0
 {{#supportPython2}}
 typing == 3.5.2.2

--- a/samples/server/petstore/flaskConnexion/requirements.txt
+++ b/samples/server/petstore/flaskConnexion/requirements.txt
@@ -1,3 +1,3 @@
-connexion == 1.0.129
+connexion == 1.1.9
 python_dateutil == 2.6.0
 setuptools >= 21.0.0


### PR DESCRIPTION
… is isolating implementation specific code

### PR checklist

- [ X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Upgraded requirements* files to specify the latest stable version.  Connexion maintainers have been isolating implementation specific code (Flask in this case), so the encoder.py template had to be modified to use the relocated JSON encoder.

