### PR TITLE
#5147: allow multiple for other plural options, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,22 +265,29 @@ NAME
 SYNOPSIS
         swagger-codegen-cli generate
                 [(-a <authorization> | --auth <authorization>)]
-                [--additional-properties <additional properties>]
+                [--additional-properties <additional properties>...]
                 [--api-package <api package>] [--artifact-id <artifact id>]
                 [--artifact-version <artifact version>]
                 [(-c <configuration file> | --config <configuration file>)]
-                [-D <system properties>] [--group-id <group id>]
+                [-D <system properties>...] [--git-repo-id <git repo id>]
+                [--git-user-id <git user id>] [--group-id <group id>]
+                [--http-user-agent <http user agent>]
                 (-i <spec file> | --input-spec <spec file>)
-                [--import-mappings <import mappings>]
-                [--instantiation-types <instantiation types>]
+                [--ignore-file-override <ignore file override location>]
+                [--import-mappings <import mappings>...]
+                [--instantiation-types <instantiation types>...]
                 [--invoker-package <invoker package>]
                 (-l <language> | --lang <language>)
-                [--language-specific-primitives <language specific primitives>]
-                [--library <library>] [--model-package <model package>]
+                [--language-specific-primitives <language specific primitives>...]
+                [--library <library>] [--model-name-prefix <model name prefix>]
+                [--model-name-suffix <model name suffix>]
+                [--model-package <model package>]
                 [(-o <output directory> | --output <output directory>)]
+                [--release-note <release note>] [--remove-operation-id-prefix]
+                [--reserved-words-mappings <reserved word mappings>...]
                 [(-s | --skip-overwrite)]
                 [(-t <template directory> | --template-dir <template directory>)]
-                [--type-mappings <type mappings>] [(-v | --verbose)]
+                [--type-mappings <type mappings>...] [(-v | --verbose)]
 
 OPTIONS
         -a <authorization>, --auth <authorization>
@@ -558,8 +565,13 @@ To specify an import mapping, use the `--import-mappings` argument and specify t
 Or for multiple mappings:
 
 ```
-Pet=my.models.MyPet,Order=my.models.MyOrder
+--import-mappings Pet=my.models.MyPet,Order=my.models.MyOrder
 ```
+or
+```
+--import-mappings Pet=my.models.MyPet --import-mappings Order=my.models.MyOrder
+```
+
 
 ### Validating your OpenAPI Spec
 

--- a/bin/csharp-property-changed-petstore.sh
+++ b/bin/csharp-property-changed-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClientWithPropertyChanged --additional-properties=generatePropertyChanged=true,packageGuid={5CD900DE-8266-412F-A758-28E1F9C623D5}"
+ags="generate $@ -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/SwaggerClientWithPropertyChanged --additional-properties generatePropertyChanged=true --additional-properties packageGuid={5CD900DE-8266-412F-A758-28E1F9C623D5}"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
+++ b/modules/swagger-codegen-cli/src/main/java/io/swagger/codegen/cmd/Generate.java
@@ -76,23 +76,29 @@ public class Generate implements Runnable {
     private String modelNameSuffix;
 
     @Option(name = {"--instantiation-types"}, title = "instantiation types", description = "sets instantiation type mappings in the format of type=instantiatedType,type=instantiatedType." +
-            "For example (in Java): array=ArrayList,map=HashMap. In other words array types will get instantiated as ArrayList in generated code.")
-    private String instantiationTypes;
+            "For example (in Java): array=ArrayList,map=HashMap. In other words array types will get instantiated as ArrayList in generated code."
+            + " You can also have multiple occurrences of this option.")
+    private List<String> instantiationTypes = new ArrayList<>();
 
     @Option(name = {"--type-mappings"}, title = "type mappings", description = "sets mappings between swagger spec types and generated code types " +
-            "in the format of swaggerType=generatedType,swaggerType=generatedType. For example: array=List,map=Map,string=String")
-    private String typeMappings;
+            "in the format of swaggerType=generatedType,swaggerType=generatedType. For example: array=List,map=Map,string=String."
+            + " You can also have multiple occurrences of this option.")
+    private List<String> typeMappings = new ArrayList<>();
 
