### PR TITLE
Fix typo in Ruby examples/mustache files

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_test.mustache
@@ -19,7 +19,7 @@ require 'json'
   end
 
   describe 'test an instance of {{classname}}' do
-    it 'should create an instact of {{classname}}' do
+    it 'should create an instance of {{classname}}' do
       expect(@instance).to be_instance_of({{moduleName}}::{{classname}})
     end
   end

--- a/modules/swagger-codegen/src/main/resources/ruby/model_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/model_test.mustache
@@ -20,7 +20,7 @@ require 'date'
   end
 
   describe 'test an instance of {{classname}}' do
-    it 'should create an instact of {{classname}}' do
+    it 'should create an instance of {{classname}}' do
       expect(@instance).to be_instance_of({{moduleName}}::{{classname}})
     end
   end

--- a/samples/client/petstore-security-test/ruby/spec/api/fake_api_spec.rb
+++ b/samples/client/petstore-security-test/ruby/spec/api/fake_api_spec.rb
@@ -38,7 +38,7 @@ describe 'FakeApi' do
   end
 
   describe 'test an instance of FakeApi' do
-    it 'should create an instact of FakeApi' do
+    it 'should create an instance of FakeApi' do
       expect(@instance).to be_instance_of(Petstore::FakeApi)
     end
   end

--- a/samples/client/petstore-security-test/ruby/spec/models/model_return_spec.rb
+++ b/samples/client/petstore-security-test/ruby/spec/models/model_return_spec.rb
@@ -39,7 +39,7 @@ describe 'ModelReturn' do
   end
 
   describe 'test an instance of ModelReturn' do
-    it 'should create an instact of ModelReturn' do
+    it 'should create an instance of ModelReturn' do
       expect(@instance).to be_instance_of(Petstore::ModelReturn)
     end
   end

--- a/samples/client/petstore/ruby/spec/api/fake_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/fake_api_spec.rb
@@ -31,7 +31,7 @@ describe 'FakeApi' do
   end
 
   describe 'test an instance of FakeApi' do
-    it 'should create an instact of FakeApi' do
+    it 'should create an instance of FakeApi' do
       expect(@instance).to be_instance_of(Petstore::FakeApi)
     end
   end

--- a/samples/client/petstore/ruby/spec/api/pet_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/pet_api_spec.rb
@@ -31,7 +31,7 @@ describe 'PetApi' do
   end
 
   describe 'test an instance of PetApi' do
-    it 'should create an instact of PetApi' do
+    it 'should create an instance of PetApi' do
       expect(@instance).to be_instance_of(Petstore::PetApi)
     end
   end

--- a/samples/client/petstore/ruby/spec/api/store_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/store_api_spec.rb
@@ -31,7 +31,7 @@ describe 'StoreApi' do
   end
 
   describe 'test an instance of StoreApi' do
-    it 'should create an instact of StoreApi' do
+    it 'should create an instance of StoreApi' do
       expect(@instance).to be_instance_of(Petstore::StoreApi)
     end
   end

--- a/samples/client/petstore/ruby/spec/api/user_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/user_api_spec.rb
@@ -31,7 +31,7 @@ describe 'UserApi' do
   end
 
   describe 'test an instance of UserApi' do
-    it 'should create an instact of UserApi' do
+    it 'should create an instance of UserApi' do
       expect(@instance).to be_instance_of(Petstore::UserApi)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/additional_properties_class_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/additional_properties_class_spec.rb
@@ -32,7 +32,7 @@ describe 'AdditionalPropertiesClass' do
   end
 
   describe 'test an instance of AdditionalPropertiesClass' do
-    it 'should create an instact of AdditionalPropertiesClass' do
+    it 'should create an instance of AdditionalPropertiesClass' do
       expect(@instance).to be_instance_of(Petstore::AdditionalPropertiesClass)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/animal_farm_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/animal_farm_spec.rb
@@ -32,7 +32,7 @@ describe 'AnimalFarm' do
   end
 
   describe 'test an instance of AnimalFarm' do
