### PR TITLE
[CPP] Fix cpp escape issue part of #5949

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
@@ -7,36 +7,36 @@ import io.swagger.models.properties.Property;
 
 abstract public class AbstractCppCodegen extends DefaultCodegen implements CodegenConfig {
 
-	@Override
-	public String toVarName(String name) {
-		if (typeMapping.keySet().contains(name) || typeMapping.values().contains(name)
-				|| importMapping.values().contains(name) || defaultIncludes.contains(name)
-				|| languageSpecificPrimitives.contains(name)) {
-			return sanitizeName(name);
-		}
+    @Override
+    public String toVarName(String name) {
+        if (typeMapping.keySet().contains(name) || typeMapping.values().contains(name)
+                || importMapping.values().contains(name) || defaultIncludes.contains(name)
+                || languageSpecificPrimitives.contains(name)) {
+            return sanitizeName(name);
+        }
 
-		if (name.length() > 1) {
-			return sanitizeName(Character.toUpperCase(name.charAt(0)) + name.substring(1));
-		}
+        if (name.length() > 1) {
+            return sanitizeName(Character.toUpperCase(name.charAt(0)) + name.substring(1));
+        }
 
-		return sanitizeName(name);
-	}
+        return sanitizeName(name);
+    }
 
-	@Override
-	public String toParamName(String name) {
-		return sanitizeName(super.toParamName(name));
-	}
+    @Override
+    public String toParamName(String name) {
+        return sanitizeName(super.toParamName(name));
+    }
 
-	@Override
-	public CodegenProperty fromProperty(String name, Property p) {
-		CodegenProperty property = super.fromProperty(name, p);
-		String nameInCamelCase = property.nameInCamelCase;
-		if (nameInCamelCase.length() > 1) {
-			nameInCamelCase = sanitizeName(Character.toLowerCase(nameInCamelCase.charAt(0)) + nameInCamelCase.substring(1));
-		} else {
-			nameInCamelCase = sanitizeName(nameInCamelCase);
-		}
-		property.nameInCamelCase = nameInCamelCase;
-		return property;
-	}
+    @Override
+    public CodegenProperty fromProperty(String name, Property p) {
+        CodegenProperty property = super.fromProperty(name, p);
+        String nameInCamelCase = property.nameInCamelCase;
+        if (nameInCamelCase.length() > 1) {
+            nameInCamelCase = sanitizeName(Character.toLowerCase(nameInCamelCase.charAt(0)) + nameInCamelCase.substring(1));
+        } else {
+            nameInCamelCase = sanitizeName(nameInCamelCase);
+        }
+        property.nameInCamelCase = nameInCamelCase;
+        return property;
+    }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractCppCodegen.java
@@ -1,0 +1,42 @@
+package io.swagger.codegen.languages;
+
+import io.swagger.codegen.CodegenConfig;
+import io.swagger.codegen.CodegenProperty;
+import io.swagger.codegen.DefaultCodegen;
+import io.swagger.models.properties.Property;
+
+abstract public class AbstractCppCodegen extends DefaultCodegen implements CodegenConfig {
+
+	@Override
+	public String toVarName(String name) {
+		if (typeMapping.keySet().contains(name) || typeMapping.values().contains(name)
+				|| importMapping.values().contains(name) || defaultIncludes.contains(name)
+				|| languageSpecificPrimitives.contains(name)) {
+			return sanitizeName(name);
+		}
+
+		if (name.length() > 1) {
+			return sanitizeName(Character.toUpperCase(name.charAt(0)) + name.substring(1));
+		}
+
+		return sanitizeName(name);
+	}
+
+	@Override
+	public String toParamName(String name) {
+		return sanitizeName(super.toParamName(name));
+	}
+
+	@Override
+	public CodegenProperty fromProperty(String name, Property p) {
+		CodegenProperty property = super.fromProperty(name, p);
+		String nameInCamelCase = property.nameInCamelCase;
+		if (nameInCamelCase.length() > 1) {
+			nameInCamelCase = sanitizeName(Character.toLowerCase(nameInCamelCase.charAt(0)) + nameInCamelCase.substring(1));
+		} else {
+			nameInCamelCase = sanitizeName(nameInCamelCase);
+		}
+		property.nameInCamelCase = nameInCamelCase;
+		return property;
+	}
+}

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/CppRestClientCodegen.java
@@ -1,22 +1,47 @@
 package io.swagger.codegen.languages;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import io.swagger.codegen.*;
-import io.swagger.codegen.examples.ExampleGenerator;
+
+import io.swagger.codegen.CliOption;
+import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.CodegenModel;
+import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.CodegenParameter;
+import io.swagger.codegen.CodegenProperty;
+import io.swagger.codegen.CodegenType;
+import io.swagger.codegen.SupportingFile;
 import io.swagger.codegen.utils.ModelUtils;
 import io.swagger.models.Model;
 import io.swagger.models.Operation;
 import io.swagger.models.Response;
 import io.swagger.models.Swagger;
-import io.swagger.models.properties.*;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BaseIntegerProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.DecimalProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.FileProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
+import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 
-import java.util.*;
-import java.io.File;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
-
-public class CppRestClientCodegen extends DefaultCodegen implements CodegenConfig {
+public class CppRestClientCodegen extends AbstractCppCodegen {
 
     public static final String DECLSPEC = "declspec";
     public static final String DEFAULT_INCLUDE = "defaultInclude";
@@ -379,21 +404,6 @@ public class CppRestClientCodegen extends DefaultCodegen implements CodegenConfi
         } else {
             return Character.toUpperCase(type.charAt(0)) + type.substring(1);
         }
-    }
-
-    @Override
-    public String toVarName(String name) {
-        if (typeMapping.keySet().contains(name) || typeMapping.values().contains(name)
-                || importMapping.values().contains(name) || defaultIncludes.contains(name)
-                || languageSpecificPrimitives.contains(name)) {
-            return name;
-        }
-
-        if (name.length() > 1) {
-            return Character.toUpperCase(name.charAt(0)) + name.substring(1);
-        }
-
-        return name;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PistacheServerCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PistacheServerCodegen.java
@@ -1,18 +1,42 @@
 package io.swagger.codegen.languages;
 
 
-import io.swagger.codegen.*;
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.swagger.codegen.CodegenModel;
+import io.swagger.codegen.CodegenOperation;
+import io.swagger.codegen.CodegenParameter;
+import io.swagger.codegen.CodegenProperty;
+import io.swagger.codegen.CodegenType;
+import io.swagger.codegen.DefaultCodegen;
+import io.swagger.codegen.SupportingFile;
 import io.swagger.models.Model;
 import io.swagger.models.Operation;
 import io.swagger.models.Response;
 import io.swagger.models.Swagger;
-import io.swagger.models.properties.*;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BaseIntegerProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.DecimalProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.FileProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
+import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 
-import javax.validation.constraints.Null;
-import java.io.File;
-import java.util.*;
-
-public class PistacheServerCodegen extends DefaultCodegen implements CodegenConfig {
+public class PistacheServerCodegen extends AbstractCppCodegen {
     protected String implFolder = "impl";
 
     @Override
@@ -374,21 +398,6 @@ public class PistacheServerCodegen extends DefaultCodegen implements CodegenConf
         } else {
             return Character.toUpperCase(type.charAt(0)) + type.substring(1);
         }
-    }
-
-    @Override
-    public String toVarName(String name) {
-        if (typeMapping.keySet().contains(name) || typeMapping.values().contains(name)
-                || importMapping.values().contains(name) || defaultIncludes.contains(name)
-                || languageSpecificPrimitives.contains(name)) {
-            return name;
-        }
-
-        if (name.length() > 1) {
-            return Character.toUpperCase(name.charAt(0)) + name.substring(1);
-        }
-
-        return name;
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RestbedCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/RestbedCodegen.java
@@ -10,19 +10,13 @@ import java.util.Map;
 import java.util.Set;
 
 import io.swagger.codegen.CliOption;
-import io.swagger.codegen.CodegenConfig;
 import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.CodegenModel;
 import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.CodegenParameter;
-import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.CodegenType;
-import io.swagger.codegen.DefaultCodegen;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.models.Model;
-import io.swagger.models.Operation;
-import io.swagger.models.Response;
-import io.swagger.models.Swagger;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.BaseIntegerProperty;
 import io.swagger.models.properties.BooleanProperty;
@@ -39,7 +33,7 @@ import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 
-public class RestbedCodegen extends DefaultCodegen implements CodegenConfig {
+public class RestbedCodegen extends AbstractCppCodegen {
 
   public static final String DECLSPEC = "declspec";
   public static final String DEFAULT_INCLUDE = "defaultInclude";
@@ -385,21 +379,6 @@ public class RestbedCodegen extends DefaultCodegen implements CodegenConfig {
       } else {
           return Character.toUpperCase(type.charAt(0)) + type.substring(1);
       }
-  }
-
-  @Override
-  public String toVarName(String name) {
-      if (typeMapping.keySet().contains(name) || typeMapping.values().contains(name)
-              || importMapping.values().contains(name) || defaultIncludes.contains(name)
-              || languageSpecificPrimitives.contains(name)) {
-          return name;
-      }
-
-      if (name.length() > 1) {
-          return Character.toUpperCase(name.charAt(0)) + name.substring(1);
-      }
-
-      return name;
   }
 
   @Override

--- a/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-header.mustache
@@ -51,7 +51,7 @@ public:
     /// </summary>
     {{^isNotContainer}}{{{datatype}}}& {{getter}}();
     {{/isNotContainer}}{{#isNotContainer}}{{{datatype}}} {{getter}}() const;
-    {{/isNotContainer}}{{^required}}bool {{baseName}}IsSet() const;
+    {{/isNotContainer}}{{^required}}bool {{nameInCamelCase}}IsSet() const;
     void unset{{name}}();
     {{/required}}
     void {{setter}}({{{datatype}}} value);

--- a/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/model-source.mustache
@@ -577,7 +577,7 @@ void {{classname}}::{{setter}}({{{datatype}}} value)
 }
 {{/isNotContainer}}
 {{^required}}
-bool {{classname}}::{{baseName}}IsSet() const
+bool {{classname}}::{{nameInCamelCase}}IsSet() const
 {
     return m_{{name}}IsSet;
 }

--- a/modules/swagger-codegen/src/main/resources/pistache-server/model-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/pistache-server/model-header.mustache
@@ -46,7 +46,7 @@ public:
     {{^isNotContainer}}{{{datatype}}}& {{getter}}();
     {{/isNotContainer}}{{#isNotContainer}}{{{datatype}}} {{getter}}() const;
     void {{setter}}({{{datatype}}} value);
-    {{/isNotContainer}}{{^required}}bool {{baseName}}IsSet() const;
+    {{/isNotContainer}}{{^required}}bool {{nameInCamelCase}}IsSet() const;
     void unset{{name}}();
     {{/required}}
     {{/vars}}

--- a/modules/swagger-codegen/src/main/resources/pistache-server/model-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/pistache-server/model-source.mustache
@@ -125,7 +125,7 @@ void {{classname}}::{{setter}}({{{datatype}}} value)
     {{^required}}m_{{name}}IsSet = true;{{/required}}
 }
 {{/isNotContainer}}
-{{^required}}bool {{classname}}::{{baseName}}IsSet() const
+{{^required}}bool {{classname}}::{{nameInCamelCase}}IsSet() const
 {
     return m_{{name}}IsSet;
 }


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This change escapes special characters in the property names in the three c++ generators, while preserving the petstore samples. Part of #5949