-    @Option(name = {"--additional-properties"}, title = "additional properties", description = "sets additional properties that can be referenced by the mustache templates in the format of name=value,name=value")
-    private String additionalProperties;
+    @Option(name = {"--additional-properties"}, title = "additional properties",
+            description = "sets additional properties that can be referenced by the mustache templates in the format of name=value,name=value."
+                    + " You can also have multiple occurrences of this option.")
+    private List<String> additionalProperties = new ArrayList<>();
 
     @Option(name = {"--language-specific-primitives"}, title = "language specific primitives",
-            description = "specifies additional language specific primitive types in the format of type1,type2,type3,type3. For example: String,boolean,Boolean,Double")
-    private String languageSpecificPrimitives;
+            description = "specifies additional language specific primitive types in the format of type1,type2,type3,type3. For example: String,boolean,Boolean,Double."
+                    + " You can also have multiple occurrences of this option.")
+    private List<String> languageSpecificPrimitives = new ArrayList<>();
 
     @Option(name = {"--import-mappings"}, title = "import mappings",
-            description = "specifies mappings between a given class and the import that should be used for that class in the format of type=import,type=import")
-    private String importMappings;
+            description = "specifies mappings between a given class and the import that should be used for that class in the format of type=import,type=import."
+                    + " You can also have multiple occurrences of this option.")
+    private List<String> importMappings = new ArrayList<>();
 
     @Option(name = {"--invoker-package"}, title = "invoker package", description = CodegenConstants.INVOKER_PACKAGE_DESC)
     private String invokerPackage;
