### PR TITLE
[javascript] Use arrow function with usePromises in ES6 ApiClient.js for superagent callback to preserve `this` context

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript-es6/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript-es6/ApiClient.mustache
@@ -447,7 +447,7 @@ export default class ApiClient {
         }
 
         {{#usePromises}}return new Promise((resolve, reject) => {
-            request.end(function(error, response) {
+            request.end((error, response) => {
                 if (error) {
                     reject(error);
                 } else {

--- a/samples/client/petstore-security-test/javascript/src/ApiClient.js
+++ b/samples/client/petstore-security-test/javascript/src/ApiClient.js
@@ -173,12 +173,15 @@
    * @returns {Boolean} <code>true</code> if <code>param</code> represents a file.
    */
   exports.prototype.isFileParam = function(param) {
-    // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if (typeof window === 'undefined' &&
-        typeof require === 'function' &&
-        require('fs') &&
-        param instanceof require('fs').ReadStream) {
-      return true;
+    // fs.ReadStream in Node.js and Electron (but not in runtime like browserify)
+    if (typeof require === 'function') {
+      var fs;
+      try {
+        fs = require('fs');
+      } catch (err) {}
+      if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
+        return true;
+      }
     }
     // Buffer in Node.js
     if (typeof Buffer === 'function' && param instanceof Buffer) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Without this change, consuming the API results in `cannot read property 'deserialize' of undefined` from `ApiClient`.  Using a plain anonymous function instead of an arrow function drops the `this` context for `ApiClient` in the superagent callback.