-    it 'should create an instact of AnimalFarm' do
+    it 'should create an instance of AnimalFarm' do
       expect(@instance).to be_instance_of(Petstore::AnimalFarm)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/animal_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/animal_spec.rb
@@ -32,7 +32,7 @@ describe 'Animal' do
   end
 
   describe 'test an instance of Animal' do
-    it 'should create an instact of Animal' do
+    it 'should create an instance of Animal' do
       expect(@instance).to be_instance_of(Petstore::Animal)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/api_response_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/api_response_spec.rb
@@ -32,7 +32,7 @@ describe 'ApiResponse' do
   end
 
   describe 'test an instance of ApiResponse' do
-    it 'should create an instact of ApiResponse' do
+    it 'should create an instance of ApiResponse' do
       expect(@instance).to be_instance_of(Petstore::ApiResponse)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/array_of_array_of_number_only_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/array_of_array_of_number_only_spec.rb
@@ -39,7 +39,7 @@ describe 'ArrayOfArrayOfNumberOnly' do
   end
 
   describe 'test an instance of ArrayOfArrayOfNumberOnly' do
-    it 'should create an instact of ArrayOfArrayOfNumberOnly' do
+    it 'should create an instance of ArrayOfArrayOfNumberOnly' do
       expect(@instance).to be_instance_of(Petstore::ArrayOfArrayOfNumberOnly)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/array_of_number_only_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/array_of_number_only_spec.rb
@@ -39,7 +39,7 @@ describe 'ArrayOfNumberOnly' do
   end
 
   describe 'test an instance of ArrayOfNumberOnly' do
-    it 'should create an instact of ArrayOfNumberOnly' do
+    it 'should create an instance of ArrayOfNumberOnly' do
       expect(@instance).to be_instance_of(Petstore::ArrayOfNumberOnly)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/array_test_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/array_test_spec.rb
@@ -39,7 +39,7 @@ describe 'ArrayTest' do
   end
 
   describe 'test an instance of ArrayTest' do
-    it 'should create an instact of ArrayTest' do
+    it 'should create an instance of ArrayTest' do
       expect(@instance).to be_instance_of(Petstore::ArrayTest)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/capitalization_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/capitalization_spec.rb
@@ -27,7 +27,7 @@ describe 'Capitalization' do
   end
 
   describe 'test an instance of Capitalization' do
-    it 'should create an instact of Capitalization' do
+    it 'should create an instance of Capitalization' do
       expect(@instance).to be_instance_of(Petstore::Capitalization)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/cat_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/cat_spec.rb
@@ -32,7 +32,7 @@ describe 'Cat' do
   end
 
   describe 'test an instance of Cat' do
-    it 'should create an instact of Cat' do
+    it 'should create an instance of Cat' do
       expect(@instance).to be_instance_of(Petstore::Cat)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/category_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/category_spec.rb
@@ -32,7 +32,7 @@ describe 'Category' do
   end
 
   describe 'test an instance of Category' do
-    it 'should create an instact of Category' do
+    it 'should create an instance of Category' do
       expect(@instance).to be_instance_of(Petstore::Category)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/class_model_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/class_model_spec.rb
@@ -27,7 +27,7 @@ describe 'ClassModel' do
   end
 
   describe 'test an instance of ClassModel' do
-    it 'should create an instact of ClassModel' do
+    it 'should create an instance of ClassModel' do
       expect(@instance).to be_instance_of(Petstore::ClassModel)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/client_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/client_spec.rb
@@ -39,7 +39,7 @@ describe 'Client' do
   end
 
   describe 'test an instance of Client' do
-    it 'should create an instact of Client' do
+    it 'should create an instance of Client' do
       expect(@instance).to be_instance_of(Petstore::Client)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/dog_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/dog_spec.rb
@@ -32,7 +32,7 @@ describe 'Dog' do
   end
 
   describe 'test an instance of Dog' do
-    it 'should create an instact of Dog' do
+    it 'should create an instance of Dog' do
       expect(@instance).to be_instance_of(Petstore::Dog)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/enum_arrays_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/enum_arrays_spec.rb
@@ -39,7 +39,7 @@ describe 'EnumArrays' do
   end
 
   describe 'test an instance of EnumArrays' do
