### PR TITLE
Html2 speed Up | Raw html using java parser instead of JS parser

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtml2Generator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/StaticHtml2Generator.java
@@ -1,14 +1,7 @@
 package io.swagger.codegen.languages;
 
-import io.swagger.codegen.CliOption;
-import io.swagger.codegen.CodegenConfig;
-import io.swagger.codegen.CodegenConstants;
-import io.swagger.codegen.CodegenOperation;
-import io.swagger.codegen.CodegenParameter;
-import io.swagger.codegen.CodegenResponse;
-import io.swagger.codegen.CodegenType;
-import io.swagger.codegen.DefaultCodegen;
-import io.swagger.codegen.SupportingFile;
+import com.samskivert.mustache.Mustache;
+import io.swagger.codegen.*;
 import io.swagger.models.Info;
 import org.yaml.snakeyaml.error.Mark;
 import io.swagger.codegen.utils.Markdown;
@@ -129,6 +122,7 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
                     response.code = "default";
                 }
             }
+            op.formParams = postProcessParameterEnum(op.formParams);
         }
         return objs;
     }
@@ -213,6 +207,30 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
         } else {
             LOGGER.error("Swagger object description is empty [" + swagger.getInfo().getTitle() + "]");
         }
+    }
+
+    /**
+     * Format to HTML the enums contained in every operations
+     *
+     * @param parameterList The whole parameters contained in one operation
+     * @return String | Html formated enum
+     */
+    public List<CodegenParameter> postProcessParameterEnum(List<CodegenParameter> parameterList) {
+        String enumFormatted = "";
+        for(CodegenParameter parameter : parameterList) {
+            if (parameter.isEnum) {
+                for (int i = 0; i < parameter._enum.size(); i++) {
+                    String spacer = (i == (parameter._enum.size() - 1)) ? " " : ", ";
+
+                    if (parameter._enum.get(i) != null)
+                        enumFormatted += "`" + parameter._enum.get(i) + "`" + spacer;
+                }
+                Markdown markInstance = new Markdown();
+                if (!enumFormatted.isEmpty())
+                    parameter.vendorExtensions.put("x-eumFormatted", markInstance.toHtml(enumFormatted));
+            }
+        }
+        return parameterList;
     }
 
     private String sanitizePath(String p) {

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/index.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/index.mustache
@@ -59,11 +59,6 @@
         });
       }
 
-
-      // load google web fonts
-      loadGoogleFontCss();
-
-
       // Bootstrap Scrollspy
       $(this).scrollspy({ target: '#scrollingNav', offset: 18 });
 
@@ -105,21 +100,6 @@
 
       //Convert elements with "marked" class to markdown
       processMarked();
-
-      /**
-       * Load google fonts.
-       */
-      function loadGoogleFontCss() {
-        WebFont.load({
-          active: function() {
-            // Update scrollspy
-            $(window).scrollspy('refresh')
-          },
-          google: {
-            families: ['Source Code Pro', 'Source Sans Pro:n4,n6,n7']
-          }
-        });
-      }
     });
   </script>
   <style type="text/css">
@@ -132,10 +112,10 @@
   <script>
     // Script section to load models into a JS Var
     var defs = {}
-    {{#models}}
-    {{#model}}
-    defs.{{name}} = {{{modelJson}}};
-    {{/model}}
+        {{#models}}
+        {{#model}}
+            defs.{{name}} = {{{modelJson}}};
+        {{/model}}
     {{/models}}
   </script>
 
@@ -359,7 +339,7 @@
                               {{#schema}}
                                 <div class="tab-pane active" id="responses-{{nickname}}-{{code}}-schema">
                                   <div id='responses-{{nickname}}-{{code}}-schema-{{code}}' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
-                                                               <script>
+                                    <script>
                                       $(document).ready(function() {
                                         var schemaWrapper = {{{jsonSchema}}};
                                         var schema = schemaWrapper.schema;

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/js_jsonschemaview.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/js_jsonschemaview.mustache
@@ -258,7 +258,7 @@ var JSONSchemaView = (function () {
       }
 
       if (this.isArray) {
-        var view = new JSONSchemaView(this.schema.items, this.open - 1);
+        var view = new JSONSchemaView(this.schema.items, Infinity);
         inner.appendChild(view.render());
       }
 

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/param.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/param.mustache
@@ -2,25 +2,39 @@
 <td>
 
 
-<script>
-												$(document).ready(function() {
-													var schemaWrapper = {{{jsonSchema}}};
-													var schema = schemaWrapper;
+    <div id="d2e199_{{nickname}}_{{paramName}}">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    {{dataType}}
+                </span>
+                {{#dataFormat}}
+                    <span class="format">
+                        ({{dataFormat}})
+                    </span>
+                {{/dataFormat}}
 
-
-
-
-													var view = new JSONSchemaView(schema,1);
-													var result = $('#d2e199_{{nickname}}_{{paramName}}');
-													result.empty();
-													result.append(view.render());
-
-
-
-
-
-												});
-												</script>
-												<div id="d2e199_{{nickname}}_{{paramName}}"></div>
+                {{#description}}
+                    <div class="inner description">
+                        {{description}}
+                    </div>
+                {{/description}}
+            </div>
+            {{#isEnum}}
+                {{#vendorExtensions.x-eumFormatted}}
+                    <div class="inner enums" id="{{nickname}}_{{paramName}}_enum">
+                        <span class="inner">
+                            <b>Enum: </b>{{{vendorExtensions.x-eumFormatted}}}
+                        </span>
+                    </div>
+                {{/vendorExtensions.x-eumFormatted}}
+            {{/isEnum}}
+            {{#required}}
+                <div class="inner required">
+                    Required
+                </div>
+            {{/required}}
+        </div>
+    </div>
 </td>
 </tr>

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/styles.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/styles.mustache
@@ -1,6 +1,11 @@
 /* ------------------------------------------------------------------------------------------
  * Content
  * ------------------------------------------------------------------------------------------ */
+
+@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
+* {
+  font-family: 'Source Code Pro', sans-serif;
+}
 body {
   min-width: 980px;
 }


### PR DESCRIPTION
Some code to speed up the render of HTML2 documentation. 
- Parse Html markdown with Java's parser instead of JS. 
- Kill some JS that slow down the page loading ( and causes Flash of Unstyled Text (FOUT) )
- Use mustache variable to build html instead of javascript