### PR TITLE
[Swift3] Set more liberal Swift3 decoder, behind lenientTypeCast option

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/Swift3Codegen.java
@@ -39,11 +39,13 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
     public static final String POD_DOCUMENTATION_URL = "podDocumentationURL";
     public static final String SWIFT_USE_API_NAMESPACE = "swiftUseApiNamespace";
     public static final String DEFAULT_POD_AUTHORS = "Swagger Codegen";
+    public static final String LENIENT_TYPE_CAST = "lenientTypeCast";
     protected static final String LIBRARY_PROMISE_KIT = "PromiseKit";
     protected static final String LIBRARY_RX_SWIFT = "RxSwift";
     protected static final String[] RESPONSE_LIBRARIES = {LIBRARY_PROMISE_KIT, LIBRARY_RX_SWIFT};
     protected String projectName = "SwaggerClient";
     protected boolean unwrapRequired;
+    protected boolean lenientTypeCast = false;
     protected boolean swiftUseApiNamespace;
     protected String[] responseAs = new String[0];
     protected String sourceFolder = "Classes" + File.separator + "Swaggers";
@@ -171,12 +173,14 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(SWIFT_USE_API_NAMESPACE, "Flag to make all the API classes inner-class of {{projectName}}API"));
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "hides the timestamp when files were generated")
                 .defaultValue(Boolean.TRUE.toString()));
