### PR TITLE
[C++][Restbed] use file.separator instead of "/" for file path

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RestbedCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RestbedCodegen.java
@@ -1,5 +1,6 @@
 package io.swagger.codegen.languages;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -181,7 +182,7 @@ public class RestbedCodegen extends DefaultCodegen implements CodegenConfig {
    * when the class is instantiated
    */
   public String modelFileFolder() {
-      return outputFolder + "/model";
+      return (outputFolder + "/model").replace("/", File.separator);
   }
 
   /**
@@ -190,7 +191,7 @@ public class RestbedCodegen extends DefaultCodegen implements CodegenConfig {
    */
   @Override
   public String apiFileFolder() {
-      return outputFolder + "/api";
+      return (outputFolder + "/api").replace("/", File.separator);
   }
 
   @Override


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Use file.separator instead of "/" for file path in different platforms (Windows, Linux, Mac)
