### PR TITLE
Add null/nil as reserved keyword in some generators

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AndroidClientCodegen.java
@@ -64,7 +64,7 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
                     "import", "public", "throws", "case", "enum", "instanceof", "return", "transient",
                     "catch", "extends", "int", "short", "try", "char", "final", "interface", "static",
                     "void", "class", "finally", "long", "strictfp", "volatile", "const", "float",
-                    "native", "super", "while")
+                    "native", "super", "while", "null")
         );
 
         languageSpecificPrimitives = new HashSet<String>(

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -69,6 +69,17 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
         typeMapping.put("file", "file");
         typeMapping.put("UUID", "str");
 
+        // from https://docs.python.org/release/2.5.4/ref/keywords.html
+        setReservedWordsLowerCase(
+                Arrays.asList(
+                    // @property
+                    "property",
+                    // python reserved words
+                    "and", "del", "from", "not", "while", "as", "elif", "global", "or", "with",
+                    "assert", "else", "if", "pass", "yield", "break", "except", "import",
+                    "print", "class", "exec", "in", "raise", "continue", "finally", "is",
+                    "return", "def", "for", "lambda", "try", "self", "None"));
+
         // set the output folder here
         outputFolder = "generated-code/connexion";
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
@@ -56,7 +56,8 @@ public class GoClientCodegen extends DefaultCodegen implements CodegenConfig {
                 "case", "defer", "go", "map", "struct",
                 "chan", "else", "goto", "package", "switch",
                 "const", "fallthrough", "if", "range", "type",
-                "continue", "for", "import", "return", "var", "error", "ApiResponse")
+                "continue", "for", "import", "return", "var", "error", "ApiResponse",
+                "nil")
                 // Added "error" as it's used so frequently that it may as well be a keyword
         );
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoServerCodegen.java
@@ -68,7 +68,8 @@ public class GoServerCodegen extends DefaultCodegen implements CodegenConfig {
                 "case", "defer", "go", "map", "struct",
                 "chan", "else", "goto", "package", "switch",
                 "const", "fallthrough", "if", "range", "type",
-                "continue", "for", "import", "return", "var", "error", "ApiResponse")
+                "continue", "for", "import", "return", "var", "error", "ApiResponse",
+                "nil")
                 // Added "error" as it's used so frequently that it may as well be a keyword
         );
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -101,7 +101,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
                     "and", "del", "from", "not", "while", "as", "elif", "global", "or", "with",
                     "assert", "else", "if", "pass", "yield", "break", "except", "import",
                     "print", "class", "exec", "in", "raise", "continue", "finally", "is",
-                    "return", "def", "for", "lambda", "try", "self"));
+                    "return", "def", "for", "lambda", "try", "self", "None"));
 
         regexModifiers = new HashMap<Character, String>();
         regexModifiers.put('i', "IGNORECASE");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Similar to https://github.com/swagger-api/swagger-codegen/pull/5617, we will add null/nil/none as reserved keyword to a few generators.
