### PR TITLE
updated maven-war-plugin

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
@@ -35,7 +35,7 @@
             <!-- Java EE 7 doesn't need a web.xml -->
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -80,7 +80,7 @@
       <!-- build WAR file -->
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
         <configuration>
            <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
@@ -11,7 +11,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/pom.mustache
@@ -20,7 +20,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
@@ -12,7 +12,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pom.mustache
@@ -12,7 +12,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -11,7 +11,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.1.0</version>
         <configuration>
             <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>

--- a/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
@@ -11,7 +11,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.0</version>
                 <configuration>
                     <webResources>
                         <resource>

--- a/samples/client/petstore/jaxrs-cxf-client/pom.xml
+++ b/samples/client/petstore/jaxrs-cxf-client/pom.xml
@@ -80,7 +80,7 @@
       <!-- build WAR file -->
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
         <configuration>
            <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/pom.xml
@@ -80,7 +80,7 @@
       <!-- build WAR file -->
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
         <configuration>
            <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>

--- a/samples/server/petstore/jaxrs-cxf-cdi/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-cdi/pom.xml
@@ -35,7 +35,7 @@
             <!-- Java EE 7 doesn't need a web.xml -->
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/pom.xml
@@ -80,7 +80,7 @@
       <!-- build WAR file -->
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
         <configuration>
            <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>

--- a/samples/server/petstore/jaxrs-cxf/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf/pom.xml
@@ -80,7 +80,7 @@
       <!-- build WAR file -->
       <plugin>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
         <configuration>
            <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>

--- a/samples/server/petstore/jaxrs-resteasy/default/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/default/pom.xml
@@ -12,7 +12,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
@@ -12,7 +12,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
@@ -12,7 +12,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/samples/server/petstore/jaxrs-resteasy/joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/joda/pom.xml
@@ -12,7 +12,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/samples/server/petstore/jaxrs-spec/pom.xml
+++ b/samples/server/petstore/jaxrs-spec/pom.xml
@@ -11,7 +11,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.1.0</version>
 		<configuration>
 			<failOnMissingWebXml>false</failOnMissingWebXml>
 		</configuration>

--- a/samples/server/petstore/jaxrs/jersey1/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey1/pom.xml
@@ -11,7 +11,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/samples/server/petstore/jaxrs/jersey2/pom.xml
+++ b/samples/server/petstore/jaxrs/jersey2/pom.xml
@@ -20,7 +20,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.1.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/samples/server/petstore/spring-mvc-j8-async/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-async/pom.xml
@@ -11,7 +11,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/samples/server/petstore/spring-mvc/pom.xml
+++ b/samples/server/petstore/spring-mvc/pom.xml
@@ -11,7 +11,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Updated maven-war-plugin to latest version.

The default for failOnMissingWebXml changed from true to false which may simplify several poms but for now I've not touched the existing configuration.