### PR TITLE
[cpprest] fix cpprest model source mustache template

### DIFF
--- a/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
@@ -110,7 +110,7 @@ void {{classname}}::fromJson(web::json::value& val)
     {{/isDateTime}}{{^isDateTime}}{{#vendorExtensions.x-codegen-file}}{{setter}}(ModelBase::fileFromJson(val[U("{{baseName}}")]));
     {{/vendorExtensions.x-codegen-file}}{{^vendorExtensions.x-codegen-file}}{{{datatype}}} new{{name}}({{{defaultValue}}});
     new{{name}}->fromJson(val[U("{{baseName}}")]);
-    {{setter}}( newItem );
+    {{setter}}( new{{name}} );
     {{/vendorExtensions.x-codegen-file}}{{/isDateTime}}{{/isString}}{{/required}}{{/isPrimitiveType}}{{/isListContainer}}{{/vars}}
 }
 


### PR DESCRIPTION
which was generating code that doesn't compile because of a wrong variable name

I have run the `cpprest-petstore.sh` and everything seems fine. I did not get changes in the generated files which I suspect is the reason this was overlooked in the first place (the relevant part of the template is not used for any generation in the petstore example).