### PR TITLE
Fix issue with buffered sink handling in OkHttp

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ProgressRequestBody.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ProgressRequestBody.mustache
@@ -23,8 +23,6 @@ public class ProgressRequestBody extends RequestBody {
 
     private final ProgressRequestListener progressListener;
 
-    private BufferedSink bufferedSink;
-
     public ProgressRequestBody(RequestBody requestBody, ProgressRequestListener progressListener) {
         this.requestBody = requestBody;
         this.progressListener = progressListener;
@@ -42,13 +40,9 @@ public class ProgressRequestBody extends RequestBody {
 
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
-        if (bufferedSink == null) {
-            bufferedSink = Okio.buffer(sink(sink));
-        }
-
+        BufferedSink bufferedSink = Okio.buffer(sink(sink));
         requestBody.writeTo(bufferedSink);
         bufferedSink.flush();
-
     }
 
     private Sink sink(Sink sink) {

--- a/samples/client/petstore-security-test/java/okhttp-gson/src/main/java/io/swagger/client/ProgressRequestBody.java
+++ b/samples/client/petstore-security-test/java/okhttp-gson/src/main/java/io/swagger/client/ProgressRequestBody.java
@@ -34,8 +34,6 @@ public class ProgressRequestBody extends RequestBody {
 
     private final ProgressRequestListener progressListener;
 
-    private BufferedSink bufferedSink;
-
     public ProgressRequestBody(RequestBody requestBody, ProgressRequestListener progressListener) {
         this.requestBody = requestBody;
         this.progressListener = progressListener;
@@ -53,13 +51,9 @@ public class ProgressRequestBody extends RequestBody {
 
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
-        if (bufferedSink == null) {
-            bufferedSink = Okio.buffer(sink(sink));
-        }
-
+        BufferedSink bufferedSink = Okio.buffer(sink(sink));
         requestBody.writeTo(bufferedSink);
         bufferedSink.flush();
-
     }
 
     private Sink sink(Sink sink) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ProgressRequestBody.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/io/swagger/client/ProgressRequestBody.java
@@ -34,8 +34,6 @@ public class ProgressRequestBody extends RequestBody {
 
     private final ProgressRequestListener progressListener;
 
-    private BufferedSink bufferedSink;
-
     public ProgressRequestBody(RequestBody requestBody, ProgressRequestListener progressListener) {
         this.requestBody = requestBody;
         this.progressListener = progressListener;
@@ -53,13 +51,9 @@ public class ProgressRequestBody extends RequestBody {
 
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
-        if (bufferedSink == null) {
-            bufferedSink = Okio.buffer(sink(sink));
-        }
-
+        BufferedSink bufferedSink = Okio.buffer(sink(sink));
         requestBody.writeTo(bufferedSink);
         bufferedSink.flush();
-
     }
 
     private Sink sink(Sink sink) {


### PR DESCRIPTION
Fixes unexpected end of stream exceptions when using the okhttp-gson library
and making asynchronous calls.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixes unexpected end of stream exceptions when using the `okhttp-gson` library
and making asynchronous calls. Fix implemented as proposed by @Megamzero. 

See #4095 