### PR TITLE
[CPP] Fixing some more ordering of checks

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -312,10 +312,10 @@ public class CppRestClientCodegen extends DefaultCodegen implements CodegenConfi
             return "0.0";
         } else if (p instanceof FloatProperty) {
             return "0.0f";
-        } else if (p instanceof IntegerProperty || p instanceof BaseIntegerProperty) {
-            return "0";
         } else if (p instanceof LongProperty) {
             return "0L";
+        } else if (p instanceof IntegerProperty || p instanceof BaseIntegerProperty) {
+            return "0";
         } else if (p instanceof DecimalProperty) {
             return "0.0";
         } else if (p instanceof MapProperty) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PistacheServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PistacheServerCodegen.java
@@ -286,10 +286,10 @@ public class PistacheServerCodegen extends DefaultCodegen implements CodegenConf
             return "0.0";
         } else if (p instanceof FloatProperty) {
             return "0.0f";
-        } else if (p instanceof IntegerProperty || p instanceof BaseIntegerProperty) {
-            return "0";
         } else if (p instanceof LongProperty) {
             return "0L";
+        } else if (p instanceof IntegerProperty || p instanceof BaseIntegerProperty) {
+            return "0";
         } else if (p instanceof DecimalProperty) {
             return "0.0";
         } else if (p instanceof MapProperty) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RestbedCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RestbedCodegen.java
