### PR TITLE
Enable environment variable for server generation

### DIFF
--- a/modules/swagger-generator/src/main/java/io/swagger/generator/resource/SwaggerResource.java
+++ b/modules/swagger-generator/src/main/java/io/swagger/generator/resource/SwaggerResource.java
@@ -205,8 +205,20 @@ public class SwaggerResource {
         }
         String filename = Generator.generateServer(framework, opts);
         System.out.println("generated name: " + filename);
+        String host = System.getenv("GENERATOR_HOST");
 
-        String host = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort();
+        if(StringUtils.isBlank(host)) {
+            String scheme = request.getHeader("X-SSL");
+            String port = "";
+            if("1".equals(scheme)) {
+                scheme = "https";
+            }
+            else {
+                scheme = request.getScheme();
+                port = ":" + request.getServerPort();
+            }
+            host = scheme + "://" + request.getServerName() + port;
+        }
 
         if (filename != null) {
             String code = String.valueOf(UUID.randomUUID().toString());


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Add use of GENERATOR_HOST environment variable for /servers/{framework} as used for /clients/{language}

