### PR TITLE
[Java] Add JSON-patch support to other Java API clients

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -465,7 +465,7 @@ public class ApiClient {
    */
   public boolean isJsonMime(String mime) {
     String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) && mime.equalsIgnoreCase("application/json-patch+json"));
+    return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
   }
 
   /**

--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -465,7 +465,7 @@ public class ApiClient {
    */
   public boolean isJsonMime(String mime) {
     String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && mime.matches(jsonMime);
+    return mime != null && (mime.matches(jsonMime) && mime.equalsIgnoreCase("application/json-patch+json"));
   }
 
   /**

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -443,7 +443,7 @@ public class ApiClient {
    */
   public boolean isJsonMime(String mime) {
     String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && mime.matches(jsonMime);
+    return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
   }
 
   /**

--- a/samples/client/petstore/java/jersey1/pom.xml
+++ b/samples/client/petstore/java/jersey1/pom.xml
@@ -235,6 +235,8 @@
       <version>2.2</version>
     </dependency>
 
+
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
@@ -466,7 +466,7 @@ public class ApiClient {
    */
   public boolean isJsonMime(String mime) {
     String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && mime.matches(jsonMime);
+    return mime != null && (mime.matches(jsonMime) && mime.equalsIgnoreCase("application/json-patch+json"));
   }
 
   /**

--- a/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/io/swagger/client/ApiClient.java
@@ -466,7 +466,7 @@ public class ApiClient {
    */
   public boolean isJsonMime(String mime) {
     String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && (mime.matches(jsonMime) && mime.equalsIgnoreCase("application/json-patch+json"));
+    return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
   }
 
   /**

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/ApiClient.java
@@ -437,7 +437,7 @@ public class ApiClient {
    */
   public boolean isJsonMime(String mime) {
     String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && mime.matches(jsonMime);
+    return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
   }
 
   /**

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/io/swagger/client/ApiClient.java
@@ -438,7 +438,7 @@ public class ApiClient {
    */
   public boolean isJsonMime(String mime) {
     String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && mime.matches(jsonMime);
+    return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
   }
 
   /**

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
@@ -438,7 +438,7 @@ public class ApiClient {
    */
   public boolean isJsonMime(String mime) {
     String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-    return mime != null && mime.matches(jsonMime);
+    return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
   }
 
   /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/io/swagger/client/ApiClient.java
@@ -751,7 +751,7 @@ public class ApiClient {
      */
     public boolean isJsonMime(String mime) {
       String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
-      return mime != null && mime.matches(jsonMime);
+      return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
     }
 
     /**

--- a/samples/client/petstore/java/retrofit/pom.xml
+++ b/samples/client/petstore/java/retrofit/pom.xml
@@ -203,6 +203,7 @@
       <version>${jodatime-version}</version>
   </dependency>
 
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/samples/client/petstore/java/retrofit2-play24/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play24/pom.xml
@@ -232,6 +232,7 @@
         <version>${play-version}</version>
     </dependency>
 
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/samples/client/petstore/java/retrofit2/pom.xml
+++ b/samples/client/petstore/java/retrofit2/pom.xml
@@ -201,6 +201,7 @@
     </dependency>
 
 
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/samples/client/petstore/java/retrofit2rx/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx/pom.xml
@@ -211,6 +211,7 @@
     </dependency>
 
 
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/samples/client/petstore/java/retrofit2rx2/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx2/pom.xml
@@ -211,6 +211,7 @@
     </dependency>
 
 
+
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Similar to https://github.com/swagger-api/swagger-codegen/pull/5764, we're adding JSON-patch support to other Java API clients (e.g. jersey2)