@@ -121,9 +127,10 @@ public class Generate implements Runnable {
     @Option(name = {"--http-user-agent"}, title = "http user agent", description = CodegenConstants.HTTP_USER_AGENT_DESC)
     private String httpUserAgent;
     
-    @Option(name = {"--reserved-words-mappings"}, title = "import mappings",
-            description = "specifies how a reserved name should be escaped to. Otherwise, the default _<name> is used. For example id=identifier")
-    private String reservedWordsMappings;
+    @Option(name = {"--reserved-words-mappings"}, title = "reserved word mappings",
+            description = "specifies how a reserved name should be escaped to. Otherwise, the default _<name> is used. For example id=identifier."
+                    + " You can also have multiple occurrences of this option.")
+    private List<String> reservedWordsMappings = new ArrayList<>();
 
     @Option(name = {"--ignore-file-override"}, title = "ignore file override location", description = CodegenConstants.IGNORE_FILE_OVERRIDE_DESC)
     private String ignoreFileOverride;
@@ -233,12 +240,12 @@ public class Generate implements Runnable {
         }
 
         applySystemPropertiesKvpList(systemProperties, configurator);
-        applyInstantiationTypesKvp(instantiationTypes, configurator);
-        applyImportMappingsKvp(importMappings, configurator);
-        applyTypeMappingsKvp(typeMappings, configurator);
-        applyAdditionalPropertiesKvp(additionalProperties, configurator);
-        applyLanguageSpecificPrimitivesCsv(languageSpecificPrimitives, configurator);
-        applyReservedWordsMappingsKvp(reservedWordsMappings, configurator);
+        applyInstantiationTypesKvpList(instantiationTypes, configurator);
+        applyImportMappingsKvpList(importMappings, configurator);
+        applyTypeMappingsKvpList(typeMappings, configurator);
+        applyAdditionalPropertiesKvpList(additionalProperties, configurator);
+        applyLanguageSpecificPrimitivesCsvList(languageSpecificPrimitives, configurator);
+        applyReservedWordsMappingsKvpList(reservedWordsMappings, configurator);
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
 
         new DefaultGenerator().opts(clientOptInput).generate();

--- a/modules/swagger-codegen-cli/src/test/java/io/swagger/codegen/cmd/GenerateTest.java
+++ b/modules/swagger-codegen-cli/src/test/java/io/swagger/codegen/cmd/GenerateTest.java
@@ -218,7 +218,7 @@ public class GenerateTest {
     @Test
     public void testInstantiationTypes() throws Exception {
 
-        setupAndRunGenericTest("--instantiation-types", "hello=world,key=,foo=bar");
+        setupAndRunGenericTest("--instantiation-types", "hello=world,key=,foo=bar,key2");
 
         new FullVerifications() {{
             configurator.addInstantiationType("hello", "world");
@@ -227,12 +227,30 @@ public class GenerateTest {
             times = 1;
             configurator.addInstantiationType("key", "");
             times = 1;
+            configurator.addInstantiationType("key2", "");
+            times = 1;
+        }};
+
+        setupAndRunGenericTest("--instantiation-types", "hello=world",
+                "--instantiation-types", "key=",
+                "--instantiation-types", "foo=bar",
+                "--instantiation-types", "key2");
+
+        new FullVerifications() {{
+            configurator.addInstantiationType("hello", "world");
+            times = 1;
+            configurator.addInstantiationType("foo", "bar");
+            times = 1;
+            configurator.addInstantiationType("key", "");
+            times = 1;
+            configurator.addInstantiationType("key2", "");
+            times = 1;
         }};
     }
 
     @Test
     public void testTypeMappings() throws Exception {
-        setupAndRunGenericTest("--type-mappings", "hello=world,key=,foo=bar");
+        setupAndRunGenericTest("--type-mappings", "hello=world,key=,foo=bar,key2");
 
         new FullVerifications() {{
             configurator.addTypeMapping("hello", "world");
@@ -241,12 +259,30 @@ public class GenerateTest {
             times = 1;
             configurator.addTypeMapping("key", "");
             times = 1;
+            configurator.addTypeMapping("key2", "");
+            times = 1;
+        }};
+
+        setupAndRunGenericTest("--type-mappings", "hello=world",
+                "--type-mappings", "key=",
+                "--type-mappings", "foo=bar",
+                "--type-mappings", "key2");
+
+        new FullVerifications() {{
+            configurator.addTypeMapping("hello", "world");
+            times = 1;
+            configurator.addTypeMapping("foo", "bar");
+            times = 1;
+            configurator.addTypeMapping("key", "");
+            times = 1;
+            configurator.addTypeMapping("key2", "");
+            times = 1;
         }};
     }
 
     @Test
     public void testAdditionalProperties() throws Exception {
-        setupAndRunGenericTest("--additional-properties", "hello=world,key=,foo=bar");
+        setupAndRunGenericTest("--additional-properties", "hello=world,key=,foo=bar,key2");
 
         new FullVerifications() {{
             configurator.addAdditionalProperty("hello", "world");
@@ -255,12 +291,31 @@ public class GenerateTest {
             times = 1;
             configurator.addAdditionalProperty("key", "");
             times = 1;
+            configurator.addAdditionalProperty("key2", "");
+            times = 1;
+        }};
+
+        setupAndRunGenericTest("--additional-properties", "hello=world",
+                "--additional-properties", "key=",
+                "--additional-properties", "foo=bar",
+                "--additional-properties", "key2");
+
+        new FullVerifications() {{
+            configurator.addAdditionalProperty("hello", "world");
+            times = 1;
+            configurator.addAdditionalProperty("foo", "bar");
+            times = 1;
+            configurator.addAdditionalProperty("key", "");
+            times = 1;
+            configurator.addAdditionalProperty("key2", "");
+            times = 1;
         }};
     }
 
     @Test
     public void testLanguageSpecificPrimitives() throws Exception {
-        setupAndRunGenericTest("--language-specific-primitives", "foo,bar,,hello,world");
+        setupAndRunGenericTest("--language-specific-primitives", "foo,,bar",
+                               "--language-specific-primitives", "hello,world");
 
         new FullVerifications() {{
             configurator.addLanguageSpecificPrimitive("foo");
@@ -276,7 +331,7 @@ public class GenerateTest {
 
     @Test
     public void testImportMappings() throws Exception {
-        setupAndRunGenericTest("--import-mappings", "hello=world,key=,foo=bar");
+        setupAndRunGenericTest("--import-mappings", "hello=world,key=,foo=bar,key2");
 
         new FullVerifications() {{
             configurator.addImportMapping("hello", "world");
@@ -284,6 +339,24 @@ public class GenerateTest {
             configurator.addImportMapping("foo", "bar");
             times = 1;
             configurator.addImportMapping("key", "");
+            times = 1;
+            configurator.addImportMapping("key2", "");
+            times = 1;
+        }};
+
+        setupAndRunGenericTest("--import-mappings", "hello=world",
+                "--import-mappings", "key=",
+                "--import-mappings", "foo=bar",
+                "--import-mappings", "key2");
+
+        new FullVerifications() {{
+            configurator.addImportMapping("hello", "world");
+            times = 1;
+            configurator.addImportMapping("foo", "bar");
+            times = 1;
+            configurator.addImportMapping("key", "");
+            times = 1;
+            configurator.addImportMapping("key2", "");
             times = 1;
         }};
     }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfiguratorUtils.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/config/CodegenConfiguratorUtils.java
@@ -13,6 +13,15 @@ import java.util.*;
  *     This class exists to facilitate testing. These methods could be applied
  *     to CodegenConfigurator, but this complicates things when mocking CodegenConfigurator.
  * </p>
+ * <ul>
+ *     <li>The methods named {@code apply...Kvp} take a string of comma-separated key-value pairs.</li>
+ *     <li>The methods named {@code apply...KvpList} take a list of such strings.</li>
+ *     <li>The method named {@code apply...Csv} takes a string of comma-separated values.</li>
+ *     <li>The method named {@code apply...CsvList} takes a list of such strings.</li>
+ * </ul>
+ * <p>
+ *     The corresponding {@code add...} method on the passed configurator is called for each key-value pair (or value).
+ * </p>  
  */
 public final class CodegenConfiguratorUtils {
 
@@ -29,10 +38,22 @@ public final class CodegenConfiguratorUtils {
         }
     }
 
+    public static void applyInstantiationTypesKvpList(List<String> instantiationTypes, CodegenConfigurator configurator) {
+        for(String propString : instantiationTypes) {
+            applyInstantiationTypesKvp(propString, configurator);
+        }
+    }
+    
     public static void applyInstantiationTypesKvp(String instantiationTypes, CodegenConfigurator configurator) {
         final Map<String, String> map = createMapFromKeyValuePairs(instantiationTypes);
         for (Map.Entry<String, String> entry : map.entrySet()) {
             configurator.addInstantiationType(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public static void applyImportMappingsKvpList(List<String> importMappings, CodegenConfigurator configurator) {
+        for(String propString : importMappings) {
+            applyImportMappingsKvp(propString, configurator);
         }
     }
 
@@ -43,10 +64,22 @@ public final class CodegenConfiguratorUtils {
         }
     }
 
+    public static void applyTypeMappingsKvpList(List<String> typeMappings, CodegenConfigurator configurator) {
+        for(String propString : typeMappings) {
+            applyTypeMappingsKvp(propString, configurator);
+        }
+    }
+
     public static void applyTypeMappingsKvp(String typeMappings, CodegenConfigurator configurator) {
         final Map<String, String> map = createMapFromKeyValuePairs(typeMappings);
         for (Map.Entry<String, String> entry : map.entrySet()) {
             configurator.addTypeMapping(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public static void applyAdditionalPropertiesKvpList(List<String> additionalProperties, CodegenConfigurator configurator) {
+        for(String propString : additionalProperties) {
+            applyAdditionalPropertiesKvp(propString, configurator);
         }
     }
 
@@ -57,10 +90,22 @@ public final class CodegenConfiguratorUtils {
         }
     }
 
+    public static void applyLanguageSpecificPrimitivesCsvList(List<String> languageSpecificPrimitives, CodegenConfigurator configurator) {
+        for(String propString : languageSpecificPrimitives) {
+            applyLanguageSpecificPrimitivesCsv(propString, configurator);
+        }
+    }
+
     public static void applyLanguageSpecificPrimitivesCsv(String languageSpecificPrimitives, CodegenConfigurator configurator) {
         final Set<String> set = createSetFromCsvList(languageSpecificPrimitives);
         for (String item : set) {
             configurator.addLanguageSpecificPrimitive(item);
+        }
+    }
+
+    public static void applyReservedWordsMappingsKvpList(List<String> reservedWordMappings, CodegenConfigurator configurator) {
+        for(String propString : reservedWordMappings) {
+            applyReservedWordsMappingsKvp(propString, configurator);
         }
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change.
  → bin/run-all-petstore, with no changes (apart from those who already happen in master, see #5859 + #5861).
- [x] Filed the PR against the correct branch: master for non-breaking changes.

### Description of the PR

As discussed in #5147, all the options which previously had comma separated lists of values now also allow multiple values (or multiple key-value-pairs), as was previously (in #5191) already done for `-D`.
This affects those with key-value-pairs:

    --additional-properties
    --import-mappings
    --instantiation-types
    --reserved-word-mappings
    --type-mappings

and this option with a simple list of values:

    --language-specific-primitives

I also regenerated the output of `help generate` in README.md, which was already out-of-date before.