### PR TITLE
[javascript] Fix usages of `exports` in generated ES6 code

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript-es6/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript-es6/ApiClient.mustache
@@ -347,7 +347,7 @@ export default class ApiClient {
             data = response.text;
         }
 
-        return exports.convertToType(data, returnType);
+        return ApiClient.convertToType(data, returnType);
     }
 
     {{#emitJSDoc}}{{^usePromises}}/**
@@ -521,7 +521,7 @@ export default class ApiClient {
             case 'String':
                 return String(data);
             case 'Date':
-                return this.parseDate(String(data));
+                return ApiClient.parseDate(String(data));
             case 'Blob':
                 return data;
             default:
@@ -536,7 +536,7 @@ export default class ApiClient {
                     var itemType = type[0];
 
                     return data.map((item) => {
-                        return exports.convertToType(item, itemType);
+                        return ApiClient.convertToType(item, itemType);
                     });
                 } else if (typeof type === 'object') {
                     // for plain object type like: {'String': 'Integer'}
@@ -552,8 +552,8 @@ export default class ApiClient {
                     var result = {};
                     for (var k in data) {
                         if (data.hasOwnProperty(k)) {
-                            var key = exports.convertToType(k, keyType);
-                            var value = exports.convertToType(data[k], valueType);
+                            var key = ApiClient.convertToType(k, keyType);
+                            var value = ApiClient.convertToType(data[k], valueType);
                             result[key] = value;
                         }
                     }
@@ -575,12 +575,12 @@ export default class ApiClient {
         if (Array.isArray(data)) {
             for (var i = 0; i < data.length; i++) {
                 if (data.hasOwnProperty(i))
-                    obj[i] = exports.convertToType(data[i], itemType);
+                    obj[i] = ApiClient.convertToType(data[i], itemType);
             }
         } else {
             for (var k in data) {
                 if (data.hasOwnProperty(k))
-                    obj[k] = exports.convertToType(data[k], itemType);
+                    obj[k] = ApiClient.convertToType(data[k], itemType);
             }
         }
     };

--- a/modules/swagger-codegen/src/main/resources/Javascript-es6/partial_model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript-es6/partial_model_generic.mustache
@@ -20,7 +20,7 @@ export default class {{classname}} {
     constructor({{#vendorExtensions.x-all-required}}{{name}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-all-required}}) {
         {{#parent}}{{^parentModel}}{{#vendorExtensions.x-isArray}}
         this = new Array();
-        Object.setPrototypeOf(this, exports);{{/vendorExtensions.x-isArray}}{{/parentModel}}{{/parent}}
+        Object.setPrototypeOf(this, {{classname}});{{/vendorExtensions.x-isArray}}{{/parentModel}}{{/parent}}
 
         {{#useInheritance}}
         {{#parentModel}}{{classname}}.call(this{{#vendorExtensions.x-all-required}}, {{name}}{{/vendorExtensions.x-all-required}});{{/parentModel}}
@@ -41,7 +41,7 @@ export default class {{classname}} {
     */{{/emitJSDoc}}
     static constructFromObject(data, obj) {
         if (data){{! TODO: support polymorphism: discriminator property on data determines class to instantiate.}} {
-            obj = obj || new exports();
+            obj = obj || new {{classname}}();
 
             {{#parent}}{{^parentModel}}ApiClient.constructFromObject(data, obj, '{{vendorExtensions.x-itemType}}');{{/parentModel}}
             {{/parent}}

--- a/samples/client/petstore-security-test/javascript/src/ApiClient.js
+++ b/samples/client/petstore-security-test/javascript/src/ApiClient.js
@@ -173,12 +173,15 @@
    * @returns {Boolean} <code>true</code> if <code>param</code> represents a file.
    */
   exports.prototype.isFileParam = function(param) {
-    // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if (typeof window === 'undefined' &&
-        typeof require === 'function' &&
-        require('fs') &&
-        param instanceof require('fs').ReadStream) {
-      return true;
+    // fs.ReadStream in Node.js and Electron (but not in runtime like browserify)
+    if (typeof require === 'function') {
+      var fs;
+      try {
+        fs = require('fs');
+      } catch (err) {}
+      if (fs && fs.ReadStream && param instanceof fs.ReadStream) {
+        return true;
+      }
     }
     // Buffer in Node.js
     if (typeof Buffer === 'function' && param instanceof Buffer) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

`exports` is not a valid global identifier in ES6 modules.