### PR TITLE
[JavaScript] set ES6 as the default for JS generator in the 2.3.0 branch

### DIFF
--- a/bin/javascript-petstore.sh
+++ b/bin/javascript-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples/client/petstore/javascript  -DappName=PetstoreClient"
+ags="$@ generate -t modules/swagger-codegen/src/main/resources/Javascript -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples/client/petstore/javascript  -DappName=PetstoreClient --additional-properties useES6=false"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/javascript-promise-petstore.sh
+++ b/bin/javascript-promise-petstore.sh
@@ -31,7 +31,7 @@ ags="$@ generate \
 -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml \
 -l javascript \
 -o samples/client/petstore/javascript-promise \
---additional-properties usePromises=true \
+--additional-properties usePromises=true,useES6=false \
 -DappName=PetstoreClient"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/javascript-petstore.bat
+++ b/bin/windows/javascript-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples\client\petstore\javascript -DappName=PetstoreClient
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples\client\petstore\javascript -DappName=PetstoreClient --additional-properties useES6=false
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/javascript-promise-petstore.bat
+++ b/bin/windows/javascript-promise-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples\client\petstore\javascript-promise --additional-properties usePromises=true -DappName=PetstoreClient
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -l javascript -o samples\client\petstore\javascript-promise --additional-properties usePromises=true,useES6=false -DappName=PetstoreClient
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavascriptClientCodegen.java
@@ -96,7 +96,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     protected String modelDocPath = "docs/";
     protected String apiTestPath = "api/";
     protected String modelTestPath = "model/";
-    protected boolean useES6 = false; // default is ES5
+    protected boolean useES6 = true; // default is ES6
 
     public JavascriptClientCodegen() {
         super();
@@ -269,7 +269,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         if (additionalProperties.containsKey(USE_ES6)) {
             setUseES6(convertPropertyToBooleanAndWriteBack(USE_ES6));
         } else {
-            setUseES6(false);
+            setUseES6(true); // default to ES6
         }
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Closes https://github.com/swagger-api/swagger-codegen/issues/5909 
