### PR TITLE
[kotlin] Support nested enums in models

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class.mustache
@@ -1,0 +1,22 @@
+/**
+ * {{{description}}}
+{{#vars}}
+ * @param {{name}} {{{description}}}
+{{/vars}}
+ */
+data class {{classname}} (
+{{#requiredVars}}
+{{>data_class_req_var}}{{^-last}},
+{{/-last}}{{/requiredVars}}{{#hasRequired}},
+{{/hasRequired}}{{#optionalVars}}{{>data_class_opt_var}}{{^-last}},
+{{/-last}}{{/optionalVars}}
+) {
+{{#hasEnums}}{{#vars}}{{#isEnum}}
+    enum class {{nameInCamelCase}}(val value: {{datatype}}) {
+    {{#_enum}}
+        {{{this}}}({{#isString}}"{{/isString}}{{{this}}}{{#isString}}"{{/isString}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{/_enum}}
+    }
+
+{{/isEnum}}{{/vars}}{{/hasEnums}}
+}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_opt_var.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_opt_var.mustache
@@ -1,0 +1,4 @@
+{{#description}}
+    /* {{{description}}} */
+{{/description}}
+    val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_req_var.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/data_class_req_var.mustache
@@ -1,0 +1,4 @@
+{{#description}}
+    /* {{{description}}} */
+{{/description}}
+    val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}}

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/enum_class.mustache
@@ -1,0 +1,9 @@
+/**
+* {{{description}}}
+* Values: {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
+*/
+enum class {{classname}}(val value: {{dataType}}){
+{{#allowableValues}}{{#enumVars}}
+    {{name}}({{#isString}}"{{/isString}}{{{value}}}{{#isString}}"{{/isString}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+{{/enumVars}}{{/allowableValues}}
+)

--- a/modules/swagger-codegen/src/main/resources/kotlin-client/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/model.mustache
@@ -6,19 +6,6 @@ package {{modelPackage}}
 
 {{#models}}
 {{#model}}
-/**
-* {{{description}}}
-{{#vars}}
-* @param {{name}} {{{description}}}
-{{/vars}}
-*/
-data class {{classname}} (
-  {{#vars}}
-  {{#description}}
-  /* {{{description}}} */
-  {{/description}}
-  val {{{name}}}: {{{datatype}}}{{^required}}?{{/required}}{{#hasMore}},{{/hasMore}}
-  {{/vars}}
-)
+{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{>data_class}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/ApiResponse.kt
@@ -13,13 +13,15 @@ package io.swagger.client.models
 
 
 /**
-* Describes the result of uploading an image resource
-* @param code 
-* @param type 
-* @param message 
-*/
+ * Describes the result of uploading an image resource
+ * @param code 
+ * @param type 
+ * @param message 
+ */
 data class ApiResponse (
-  val code: kotlin.Int?,
-  val type: kotlin.String?,
-  val message: kotlin.String?
-)
+    val code: kotlin.Int? = null,
+    val type: kotlin.String? = null,
+    val message: kotlin.String? = null
+) {
+
+}

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Category.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Category.kt
@@ -13,11 +13,13 @@ package io.swagger.client.models
 
 
 /**
-* A category for a pet
-* @param id 
-* @param name 
-*/
+ * A category for a pet
+ * @param id 
+ * @param name 
+ */
 data class Category (
-  val id: kotlin.Long?,
-  val name: kotlin.String?
-)
+    val id: kotlin.Long? = null,
+    val name: kotlin.String? = null
+) {
+
+}

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Order.kt
@@ -13,20 +13,29 @@ package io.swagger.client.models
 
 
 /**
-* An order for a pets from the pet store
-* @param id 
-* @param petId 
-* @param quantity 
-* @param shipDate 
-* @param status Order Status
-* @param complete 
-*/
+ * An order for a pets from the pet store
+ * @param id 
+ * @param petId 
+ * @param quantity 
+ * @param shipDate 
+ * @param status Order Status
+ * @param complete 
+ */
 data class Order (
-  val id: kotlin.Long?,
-  val petId: kotlin.Long?,
-  val quantity: kotlin.Int?,
-  val shipDate: java.time.LocalDateTime?,
-  /* Order Status */
-  val status: kotlin.String?,
-  val complete: kotlin.Boolean?
-)
+    val id: kotlin.Long? = null,
+    val petId: kotlin.Long? = null,
+    val quantity: kotlin.Int? = null,
+    val shipDate: java.time.LocalDateTime? = null,
+    /* Order Status */
+    val status: Order.Status? = null,
+    val complete: kotlin.Boolean? = null
+) {
+
+    enum class Status(val value: kotlin.String) {
+        placed("placed"),
+        approved("approved"),
+        delivered("delivered");
+    }
+
+
+}

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Pet.kt
@@ -15,20 +15,29 @@ import io.swagger.client.models.Category
 import io.swagger.client.models.Tag
 
 /**
-* A pet for sale in the pet store
-* @param id 
-* @param category 
-* @param name 
-* @param photoUrls 
-* @param tags 
-* @param status pet status in the store
-*/
+ * A pet for sale in the pet store
+ * @param id 
+ * @param category 
+ * @param name 
+ * @param photoUrls 
+ * @param tags 
+ * @param status pet status in the store
+ */
 data class Pet (
-  val id: kotlin.Long?,
-  val category: Category?,
-  val name: kotlin.String,
-  val photoUrls: kotlin.collections.List<kotlin.String>,
-  val tags: kotlin.collections.List<Tag>?,
-  /* pet status in the store */
-  val status: kotlin.String?
-)
+    val name: kotlin.String,
+    val photoUrls: kotlin.collections.List<kotlin.String>,
+    val id: kotlin.Long? = null,
+    val category: Category? = null,
+    val tags: kotlin.collections.List<Tag>? = null,
+    /* pet status in the store */
+    val status: Pet.Status? = null
+) {
+
+    enum class Status(val value: kotlin.String) {
+        available("available"),
+        pending("pending"),
+        sold("sold");
+    }
+
+
+}

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/Tag.kt
@@ -13,11 +13,13 @@ package io.swagger.client.models
 
 
 /**
-* A tag for a pet
-* @param id 
-* @param name 
-*/
+ * A tag for a pet
+ * @param id 
+ * @param name 
+ */
 data class Tag (
-  val id: kotlin.Long?,
-  val name: kotlin.String?
-)
+    val id: kotlin.Long? = null,
+    val name: kotlin.String? = null
+) {
+
+}

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/User.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/models/User.kt
@@ -13,24 +13,26 @@ package io.swagger.client.models
 
 
 /**
-* A User who is purchasing from the pet store
-* @param id 
-* @param username 
-* @param firstName 
-* @param lastName 
-* @param email 
-* @param password 
-* @param phone 
-* @param userStatus User Status
-*/
+ * A User who is purchasing from the pet store
+ * @param id 
+ * @param username 
+ * @param firstName 
+ * @param lastName 
+ * @param email 
+ * @param password 
+ * @param phone 
+ * @param userStatus User Status
+ */
 data class User (
-  val id: kotlin.Long?,
-  val username: kotlin.String?,
-  val firstName: kotlin.String?,
-  val lastName: kotlin.String?,
-  val email: kotlin.String?,
-  val password: kotlin.String?,
-  val phone: kotlin.String?,
-  /* User Status */
-  val userStatus: kotlin.Int?
-)
+    val id: kotlin.Long? = null,
+    val username: kotlin.String? = null,
+    val firstName: kotlin.String? = null,
+    val lastName: kotlin.String? = null,
+    val email: kotlin.String? = null,
+    val password: kotlin.String? = null,
+    val phone: kotlin.String? = null,
+    /* User Status */
+    val userStatus: kotlin.Int? = null
+) {
+
+}

--- a/samples/client/petstore/kotlin/src/test/kotlin/io/swagger/client/functional/EvaluateTest.kt
+++ b/samples/client/petstore/kotlin/src/test/kotlin/io/swagger/client/functional/EvaluateTest.kt
@@ -9,7 +9,7 @@ class EvaluateTest : ShouldSpec() {
     init {
         should("query against pet statuses") {
             val api = PetApi()
-            val results = api.findPetsByStatus(listOf("available", "pending"))
+            val results = api.findPetsByStatus(listOf("sold"))
 
             results.size should beGreaterThan(1)
         }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This updates model generation to support nested enums. Verified that top-level enums were handled correctly by default behavior in DefaultCodegen.

This checks off a couple of todos in #5730, although enum-related tests aren't included in this PR. I'll update the tracking issue to include testing of top-level and nested enums.

