### PR TITLE
Issue #5810 - demonstrate how it would look with {{baseName}}.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
@@ -38,7 +38,7 @@ public interface {{classname}} extends ApiClient.Api {
     "{{baseName}}: {{=<% %>=}}{<%paramName%>}<%={{ }}=%>"{{#hasMore}},
     {{/hasMore}}{{/headerParams}}
   })
-  {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}}({{#allParams}}{{^isBodyParam}}{{^legacyDates}}@Param("{{paramName}}") {{/legacyDates}}{{#legacyDates}}@Param(value="{{paramName}}", expander=ParamExpander.class) {{/legacyDates}}{{/isBodyParam}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+  {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{nickname}}({{#allParams}}{{^isBodyParam}}{{^legacyDates}}@Param("{{baseName}}") {{/legacyDates}}{{#legacyDates}}@Param(value="{{baseName}}", expander=ParamExpander.class) {{/legacyDates}}{{/isBodyParam}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
     {{#hasQueryParams}}
 
   /**

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/FakeApi.java
@@ -107,7 +107,7 @@ public interface FakeApi extends ApiClient.Api {
     "Content-Type: application/xml; charset&#x3D;utf-8",
     "Accept: application/xml; charset&#x3D;utf-8,application/json; charset&#x3D;utf-8",
   })
-  void testEndpointParameters(@Param("number") BigDecimal number, @Param("_double") Double _double, @Param("patternWithoutDelimiter") String patternWithoutDelimiter, @Param("_byte") byte[] _byte, @Param("integer") Integer integer, @Param("int32") Integer int32, @Param("int64") Long int64, @Param("_float") Float _float, @Param("string") String string, @Param("binary") byte[] binary, @Param("date") LocalDate date, @Param("dateTime") DateTime dateTime, @Param("password") String password, @Param("paramCallback") String paramCallback);
+  void testEndpointParameters(@Param("number") BigDecimal number, @Param("double") Double _double, @Param("pattern_without_delimiter") String patternWithoutDelimiter, @Param("byte") byte[] _byte, @Param("integer") Integer integer, @Param("int32") Integer int32, @Param("int64") Long int64, @Param("float") Float _float, @Param("string") String string, @Param("binary") byte[] binary, @Param("date") LocalDate date, @Param("dateTime") DateTime dateTime, @Param("password") String password, @Param("callback") String paramCallback);
 
   /**
    * To test enum parameters
@@ -129,7 +129,7 @@ public interface FakeApi extends ApiClient.Api {
     
     "enum_header_string: {enumHeaderString}"
   })
-  void testEnumParameters(@Param("enumFormStringArray") List<String> enumFormStringArray, @Param("enumFormString") String enumFormString, @Param("enumHeaderStringArray") List<String> enumHeaderStringArray, @Param("enumHeaderString") String enumHeaderString, @Param("enumQueryStringArray") List<String> enumQueryStringArray, @Param("enumQueryString") String enumQueryString, @Param("enumQueryInteger") Integer enumQueryInteger, @Param("enumQueryDouble") Double enumQueryDouble);
+  void testEnumParameters(@Param("enum_form_string_array") List<String> enumFormStringArray, @Param("enum_form_string") String enumFormString, @Param("enum_header_string_array") List<String> enumHeaderStringArray, @Param("enum_header_string") String enumHeaderString, @Param("enum_query_string_array") List<String> enumQueryStringArray, @Param("enum_query_string") String enumQueryString, @Param("enum_query_integer") Integer enumQueryInteger, @Param("enum_query_double") Double enumQueryDouble);
 
   /**
    * To test enum parameters

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/PetApi.java
@@ -41,7 +41,7 @@ public interface PetApi extends ApiClient.Api {
     "Accept: application/json",
     "api_key: {apiKey}"
   })
-  void deletePet(@Param("petId") Long petId, @Param("apiKey") String apiKey);
+  void deletePet(@Param("petId") Long petId, @Param("api_key") String apiKey);
 
   /**
    * Finds Pets by status

--- a/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/io/swagger/client/api/StoreApi.java
@@ -25,7 +25,7 @@ public interface StoreApi extends ApiClient.Api {
     "Content-Type: application/json",
     "Accept: application/json",
   })
-  void deleteOrder(@Param("orderId") String orderId);
+  void deleteOrder(@Param("order_id") String orderId);
 
   /**
    * Returns pet inventories by status
@@ -50,7 +50,7 @@ public interface StoreApi extends ApiClient.Api {
     "Content-Type: application/json",
     "Accept: application/json",
   })
-  Order getOrderById(@Param("orderId") Long orderId);
+  Order getOrderById(@Param("order_id") Long orderId);
 
   /**
    * Place an order for a pet


### PR DESCRIPTION
:x: do not merge, this is just a demonstration that test will fail if it is done this way.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes. 

### Description of the PR

In #5810 we found another case of the {{baseName}}/{{paramName}} problem (see #4898). But simply changing {{baseName}} to {{paramName}} here won't cut it, because the same name is used in other parts of feign's annotations. This PR (which should not be merged) demonstrates this.