### PR TITLE
removed obsolete jersey2-version

### DIFF
--- a/modules/swagger-codegen-maven-plugin/README.md
+++ b/modules/swagger-codegen-maven-plugin/README.md
@@ -11,7 +11,7 @@ Add to your `build->plugins` section (default phase is `generate-sources` phase)
 <plugin>
     <groupId>io.swagger</groupId>
     <artifactId>swagger-codegen-maven-plugin</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <executions>
         <execution>
             <goals>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -180,7 +180,6 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.15</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -231,7 +231,6 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.15</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>

--- a/samples/client/petstore/jaxrs-cxf-client/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client/pom.xml
@@ -186,7 +186,6 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.15</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>

--- a/samples/client/petstore/jaxrs-cxf/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf/pom.xml
@@ -164,7 +164,6 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.15</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
@@ -167,7 +167,6 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.10</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
@@ -167,7 +167,6 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.10</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -186,7 +186,6 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.15</swagger-core-version>
     <jetty-version>9.2.9.v20150224</jetty-version>
-    <jersey2-version>2.22.2</jersey2-version>
     <junit-version>4.12</junit-version>
     <logback-version>1.1.7</logback-version>
     <servlet-api-version>2.5</servlet-api-version>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

jersey2-version in CXF projects is confusing, it doesn't make sense to mix up two JAX-RS implementations and the property is not in use.

I also updated the README.md file for swagger-codegen-maven-plugin as the version 2.2.2 is already released and available on central.