### PR TITLE
[Swift3] Fix handling of query item with array value

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/APIHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/APIHelper.mustache
@@ -49,16 +49,30 @@ class APIHelper {
         return destination
     }
 
-
     static func mapValuesToQueryItems(values: [String:Any?]) -> [URLQueryItem]? {
         let returnValues = values
             .filter { $0.1 != nil }
-            .map { (item: (_key: String, _value: Any?)) -> URLQueryItem in
-                URLQueryItem(name: item._key, value:"\(item._value!)")
+            .map { (item: (_key: String, _value: Any?)) -> [URLQueryItem] in
+                if let value = item._value as? Array<String> {
+                    return value.map { (v) -> URLQueryItem in
+                        URLQueryItem(
+                            name: item._key,
+                            value: v
+                        )
+                    }
+                } else {
+                    return [URLQueryItem(
+                        name: item._key,
+                        value: "\(item._value!)"
+                    )]
+                }
             }
+            .flatMap { $0 }
+
         if returnValues.count == 0 {
             return nil
         }
+
         return returnValues
     }
 

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIHelper.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/APIHelper.swift
@@ -49,16 +49,30 @@ class APIHelper {
         return destination
     }
 
-
     static func mapValuesToQueryItems(values: [String:Any?]) -> [URLQueryItem]? {
         let returnValues = values
             .filter { $0.1 != nil }
-            .map { (item: (_key: String, _value: Any?)) -> URLQueryItem in
-                URLQueryItem(name: item._key, value:"\(item._value!)")
+            .map { (item: (_key: String, _value: Any?)) -> [URLQueryItem] in
+                if let value = item._value as? Array<String> {
+                    return value.map { (v) -> URLQueryItem in
+                        URLQueryItem(
+                            name: item._key,
+                            value: v
+                        )
+                    }
+                } else {
+                    return [URLQueryItem(
+                        name: item._key,
+                        value: "\(item._value!)"
+                    )]
+                }
             }
+            .flatMap { $0 }
+
         if returnValues.count == 0 {
             return nil
         }
+
         return returnValues
     }
 

--- a/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIHelper.swift
+++ b/samples/client/petstore/swift3/promisekit/PetstoreClient/Classes/Swaggers/APIHelper.swift
@@ -49,16 +49,30 @@ class APIHelper {
         return destination
     }
 
-
     static func mapValuesToQueryItems(values: [String:Any?]) -> [URLQueryItem]? {
         let returnValues = values
             .filter { $0.1 != nil }
-            .map { (item: (_key: String, _value: Any?)) -> URLQueryItem in
-                URLQueryItem(name: item._key, value:"\(item._value!)")
+            .map { (item: (_key: String, _value: Any?)) -> [URLQueryItem] in
+                if let value = item._value as? Array<String> {
+                    return value.map { (v) -> URLQueryItem in
+                        URLQueryItem(
+                            name: item._key,
+                            value: v
+                        )
+                    }
+                } else {
+                    return [URLQueryItem(
+                        name: item._key,
+                        value: "\(item._value!)"
+                    )]
+                }
             }
+            .flatMap { $0 }
+
         if returnValues.count == 0 {
             return nil
         }
+
         return returnValues
     }
 

--- a/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIHelper.swift
+++ b/samples/client/petstore/swift3/rxswift/PetstoreClient/Classes/Swaggers/APIHelper.swift
@@ -49,16 +49,30 @@ class APIHelper {
         return destination
     }
 
-
     static func mapValuesToQueryItems(values: [String:Any?]) -> [URLQueryItem]? {
         let returnValues = values
             .filter { $0.1 != nil }
-            .map { (item: (_key: String, _value: Any?)) -> URLQueryItem in
-                URLQueryItem(name: item._key, value:"\(item._value!)")
+            .map { (item: (_key: String, _value: Any?)) -> [URLQueryItem] in
+                if let value = item._value as? Array<String> {
+                    return value.map { (v) -> URLQueryItem in
+                        URLQueryItem(
+                            name: item._key,
+                            value: v
+                        )
+                    }
+                } else {
+                    return [URLQueryItem(
+                        name: item._key,
+                        value: "\(item._value!)"
+                    )]
+                }
             }
+            .flatMap { $0 }
+
         if returnValues.count == 0 {
             return nil
         }
+
         return returnValues
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Query items with array values should be returned as a multiple query items, each with a single value, as per the URI specification. 