-    it 'should create an instact of EnumArrays' do
+    it 'should create an instance of EnumArrays' do
       expect(@instance).to be_instance_of(Petstore::EnumArrays)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/enum_class_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/enum_class_spec.rb
@@ -32,7 +32,7 @@ describe 'EnumClass' do
   end
 
   describe 'test an instance of EnumClass' do
-    it 'should create an instact of EnumClass' do
+    it 'should create an instance of EnumClass' do
       expect(@instance).to be_instance_of(Petstore::EnumClass)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/enum_test_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/enum_test_spec.rb
@@ -32,7 +32,7 @@ describe 'EnumTest' do
   end
 
   describe 'test an instance of EnumTest' do
-    it 'should create an instact of EnumTest' do
+    it 'should create an instance of EnumTest' do
       expect(@instance).to be_instance_of(Petstore::EnumTest)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/format_test_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/format_test_spec.rb
@@ -32,7 +32,7 @@ describe 'FormatTest' do
   end
 
   describe 'test an instance of FormatTest' do
-    it 'should create an instact of FormatTest' do
+    it 'should create an instance of FormatTest' do
       expect(@instance).to be_instance_of(Petstore::FormatTest)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/has_only_read_only_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/has_only_read_only_spec.rb
@@ -39,7 +39,7 @@ describe 'HasOnlyReadOnly' do
   end
 
   describe 'test an instance of HasOnlyReadOnly' do
-    it 'should create an instact of HasOnlyReadOnly' do
+    it 'should create an instance of HasOnlyReadOnly' do
       expect(@instance).to be_instance_of(Petstore::HasOnlyReadOnly)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/list_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/list_spec.rb
@@ -39,7 +39,7 @@ describe 'List' do
   end
 
   describe 'test an instance of List' do
-    it 'should create an instact of List' do
+    it 'should create an instance of List' do
       expect(@instance).to be_instance_of(Petstore::List)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/map_test_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/map_test_spec.rb
@@ -39,7 +39,7 @@ describe 'MapTest' do
   end
 
   describe 'test an instance of MapTest' do
-    it 'should create an instact of MapTest' do
+    it 'should create an instance of MapTest' do
       expect(@instance).to be_instance_of(Petstore::MapTest)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/mixed_properties_and_additional_properties_class_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/mixed_properties_and_additional_properties_class_spec.rb
@@ -32,7 +32,7 @@ describe 'MixedPropertiesAndAdditionalPropertiesClass' do
   end
 
   describe 'test an instance of MixedPropertiesAndAdditionalPropertiesClass' do
-    it 'should create an instact of MixedPropertiesAndAdditionalPropertiesClass' do
+    it 'should create an instance of MixedPropertiesAndAdditionalPropertiesClass' do
       expect(@instance).to be_instance_of(Petstore::MixedPropertiesAndAdditionalPropertiesClass)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/model_200_response_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/model_200_response_spec.rb
@@ -32,7 +32,7 @@ describe 'Model200Response' do
   end
 
   describe 'test an instance of Model200Response' do
-    it 'should create an instact of Model200Response' do
+    it 'should create an instance of Model200Response' do
       expect(@instance).to be_instance_of(Petstore::Model200Response)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/model_return_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/model_return_spec.rb
@@ -32,7 +32,7 @@ describe 'ModelReturn' do
   end
 
   describe 'test an instance of ModelReturn' do
-    it 'should create an instact of ModelReturn' do
+    it 'should create an instance of ModelReturn' do
       expect(@instance).to be_instance_of(Petstore::ModelReturn)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/name_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/name_spec.rb
@@ -32,7 +32,7 @@ describe 'Name' do
   end
 
   describe 'test an instance of Name' do
-    it 'should create an instact of Name' do
+    it 'should create an instance of Name' do
       expect(@instance).to be_instance_of(Petstore::Name)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/number_only_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/number_only_spec.rb
@@ -39,7 +39,7 @@ describe 'NumberOnly' do
   end
 
   describe 'test an instance of NumberOnly' do
