### PR TITLE
[Typescript-Angular2] Removed models namespace from inheritance template

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/modelGeneric.mustache
@@ -1,4 +1,4 @@
-export interface {{classname}} {{#parent}}extends models.{{{parent}}} {{/parent}}{
+export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{#additionalPropertiesType}}
     [key: string]: {{{additionalPropertiesType}}}{{#hasVars}} | any{{/hasVars}};
 


### PR DESCRIPTION
### PR checklist

- [done ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [done ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [done ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This change removes the `models.` namespace usage for interfaces that extend a parent.  This was originally modified by commit `7ea419dc5d1aab6c275986ac5322f46e994973bd` which removed the hard-coded inclusion of the entire `models.ts` file. 

This PR is currently tracked by issue #5658 
