### PR TITLE
[JavaScript] Fixed *WithHttpInfo methods in 'usePromises' mode to be ES5 compatible

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -450,7 +450,7 @@
             if (_this.enableCookies && typeof window === 'undefined'){
               _this.agent.saveCookies(response);
             }
-            resolve({data, response});
+            resolve({data: data, response: response});
           } catch (err) {
             reject(err);
           }

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -447,7 +447,7 @@
             if (_this.enableCookies && typeof window === 'undefined'){
               _this.agent.saveCookies(response);
             }
-            resolve({data, response});
+            resolve({data: data, response: response});
           } catch (err) {
             reject(err);
           }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This is a bug-fix PR for the change introduced in #4902. The syntax was not ES5 compatible, thus this change should be applied to the ES5 JS generator.