@@ -318,10 +318,10 @@ public class RestbedCodegen extends DefaultCodegen implements CodegenConfig {
           return "0.0";
       } else if (p instanceof FloatProperty) {
           return "0.0f";
-      } else if (p instanceof IntegerProperty || p instanceof BaseIntegerProperty) {
-          return "0";
       } else if (p instanceof LongProperty) {
           return "0L";
+      } else if (p instanceof IntegerProperty || p instanceof BaseIntegerProperty) {
+          return "0";
       } else if (p instanceof DecimalProperty) {
           return "0.0";
       } else if (p instanceof MapProperty) {

--- a/samples/client/petstore/cpprest/model/Category.cpp
+++ b/samples/client/petstore/cpprest/model/Category.cpp
@@ -21,7 +21,7 @@ namespace model {
 
 Category::Category()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Name = U("");
     m_NameIsSet = false;

--- a/samples/client/petstore/cpprest/model/Order.cpp
+++ b/samples/client/petstore/cpprest/model/Order.cpp
@@ -21,9 +21,9 @@ namespace model {
 
 Order::Order()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
-    m_PetId = 0;
+    m_PetId = 0L;
     m_PetIdIsSet = false;
     m_Quantity = 0;
     m_QuantityIsSet = false;

--- a/samples/client/petstore/cpprest/model/Pet.cpp
+++ b/samples/client/petstore/cpprest/model/Pet.cpp
@@ -21,7 +21,7 @@ namespace model {
 
 Pet::Pet()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_CategoryIsSet = false;
     m_Name = U("");

--- a/samples/client/petstore/cpprest/model/Tag.cpp
+++ b/samples/client/petstore/cpprest/model/Tag.cpp
@@ -21,7 +21,7 @@ namespace model {
 
 Tag::Tag()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Name = U("");
     m_NameIsSet = false;

--- a/samples/client/petstore/cpprest/model/User.cpp
+++ b/samples/client/petstore/cpprest/model/User.cpp
@@ -21,7 +21,7 @@ namespace model {
 
 User::User()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Username = U("");
     m_UsernameIsSet = false;

--- a/samples/server/petstore/pistache-server/model/Category.cpp
+++ b/samples/server/petstore/pistache-server/model/Category.cpp
@@ -20,7 +20,7 @@ namespace model {
 
 Category::Category()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Name = "";
     m_NameIsSet = false;

--- a/samples/server/petstore/pistache-server/model/Order.cpp
+++ b/samples/server/petstore/pistache-server/model/Order.cpp
@@ -20,9 +20,9 @@ namespace model {
 
 Order::Order()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
-    m_PetId = 0;
+    m_PetId = 0L;
     m_PetIdIsSet = false;
     m_Quantity = 0;
     m_QuantityIsSet = false;

--- a/samples/server/petstore/pistache-server/model/Pet.cpp
+++ b/samples/server/petstore/pistache-server/model/Pet.cpp
@@ -20,7 +20,7 @@ namespace model {
 
 Pet::Pet()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_CategoryIsSet = false;
     m_Name = "";

--- a/samples/server/petstore/pistache-server/model/Tag.cpp
+++ b/samples/server/petstore/pistache-server/model/Tag.cpp
@@ -20,7 +20,7 @@ namespace model {
 
 Tag::Tag()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Name = "";
     m_NameIsSet = false;

--- a/samples/server/petstore/pistache-server/model/User.cpp
+++ b/samples/server/petstore/pistache-server/model/User.cpp
@@ -20,7 +20,7 @@ namespace model {
 
 User::User()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_IdIsSet = false;
     m_Username = "";
     m_UsernameIsSet = false;

--- a/samples/server/petstore/restbed/model/Category.cpp
+++ b/samples/server/petstore/restbed/model/Category.cpp
@@ -30,7 +30,7 @@ namespace model {
 
 Category::Category()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_Name = "";
     
 }
@@ -54,7 +54,7 @@ void Category::fromJsonString(std::string const& jsonString)
 	std::stringstream ss(jsonString);
 	ptree pt;
 	read_json(ss,pt);
-	m_Id = pt.get("Id", 0);
+	m_Id = pt.get("Id", 0L);
 	m_Name = pt.get("Name", "");
 }
 

--- a/samples/server/petstore/restbed/model/Order.cpp
+++ b/samples/server/petstore/restbed/model/Order.cpp
@@ -30,8 +30,8 @@ namespace model {
 
 Order::Order()
 {
-    m_Id = 0;
-    m_PetId = 0;
+    m_Id = 0L;
+    m_PetId = 0L;
     m_Quantity = 0;
     m_ShipDate = "";
     m_Status = "";
@@ -62,8 +62,8 @@ void Order::fromJsonString(std::string const& jsonString)
 	std::stringstream ss(jsonString);
 	ptree pt;
 	read_json(ss,pt);
-	m_Id = pt.get("Id", 0);
-	m_PetId = pt.get("PetId", 0);
+	m_Id = pt.get("Id", 0L);
+	m_PetId = pt.get("PetId", 0L);
 	m_Quantity = pt.get("Quantity", 0);
 	m_ShipDate = pt.get("ShipDate", "");
 	m_Status = pt.get("Status", "");

--- a/samples/server/petstore/restbed/model/Pet.cpp
+++ b/samples/server/petstore/restbed/model/Pet.cpp
@@ -30,7 +30,7 @@ namespace model {
 
 Pet::Pet()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_Name = "";
     m_Status = "";
     
@@ -56,7 +56,7 @@ void Pet::fromJsonString(std::string const& jsonString)
 	std::stringstream ss(jsonString);
 	ptree pt;
 	read_json(ss,pt);
-	m_Id = pt.get("Id", 0);
+	m_Id = pt.get("Id", 0L);
 	m_Name = pt.get("Name", "");
 	m_Status = pt.get("Status", "");
 }

--- a/samples/server/petstore/restbed/model/Tag.cpp
+++ b/samples/server/petstore/restbed/model/Tag.cpp
@@ -30,7 +30,7 @@ namespace model {
 
 Tag::Tag()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_Name = "";
     
 }
@@ -54,7 +54,7 @@ void Tag::fromJsonString(std::string const& jsonString)
 	std::stringstream ss(jsonString);
 	ptree pt;
 	read_json(ss,pt);
-	m_Id = pt.get("Id", 0);
+	m_Id = pt.get("Id", 0L);
 	m_Name = pt.get("Name", "");
 }
 

--- a/samples/server/petstore/restbed/model/User.cpp
+++ b/samples/server/petstore/restbed/model/User.cpp
@@ -30,7 +30,7 @@ namespace model {
 
 User::User()
 {
-    m_Id = 0;
+    m_Id = 0L;
     m_Username = "";
     m_FirstName = "";
     m_LastName = "";
@@ -66,7 +66,7 @@ void User::fromJsonString(std::string const& jsonString)
 	std::stringstream ss(jsonString);
 	ptree pt;
 	read_json(ss,pt);
-	m_Id = pt.get("Id", 0);
+	m_Id = pt.get("Id", 0L);
 	m_Username = pt.get("Username", "");
 	m_FirstName = pt.get("FirstName", "");
 	m_LastName = pt.get("LastName", "");


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This issue is similar to 8237e49, in which some type checking has in the wrong order. It was picked up by
https://lgtm.com/projects/g/swagger-api/swagger-codegen/alerts/
as 'Contradictory Type checks' (at the very top). In this case, these are not really causing bugs as the generated code compiles anyway (won't be the case for java). Note that it requires changes to the petstore samples as it now generates the correct default values for long (with an 'L' in the end). 

Also note that the problem in #5753 would have been picked up if Pull request integration: 
https://lgtm.com/projects/g/swagger-api/swagger-codegen/ci/
is enabled.