### PR TITLE
[Python] Increase range of valid status codes

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -191,7 +191,7 @@ class RESTClientObject(object):
             # log response body
             logger.debug("response body: %s", r.data)
 
-        if r.status not in range(200, 206):
+        if not 200 <= r.status <= 299:
             raise ApiException(http_resp=r)
 
         return r

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -200,7 +200,7 @@ class RESTClientObject(object):
             # log response body
             logger.debug("response body: %s", r.data)
 
-        if r.status not in range(200, 206):
+        if not 200 <= r.status <= 299:
             raise ApiException(http_resp=r)
 
         return r


### PR DESCRIPTION
swagger-client shouldn't throw ApiException if status code in range 200-299

closes #5105