-    it 'should create an instact of NumberOnly' do
+    it 'should create an instance of NumberOnly' do
       expect(@instance).to be_instance_of(Petstore::NumberOnly)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/order_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/order_spec.rb
@@ -32,7 +32,7 @@ describe 'Order' do
   end
 
   describe 'test an instance of Order' do
-    it 'should create an instact of Order' do
+    it 'should create an instance of Order' do
       expect(@instance).to be_instance_of(Petstore::Order)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/outer_boolean_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/outer_boolean_spec.rb
@@ -27,7 +27,7 @@ describe 'OuterBoolean' do
   end
 
   describe 'test an instance of OuterBoolean' do
-    it 'should create an instact of OuterBoolean' do
+    it 'should create an instance of OuterBoolean' do
       expect(@instance).to be_instance_of(Petstore::OuterBoolean)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/outer_composite_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/outer_composite_spec.rb
@@ -27,7 +27,7 @@ describe 'OuterComposite' do
   end
 
   describe 'test an instance of OuterComposite' do
-    it 'should create an instact of OuterComposite' do
+    it 'should create an instance of OuterComposite' do
       expect(@instance).to be_instance_of(Petstore::OuterComposite)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/outer_enum_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/outer_enum_spec.rb
@@ -27,7 +27,7 @@ describe 'OuterEnum' do
   end
 
   describe 'test an instance of OuterEnum' do
-    it 'should create an instact of OuterEnum' do
+    it 'should create an instance of OuterEnum' do
       expect(@instance).to be_instance_of(Petstore::OuterEnum)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/outer_number_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/outer_number_spec.rb
@@ -27,7 +27,7 @@ describe 'OuterNumber' do
   end
 
   describe 'test an instance of OuterNumber' do
-    it 'should create an instact of OuterNumber' do
+    it 'should create an instance of OuterNumber' do
       expect(@instance).to be_instance_of(Petstore::OuterNumber)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/outer_string_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/outer_string_spec.rb
@@ -27,7 +27,7 @@ describe 'OuterString' do
   end
 
   describe 'test an instance of OuterString' do
-    it 'should create an instact of OuterString' do
+    it 'should create an instance of OuterString' do
       expect(@instance).to be_instance_of(Petstore::OuterString)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/pet_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/pet_spec.rb
@@ -32,7 +32,7 @@ describe 'Pet' do
   end
 
   describe 'test an instance of Pet' do
-    it 'should create an instact of Pet' do
+    it 'should create an instance of Pet' do
       expect(@instance).to be_instance_of(Petstore::Pet)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/read_only_first_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/read_only_first_spec.rb
@@ -32,7 +32,7 @@ describe 'ReadOnlyFirst' do
   end
 
   describe 'test an instance of ReadOnlyFirst' do
-    it 'should create an instact of ReadOnlyFirst' do
+    it 'should create an instance of ReadOnlyFirst' do
       expect(@instance).to be_instance_of(Petstore::ReadOnlyFirst)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/special_model_name_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/special_model_name_spec.rb
@@ -32,7 +32,7 @@ describe 'SpecialModelName' do
   end
 
   describe 'test an instance of SpecialModelName' do
-    it 'should create an instact of SpecialModelName' do
+    it 'should create an instance of SpecialModelName' do
       expect(@instance).to be_instance_of(Petstore::SpecialModelName)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/tag_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/tag_spec.rb
@@ -32,7 +32,7 @@ describe 'Tag' do
   end
 
   describe 'test an instance of Tag' do
-    it 'should create an instact of Tag' do
+    it 'should create an instance of Tag' do
       expect(@instance).to be_instance_of(Petstore::Tag)
     end
   end

--- a/samples/client/petstore/ruby/spec/models/user_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/user_spec.rb
@@ -32,7 +32,7 @@ describe 'User' do
   end
 
   describe 'test an instance of User' do
-    it 'should create an instact of User' do
+    it 'should create an instance of User' do
       expect(@instance).to be_instance_of(Petstore::User)
     end
   end


### PR DESCRIPTION
Changed all appearances of "instact" to "instance". Appears this was limited to Ruby files.

