### PR TITLE
Allow overriding the service delegate

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/api.mustache
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
@@ -33,7 +34,28 @@ import javax.validation.constraints.*;
 {{>generatedAnnotation}}
 {{#operations}}
 public class {{classname}}  {
-   private final {{classname}}Service delegate = {{classname}}ServiceFactory.get{{classname}}();
+   private final {{classname}}Service delegate;
+
+   public {{classname}}(@Context ServletConfig servletContext) {
+      {{classname}}Service delegate = null;
+
+      if (servletContext != null) {
+         String implClass = servletContext.getInitParameter("{{classname}}.implementation");
+         if (implClass != null && !"".equals(implClass.trim())) {
+            try {
+               delegate = ({{classname}}Service) Class.forName(implClass).newInstance();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         } 
+      }
+
+      if (delegate == null) {
+         delegate = {{classname}}ServiceFactory.get{{classname}}();
+      }
+
+      this.delegate = delegate;
+   }
 
 {{#operation}}
     @{{httpMethod}}

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/FakeApi.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
@@ -32,7 +33,28 @@ import javax.validation.constraints.*;
 @io.swagger.annotations.Api(description = "the fake API")
 
 public class FakeApi  {
-   private final FakeApiService delegate = FakeApiServiceFactory.getFakeApi();
+   private final FakeApiService delegate;
+
+   public FakeApi(@Context ServletConfig servletContext) {
+      FakeApiService delegate = null;
+
+      if (servletContext != null) {
+         String implClass = servletContext.getInitParameter("FakeApi.implementation");
+         if (implClass != null && !"".equals(implClass.trim())) {
+            try {
+               delegate = (FakeApiService) Class.forName(implClass).newInstance();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         } 
+      }
+
+      if (delegate == null) {
+         delegate = FakeApiServiceFactory.getFakeApi();
+      }
+
+      this.delegate = delegate;
+   }
 
     @POST
     @Path("/outer/boolean")

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/PetApi.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
@@ -31,7 +32,28 @@ import javax.validation.constraints.*;
 @io.swagger.annotations.Api(description = "the pet API")
 
 public class PetApi  {
-   private final PetApiService delegate = PetApiServiceFactory.getPetApi();
+   private final PetApiService delegate;
+
+   public PetApi(@Context ServletConfig servletContext) {
+      PetApiService delegate = null;
+
+      if (servletContext != null) {
+         String implClass = servletContext.getInitParameter("PetApi.implementation");
+         if (implClass != null && !"".equals(implClass.trim())) {
+            try {
+               delegate = (PetApiService) Class.forName(implClass).newInstance();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         } 
+      }
+
+      if (delegate == null) {
+         delegate = PetApiServiceFactory.getPetApi();
+      }
+
+      this.delegate = delegate;
+   }
 
     @POST
     

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/StoreApi.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
@@ -30,7 +31,28 @@ import javax.validation.constraints.*;
 @io.swagger.annotations.Api(description = "the store API")
 
 public class StoreApi  {
-   private final StoreApiService delegate = StoreApiServiceFactory.getStoreApi();
+   private final StoreApiService delegate;
+
+   public StoreApi(@Context ServletConfig servletContext) {
+      StoreApiService delegate = null;
+
+      if (servletContext != null) {
+         String implClass = servletContext.getInitParameter("StoreApi.implementation");
+         if (implClass != null && !"".equals(implClass.trim())) {
+            try {
+               delegate = (StoreApiService) Class.forName(implClass).newInstance();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         } 
+      }
+
+      if (delegate == null) {
+         delegate = StoreApiServiceFactory.getStoreApi();
+      }
+
+      this.delegate = delegate;
+   }
 
     @DELETE
     @Path("/order/{order_id}")

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/io/swagger/api/UserApi.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
@@ -30,7 +31,28 @@ import javax.validation.constraints.*;
 @io.swagger.annotations.Api(description = "the user API")
 
 public class UserApi  {
-   private final UserApiService delegate = UserApiServiceFactory.getUserApi();
+   private final UserApiService delegate;
+
+   public UserApi(@Context ServletConfig servletContext) {
+      UserApiService delegate = null;
+
+      if (servletContext != null) {
+         String implClass = servletContext.getInitParameter("UserApi.implementation");
+         if (implClass != null && !"".equals(implClass.trim())) {
+            try {
+               delegate = (UserApiService) Class.forName(implClass).newInstance();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         } 
+      }
+
+      if (delegate == null) {
+         delegate = UserApiServiceFactory.getUserApi();
+      }
+
+      this.delegate = delegate;
+   }
 
     @POST
     


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

With this update it is now possible to choose an implementation class for the service delegate. By default the generated service will behave as normal, generating a stub implementation. But now it is also possible to add an init parameter to the the Jersey servlet in web.xml with a class name, eg.:

```
<servlet>
    <servlet-name>Swagger Servlet</servlet-name>
    <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
... snip ...
    <init-param>
        <param-name>PetApi.implementation</param-name>
        <param-value>org.example.petshop.CustomPetApiService</param-value>
    </init-param>
    <load-on-startup>1</load-on-startup>
</servlet>
```
The generated PetApi class will now use the ``org.example.petshop.CustomPetApiService`` instead of using ``PetApiServiceFactory`` to make an instance of ``io.swagger.api.impl.PetApiServiceImpl``.
