### PR TITLE
fix InjectionToken in typescript angular2 client also fix configuration.ts to compile in strict mode (second commit)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -31,12 +31,14 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
     public static final String SNAPSHOT = "snapshot";
     public static final String USE_OPAQUE_TOKEN = "useOpaqueToken";
     public static final String INJECTION_TOKEN = "injectionToken";
+    public static final String INJECTION_TOKEN_IMPORT = "injectionTokenImport";
     public static final String WITH_INTERFACES = "withInterfaces";
 
     protected String npmName = null;
     protected String npmVersion = "1.0.0";
     protected String npmRepository = null;
     protected String injectionToken = "InjectionToken<string>";
+    protected String injectionTokenImport = "InjectionToken";
 
     public TypeScriptAngular2ClientCodegen() {
         super();
@@ -96,6 +98,7 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
             this.setOpaqueToken();
         }
         additionalProperties.put(INJECTION_TOKEN, this.injectionToken);
+        additionalProperties.put(INJECTION_TOKEN_IMPORT, this.injectionTokenImport);
 
         if(additionalProperties.containsKey(WITH_INTERFACES)) {
             boolean withInterfaces = Boolean.parseBoolean(additionalProperties.get(WITH_INTERFACES).toString());
@@ -340,5 +343,6 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
 
     public void setOpaqueToken() {
         this.injectionToken = "OpaqueToken";
+        this.injectionTokenImport = "OpaqueToken";
     }
 }

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/configuration.mustache
@@ -8,12 +8,12 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-    apiKeys: {[ key: string ]: string};
-    username: string;
-    password: string;
-    accessToken: string | (() => string);
-    basePath: string;
-    withCredentials: boolean;
+    apiKeys?: {[ key: string ]: string};
+    username?: string;
+    password?: string;
+    accessToken?: string | (() => string);
+    basePath?: string;
+    withCredentials?: boolean;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;

--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/variables.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/variables.mustache
@@ -1,9 +1,9 @@
-import { {{{injectionToken}}} } from '@angular/core';
+import { {{{injectionTokenImport}}} } from '@angular/core';
 
 export const BASE_PATH = new {{{injectionToken}}}('basePath');
 export const COLLECTION_FORMATS = {
-    'csv': ',',
-    'tsv': '   ',
-    'ssv': ' ',
-    'pipes': '|'
+'csv': ',',
+'tsv': '   ',
+'ssv': ' ',
+'pipes': '|'
 }


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