-
+        cliOptions.add(new CliOption(LENIENT_TYPE_CAST, "Accept and cast values for simple types (string->bool, string->int, int->string)")
+                .defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override
     public void processOpts() {
         super.processOpts();
+
         // default HIDE_GENERATION_TIMESTAMP to true
         if (!additionalProperties.containsKey(CodegenConstants.HIDE_GENERATION_TIMESTAMP)) {
             additionalProperties.put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, Boolean.TRUE.toString());
@@ -224,6 +228,8 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
         if (!additionalProperties.containsKey(POD_AUTHORS)) {
             additionalProperties.put(POD_AUTHORS, DEFAULT_POD_AUTHORS);
         }
+
+        setLenientTypeCast(convertPropertyToBooleanAndWriteBack(LENIENT_TYPE_CAST));
 
         supportingFiles.add(new SupportingFile("Podspec.mustache", "", projectName + ".podspec"));
         supportingFiles.add(new SupportingFile("Cartfile.mustache", "", "Cartfile"));
@@ -471,6 +477,10 @@ public class Swift3Codegen extends DefaultCodegen implements CodegenConfig {
 
     public void setUnwrapRequired(boolean unwrapRequired) {
         this.unwrapRequired = unwrapRequired;
+    }
+
+    public void setLenientTypeCast(boolean lenientTypeCast) {
+        this.lenientTypeCast = lenientTypeCast;
     }
 
     public void setResponseAs(String[] responseAs) {

--- a/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Models.mustache
@@ -70,10 +70,10 @@ class Decoders {
     static func decode<T>(clazz: T.Type, source: AnyObject, instance: AnyObject?) -> T {
         initialize()
         if T.self is Int32.Type && source is NSNumber {
-            return (source as! NSNumber).int32Value as! T;
+            return (source as! NSNumber).int32Value as! T
         }
         if T.self is Int64.Type && source is NSNumber {
-            return source.int64Value as! T;
+            return (source as! NSNumber).int64Value as! T
         }
         if T.self is UUID.Type && source is String {
             return UUID(uuidString: source as! String) as! T
@@ -84,6 +84,20 @@ class Decoders {
         if T.self is Data.Type && source is String {
             return Data(base64Encoded: source as! String) as! T
         }
+        {{#lenientTypeCast}}
+        if T.self is Int32.Type && source is String {
+            return (source as! NSString).intValue as! T
+        }
+        if T.self is Int64.Type && source is String {
+            return (source as! NSString).intValue as! T
+        }
+        if T.self is Bool.Type && source is String {
+            return (source as! NSString).boolValue as! T
+        }
+        if T.self is String.Type && source is NSNumber {
+            return String(describing: source) as! T
+        }
+        {{/lenientTypeCast}}
 
         let key = "\(T.self)"
         if let decoder = decoders[key] {

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Swift3OptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Swift3OptionsProvider.java
@@ -13,6 +13,7 @@ public class Swift3OptionsProvider implements OptionsProvider {
     public static final String PROJECT_NAME_VALUE = "Swagger";
     public static final String RESPONSE_AS_VALUE = "test";
     public static final String UNWRAP_REQUIRED_VALUE = "true";
+    public static final String LENIENT_TYPE_CAST_VALUE = "false";
     public static final String POD_SOURCE_VALUE = "{ :git => 'git@github.com:swagger-api/swagger-mustache.git'," +
             " :tag => 'v1.0.0-SNAPSHOT' }";
     public static final String POD_VERSION_VALUE = "v1.0.0-SNAPSHOT";
@@ -41,6 +42,7 @@ public class Swift3OptionsProvider implements OptionsProvider {
                 .put(Swift3Codegen.PROJECT_NAME, PROJECT_NAME_VALUE)
                 .put(Swift3Codegen.RESPONSE_AS, RESPONSE_AS_VALUE)
                 .put(Swift3Codegen.UNWRAP_REQUIRED, UNWRAP_REQUIRED_VALUE)
+                .put(Swift3Codegen.LENIENT_TYPE_CAST, LENIENT_TYPE_CAST_VALUE)
                 .put(Swift3Codegen.POD_SOURCE, POD_SOURCE_VALUE)
                 .put(CodegenConstants.POD_VERSION, POD_VERSION_VALUE)
                 .put(Swift3Codegen.POD_AUTHORS, POD_AUTHORS_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3OptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3OptionsTest.java
@@ -33,6 +33,8 @@ public class Swift3OptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setUnwrapRequired(Boolean.valueOf(Swift3OptionsProvider.UNWRAP_REQUIRED_VALUE));
             times = 1;
+            clientCodegen.setLenientTypeCast(Boolean.valueOf(Swift3OptionsProvider.LENIENT_TYPE_CAST_VALUE));
+            times = 1;
         }};
     }
 }

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/Swaggers/Models.swift
@@ -70,10 +70,10 @@ class Decoders {
     static func decode<T>(clazz: T.Type, source: AnyObject, instance: AnyObject?) -> T {
         initialize()
         if T.self is Int32.Type && source is NSNumber {
-            return (source as! NSNumber).int32Value as! T;
+            return (source as! NSNumber).int32Value as! T
         }
         if T.self is Int64.Type && source is NSNumber {
-            return source.int64Value as! T;
+            return (source as! NSNumber).int64Value as! T
         }
         if T.self is UUID.Type && source is String {
             return UUID(uuidString: source as! String) as! T
@@ -273,25 +273,6 @@ class Decoders {
         }
 
 
-        // Decoder for [Cat]
-        Decoders.addDecoder(clazz: [Cat].self) { (source: AnyObject, instance: AnyObject?) -> [Cat] in
-            return Decoders.decode(clazz: [Cat].self, source: source)
-        }
-        // Decoder for Cat
-        Decoders.addDecoder(clazz: Cat.self) { (source: AnyObject, instance: AnyObject?) -> Cat in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let result = instance == nil ? Cat() : instance as! Cat
-            if decoders["\(Animal.self)"] != nil {
-              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
-            }
-            
-            result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
-            result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
-            result.declawed = Decoders.decodeOptional(clazz: Bool.self, source: sourceDictionary["declawed"] as AnyObject?)
-            return result
-        }
-
-
         // Decoder for [Category]
         Decoders.addDecoder(clazz: [Category].self) { (source: AnyObject, instance: AnyObject?) -> [Category] in
             return Decoders.decode(clazz: [Category].self, source: source)
@@ -331,25 +312,6 @@ class Decoders {
             let result = instance == nil ? Client() : instance as! Client
             
             result.client = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["client"] as AnyObject?)
-            return result
-        }
-
-
-        // Decoder for [Dog]
-        Decoders.addDecoder(clazz: [Dog].self) { (source: AnyObject, instance: AnyObject?) -> [Dog] in
-            return Decoders.decode(clazz: [Dog].self, source: source)
-        }
-        // Decoder for Dog
-        Decoders.addDecoder(clazz: Dog.self) { (source: AnyObject, instance: AnyObject?) -> Dog in
-            let sourceDictionary = source as! [AnyHashable: Any]
-            let result = instance == nil ? Dog() : instance as! Dog
-            if decoders["\(Animal.self)"] != nil {
-              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
-            }
-            
-            result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
-            result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
-            result.breed = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["breed"] as AnyObject?)
             return result
         }
 
@@ -739,6 +701,44 @@ class Decoders {
             result.password = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["password"] as AnyObject?)
             result.phone = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["phone"] as AnyObject?)
             result.userStatus = Decoders.decodeOptional(clazz: Int32.self, source: sourceDictionary["userStatus"] as AnyObject?)
+            return result
+        }
+
+
+        // Decoder for [Cat]
+        Decoders.addDecoder(clazz: [Cat].self) { (source: AnyObject, instance: AnyObject?) -> [Cat] in
+            return Decoders.decode(clazz: [Cat].self, source: source)
+        }
+        // Decoder for Cat
+        Decoders.addDecoder(clazz: Cat.self) { (source: AnyObject, instance: AnyObject?) -> Cat in
+            let sourceDictionary = source as! [AnyHashable: Any]
+            let result = instance == nil ? Cat() : instance as! Cat
+            if decoders["\(Animal.self)"] != nil {
+              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            }
+
+            result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
+            result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
+            result.declawed = Decoders.decodeOptional(clazz: Bool.self, source: sourceDictionary["declawed"] as AnyObject?)
+            return result
+        }
+
+
+        // Decoder for [Dog]
+        Decoders.addDecoder(clazz: [Dog].self) { (source: AnyObject, instance: AnyObject?) -> [Dog] in
+            return Decoders.decode(clazz: [Dog].self, source: source)
+        }
+        // Decoder for Dog
+        Decoders.addDecoder(clazz: Dog.self) { (source: AnyObject, instance: AnyObject?) -> Dog in
+            let sourceDictionary = source as! [AnyHashable: Any]
+            let result = instance == nil ? Dog() : instance as! Dog
+            if decoders["\(Animal.self)"] != nil {
+              _ = Decoders.decode(clazz: Animal.self, source: source, instance: result)
+            }
+
+            result.className = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["className"] as AnyObject?)
+            result.color = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["color"] as AnyObject?)
+            result.breed = Decoders.decodeOptional(clazz: String.self, source: sourceDictionary["breed"] as AnyObject?)
             return result
         }
     }()


### PR DESCRIPTION
This adds a Swift3 option (`lenientTypeCast`) that, when set to true, generates a client JSON decoder that will accept and cast mistyped (by the server) values to their correct (expected by the client, per specification) type, as here:
 - String => Bool ("true" instead of true),
 - String => Int ("123" instead of 123),
 - NSNumber => String (123 instead of "123").

The point is to allow the same client code to handle several server implementations that may (sadly) not be up to spec, or still be "evolving".

Not a perfect/complete solution, not sure if it should be activated along other casts (I think each language/implementation handles this differently), so kept behind an option for Swift3 at this point.

See: #5746.
