### PR TITLE
Fixed missing isWildcard method used in templates

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenResponse.java
@@ -23,6 +23,10 @@ public class CodegenResponse {
     public String jsonSchema;
     public Map<String, Object> vendorExtensions;
 
+    public boolean isWildcard() {
+        return "0".equals(code) || "default".equals(code);
+    }
+
     @Override
     public String toString() {
         return String.format("%s(%s)", code, containerType);


### PR DESCRIPTION
In PHP templates (and certainly others), an isWildcard method exists to render a default proposition in switch list.
But the corresponding method was removed inconsistently from the CodegenResponse class.

So I make this PR.