### PR TITLE
Fix#5856 - Add support for PATCH

### DIFF
--- a/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
@@ -4,6 +4,7 @@
 #include <QUrl>
 #include <QFileInfo>
 #include <QBuffer>
+#include <QtGlobal>
 
 
 {{#cppNamespaceDeclarations}}
@@ -283,8 +284,16 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
         manager->deleteResource(request);
     }
     else {
-        QByteArray buff = request_content;
-        manager->sendCustomRequest(request, input->http_method.toLatin1(), &buff);
+#if (QT_VERSION >= 0x050800)
+        manager->sendCustomRequest(request, input->http_method.toLatin1(), request_content);
+#else
+        QBuffer *buffer = new QBuffer;
+        buffer->setData(request_content);
+        buffer->open(QIODevice::ReadOnly);
+
+        QNetworkReply* reply = manager->sendCustomRequest(request, input->http_method.toLatin1(), buffer);
+        buffer->setParent(reply);
+#endif
     }
 
 }

--- a/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
+++ b/modules/swagger-codegen/src/main/resources/qt5cpp/HttpRequest.cpp.mustache
@@ -283,7 +283,7 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
         manager->deleteResource(request);
     }
     else {
-        QBuffer buff(&request_content);
+        QByteArray buff = request_content;
         manager->sendCustomRequest(request, input->http_method.toLatin1(), &buff);
     }
 

--- a/samples/client/petstore-security-test/qt5cpp/client/SWGHttpRequest.cpp
+++ b/samples/client/petstore-security-test/qt5cpp/client/SWGHttpRequest.cpp
@@ -15,6 +15,7 @@
 #include <QUrl>
 #include <QFileInfo>
 #include <QBuffer>
+#include <QtGlobal>
 
 
 namespace Swagger {
@@ -292,8 +293,16 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
         manager->deleteResource(request);
     }
     else {
-        QBuffer buff(&request_content);
-        manager->sendCustomRequest(request, input->http_method.toLatin1(), &buff);
+#if (QT_VERSION >= 0x050800)
+        manager->sendCustomRequest(request, input->http_method.toLatin1(), request_content);
+#else
+        QBuffer *buffer = new QBuffer;
+        buffer->setData(request_content);
+        buffer->open(QIODevice::ReadOnly);
+
+        QNetworkReply* reply = manager->sendCustomRequest(request, input->http_method.toLatin1(), buffer);
+        buffer->setParent(reply);
+#endif
     }
 
 }

--- a/samples/client/petstore/qt5cpp/client/SWGHttpRequest.cpp
+++ b/samples/client/petstore/qt5cpp/client/SWGHttpRequest.cpp
@@ -15,6 +15,7 @@
 #include <QUrl>
 #include <QFileInfo>
 #include <QBuffer>
+#include <QtGlobal>
 
 
 namespace Swagger {
@@ -292,8 +293,16 @@ void HttpRequestWorker::execute(HttpRequestInput *input) {
         manager->deleteResource(request);
     }
     else {
-        QBuffer buff(&request_content);
-        manager->sendCustomRequest(request, input->http_method.toLatin1(), &buff);
+#if (QT_VERSION >= 0x050800)
+        manager->sendCustomRequest(request, input->http_method.toLatin1(), request_content);
+#else
+        QBuffer *buffer = new QBuffer;
+        buffer->setData(request_content);
+        buffer->open(QIODevice::ReadOnly);
+
+        QNetworkReply* reply = manager->sendCustomRequest(request, input->http_method.toLatin1(), buffer);
+        buffer->setParent(reply);
+#endif
     }
 
 }


### PR DESCRIPTION
### Description of the PR
 Add support for PATCH verb. This was a lifecycle bug. 

Correction use newer QT5 api when available, falls back on old api (with corrected calling code) for backward compatibility.

