### PR TITLE
Docs and examples need model name to be passed as baseType

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2580,8 +2580,8 @@ public class DefaultCodegen {
                         name = typeMapping.get(name);
                         p.baseType = name;
                     } else {
-                        p.baseType = name;
                         name = toModelName(name);
+                        p.baseType = name;
                         if (defaultIncludes.contains(name)) {
                             imports.add(name);
                         }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

The change made by PRhttps://github.com/swagger-api/swagger-codegen/pull/5715 introduced an error in the name of models (both files and docs) where names such as `V1TestModel` would be document as `v1TestModel`. 

**Note:** several of the changes seen on the generated `petstore` files are not introduced by this change. Running the script before applying the changes on the PR generate the same changes.

