### PR TITLE
Use id -g for determining the gid instead of -u

### DIFF
--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -11,7 +11,7 @@ docker run --rm -it \
         -w /gen \
         -e GEN_DIR=/gen \
         -e MAVEN_CONFIG=/var/maven/.m2 \
-        -u "$(id -u):$(id -u)" \
+        -u "$(id -u):$(id -g)" \
         -v "${PWD}:/gen" \
         -v "${maven_cache_repo}:/var/maven/.m2/repository" \
         --entrypoint /gen/docker-entrypoint.sh \


### PR DESCRIPTION
Fix wrong group id lookup in run-in-docker.sh

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Tiny change, the run-in-docker.sh uses id -u for determining the group id, change that to id -g and everything is fine if the user has a gid != uid.

Tested on my local machine.
