### PR TITLE
[python] Use dashes for Python PyPI package name since it is a convention

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/setup.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/setup.mustache
@@ -5,7 +5,7 @@
 import sys
 from setuptools import setup, find_packages
 
-NAME = "{{packageName}}"
+NAME = "{{packageName}}".replace('_', '-')
 VERSION = "{{packageVersion}}"
 {{#apiInfo}}
 {{#apis}}

--- a/samples/client/petstore/python/setup.py
+++ b/samples/client/petstore/python/setup.py
@@ -14,7 +14,7 @@
 import sys
 from setuptools import setup, find_packages
 
-NAME = "petstore_api"
+NAME = "petstore_api".replace('_', '-')
 VERSION = "1.0.0"
 # To install the library, run the following
 #


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

PyPI packages index conventionally uses dashes instead of underlines in the package names. Yet, Python cannot import a package folder with dashes, so the `packageName` should not have dashes, and since it is only PyPI convention, I have implemented a quick fix. Alternatively, `projectName` configuration may be introduced (like it is done for JS, Swift, and Clojure generators), but I have no experience with Java :(