### PR TITLE
[javascript] Fixed `fs` files support for Electron

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript-es6/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript-es6/ApiClient.mustache
@@ -160,9 +160,15 @@ export default class ApiClient {
     */
     {{/emitJSDoc}}
     isFileParam(param) {
-        // fs.ReadStream in Node.js (but not in runtime like browserify)
-        if (typeof window === 'undefined' && typeof require === 'function' && require('fs') && param instanceof require('fs').ReadStream) {
-            return true;
+        // fs.ReadStream in Node.js and Electron (but not in runtime like browserify)
+        if (typeof require === 'function') {
+            let fs;
+            try {
+                fs = require('fs');
+            } catch (err) {}
+            if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
+                return true;
+            }
         }
 
         // Buffer in Node.js

--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -168,12 +168,15 @@
    * @returns {Boolean} <code>true</code> if <code>param</code> represents a file.
    */
 {{/emitJSDoc}}  exports.prototype.isFileParam = function(param) {
-    // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if (typeof window === 'undefined' &&
-        typeof require === 'function' &&
-        require('fs') &&
-        param instanceof require('fs').ReadStream) {
-      return true;
+    // fs.ReadStream in Node.js and Electron (but not in runtime like browserify)
+    if (typeof require === 'function') {
+      var fs;
+      try {
+        fs = require('fs');
+      } catch (err) {}
+      if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
+        return true;
+      }
     }
     // Buffer in Node.js
     if (typeof Buffer === 'function' && param instanceof Buffer) {

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -174,12 +174,15 @@
    * @returns {Boolean} <code>true</code> if <code>param</code> represents a file.
    */
   exports.prototype.isFileParam = function(param) {
-    // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if (typeof window === 'undefined' &&
-        typeof require === 'function' &&
-        require('fs') &&
-        param instanceof require('fs').ReadStream) {
-      return true;
+    // fs.ReadStream in Node.js and Electron (but not in runtime like browserify)
+    if (typeof require === 'function') {
+      var fs;
+      try {
+        fs = require('fs');
+      } catch (err) {}
+      if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
+        return true;
+      }
     }
     // Buffer in Node.js
     if (typeof Buffer === 'function' && param instanceof Buffer) {

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -174,12 +174,15 @@
    * @returns {Boolean} <code>true</code> if <code>param</code> represents a file.
    */
   exports.prototype.isFileParam = function(param) {
-    // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if (typeof window === 'undefined' &&
-        typeof require === 'function' &&
-        require('fs') &&
-        param instanceof require('fs').ReadStream) {
-      return true;
+    // fs.ReadStream in Node.js and Electron (but not in runtime like browserify)
+    if (typeof require === 'function') {
+      var fs;
+      try {
+        fs = require('fs');
+      } catch (err) {}
+      if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
+        return true;
+      }
     }
     // Buffer in Node.js
     if (typeof Buffer === 'function' && param instanceof Buffer) {

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -174,12 +174,15 @@
    * @returns {Boolean} <code>true</code> if <code>param</code> represents a file.
    */
   exports.prototype.isFileParam = function(param) {
-    // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if (typeof window === 'undefined' &&
-        typeof require === 'function' &&
-        require('fs') &&
-        param instanceof require('fs').ReadStream) {
-      return true;
+    // fs.ReadStream in Node.js and Electron (but not in runtime like browserify)
+    if (typeof require === 'function') {
+      var fs;
+      try {
+        fs = require('fs');
+      } catch (err) {}
+      if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
+        return true;
+      }
     }
     // Buffer in Node.js
     if (typeof Buffer === 'function' && param instanceof Buffer) {

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -174,12 +174,15 @@
    * @returns {Boolean} <code>true</code> if <code>param</code> represents a file.
    */
   exports.prototype.isFileParam = function(param) {
-    // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if (typeof window === 'undefined' &&
-        typeof require === 'function' &&
-        require('fs') &&
-        param instanceof require('fs').ReadStream) {
-      return true;
+    // fs.ReadStream in Node.js and Electron (but not in runtime like browserify)
+    if (typeof require === 'function') {
+      var fs;
+      try {
+        fs = require('fs');
+      } catch (err) {}
+      if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
+        return true;
+      }
     }
     // Buffer in Node.js
     if (typeof Buffer === 'function' && param instanceof Buffer) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

[Electron](https://electron.atom.io/) has `fs` module with correctly working `ReadStream`, but the check `typeof window === 'undefined'` forced it to skip the `ReadStream` check in Electron, while it is completely valid.

P.S. Other than this, the generated client works perfectly in Electron! (Well, I had to workaround an issue in formidable (https://github.com/felixge/node-formidable/issues/337#issuecomment-153408479), which is a dependency of superagent)