### PR TITLE
[typescript-angular2] Enumerating response types and codes from api

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
@@ -85,24 +85,21 @@ export class {{classname}} {
      {{/summary}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
-{{^isResponseFile}}
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
-{{/isResponseFile}}
-{{#isResponseFile}}
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}|undefined{{/returnType}}{{^returnType}}{}{{/returnType}}> {
-{{/isResponseFile}}
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<undefined | {{#responses}}{{#dataType}}{{{dataType}}} | {{/dataType}}{{/responses}}{}> {
         return this.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-{{^isResponseFile}}
-                    return response.json() || {};
-{{/isResponseFile}}
-{{#isResponseFile}}
-                    return response.blob();
-{{/isResponseFile}}
+                {{#isResponseFile}}return response.blob();{{/isResponseFile}}
+                {{^isResponseFile}}
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    {{#responses}}{{#dataType}}case {{code}}:
+                        // {{message}}
+                        {{#isString}}return response.text();{{/isString}}{{^primitiveType}}return response.json();{{/primitiveType}}
+                    {{/dataType}}{{/responses}}default:
+                        return response.json() || {};
                 }
+                {{/isResponseFile}}
             });
     }
 
@@ -115,8 +112,7 @@ export class {{classname}} {
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
     public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '{{{path}}}'{{#pathParams}}
-                    .replace('${' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
+        const path = this.basePath + `{{{path}}}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/pet.service.ts
@@ -78,13 +78,15 @@ export class PetService {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet(body: Pet, extraHttpRequestParams?: any): Observable<{}> {
+    public addPet(body: Pet, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.addPetWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -95,13 +97,15 @@ export class PetService {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deletePet(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deletePetWithHttpInfo(petId, apiKey, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -111,13 +115,18 @@ export class PetService {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<string>, extraHttpRequestParams?: any): Observable<Array<Pet>> {
+    public findPetsByStatus(status: Array<string>, extraHttpRequestParams?: any): Observable<undefined | Array<Pet> | {}> {
         return this.findPetsByStatusWithHttpInfo(status, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -127,13 +136,18 @@ export class PetService {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, extraHttpRequestParams?: any): Observable<Array<Pet>> {
+    public findPetsByTags(tags: Array<string>, extraHttpRequestParams?: any): Observable<undefined | Array<Pet> | {}> {
         return this.findPetsByTagsWithHttpInfo(tags, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -143,13 +157,18 @@ export class PetService {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, extraHttpRequestParams?: any): Observable<Pet> {
+    public getPetById(petId: number, extraHttpRequestParams?: any): Observable<undefined | Pet | {}> {
         return this.getPetByIdWithHttpInfo(petId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -159,13 +178,15 @@ export class PetService {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet(body: Pet, extraHttpRequestParams?: any): Observable<{}> {
+    public updatePet(body: Pet, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updatePetWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -177,13 +198,15 @@ export class PetService {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<{}> {
+    public updatePetWithForm(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -195,13 +218,18 @@ export class PetService {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<ApiResponse> {
+    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<undefined | ApiResponse | {}> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -213,7 +241,7 @@ export class PetService {
      * @param body Pet object that needs to be added to the store
      */
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet';
+        const path = this.basePath + `/pet`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -263,8 +291,7 @@ export class PetService {
      * @param apiKey 
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -314,7 +341,7 @@ export class PetService {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/findByStatus';
+        const path = this.basePath + `/pet/findByStatus`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -364,7 +391,7 @@ export class PetService {
      * @param tags Tags to filter by
      */
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/findByTags';
+        const path = this.basePath + `/pet/findByTags`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -414,8 +441,7 @@ export class PetService {
      * @param petId ID of pet to return
      */
     public getPetByIdWithHttpInfo(petId: number, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -457,7 +483,7 @@ export class PetService {
      * @param body Pet object that needs to be added to the store
      */
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet';
+        const path = this.basePath + `/pet`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -508,8 +534,7 @@ export class PetService {
      * @param status Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -575,8 +600,7 @@ export class PetService {
      * @param file file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}/uploadImage'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}/uploadImage`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/store.service.ts
@@ -73,17 +73,19 @@ export class StoreService {
     }
 
     /**
-     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deleteOrder(orderId: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deleteOrderWithHttpInfo(orderId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -92,29 +94,39 @@ export class StoreService {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory(extraHttpRequestParams?: any): Observable<{ [key: string]: number; }> {
+    public getInventory(extraHttpRequestParams?: any): Observable<undefined | { [key: string]: number; } | {}> {
         return this.getInventoryWithHttpInfo(extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, extraHttpRequestParams?: any): Observable<Order> {
+    public getOrderById(orderId: number, extraHttpRequestParams?: any): Observable<undefined | Order | {}> {
         return this.getOrderByIdWithHttpInfo(orderId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -124,13 +136,18 @@ export class StoreService {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder(body: Order, extraHttpRequestParams?: any): Observable<Order> {
+    public placeOrder(body: Order, extraHttpRequestParams?: any): Observable<undefined | Order | {}> {
         return this.placeOrderWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -142,8 +159,7 @@ export class StoreService {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrderWithHttpInfo(orderId: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order/${orderId}'
-                    .replace('${' + 'orderId' + '}', String(orderId));
+        const path = this.basePath + `/store/order/${orderId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -179,7 +195,7 @@ export class StoreService {
      * Returns a map of status codes to quantities
      */
     public getInventoryWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/inventory';
+        const path = this.basePath + `/store/inventory`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -216,8 +232,7 @@ export class StoreService {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderByIdWithHttpInfo(orderId: number, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order/${orderId}'
-                    .replace('${' + 'orderId' + '}', String(orderId));
+        const path = this.basePath + `/store/order/${orderId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -254,7 +269,7 @@ export class StoreService {
      * @param body order placed for purchasing the pet
      */
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order';
+        const path = this.basePath + `/store/order`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular2/default/api/user.service.ts
@@ -77,13 +77,15 @@ export class UserService {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser(body: User, extraHttpRequestParams?: any): Observable<{}> {
+    public createUser(body: User, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUserWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -93,13 +95,15 @@ export class UserService {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput(body: Array<User>, extraHttpRequestParams?: any): Observable<{}> {
+    public createUsersWithArrayInput(body: Array<User>, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUsersWithArrayInputWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -109,13 +113,15 @@ export class UserService {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput(body: Array<User>, extraHttpRequestParams?: any): Observable<{}> {
+    public createUsersWithListInput(body: Array<User>, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUsersWithListInputWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -125,13 +131,15 @@ export class UserService {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deleteUser(username: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deleteUserWithHttpInfo(username, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -141,13 +149,18 @@ export class UserService {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    public getUserByName(username: string, extraHttpRequestParams?: any): Observable<User> {
+    public getUserByName(username: string, extraHttpRequestParams?: any): Observable<undefined | User | {}> {
         return this.getUserByNameWithHttpInfo(username, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -158,13 +171,18 @@ export class UserService {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, extraHttpRequestParams?: any): Observable<string> {
+    public loginUser(username: string, password: string, extraHttpRequestParams?: any): Observable<undefined | string | {}> {
         return this.loginUserWithHttpInfo(username, password, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.text();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -173,13 +191,15 @@ export class UserService {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser(extraHttpRequestParams?: any): Observable<{}> {
+    public logoutUser(extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.logoutUserWithHttpInfo(extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -190,13 +210,15 @@ export class UserService {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser(username: string, body: User, extraHttpRequestParams?: any): Observable<{}> {
+    public updateUser(username: string, body: User, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updateUserWithHttpInfo(username, body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -208,7 +230,7 @@ export class UserService {
      * @param body Created user object
      */
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user';
+        const path = this.basePath + `/user`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -248,7 +270,7 @@ export class UserService {
      * @param body List of user object
      */
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/createWithArray';
+        const path = this.basePath + `/user/createWithArray`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -288,7 +310,7 @@ export class UserService {
      * @param body List of user object
      */
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/createWithList';
+        const path = this.basePath + `/user/createWithList`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -328,8 +350,7 @@ export class UserService {
      * @param username The name that needs to be deleted
      */
     public deleteUserWithHttpInfo(username: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -366,8 +387,7 @@ export class UserService {
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
     public getUserByNameWithHttpInfo(username: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -405,7 +425,7 @@ export class UserService {
      * @param password The password for login in clear text
      */
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/login';
+        const path = this.basePath + `/user/login`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -453,7 +473,7 @@ export class UserService {
      * 
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/logout';
+        const path = this.basePath + `/user/logout`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -487,8 +507,7 @@ export class UserService {
      * @param body Updated user object
      */
     public updateUserWithHttpInfo(username: string, body: User, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/pet.service.ts
@@ -74,134 +74,162 @@ export class PetService {
     }
 
     /**
-     * Add a new pet to the store
      * 
+     * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet(body: Pet, extraHttpRequestParams?: any): Observable<{}> {
+    public addPet(body: Pet, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.addPetWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Deletes a pet
      * 
+     * @summary Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deletePet(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deletePetWithHttpInfo(petId, apiKey, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
+     * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<string>, extraHttpRequestParams?: any): Observable<Array<Pet>> {
+    public findPetsByStatus(status: Array<string>, extraHttpRequestParams?: any): Observable<undefined | Array<Pet> | {}> {
         return this.findPetsByStatusWithHttpInfo(status, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, extraHttpRequestParams?: any): Observable<Array<Pet>> {
+    public findPetsByTags(tags: Array<string>, extraHttpRequestParams?: any): Observable<undefined | Array<Pet> | {}> {
         return this.findPetsByTagsWithHttpInfo(tags, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Find pet by ID
      * Returns a single pet
+     * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, extraHttpRequestParams?: any): Observable<Pet> {
+    public getPetById(petId: number, extraHttpRequestParams?: any): Observable<undefined | Pet | {}> {
         return this.getPetByIdWithHttpInfo(petId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Update an existing pet
      * 
+     * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet(body: Pet, extraHttpRequestParams?: any): Observable<{}> {
+    public updatePet(body: Pet, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updatePetWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Updates a pet in the store with form data
      * 
+     * @summary Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<{}> {
+    public updatePetWithForm(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * uploads an image
      * 
+     * @summary uploads an image
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<ApiResponse> {
+    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<undefined | ApiResponse | {}> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -213,7 +241,7 @@ export class PetService {
      * @param body Pet object that needs to be added to the store
      */
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet';
+        const path = this.basePath + `/pet`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -263,8 +291,7 @@ export class PetService {
      * @param apiKey 
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -314,7 +341,7 @@ export class PetService {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/findByStatus';
+        const path = this.basePath + `/pet/findByStatus`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -364,7 +391,7 @@ export class PetService {
      * @param tags Tags to filter by
      */
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/findByTags';
+        const path = this.basePath + `/pet/findByTags`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -414,8 +441,7 @@ export class PetService {
      * @param petId ID of pet to return
      */
     public getPetByIdWithHttpInfo(petId: number, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -457,7 +483,7 @@ export class PetService {
      * @param body Pet object that needs to be added to the store
      */
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet';
+        const path = this.basePath + `/pet`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -508,8 +534,7 @@ export class PetService {
      * @param status Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -575,8 +600,7 @@ export class PetService {
      * @param file file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}/uploadImage'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}/uploadImage`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/store.service.ts
@@ -73,64 +73,81 @@ export class StoreService {
     }
 
     /**
-     * Delete purchase order by ID
-     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deleteOrder(orderId: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deleteOrderWithHttpInfo(orderId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     * @summary Returns pet inventories by status
      */
-    public getInventory(extraHttpRequestParams?: any): Observable<{ [key: string]: number; }> {
+    public getInventory(extraHttpRequestParams?: any): Observable<undefined | { [key: string]: number; } | {}> {
         return this.getInventoryWithHttpInfo(extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Find purchase order by ID
-     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+     * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, extraHttpRequestParams?: any): Observable<Order> {
+    public getOrderById(orderId: number, extraHttpRequestParams?: any): Observable<undefined | Order | {}> {
         return this.getOrderByIdWithHttpInfo(orderId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Place an order for a pet
      * 
+     * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder(body: Order, extraHttpRequestParams?: any): Observable<Order> {
+    public placeOrder(body: Order, extraHttpRequestParams?: any): Observable<undefined | Order | {}> {
         return this.placeOrderWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -142,8 +159,7 @@ export class StoreService {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrderWithHttpInfo(orderId: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order/${orderId}'
-                    .replace('${' + 'orderId' + '}', String(orderId));
+        const path = this.basePath + `/store/order/${orderId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -179,7 +195,7 @@ export class StoreService {
      * Returns a map of status codes to quantities
      */
     public getInventoryWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/inventory';
+        const path = this.basePath + `/store/inventory`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -216,8 +232,7 @@ export class StoreService {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderByIdWithHttpInfo(orderId: number, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order/${orderId}'
-                    .replace('${' + 'orderId' + '}', String(orderId));
+        const path = this.basePath + `/store/order/${orderId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -254,7 +269,7 @@ export class StoreService {
      * @param body order placed for purchasing the pet
      */
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order';
+        const path = this.basePath + `/store/order`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular2/npm/api/user.service.ts
@@ -73,130 +73,152 @@ export class UserService {
     }
 
     /**
-     * Create user
      * This can only be done by the logged in user.
+     * @summary Create user
      * @param body Created user object
      */
-    public createUser(body: User, extraHttpRequestParams?: any): Observable<{}> {
+    public createUser(body: User, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUserWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Creates list of users with given input array
      * 
+     * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput(body: Array<User>, extraHttpRequestParams?: any): Observable<{}> {
+    public createUsersWithArrayInput(body: Array<User>, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUsersWithArrayInputWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Creates list of users with given input array
      * 
+     * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput(body: Array<User>, extraHttpRequestParams?: any): Observable<{}> {
+    public createUsersWithListInput(body: Array<User>, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUsersWithListInputWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Delete user
      * This can only be done by the logged in user.
+     * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deleteUser(username: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deleteUserWithHttpInfo(username, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Get user by user name
      * 
+     * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    public getUserByName(username: string, extraHttpRequestParams?: any): Observable<User> {
+    public getUserByName(username: string, extraHttpRequestParams?: any): Observable<undefined | User | {}> {
         return this.getUserByNameWithHttpInfo(username, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Logs user into the system
      * 
+     * @summary Logs user into the system
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, extraHttpRequestParams?: any): Observable<string> {
+    public loginUser(username: string, password: string, extraHttpRequestParams?: any): Observable<undefined | string | {}> {
         return this.loginUserWithHttpInfo(username, password, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.text();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Logs out current logged in user session
      * 
+     * @summary Logs out current logged in user session
      */
-    public logoutUser(extraHttpRequestParams?: any): Observable<{}> {
+    public logoutUser(extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.logoutUserWithHttpInfo(extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Updated user
      * This can only be done by the logged in user.
+     * @summary Updated user
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser(username: string, body: User, extraHttpRequestParams?: any): Observable<{}> {
+    public updateUser(username: string, body: User, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updateUserWithHttpInfo(username, body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -208,7 +230,7 @@ export class UserService {
      * @param body Created user object
      */
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user';
+        const path = this.basePath + `/user`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -248,7 +270,7 @@ export class UserService {
      * @param body List of user object
      */
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/createWithArray';
+        const path = this.basePath + `/user/createWithArray`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -288,7 +310,7 @@ export class UserService {
      * @param body List of user object
      */
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/createWithList';
+        const path = this.basePath + `/user/createWithList`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -328,8 +350,7 @@ export class UserService {
      * @param username The name that needs to be deleted
      */
     public deleteUserWithHttpInfo(username: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -366,8 +387,7 @@ export class UserService {
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
     public getUserByNameWithHttpInfo(username: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -405,7 +425,7 @@ export class UserService {
      * @param password The password for login in clear text
      */
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/login';
+        const path = this.basePath + `/user/login`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -453,7 +473,7 @@ export class UserService {
      * 
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/logout';
+        const path = this.basePath + `/user/logout`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -487,8 +507,7 @@ export class UserService {
      * @param body Updated user object
      */
     public updateUserWithHttpInfo(username: string, body: User, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/npm/tsconfig.json
+++ b/samples/client/petstore/typescript-angular2/npm/tsconfig.json
@@ -12,14 +12,14 @@
         "outDir": "./dist",
         "noLib": false,
         "declaration": true,
-        "lib": [ "es6", "dom" ]
+        "lib": [ "es6", "dom" ],
+        "typeRoots": [ "node_modules/@types" ]
     },
     "exclude": [
         "node_modules",
         "dist"
     ],
-    "filesGlob": [
-        "./model/*.ts",
-        "./api/*.ts"
+    "files": [
+        "./index"
     ]
 }

--- a/samples/client/petstore/typescript-angular2/with-interfaces/api/PetApi.ts
+++ b/samples/client/petstore/typescript-angular2/with-interfaces/api/PetApi.ts
@@ -47,13 +47,14 @@ export class PetApi implements PetApiInterface {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet(body: models.Pet, extraHttpRequestParams?: any): Observable<{}> {
+    public addPet(body?: models.Pet, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.addPetWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -64,13 +65,14 @@ export class PetApi implements PetApiInterface {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deletePet(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deletePetWithHttpInfo(petId, apiKey, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -80,13 +82,17 @@ export class PetApi implements PetApiInterface {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<string>, extraHttpRequestParams?: any): Observable<Array<models.Pet>> {
+    public findPetsByStatus(status?: Array<string>, extraHttpRequestParams?: any): Observable<undefined | Array<models.Pet> | {}> {
         return this.findPetsByStatusWithHttpInfo(status, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -96,13 +102,17 @@ export class PetApi implements PetApiInterface {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, extraHttpRequestParams?: any): Observable<Array<models.Pet>> {
+    public findPetsByTags(tags?: Array<string>, extraHttpRequestParams?: any): Observable<undefined | Array<models.Pet> | {}> {
         return this.findPetsByTagsWithHttpInfo(tags, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -112,13 +122,17 @@ export class PetApi implements PetApiInterface {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, extraHttpRequestParams?: any): Observable<models.Pet> {
+    public getPetById(petId: number, extraHttpRequestParams?: any): Observable<undefined | models.Pet | {}> {
         return this.getPetByIdWithHttpInfo(petId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -128,13 +142,14 @@ export class PetApi implements PetApiInterface {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet(body: models.Pet, extraHttpRequestParams?: any): Observable<{}> {
+    public updatePet(body?: models.Pet, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updatePetWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -146,13 +161,14 @@ export class PetApi implements PetApiInterface {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<{}> {
+    public updatePetWithForm(petId: string, name?: string, status?: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -164,13 +180,14 @@ export class PetApi implements PetApiInterface {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: any, extraHttpRequestParams?: any): Observable<models.ApiResponse> {
+    public uploadFile(petId: number, additionalMetadata?: string, file?: any, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -181,8 +198,8 @@ export class PetApi implements PetApiInterface {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    public addPetWithHttpInfo(body: models.Pet, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet';
+    public addPetWithHttpInfo(body?: models.Pet, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/pet`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -235,8 +252,7 @@ export class PetApi implements PetApiInterface {
      * @param apiKey 
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -286,8 +302,8 @@ export class PetApi implements PetApiInterface {
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/findByStatus';
+    public findPetsByStatusWithHttpInfo(status?: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/pet/findByStatus`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -337,8 +353,8 @@ export class PetApi implements PetApiInterface {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
      */
-    public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/findByTags';
+    public findPetsByTagsWithHttpInfo(tags?: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/pet/findByTags`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -389,8 +405,7 @@ export class PetApi implements PetApiInterface {
      * @param petId ID of pet to return
      */
     public getPetByIdWithHttpInfo(petId: number, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -432,8 +447,8 @@ export class PetApi implements PetApiInterface {
      * 
      * @param body Pet object that needs to be added to the store
      */
-    public updatePetWithHttpInfo(body: models.Pet, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet';
+    public updatePetWithHttpInfo(body?: models.Pet, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/pet`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -486,9 +501,8 @@ export class PetApi implements PetApiInterface {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+    public updatePetWithFormWithHttpInfo(petId: string, name?: string, status?: string, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -551,8 +565,7 @@ export class PetApi implements PetApiInterface {
      * @param file file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: any, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}/uploadImage'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}/uploadImage`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/with-interfaces/api/StoreApi.ts
+++ b/samples/client/petstore/typescript-angular2/with-interfaces/api/StoreApi.ts
@@ -47,13 +47,14 @@ export class StoreApi implements StoreApiInterface {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deleteOrder(orderId: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deleteOrderWithHttpInfo(orderId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -62,13 +63,17 @@ export class StoreApi implements StoreApiInterface {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory(extraHttpRequestParams?: any): Observable<{ [key: string]: number; }> {
+    public getInventory(extraHttpRequestParams?: any): Observable<undefined | { [key: string]: number; } | {}> {
         return this.getInventoryWithHttpInfo(extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -78,13 +83,17 @@ export class StoreApi implements StoreApiInterface {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, extraHttpRequestParams?: any): Observable<models.Order> {
+    public getOrderById(orderId: string, extraHttpRequestParams?: any): Observable<undefined | models.Order | {}> {
         return this.getOrderByIdWithHttpInfo(orderId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -94,13 +103,17 @@ export class StoreApi implements StoreApiInterface {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder(body: models.Order, extraHttpRequestParams?: any): Observable<models.Order> {
+    public placeOrder(body?: models.Order, extraHttpRequestParams?: any): Observable<undefined | models.Order | {}> {
         return this.placeOrderWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -112,8 +125,7 @@ export class StoreApi implements StoreApiInterface {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrderWithHttpInfo(orderId: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order/${orderId}'
-                    .replace('${' + 'orderId' + '}', String(orderId));
+        const path = this.basePath + `/store/order/${orderId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -150,7 +162,7 @@ export class StoreApi implements StoreApiInterface {
      * Returns a map of status codes to quantities
      */
     public getInventoryWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/inventory';
+        const path = this.basePath + `/store/inventory`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -188,9 +200,8 @@ export class StoreApi implements StoreApiInterface {
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderByIdWithHttpInfo(orderId: number, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order/${orderId}'
-                    .replace('${' + 'orderId' + '}', String(orderId));
+    public getOrderByIdWithHttpInfo(orderId: string, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/store/order/${orderId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -227,8 +238,8 @@ export class StoreApi implements StoreApiInterface {
      * 
      * @param body order placed for purchasing the pet
      */
-    public placeOrderWithHttpInfo(body: models.Order, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order';
+    public placeOrderWithHttpInfo(body?: models.Order, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/store/order`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/with-interfaces/api/UserApi.ts
+++ b/samples/client/petstore/typescript-angular2/with-interfaces/api/UserApi.ts
@@ -47,13 +47,14 @@ export class UserApi implements UserApiInterface {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser(body: models.User, extraHttpRequestParams?: any): Observable<{}> {
+    public createUser(body?: models.User, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUserWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -63,13 +64,14 @@ export class UserApi implements UserApiInterface {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput(body: Array<models.User>, extraHttpRequestParams?: any): Observable<{}> {
+    public createUsersWithArrayInput(body?: Array<models.User>, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUsersWithArrayInputWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -79,13 +81,14 @@ export class UserApi implements UserApiInterface {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput(body: Array<models.User>, extraHttpRequestParams?: any): Observable<{}> {
+    public createUsersWithListInput(body?: Array<models.User>, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUsersWithListInputWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -95,13 +98,14 @@ export class UserApi implements UserApiInterface {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deleteUser(username: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deleteUserWithHttpInfo(username, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -111,13 +115,17 @@ export class UserApi implements UserApiInterface {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    public getUserByName(username: string, extraHttpRequestParams?: any): Observable<models.User> {
+    public getUserByName(username: string, extraHttpRequestParams?: any): Observable<undefined | models.User | {}> {
         return this.getUserByNameWithHttpInfo(username, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -128,13 +136,17 @@ export class UserApi implements UserApiInterface {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, extraHttpRequestParams?: any): Observable<string> {
+    public loginUser(username?: string, password?: string, extraHttpRequestParams?: any): Observable<undefined | string | {}> {
         return this.loginUserWithHttpInfo(username, password, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.text();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -143,13 +155,14 @@ export class UserApi implements UserApiInterface {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser(extraHttpRequestParams?: any): Observable<{}> {
+    public logoutUser(extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.logoutUserWithHttpInfo(extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -160,13 +173,14 @@ export class UserApi implements UserApiInterface {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser(username: string, body: models.User, extraHttpRequestParams?: any): Observable<{}> {
+    public updateUser(username: string, body?: models.User, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updateUserWithHttpInfo(username, body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -177,8 +191,8 @@ export class UserApi implements UserApiInterface {
      * This can only be done by the logged in user.
      * @param body Created user object
      */
-    public createUserWithHttpInfo(body: models.User, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user';
+    public createUserWithHttpInfo(body?: models.User, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/user`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -218,8 +232,8 @@ export class UserApi implements UserApiInterface {
      * 
      * @param body List of user object
      */
-    public createUsersWithArrayInputWithHttpInfo(body: Array<models.User>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/createWithArray';
+    public createUsersWithArrayInputWithHttpInfo(body?: Array<models.User>, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/user/createWithArray`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -259,8 +273,8 @@ export class UserApi implements UserApiInterface {
      * 
      * @param body List of user object
      */
-    public createUsersWithListInputWithHttpInfo(body: Array<models.User>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/createWithList';
+    public createUsersWithListInputWithHttpInfo(body?: Array<models.User>, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/user/createWithList`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -301,8 +315,7 @@ export class UserApi implements UserApiInterface {
      * @param username The name that needs to be deleted
      */
     public deleteUserWithHttpInfo(username: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -340,8 +353,7 @@ export class UserApi implements UserApiInterface {
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
     public getUserByNameWithHttpInfo(username: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -379,8 +391,8 @@ export class UserApi implements UserApiInterface {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/login';
+    public loginUserWithHttpInfo(username?: string, password?: string, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/user/login`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -429,7 +441,7 @@ export class UserApi implements UserApiInterface {
      * 
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/logout';
+        const path = this.basePath + `/user/logout`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -463,9 +475,8 @@ export class UserApi implements UserApiInterface {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUserWithHttpInfo(username: string, body: models.User, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+    public updateUserWithHttpInfo(username: string, body?: models.User, extraHttpRequestParams?: any): Observable<Response> {
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular2/with-interfaces/api/pet.service.ts
@@ -75,134 +75,162 @@ export class PetService implements PetServiceInterface {
     }
 
     /**
-     * Add a new pet to the store
      * 
+     * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet(body: Pet, extraHttpRequestParams?: any): Observable<{}> {
+    public addPet(body: Pet, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.addPetWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Deletes a pet
      * 
+     * @summary Deletes a pet
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deletePet(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deletePetWithHttpInfo(petId, apiKey, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
+     * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<string>, extraHttpRequestParams?: any): Observable<Array<Pet>> {
+    public findPetsByStatus(status: Array<string>, extraHttpRequestParams?: any): Observable<undefined | Array<Pet> | {}> {
         return this.findPetsByStatusWithHttpInfo(status, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, extraHttpRequestParams?: any): Observable<Array<Pet>> {
+    public findPetsByTags(tags: Array<string>, extraHttpRequestParams?: any): Observable<undefined | Array<Pet> | {}> {
         return this.findPetsByTagsWithHttpInfo(tags, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Find pet by ID
      * Returns a single pet
+     * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, extraHttpRequestParams?: any): Observable<Pet> {
+    public getPetById(petId: number, extraHttpRequestParams?: any): Observable<undefined | Pet | {}> {
         return this.getPetByIdWithHttpInfo(petId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Update an existing pet
      * 
+     * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet(body: Pet, extraHttpRequestParams?: any): Observable<{}> {
+    public updatePet(body: Pet, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updatePetWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Updates a pet in the store with form data
      * 
+     * @summary Updates a pet in the store with form data
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<{}> {
+    public updatePetWithForm(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updatePetWithFormWithHttpInfo(petId, name, status, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * uploads an image
      * 
+     * @summary uploads an image
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<ApiResponse> {
+    public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<undefined | ApiResponse | {}> {
         return this.uploadFileWithHttpInfo(petId, additionalMetadata, file, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -214,7 +242,7 @@ export class PetService implements PetServiceInterface {
      * @param body Pet object that needs to be added to the store
      */
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet';
+        const path = this.basePath + `/pet`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -264,8 +292,7 @@ export class PetService implements PetServiceInterface {
      * @param apiKey 
      */
     public deletePetWithHttpInfo(petId: number, apiKey?: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -315,7 +342,7 @@ export class PetService implements PetServiceInterface {
      * @param status Status values that need to be considered for filter
      */
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/findByStatus';
+        const path = this.basePath + `/pet/findByStatus`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -365,7 +392,7 @@ export class PetService implements PetServiceInterface {
      * @param tags Tags to filter by
      */
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/findByTags';
+        const path = this.basePath + `/pet/findByTags`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -415,8 +442,7 @@ export class PetService implements PetServiceInterface {
      * @param petId ID of pet to return
      */
     public getPetByIdWithHttpInfo(petId: number, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -458,7 +484,7 @@ export class PetService implements PetServiceInterface {
      * @param body Pet object that needs to be added to the store
      */
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet';
+        const path = this.basePath + `/pet`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -509,8 +535,7 @@ export class PetService implements PetServiceInterface {
      * @param status Updated status of the pet
      */
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -576,8 +601,7 @@ export class PetService implements PetServiceInterface {
      * @param file file to upload
      */
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: Blob, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/pet/${petId}/uploadImage'
-                    .replace('${' + 'petId' + '}', String(petId));
+        const path = this.basePath + `/pet/${petId}/uploadImage`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/with-interfaces/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular2/with-interfaces/api/store.service.ts
@@ -74,64 +74,81 @@ export class StoreService implements StoreServiceInterface {
     }
 
     /**
-     * Delete purchase order by ID
-     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deleteOrder(orderId: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deleteOrderWithHttpInfo(orderId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     * @summary Returns pet inventories by status
      */
-    public getInventory(extraHttpRequestParams?: any): Observable<{ [key: string]: number; }> {
+    public getInventory(extraHttpRequestParams?: any): Observable<undefined | { [key: string]: number; } | {}> {
         return this.getInventoryWithHttpInfo(extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Find purchase order by ID
-     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+     * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, extraHttpRequestParams?: any): Observable<Order> {
+    public getOrderById(orderId: number, extraHttpRequestParams?: any): Observable<undefined | Order | {}> {
         return this.getOrderByIdWithHttpInfo(orderId, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Place an order for a pet
      * 
+     * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder(body: Order, extraHttpRequestParams?: any): Observable<Order> {
+    public placeOrder(body: Order, extraHttpRequestParams?: any): Observable<undefined | Order | {}> {
         return this.placeOrderWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -143,8 +160,7 @@ export class StoreService implements StoreServiceInterface {
      * @param orderId ID of the order that needs to be deleted
      */
     public deleteOrderWithHttpInfo(orderId: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order/${orderId}'
-                    .replace('${' + 'orderId' + '}', String(orderId));
+        const path = this.basePath + `/store/order/${orderId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -180,7 +196,7 @@ export class StoreService implements StoreServiceInterface {
      * Returns a map of status codes to quantities
      */
     public getInventoryWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/inventory';
+        const path = this.basePath + `/store/inventory`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -217,8 +233,7 @@ export class StoreService implements StoreServiceInterface {
      * @param orderId ID of pet that needs to be fetched
      */
     public getOrderByIdWithHttpInfo(orderId: number, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order/${orderId}'
-                    .replace('${' + 'orderId' + '}', String(orderId));
+        const path = this.basePath + `/store/order/${orderId}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -255,7 +270,7 @@ export class StoreService implements StoreServiceInterface {
      * @param body order placed for purchasing the pet
      */
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/store/order';
+        const path = this.basePath + `/store/order`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845

--- a/samples/client/petstore/typescript-angular2/with-interfaces/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular2/with-interfaces/api/user.service.ts
@@ -74,130 +74,152 @@ export class UserService implements UserServiceInterface {
     }
 
     /**
-     * Create user
      * This can only be done by the logged in user.
+     * @summary Create user
      * @param body Created user object
      */
-    public createUser(body: User, extraHttpRequestParams?: any): Observable<{}> {
+    public createUser(body: User, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUserWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Creates list of users with given input array
      * 
+     * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput(body: Array<User>, extraHttpRequestParams?: any): Observable<{}> {
+    public createUsersWithArrayInput(body: Array<User>, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUsersWithArrayInputWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Creates list of users with given input array
      * 
+     * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput(body: Array<User>, extraHttpRequestParams?: any): Observable<{}> {
+    public createUsersWithListInput(body: Array<User>, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.createUsersWithListInputWithHttpInfo(body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Delete user
      * This can only be done by the logged in user.
+     * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, extraHttpRequestParams?: any): Observable<{}> {
+    public deleteUser(username: string, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.deleteUserWithHttpInfo(username, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Get user by user name
      * 
+     * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
-    public getUserByName(username: string, extraHttpRequestParams?: any): Observable<User> {
+    public getUserByName(username: string, extraHttpRequestParams?: any): Observable<undefined | User | {}> {
         return this.getUserByNameWithHttpInfo(username, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.json();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Logs user into the system
      * 
+     * @summary Logs user into the system
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, extraHttpRequestParams?: any): Observable<string> {
+    public loginUser(username: string, password: string, extraHttpRequestParams?: any): Observable<undefined | string | {}> {
         return this.loginUserWithHttpInfo(username, password, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    case 200:
+                        // successful operation
+                        return response.text();
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Logs out current logged in user session
      * 
+     * @summary Logs out current logged in user session
      */
-    public logoutUser(extraHttpRequestParams?: any): Observable<{}> {
+    public logoutUser(extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.logoutUserWithHttpInfo(extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
 
     /**
-     * Updated user
      * This can only be done by the logged in user.
+     * @summary Updated user
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser(username: string, body: User, extraHttpRequestParams?: any): Observable<{}> {
+    public updateUser(username: string, body: User, extraHttpRequestParams?: any): Observable<undefined | {}> {
         return this.updateUserWithHttpInfo(username, body, extraHttpRequestParams)
             .map((response: Response) => {
-                if (response.status === 204) {
-                    return undefined;
-                } else {
-                    return response.json() || {};
+                
+                switch (response.status) {
+                    case 204:
+                        return undefined;
+                    default:
+                        return response.json() || {};
                 }
             });
     }
@@ -209,7 +231,7 @@ export class UserService implements UserServiceInterface {
      * @param body Created user object
      */
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user';
+        const path = this.basePath + `/user`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -249,7 +271,7 @@ export class UserService implements UserServiceInterface {
      * @param body List of user object
      */
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/createWithArray';
+        const path = this.basePath + `/user/createWithArray`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -289,7 +311,7 @@ export class UserService implements UserServiceInterface {
      * @param body List of user object
      */
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/createWithList';
+        const path = this.basePath + `/user/createWithList`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -329,8 +351,7 @@ export class UserService implements UserServiceInterface {
      * @param username The name that needs to be deleted
      */
     public deleteUserWithHttpInfo(username: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -367,8 +388,7 @@ export class UserService implements UserServiceInterface {
      * @param username The name that needs to be fetched. Use user1 for testing. 
      */
     public getUserByNameWithHttpInfo(username: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -406,7 +426,7 @@ export class UserService implements UserServiceInterface {
      * @param password The password for login in clear text
      */
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/login';
+        const path = this.basePath + `/user/login`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -454,7 +474,7 @@ export class UserService implements UserServiceInterface {
      * 
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/logout';
+        const path = this.basePath + `/user/logout`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
@@ -488,8 +508,7 @@ export class UserService implements UserServiceInterface {
      * @param body Updated user object
      */
     public updateUserWithHttpInfo(username: string, body: User, extraHttpRequestParams?: any): Observable<Response> {
-        const path = this.basePath + '/user/${username}'
-                    .replace('${' + 'username' + '}', String(username));
+        const path = this.basePath + `/user/${username}`;
 
         let queryParameters = new URLSearchParams();
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The swagger spec can define multiple responses. So this allows two things:
1. The return type to reflect the multiple possible return types
2. The return value from the map to map to a correct type (json(), text(), undefined etc)

This also has the advantage of enabling further type checking for those enabling typescript strict null checks.

One final thing is utilising typescript string interpolation with `${variable}` instead of string replacement. Simplifies the construction of the URL path.

_n.b. I did update the sample angular2 out of the RC dependencies. Assuming this is fine as 1. it's an RC 2. even with the updates, still targeting minor version of 2.x so should be no breaking changes with the sample_