### PR TITLE
[docker] Run as non-root user, fixes ownership of generated artefacts

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,7 +14,7 @@ pattern="@Command(name = \"$1\""
 if expr "x$1" : 'x[a-z][a-z-]*$' > /dev/null && fgrep -qe "$pattern" "$cmdsrc"/*.java; then
     # If ${GEN_DIR} has been mapped elsewhere from default, and that location has not been built
     if [[ ! -f "${codegen}" ]]; then
-        (cd "${GEN_DIR}" && exec mvn -am -pl "modules/swagger-codegen-cli" package)
+        (cd "${GEN_DIR}" && exec mvn -am -pl "modules/swagger-codegen-cli" -Duser.home=$(dirname MAVEN_CONFIG) package)
     fi
     command=$1
     shift

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -10,7 +10,9 @@ mkdir -p "${maven_cache_repo}"
 docker run --rm -it \
         -w /gen \
         -e GEN_DIR=/gen \
+        -e MAVEN_CONFIG=/var/maven/.m2 \
+        -u "$(id -u):$(id -u)" \
         -v "${PWD}:/gen" \
-        -v "${maven_cache_repo}:/root/.m2/repository" \
+        -v "${maven_cache_repo}:/var/maven/.m2/repository" \
         --entrypoint /gen/docker-entrypoint.sh \
         maven:3-jdk-7 "$@"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This change uses the [official maven docker image's method](https://github.com/carlossg/docker-maven#running-as-non-root) to set the user in the docker container to the same user who invokes the `run-in-docker.sh` script. The outcome of this is that all the artefacts generated by the container (m2 cache in home dir, target directories, output client and server code, etc) are owned by the expected user instead of root.