### PR TITLE
Fix issue 5793

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
@@ -9,12 +9,14 @@ import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 public class HaskellServantCodegen extends DefaultCodegen implements CodegenConfig {
 
     // source folder where to write the files
     protected String sourceFolder = "src";
     protected String apiVersion = "0.0.1";
+    private static final Pattern LEADING_UNDERSCORE = Pattern.compile("^_+");
 
     /**
      * Configures the type of generator.
@@ -468,12 +470,14 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
 
     private String fixOperatorChars(String string) {
         StringBuilder sb = new StringBuilder();
-        String name;
+        String name = string;
         //Check if it is a reserved word, in which case the underscore is added when property name is generated.
-        if (string.startsWith("_") && escapeReservedWord(string.substring(1, string.length())).equals(string)) {
-            name = string.substring(1, string.length());
-        } else {
-            name = string;
+        if (string.startsWith("_")) {
+            if (reservedWords.contains(string.substring(1, string.length()))) {
+                name = string.substring(1, string.length());
+            } else if (reservedWordsMappings.containsValue(string)) {
+                name = LEADING_UNDERSCORE.matcher(string).replaceFirst("");
+            }
         }
         for (char c : name.toCharArray()) {
             String cString = String.valueOf(c);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
@@ -469,9 +469,10 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
     private String fixOperatorChars(String string) {
         StringBuilder sb = new StringBuilder();
         for (char c : string.toCharArray()) {
-            if (specialCharReplacements.containsKey(c)) {
+            String cString = String.valueOf(c);
+            if (specialCharReplacements.containsKey(cString)) {
                 sb.append("'");
-                sb.append(specialCharReplacements.get(c));
+                sb.append(specialCharReplacements.get(cString));
             } else {
                 sb.append(c);
             }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/HaskellServantCodegen.java
@@ -468,7 +468,14 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
 
     private String fixOperatorChars(String string) {
         StringBuilder sb = new StringBuilder();
-        for (char c : string.toCharArray()) {
+        String name;
+        //Check if it is a reserved word, in which case the underscore is added when property name is generated.
+        if (string.startsWith("_") && escapeReservedWord(string.substring(1, string.length())).equals(string)) {
+            name = string.substring(1, string.length());
+        } else {
+            name = string;
+        }
+        for (char c : name.toCharArray()) {
             String cString = String.valueOf(c);
             if (specialCharReplacements.containsKey(cString)) {
                 sb.append("'");
@@ -499,7 +506,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         // From the model name, compute the prefix for the fields.
         String prefix = camelize(model.classname, true);
         for(CodegenProperty prop : model.vars) {
-            prop.name = prefix + camelize(fixOperatorChars(prop.name));
+            prop.name = toVarName(prefix + camelize(fixOperatorChars(prop.name)));
         }
 
         // Create newtypes for things with non-object types


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fix a bug that leads to generated field names not escaping special characters. (#5793)
