### PR TITLE
[C#] Fix enum float value in C# and minor format fix in auto-generated doc

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CSharpClientCodegen.java
@@ -560,6 +560,9 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         if ("int?".equalsIgnoreCase(datatype) || "long?".equalsIgnoreCase(datatype) ||
             "double?".equalsIgnoreCase(datatype) || "float?".equalsIgnoreCase(datatype)) {
             return value;
+        } else if ("float?".equalsIgnoreCase(datatype)) {
+            // for float in C#, append "f". e.g. 3.14 => 3.14f
+            return value + "f";
         } else {
             return "\"" + escapeText(value) + "\"";
         }

--- a/modules/swagger-codegen/src/main/resources/csharp/README.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/README.mustache
@@ -102,18 +102,27 @@ namespace Example
     {
         public void main()
         {
-            {{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}{{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
+{{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}
+            {{#hasAuthMethods}}
+            {{#authMethods}}
+            {{#isBasic}}
             // Configure HTTP basic authorization: {{{name}}}
             Configuration.Default.Username = "YOUR_USERNAME";
-            Configuration.Default.Password = "YOUR_PASSWORD";{{/isBasic}}{{#isApiKey}}
+            Configuration.Default.Password = "YOUR_PASSWORD";
+            {{/isBasic}}
+            {{#isApiKey}}
             // Configure API key authorization: {{{name}}}
             Configuration.Default.ApiKey.Add("{{{keyParamName}}}", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add("{{{keyParamName}}}", "Bearer");{{/isApiKey}}{{#isOAuth}}
+            // Configuration.Default.ApiKeyPrefix.Add("{{{keyParamName}}}", "Bearer");
+            {{/isApiKey}}
+            {{#isOAuth}}
             // Configure OAuth2 access token for authorization: {{{name}}}
-            Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";{{/isOAuth}}{{/authMethods}}
-            {{/hasAuthMethods}}
+            Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
+            {{/isOAuth}}
+            {{/authMethods}}
 
+            {{/hasAuthMethods}}
             var apiInstance = new {{classname}}();
             {{#allParams}}
             {{#isPrimitiveType}}
@@ -136,9 +145,10 @@ namespace Example
             {
                 Debug.Print("Exception when calling {{classname}}.{{operationId}}: " + e.Message );
             }
+{{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
         }
     }
-}{{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
+}
 ```
 
 <a name="documentation-for-api-endpoints"></a>

--- a/modules/swagger-codegen/src/main/resources/csharp/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api_doc.mustache
@@ -32,18 +32,26 @@ namespace Example
     {
         public void main()
         {
-            {{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
+            {{#hasAuthMethods}}
+            {{#authMethods}}
+            {{#isBasic}}
             // Configure HTTP basic authorization: {{{name}}}
             Configuration.Default.Username = "YOUR_USERNAME";
-            Configuration.Default.Password = "YOUR_PASSWORD";{{/isBasic}}{{#isApiKey}}
+            Configuration.Default.Password = "YOUR_PASSWORD";
+            {{/isBasic}}
+            {{#isApiKey}}
             // Configure API key authorization: {{{name}}}
             Configuration.Default.ApiKey.Add("{{{keyParamName}}}", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add("{{{keyParamName}}}", "Bearer");{{/isApiKey}}{{#isOAuth}}
+            // Configuration.Default.ApiKeyPrefix.Add("{{{keyParamName}}}", "Bearer");
+            {{/isApiKey}}
+            {{#isOAuth}}
             // Configure OAuth2 access token for authorization: {{{name}}}
-            Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";{{/isOAuth}}{{/authMethods}}
-            {{/hasAuthMethods}}
+            Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
+            {{/isOAuth}}
+            {{/authMethods}}
 
+            {{/hasAuthMethods}}
             var apiInstance = new {{classname}}();
             {{#allParams}}
             {{#isPrimitiveType}}

--- a/samples/client/petstore/csharp/SwaggerClient/README.md
+++ b/samples/client/petstore/csharp/SwaggerClient/README.md
@@ -67,7 +67,7 @@ namespace Example
     {
         public void main()
         {
-            
+
             var apiInstance = new FakeApi();
             var body = new OuterBoolean(); // OuterBoolean | Input boolean as post body (optional) 
 
@@ -80,6 +80,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling FakeApi.FakeOuterBooleanSerialize: " + e.Message );
             }
+
         }
     }
 }

--- a/samples/client/petstore/csharp/SwaggerClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/FakeApi.md
@@ -35,7 +35,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new OuterBoolean(); // OuterBoolean | Input boolean as post body (optional) 
 
@@ -96,7 +95,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new OuterComposite(); // OuterComposite | Input composite as post body (optional) 
 
@@ -157,7 +155,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new OuterNumber(); // OuterNumber | Input number as post body (optional) 
 
@@ -218,7 +215,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new OuterString(); // OuterString | Input string as post body (optional) 
 
@@ -279,7 +275,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new ModelClient(); // ModelClient | client model
 
@@ -341,7 +336,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure HTTP basic authorization: http_basic_test
             Configuration.Default.Username = "YOUR_USERNAME";
             Configuration.Default.Password = "YOUR_PASSWORD";
@@ -432,7 +426,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional) 
             var enumFormString = enumFormString_example;  // string | Form parameter enum test (string) (optional)  (default to -efg)

--- a/samples/client/petstore/csharp/SwaggerClient/docs/PetApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/PetApi.md
@@ -36,7 +36,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -100,7 +99,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -166,7 +164,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -231,7 +228,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -296,7 +292,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure API key authorization: api_key
             Configuration.Default.ApiKey.Add("api_key", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
@@ -363,7 +358,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -427,7 +421,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -495,7 +488,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 

--- a/samples/client/petstore/csharp/SwaggerClient/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/StoreApi.md
@@ -32,7 +32,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var orderId = orderId_example;  // string | ID of the order that needs to be deleted
 
@@ -93,7 +92,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure API key authorization: api_key
             Configuration.Default.ApiKey.Add("api_key", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
@@ -156,7 +154,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var orderId = 789;  // long? | ID of pet that needs to be fetched
 
@@ -218,7 +215,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var body = new Order(); // Order | order placed for purchasing the pet
 

--- a/samples/client/petstore/csharp/SwaggerClient/docs/UserApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/UserApi.md
@@ -36,7 +36,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new User(); // User | Created user object
 
@@ -97,7 +96,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new List<User>(); // List<User> | List of user object
 
@@ -158,7 +156,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new List<User>(); // List<User> | List of user object
 
@@ -219,7 +216,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The name that needs to be deleted
 
@@ -280,7 +276,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The name that needs to be fetched. Use user1 for testing. 
 
@@ -342,7 +337,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The user name for login
             var password = password_example;  // string | The password for login in clear text
@@ -406,7 +400,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
 
             try
@@ -463,7 +456,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | name that need to be deleted
             var body = new User(); // User | Updated user object

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/README.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/README.md
@@ -47,20 +47,20 @@ namespace Example
     {
         public void main()
         {
-            
+
             var apiInstance = new FakeApi();
-            var body = new ModelClient(); // ModelClient | client model
+            var body = new OuterBoolean(); // OuterBoolean | Input boolean as post body (optional) 
 
             try
             {
-                // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(body);
+                OuterBoolean result = apiInstance.FakeOuterBooleanSerialize(body);
                 Debug.WriteLine(result);
             }
             catch (Exception e)
             {
-                Debug.Print("Exception when calling FakeApi.TestClientModel: " + e.Message );
+                Debug.Print("Exception when calling FakeApi.FakeOuterBooleanSerialize: " + e.Message );
             }
+
         }
     }
 }
@@ -73,6 +73,10 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*FakeApi* | [**FakeOuterBooleanSerialize**](docs/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
+*FakeApi* | [**FakeOuterCompositeSerialize**](docs/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
+*FakeApi* | [**FakeOuterNumberSerialize**](docs/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
+*FakeApi* | [**FakeOuterStringSerialize**](docs/FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
 *FakeApi* | [**TestClientModel**](docs/FakeApi.md#testclientmodel) | **PATCH** /fake | To test \"client\" model
 *FakeApi* | [**TestEndpointParameters**](docs/FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 *FakeApi* | [**TestEnumParameters**](docs/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
@@ -109,10 +113,8 @@ Class | Method | HTTP request | Description
  - [Model.ArrayOfNumberOnly](docs/ArrayOfNumberOnly.md)
  - [Model.ArrayTest](docs/ArrayTest.md)
  - [Model.Capitalization](docs/Capitalization.md)
- - [Model.Cat](docs/Cat.md)
  - [Model.Category](docs/Category.md)
  - [Model.ClassModel](docs/ClassModel.md)
- - [Model.Dog](docs/Dog.md)
  - [Model.EnumArrays](docs/EnumArrays.md)
  - [Model.EnumClass](docs/EnumClass.md)
  - [Model.EnumTest](docs/EnumTest.md)
@@ -127,12 +129,18 @@ Class | Method | HTTP request | Description
  - [Model.Name](docs/Name.md)
  - [Model.NumberOnly](docs/NumberOnly.md)
  - [Model.Order](docs/Order.md)
+ - [Model.OuterBoolean](docs/OuterBoolean.md)
+ - [Model.OuterComposite](docs/OuterComposite.md)
  - [Model.OuterEnum](docs/OuterEnum.md)
+ - [Model.OuterNumber](docs/OuterNumber.md)
+ - [Model.OuterString](docs/OuterString.md)
  - [Model.Pet](docs/Pet.md)
  - [Model.ReadOnlyFirst](docs/ReadOnlyFirst.md)
  - [Model.SpecialModelName](docs/SpecialModelName.md)
  - [Model.Tag](docs/Tag.md)
  - [Model.User](docs/User.md)
+ - [Model.Cat](docs/Cat.md)
+ - [Model.Dog](docs/Dog.md)
 
 
 <a name="documentation-for-authorization"></a>

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/FakeApi.md
@@ -4,10 +4,254 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**FakeOuterBooleanSerialize**](FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
+[**FakeOuterCompositeSerialize**](FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
+[**FakeOuterNumberSerialize**](FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
+[**FakeOuterStringSerialize**](FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
 [**TestClientModel**](FakeApi.md#testclientmodel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**TestEndpointParameters**](FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 [**TestEnumParameters**](FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
 
+
+<a name="fakeouterbooleanserialize"></a>
+# **FakeOuterBooleanSerialize**
+> OuterBoolean FakeOuterBooleanSerialize (OuterBoolean body = null)
+
+
+
+Test serialization of outer boolean types
+
+### Example
+```csharp
+using System;
+using System.Diagnostics;
+using IO.Swagger.Api;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
+
+namespace Example
+{
+    public class FakeOuterBooleanSerializeExample
+    {
+        public void main()
+        {
+            var apiInstance = new FakeApi();
+            var body = new OuterBoolean(); // OuterBoolean | Input boolean as post body (optional) 
+
+            try
+            {
+                OuterBoolean result = apiInstance.FakeOuterBooleanSerialize(body);
+                Debug.WriteLine(result);
+            }
+            catch (Exception e)
+            {
+                Debug.Print("Exception when calling FakeApi.FakeOuterBooleanSerialize: " + e.Message );
+            }
+        }
+    }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**OuterBoolean**](OuterBoolean.md)| Input boolean as post body | [optional] 
+
+### Return type
+
+[**OuterBoolean**](OuterBoolean.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a name="fakeoutercompositeserialize"></a>
+# **FakeOuterCompositeSerialize**
+> OuterComposite FakeOuterCompositeSerialize (OuterComposite body = null)
+
+
+
+Test serialization of object with outer number type
+
+### Example
+```csharp
+using System;
+using System.Diagnostics;
+using IO.Swagger.Api;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
+
+namespace Example
+{
+    public class FakeOuterCompositeSerializeExample
+    {
+        public void main()
+        {
+            var apiInstance = new FakeApi();
+            var body = new OuterComposite(); // OuterComposite | Input composite as post body (optional) 
+
+            try
+            {
+                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(body);
+                Debug.WriteLine(result);
+            }
+            catch (Exception e)
+            {
+                Debug.Print("Exception when calling FakeApi.FakeOuterCompositeSerialize: " + e.Message );
+            }
+        }
+    }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**OuterComposite**](OuterComposite.md)| Input composite as post body | [optional] 
+
+### Return type
+
+[**OuterComposite**](OuterComposite.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a name="fakeouternumberserialize"></a>
+# **FakeOuterNumberSerialize**
+> OuterNumber FakeOuterNumberSerialize (OuterNumber body = null)
+
+
+
+Test serialization of outer number types
+
+### Example
+```csharp
+using System;
+using System.Diagnostics;
+using IO.Swagger.Api;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
+
+namespace Example
+{
+    public class FakeOuterNumberSerializeExample
+    {
+        public void main()
+        {
+            var apiInstance = new FakeApi();
+            var body = new OuterNumber(); // OuterNumber | Input number as post body (optional) 
+
+            try
+            {
+                OuterNumber result = apiInstance.FakeOuterNumberSerialize(body);
+                Debug.WriteLine(result);
+            }
+            catch (Exception e)
+            {
+                Debug.Print("Exception when calling FakeApi.FakeOuterNumberSerialize: " + e.Message );
+            }
+        }
+    }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**OuterNumber**](OuterNumber.md)| Input number as post body | [optional] 
+
+### Return type
+
+[**OuterNumber**](OuterNumber.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a name="fakeouterstringserialize"></a>
+# **FakeOuterStringSerialize**
+> OuterString FakeOuterStringSerialize (OuterString body = null)
+
+
+
+Test serialization of outer string types
+
+### Example
+```csharp
+using System;
+using System.Diagnostics;
+using IO.Swagger.Api;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
+
+namespace Example
+{
+    public class FakeOuterStringSerializeExample
+    {
+        public void main()
+        {
+            var apiInstance = new FakeApi();
+            var body = new OuterString(); // OuterString | Input string as post body (optional) 
+
+            try
+            {
+                OuterString result = apiInstance.FakeOuterStringSerialize(body);
+                Debug.WriteLine(result);
+            }
+            catch (Exception e)
+            {
+                Debug.Print("Exception when calling FakeApi.FakeOuterStringSerialize: " + e.Message );
+            }
+        }
+    }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**OuterString**](OuterString.md)| Input string as post body | [optional] 
+
+### Return type
+
+[**OuterString**](OuterString.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 <a name="testclientmodel"></a>
 # **TestClientModel**
@@ -31,7 +275,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new ModelClient(); // ModelClient | client model
 
@@ -93,7 +336,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure HTTP basic authorization: http_basic_test
             Configuration.Default.Username = "YOUR_USERNAME";
             Configuration.Default.Password = "YOUR_PASSWORD";
@@ -184,7 +426,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional) 
             var enumFormString = enumFormString_example;  // string | Form parameter enum test (string) (optional)  (default to -efg)

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/OuterBoolean.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/OuterBoolean.md
@@ -1,0 +1,8 @@
+# IO.Swagger.Model.OuterBoolean
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/OuterComposite.md
@@ -1,0 +1,11 @@
+# IO.Swagger.Model.OuterComposite
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**MyNumber** | [**OuterNumber**](OuterNumber.md) |  | [optional] 
+**MyString** | [**OuterString**](OuterString.md) |  | [optional] 
+**MyBoolean** | [**OuterBoolean**](OuterBoolean.md) |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/OuterNumber.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/OuterNumber.md
@@ -1,0 +1,8 @@
+# IO.Swagger.Model.OuterNumber
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/OuterString.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/OuterString.md
@@ -1,0 +1,8 @@
+# IO.Swagger.Model.OuterString
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/PetApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/PetApi.md
@@ -36,7 +36,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -100,7 +99,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -166,7 +164,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -231,7 +228,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -296,7 +292,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure API key authorization: api_key
             Configuration.Default.ApiKey.Add("api_key", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
@@ -363,7 +358,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -427,7 +421,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -495,7 +488,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/StoreApi.md
@@ -32,7 +32,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var orderId = orderId_example;  // string | ID of the order that needs to be deleted
 
@@ -93,7 +92,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure API key authorization: api_key
             Configuration.Default.ApiKey.Add("api_key", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
@@ -156,7 +154,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var orderId = 789;  // long? | ID of pet that needs to be fetched
 
@@ -218,7 +215,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var body = new Order(); // Order | order placed for purchasing the pet
 

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/UserApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/UserApi.md
@@ -36,7 +36,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new User(); // User | Created user object
 
@@ -97,7 +96,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new List<User>(); // List<User> | List of user object
 
@@ -158,7 +156,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new List<User>(); // List<User> | List of user object
 
@@ -219,7 +216,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The name that needs to be deleted
 
@@ -280,7 +276,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The name that needs to be fetched. Use user1 for testing. 
 
@@ -342,7 +337,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The user name for login
             var password = password_example;  // string | The password for login in clear text
@@ -406,7 +400,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
 
             try
@@ -463,7 +456,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | name that need to be deleted
             var body = new User(); // User | Updated user object

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/FakeApi.cs
@@ -25,6 +25,90 @@ namespace IO.Swagger.Api
     {
         #region Synchronous Operations
         /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer boolean types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input boolean as post body (optional)</param>
+        /// <returns>OuterBoolean</returns>
+        OuterBoolean FakeOuterBooleanSerialize (OuterBoolean body = null);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer boolean types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input boolean as post body (optional)</param>
+        /// <returns>ApiResponse of OuterBoolean</returns>
+        ApiResponse<OuterBoolean> FakeOuterBooleanSerializeWithHttpInfo (OuterBoolean body = null);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of object with outer number type
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input composite as post body (optional)</param>
+        /// <returns>OuterComposite</returns>
+        OuterComposite FakeOuterCompositeSerialize (OuterComposite body = null);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of object with outer number type
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input composite as post body (optional)</param>
+        /// <returns>ApiResponse of OuterComposite</returns>
+        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo (OuterComposite body = null);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer number types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input number as post body (optional)</param>
+        /// <returns>OuterNumber</returns>
+        OuterNumber FakeOuterNumberSerialize (OuterNumber body = null);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer number types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input number as post body (optional)</param>
+        /// <returns>ApiResponse of OuterNumber</returns>
+        ApiResponse<OuterNumber> FakeOuterNumberSerializeWithHttpInfo (OuterNumber body = null);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer string types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input string as post body (optional)</param>
+        /// <returns>OuterString</returns>
+        OuterString FakeOuterStringSerialize (OuterString body = null);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer string types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input string as post body (optional)</param>
+        /// <returns>ApiResponse of OuterString</returns>
+        ApiResponse<OuterString> FakeOuterStringSerializeWithHttpInfo (OuterString body = null);
+        /// <summary>
         /// To test \&quot;client\&quot; model
         /// </summary>
         /// <remarks>
@@ -129,6 +213,90 @@ namespace IO.Swagger.Api
         ApiResponse<Object> TestEnumParametersWithHttpInfo (List<string> enumFormStringArray = null, string enumFormString = null, List<string> enumHeaderStringArray = null, string enumHeaderString = null, List<string> enumQueryStringArray = null, string enumQueryString = null, int? enumQueryInteger = null, double? enumQueryDouble = null);
         #endregion Synchronous Operations
         #region Asynchronous Operations
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer boolean types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input boolean as post body (optional)</param>
+        /// <returns>Task of OuterBoolean</returns>
+        System.Threading.Tasks.Task<OuterBoolean> FakeOuterBooleanSerializeAsync (OuterBoolean body = null);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer boolean types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input boolean as post body (optional)</param>
+        /// <returns>Task of ApiResponse (OuterBoolean)</returns>
+        System.Threading.Tasks.Task<ApiResponse<OuterBoolean>> FakeOuterBooleanSerializeAsyncWithHttpInfo (OuterBoolean body = null);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of object with outer number type
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input composite as post body (optional)</param>
+        /// <returns>Task of OuterComposite</returns>
+        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync (OuterComposite body = null);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of object with outer number type
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input composite as post body (optional)</param>
+        /// <returns>Task of ApiResponse (OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeAsyncWithHttpInfo (OuterComposite body = null);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer number types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input number as post body (optional)</param>
+        /// <returns>Task of OuterNumber</returns>
+        System.Threading.Tasks.Task<OuterNumber> FakeOuterNumberSerializeAsync (OuterNumber body = null);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer number types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input number as post body (optional)</param>
+        /// <returns>Task of ApiResponse (OuterNumber)</returns>
+        System.Threading.Tasks.Task<ApiResponse<OuterNumber>> FakeOuterNumberSerializeAsyncWithHttpInfo (OuterNumber body = null);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer string types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input string as post body (optional)</param>
+        /// <returns>Task of OuterString</returns>
+        System.Threading.Tasks.Task<OuterString> FakeOuterStringSerializeAsync (OuterString body = null);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Test serialization of outer string types
+        /// </remarks>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input string as post body (optional)</param>
+        /// <returns>Task of ApiResponse (OuterString)</returns>
+        System.Threading.Tasks.Task<ApiResponse<OuterString>> FakeOuterStringSerializeAsyncWithHttpInfo (OuterString body = null);
         /// <summary>
         /// To test \&quot;client\&quot; model
         /// </summary>
@@ -342,6 +510,562 @@ namespace IO.Swagger.Api
         public void AddDefaultHeader(string key, string value)
         {
             this.Configuration.AddDefaultHeader(key, value);
+        }
+
+        /// <summary>
+        ///  Test serialization of outer boolean types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input boolean as post body (optional)</param>
+        /// <returns>OuterBoolean</returns>
+        public OuterBoolean FakeOuterBooleanSerialize (OuterBoolean body = null)
+        {
+             ApiResponse<OuterBoolean> localVarResponse = FakeOuterBooleanSerializeWithHttpInfo(body);
+             return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  Test serialization of outer boolean types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input boolean as post body (optional)</param>
+        /// <returns>ApiResponse of OuterBoolean</returns>
+        public ApiResponse< OuterBoolean > FakeOuterBooleanSerializeWithHttpInfo (OuterBoolean body = null)
+        {
+
+            var localVarPath = "./fake/outer/boolean";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (body != null && body.GetType() != typeof(byte[]))
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body); // http body (model) parameter
+            }
+            else
+            {
+                localVarPostBody = body; // byte array
+            }
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("FakeOuterBooleanSerialize", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<OuterBoolean>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                (OuterBoolean) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterBoolean)));
+        }
+
+        /// <summary>
+        ///  Test serialization of outer boolean types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input boolean as post body (optional)</param>
+        /// <returns>Task of OuterBoolean</returns>
+        public async System.Threading.Tasks.Task<OuterBoolean> FakeOuterBooleanSerializeAsync (OuterBoolean body = null)
+        {
+             ApiResponse<OuterBoolean> localVarResponse = await FakeOuterBooleanSerializeAsyncWithHttpInfo(body);
+             return localVarResponse.Data;
+
+        }
+
+        /// <summary>
+        ///  Test serialization of outer boolean types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input boolean as post body (optional)</param>
+        /// <returns>Task of ApiResponse (OuterBoolean)</returns>
+        public async System.Threading.Tasks.Task<ApiResponse<OuterBoolean>> FakeOuterBooleanSerializeAsyncWithHttpInfo (OuterBoolean body = null)
+        {
+
+            var localVarPath = "./fake/outer/boolean";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (body != null && body.GetType() != typeof(byte[]))
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body); // http body (model) parameter
+            }
+            else
+            {
+                localVarPostBody = body; // byte array
+            }
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) await Configuration.ApiClient.CallApiAsync(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("FakeOuterBooleanSerialize", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<OuterBoolean>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                (OuterBoolean) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterBoolean)));
+        }
+
+        /// <summary>
+        ///  Test serialization of object with outer number type
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input composite as post body (optional)</param>
+        /// <returns>OuterComposite</returns>
+        public OuterComposite FakeOuterCompositeSerialize (OuterComposite body = null)
+        {
+             ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(body);
+             return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  Test serialization of object with outer number type
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input composite as post body (optional)</param>
+        /// <returns>ApiResponse of OuterComposite</returns>
+        public ApiResponse< OuterComposite > FakeOuterCompositeSerializeWithHttpInfo (OuterComposite body = null)
+        {
+
+            var localVarPath = "./fake/outer/composite";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (body != null && body.GetType() != typeof(byte[]))
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body); // http body (model) parameter
+            }
+            else
+            {
+                localVarPostBody = body; // byte array
+            }
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("FakeOuterCompositeSerialize", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<OuterComposite>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                (OuterComposite) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterComposite)));
+        }
+
+        /// <summary>
+        ///  Test serialization of object with outer number type
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input composite as post body (optional)</param>
+        /// <returns>Task of OuterComposite</returns>
+        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync (OuterComposite body = null)
+        {
+             ApiResponse<OuterComposite> localVarResponse = await FakeOuterCompositeSerializeAsyncWithHttpInfo(body);
+             return localVarResponse.Data;
+
+        }
+
+        /// <summary>
+        ///  Test serialization of object with outer number type
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input composite as post body (optional)</param>
+        /// <returns>Task of ApiResponse (OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeAsyncWithHttpInfo (OuterComposite body = null)
+        {
+
+            var localVarPath = "./fake/outer/composite";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (body != null && body.GetType() != typeof(byte[]))
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body); // http body (model) parameter
+            }
+            else
+            {
+                localVarPostBody = body; // byte array
+            }
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) await Configuration.ApiClient.CallApiAsync(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("FakeOuterCompositeSerialize", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<OuterComposite>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                (OuterComposite) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterComposite)));
+        }
+
+        /// <summary>
+        ///  Test serialization of outer number types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input number as post body (optional)</param>
+        /// <returns>OuterNumber</returns>
+        public OuterNumber FakeOuterNumberSerialize (OuterNumber body = null)
+        {
+             ApiResponse<OuterNumber> localVarResponse = FakeOuterNumberSerializeWithHttpInfo(body);
+             return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  Test serialization of outer number types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input number as post body (optional)</param>
+        /// <returns>ApiResponse of OuterNumber</returns>
+        public ApiResponse< OuterNumber > FakeOuterNumberSerializeWithHttpInfo (OuterNumber body = null)
+        {
+
+            var localVarPath = "./fake/outer/number";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (body != null && body.GetType() != typeof(byte[]))
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body); // http body (model) parameter
+            }
+            else
+            {
+                localVarPostBody = body; // byte array
+            }
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("FakeOuterNumberSerialize", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<OuterNumber>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                (OuterNumber) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterNumber)));
+        }
+
+        /// <summary>
+        ///  Test serialization of outer number types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input number as post body (optional)</param>
+        /// <returns>Task of OuterNumber</returns>
+        public async System.Threading.Tasks.Task<OuterNumber> FakeOuterNumberSerializeAsync (OuterNumber body = null)
+        {
+             ApiResponse<OuterNumber> localVarResponse = await FakeOuterNumberSerializeAsyncWithHttpInfo(body);
+             return localVarResponse.Data;
+
+        }
+
+        /// <summary>
+        ///  Test serialization of outer number types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input number as post body (optional)</param>
+        /// <returns>Task of ApiResponse (OuterNumber)</returns>
+        public async System.Threading.Tasks.Task<ApiResponse<OuterNumber>> FakeOuterNumberSerializeAsyncWithHttpInfo (OuterNumber body = null)
+        {
+
+            var localVarPath = "./fake/outer/number";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (body != null && body.GetType() != typeof(byte[]))
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body); // http body (model) parameter
+            }
+            else
+            {
+                localVarPostBody = body; // byte array
+            }
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) await Configuration.ApiClient.CallApiAsync(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("FakeOuterNumberSerialize", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<OuterNumber>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                (OuterNumber) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterNumber)));
+        }
+
+        /// <summary>
+        ///  Test serialization of outer string types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input string as post body (optional)</param>
+        /// <returns>OuterString</returns>
+        public OuterString FakeOuterStringSerialize (OuterString body = null)
+        {
+             ApiResponse<OuterString> localVarResponse = FakeOuterStringSerializeWithHttpInfo(body);
+             return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  Test serialization of outer string types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input string as post body (optional)</param>
+        /// <returns>ApiResponse of OuterString</returns>
+        public ApiResponse< OuterString > FakeOuterStringSerializeWithHttpInfo (OuterString body = null)
+        {
+
+            var localVarPath = "./fake/outer/string";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (body != null && body.GetType() != typeof(byte[]))
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body); // http body (model) parameter
+            }
+            else
+            {
+                localVarPostBody = body; // byte array
+            }
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("FakeOuterStringSerialize", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<OuterString>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                (OuterString) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterString)));
+        }
+
+        /// <summary>
+        ///  Test serialization of outer string types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input string as post body (optional)</param>
+        /// <returns>Task of OuterString</returns>
+        public async System.Threading.Tasks.Task<OuterString> FakeOuterStringSerializeAsync (OuterString body = null)
+        {
+             ApiResponse<OuterString> localVarResponse = await FakeOuterStringSerializeAsyncWithHttpInfo(body);
+             return localVarResponse.Data;
+
+        }
+
+        /// <summary>
+        ///  Test serialization of outer string types
+        /// </summary>
+        /// <exception cref="IO.Swagger.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">Input string as post body (optional)</param>
+        /// <returns>Task of ApiResponse (OuterString)</returns>
+        public async System.Threading.Tasks.Task<ApiResponse<OuterString>> FakeOuterStringSerializeAsyncWithHttpInfo (OuterString body = null)
+        {
+
+            var localVarPath = "./fake/outer/string";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (body != null && body.GetType() != typeof(byte[]))
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body); // http body (model) parameter
+            }
+            else
+            {
+                localVarPostBody = body; // byte array
+            }
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) await Configuration.ApiClient.CallApiAsync(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("FakeOuterStringSerialize", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<OuterString>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Key, x => x.Value.ToString()),
+                (OuterString) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterString)));
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Model/OuterBoolean.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Model/OuterBoolean.cs
@@ -12,16 +12,12 @@ using System;
 using System.Linq;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using PropertyChanged;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 
 namespace IO.Swagger.Model
 {
@@ -29,8 +25,7 @@ namespace IO.Swagger.Model
     /// OuterBoolean
     /// </summary>
     [DataContract]
-    [ImplementPropertyChanged]
-    public partial class OuterBoolean :  IEquatable<OuterBoolean>, IValidatableObject
+    public partial class OuterBoolean :  IEquatable<OuterBoolean>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterBoolean" /> class.
@@ -99,36 +94,6 @@ namespace IO.Swagger.Model
                 // Suitable nullity checks etc, of course :)
                 return hash;
             }
-        }
-
-        /// <summary>
-        /// Property changed event handler
-        /// </summary>
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        /// <summary>
-        /// Trigger when a property changed
-        /// </summary>
-        /// <param name="propertyName">Property Name</param>
-        public virtual void OnPropertyChanged(string propertyName)
-        {
-            // NOTE: property changed is handled via "code weaving" using Fody.
-            // Properties with setters are modified at compile time to notify of changes.
-            var propertyChanged = PropertyChanged;
-            if (propertyChanged != null)
-            {
-                propertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// To validate all properties of the instance
-        /// </summary>
-        /// <param name="validationContext">Validation context</param>
-        /// <returns>Validation Result</returns>
-        IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
-        {
-            yield break;
         }
     }
 

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Model/OuterComposite.cs
@@ -12,16 +12,12 @@ using System;
 using System.Linq;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using PropertyChanged;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 
 namespace IO.Swagger.Model
 {
@@ -29,8 +25,7 @@ namespace IO.Swagger.Model
     /// OuterComposite
     /// </summary>
     [DataContract]
-    [ImplementPropertyChanged]
-    public partial class OuterComposite :  IEquatable<OuterComposite>, IValidatableObject
+    public partial class OuterComposite :  IEquatable<OuterComposite>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -143,36 +138,6 @@ namespace IO.Swagger.Model
                     hash = hash * 59 + this.MyBoolean.GetHashCode();
                 return hash;
             }
-        }
-
-        /// <summary>
-        /// Property changed event handler
-        /// </summary>
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        /// <summary>
-        /// Trigger when a property changed
-        /// </summary>
-        /// <param name="propertyName">Property Name</param>
-        public virtual void OnPropertyChanged(string propertyName)
-        {
-            // NOTE: property changed is handled via "code weaving" using Fody.
-            // Properties with setters are modified at compile time to notify of changes.
-            var propertyChanged = PropertyChanged;
-            if (propertyChanged != null)
-            {
-                propertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// To validate all properties of the instance
-        /// </summary>
-        /// <param name="validationContext">Validation context</param>
-        /// <returns>Validation Result</returns>
-        IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
-        {
-            yield break;
         }
     }
 

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Model/OuterNumber.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Model/OuterNumber.cs
@@ -12,31 +12,26 @@ using System;
 using System.Linq;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using PropertyChanged;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 
 namespace IO.Swagger.Model
 {
     /// <summary>
-    /// OuterBoolean
+    /// OuterNumber
     /// </summary>
     [DataContract]
-    [ImplementPropertyChanged]
-    public partial class OuterBoolean :  IEquatable<OuterBoolean>, IValidatableObject
+    public partial class OuterNumber :  IEquatable<OuterNumber>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="OuterBoolean" /> class.
+        /// Initializes a new instance of the <see cref="OuterNumber" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public OuterBoolean()
+        public OuterNumber()
         {
         }
         
@@ -47,7 +42,7 @@ namespace IO.Swagger.Model
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.Append("class OuterBoolean {\n");
+            sb.Append("class OuterNumber {\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -69,15 +64,15 @@ namespace IO.Swagger.Model
         public override bool Equals(object obj)
         {
             // credit: http://stackoverflow.com/a/10454552/677735
-            return this.Equals(obj as OuterBoolean);
+            return this.Equals(obj as OuterNumber);
         }
 
         /// <summary>
-        /// Returns true if OuterBoolean instances are equal
+        /// Returns true if OuterNumber instances are equal
         /// </summary>
-        /// <param name="other">Instance of OuterBoolean to be compared</param>
+        /// <param name="other">Instance of OuterNumber to be compared</param>
         /// <returns>Boolean</returns>
-        public bool Equals(OuterBoolean other)
+        public bool Equals(OuterNumber other)
         {
             // credit: http://stackoverflow.com/a/10454552/677735
             if (other == null)
@@ -99,36 +94,6 @@ namespace IO.Swagger.Model
                 // Suitable nullity checks etc, of course :)
                 return hash;
             }
-        }
-
-        /// <summary>
-        /// Property changed event handler
-        /// </summary>
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        /// <summary>
-        /// Trigger when a property changed
-        /// </summary>
-        /// <param name="propertyName">Property Name</param>
-        public virtual void OnPropertyChanged(string propertyName)
-        {
-            // NOTE: property changed is handled via "code weaving" using Fody.
-            // Properties with setters are modified at compile time to notify of changes.
-            var propertyChanged = PropertyChanged;
-            if (propertyChanged != null)
-            {
-                propertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// To validate all properties of the instance
-        /// </summary>
-        /// <param name="validationContext">Validation context</param>
-        /// <returns>Validation Result</returns>
-        IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
-        {
-            yield break;
         }
     }
 

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Model/OuterString.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Model/OuterString.cs
@@ -12,31 +12,26 @@ using System;
 using System.Linq;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using PropertyChanged;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 
 namespace IO.Swagger.Model
 {
     /// <summary>
-    /// OuterBoolean
+    /// OuterString
     /// </summary>
     [DataContract]
-    [ImplementPropertyChanged]
-    public partial class OuterBoolean :  IEquatable<OuterBoolean>, IValidatableObject
+    public partial class OuterString :  IEquatable<OuterString>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="OuterBoolean" /> class.
+        /// Initializes a new instance of the <see cref="OuterString" /> class.
         /// </summary>
         [JsonConstructorAttribute]
-        public OuterBoolean()
+        public OuterString()
         {
         }
         
@@ -47,7 +42,7 @@ namespace IO.Swagger.Model
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.Append("class OuterBoolean {\n");
+            sb.Append("class OuterString {\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -69,15 +64,15 @@ namespace IO.Swagger.Model
         public override bool Equals(object obj)
         {
             // credit: http://stackoverflow.com/a/10454552/677735
-            return this.Equals(obj as OuterBoolean);
+            return this.Equals(obj as OuterString);
         }
 
         /// <summary>
-        /// Returns true if OuterBoolean instances are equal
+        /// Returns true if OuterString instances are equal
         /// </summary>
-        /// <param name="other">Instance of OuterBoolean to be compared</param>
+        /// <param name="other">Instance of OuterString to be compared</param>
         /// <returns>Boolean</returns>
-        public bool Equals(OuterBoolean other)
+        public bool Equals(OuterString other)
         {
             // credit: http://stackoverflow.com/a/10454552/677735
             if (other == null)
@@ -99,36 +94,6 @@ namespace IO.Swagger.Model
                 // Suitable nullity checks etc, of course :)
                 return hash;
             }
-        }
-
-        /// <summary>
-        /// Property changed event handler
-        /// </summary>
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        /// <summary>
-        /// Trigger when a property changed
-        /// </summary>
-        /// <param name="propertyName">Property Name</param>
-        public virtual void OnPropertyChanged(string propertyName)
-        {
-            // NOTE: property changed is handled via "code weaving" using Fody.
-            // Properties with setters are modified at compile time to notify of changes.
-            var propertyChanged = PropertyChanged;
-            if (propertyChanged != null)
-            {
-                propertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// To validate all properties of the instance
-        /// </summary>
-        /// <param name="validationContext">Validation context</param>
-        /// <returns>Validation Result</returns>
-        IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
-        {
-            yield break;
         }
     }
 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/README.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/README.md
@@ -67,7 +67,7 @@ namespace Example
     {
         public void main()
         {
-            
+
             var apiInstance = new FakeApi();
             var body = new OuterBoolean(); // OuterBoolean | Input boolean as post body (optional) 
 
@@ -80,6 +80,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling FakeApi.FakeOuterBooleanSerialize: " + e.Message );
             }
+
         }
     }
 }
@@ -132,10 +133,8 @@ Class | Method | HTTP request | Description
  - [Model.ArrayOfNumberOnly](docs/ArrayOfNumberOnly.md)
  - [Model.ArrayTest](docs/ArrayTest.md)
  - [Model.Capitalization](docs/Capitalization.md)
- - [Model.Cat](docs/Cat.md)
  - [Model.Category](docs/Category.md)
  - [Model.ClassModel](docs/ClassModel.md)
- - [Model.Dog](docs/Dog.md)
  - [Model.EnumArrays](docs/EnumArrays.md)
  - [Model.EnumClass](docs/EnumClass.md)
  - [Model.EnumTest](docs/EnumTest.md)
@@ -160,6 +159,8 @@ Class | Method | HTTP request | Description
  - [Model.SpecialModelName](docs/SpecialModelName.md)
  - [Model.Tag](docs/Tag.md)
  - [Model.User](docs/User.md)
+ - [Model.Cat](docs/Cat.md)
+ - [Model.Dog](docs/Dog.md)
 
 
 <a name="documentation-for-authorization"></a>

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/FakeApi.md
@@ -35,7 +35,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new OuterBoolean(); // OuterBoolean | Input boolean as post body (optional) 
 
@@ -96,7 +95,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new OuterComposite(); // OuterComposite | Input composite as post body (optional) 
 
@@ -157,7 +155,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new OuterNumber(); // OuterNumber | Input number as post body (optional) 
 
@@ -218,7 +215,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new OuterString(); // OuterString | Input string as post body (optional) 
 
@@ -279,7 +275,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var body = new ModelClient(); // ModelClient | client model
 
@@ -341,7 +336,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure HTTP basic authorization: http_basic_test
             Configuration.Default.Username = "YOUR_USERNAME";
             Configuration.Default.Password = "YOUR_PASSWORD";
@@ -432,7 +426,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new FakeApi();
             var enumFormStringArray = new List<string>(); // List<string> | Form parameter enum test (string array) (optional) 
             var enumFormString = enumFormString_example;  // string | Form parameter enum test (string) (optional)  (default to -efg)

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/PetApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/PetApi.md
@@ -36,7 +36,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -100,7 +99,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -166,7 +164,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -231,7 +228,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -296,7 +292,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure API key authorization: api_key
             Configuration.Default.ApiKey.Add("api_key", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
@@ -363,7 +358,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -427,7 +421,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
@@ -495,7 +488,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure OAuth2 access token for authorization: petstore_auth
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/StoreApi.md
@@ -32,7 +32,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var orderId = orderId_example;  // string | ID of the order that needs to be deleted
 
@@ -93,7 +92,6 @@ namespace Example
     {
         public void main()
         {
-            
             // Configure API key authorization: api_key
             Configuration.Default.ApiKey.Add("api_key", "YOUR_API_KEY");
             // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
@@ -156,7 +154,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var orderId = 789;  // long? | ID of pet that needs to be fetched
 
@@ -218,7 +215,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new StoreApi();
             var body = new Order(); // Order | order placed for purchasing the pet
 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/UserApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/UserApi.md
@@ -36,7 +36,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new User(); // User | Created user object
 
@@ -97,7 +96,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new List<User>(); // List<User> | List of user object
 
@@ -158,7 +156,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var body = new List<User>(); // List<User> | List of user object
 
@@ -219,7 +216,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The name that needs to be deleted
 
@@ -280,7 +276,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The name that needs to be fetched. Use user1 for testing. 
 
@@ -342,7 +337,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | The user name for login
             var password = password_example;  // string | The password for login in clear text
@@ -406,7 +400,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
 
             try
@@ -463,7 +456,6 @@ namespace Example
     {
         public void main()
         {
-            
             var apiInstance = new UserApi();
             var username = username_example;  // string | name that need to be deleted
             var body = new User(); // User | Updated user object

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger.Test/IO.Swagger.Test.csproj
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger.Test/IO.Swagger.Test.csproj
@@ -66,7 +66,8 @@ Contact: apiteam@swagger.io
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs"/>
+    <Compile Include="**\*.cs"
+             Exclude="obj\**"/>
   </ItemGroup>
   <ItemGroup>
       <None Include="packages.config" />

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/FakeApi.cs
@@ -579,7 +579,6 @@ namespace IO.Swagger.Api
             return new ApiResponse<OuterBoolean>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 (OuterBoolean) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterBoolean)));
-            
         }
 
         /// <summary>
@@ -650,7 +649,6 @@ namespace IO.Swagger.Api
             return new ApiResponse<OuterBoolean>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 (OuterBoolean) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterBoolean)));
-            
         }
 
         /// <summary>
@@ -720,7 +718,6 @@ namespace IO.Swagger.Api
             return new ApiResponse<OuterComposite>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 (OuterComposite) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterComposite)));
-            
         }
 
         /// <summary>
@@ -791,7 +788,6 @@ namespace IO.Swagger.Api
             return new ApiResponse<OuterComposite>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 (OuterComposite) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterComposite)));
-            
         }
 
         /// <summary>
@@ -861,7 +857,6 @@ namespace IO.Swagger.Api
             return new ApiResponse<OuterNumber>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 (OuterNumber) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterNumber)));
-            
         }
 
         /// <summary>
@@ -932,7 +927,6 @@ namespace IO.Swagger.Api
             return new ApiResponse<OuterNumber>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 (OuterNumber) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterNumber)));
-            
         }
 
         /// <summary>
@@ -1002,7 +996,6 @@ namespace IO.Swagger.Api
             return new ApiResponse<OuterString>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 (OuterString) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterString)));
-            
         }
 
         /// <summary>
@@ -1073,7 +1066,6 @@ namespace IO.Swagger.Api
             return new ApiResponse<OuterString>(localVarStatusCode,
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 (OuterString) Configuration.ApiClient.Deserialize(localVarResponse, typeof(OuterString)));
-            
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/IO.Swagger.csproj
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/IO.Swagger.csproj
@@ -64,10 +64,8 @@ Contact: apiteam@swagger.io
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Api\**\*.cs"/>
-    <Compile Include="Client\**\*.cs"/>
-    <Compile Include="Model\**\*.cs"/>
-    <Compile Include="Properties\**\*.cs"/>
+    <Compile Include="**\*.cs"
+             Exclude="obj\**" />
   </ItemGroup>
   <ItemGroup>
       <None Include="packages.config" />

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/OuterNumber.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/OuterNumber.cs
@@ -127,7 +127,7 @@ namespace IO.Swagger.Model
         /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
-        { 
+        {
             yield break;
         }
     }

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/OuterString.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/OuterString.cs
@@ -127,7 +127,7 @@ namespace IO.Swagger.Model
         /// <param name="validationContext">Validation context</param>
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
-        { 
+        {
             yield break;
         }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Similar to https://github.com/swagger-api/swagger-codegen/pull/5724, this PR fixes similar issues for enum float value in C#
