### PR TITLE
withXml with Jackson for Java clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ samples/client/petstore/typescript-node/npm/npm-debug.log
 
 # aspnetcore
 samples/server/petstore/aspnetcore/.vs/
+effective.pom

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -239,6 +239,12 @@ public class CodeGenMojo extends AbstractMojo {
     private Boolean generateApiDocumentation = true;
 
     /**
+     * Generate the api documentation
+     */
+    @Parameter(name = "withXml", required = false)
+    private Boolean withXml = false;
+
+    /**
      * Skip the execution.
      */
     @Parameter(name = "skip", property = "codegen.skip", required = false, defaultValue = "false")
@@ -384,6 +390,7 @@ public class CodeGenMojo extends AbstractMojo {
         System.setProperty("modelDocs", generateModelDocumentation.toString());
         System.setProperty("apiTests", generateApiTests.toString());
         System.setProperty("apiDocs", generateApiDocumentation.toString());
+        System.setProperty("withXml", withXml.toString());
 
         if (configOptions != null) {
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenModel.java
@@ -19,7 +19,7 @@ public class CodegenModel {
     public List<CodegenModel> interfaceModels;
     public List<CodegenModel> children;
 
-    public String name, classname, title, description, classVarName, modelJson, dataType;
+    public String name, classname, title, description, classVarName, modelJson, dataType, xmlPrefix, xmlNamespace, xmlName;
     public String classFilename; // store the class file name, mainly used for import
     public String unescapedDescription;
     public String discriminator;
@@ -92,6 +92,12 @@ public class CodegenModel {
             return false;
         if (dataType != null ? !dataType.equals(that.dataType) : that.dataType != null)
             return false;
+        if (xmlPrefix != null ? !xmlPrefix.equals(that.xmlPrefix) : that.xmlPrefix != null)
+            return false;
+        if (xmlNamespace != null ? !xmlNamespace.equals(that.xmlNamespace) : that.xmlNamespace != null)
+            return false;
+        if (xmlName != null ? !xmlName.equals(that.xmlName) : that.xmlName != null)
+        	return false;
         if (classFilename != null ? !classFilename.equals(that.classFilename) : that.classFilename != null)
             return false;
         if (unescapedDescription != null ? !unescapedDescription.equals(that.unescapedDescription) : that.unescapedDescription != null)
@@ -152,6 +158,9 @@ public class CodegenModel {
         result = 31 * result + (classVarName != null ? classVarName.hashCode() : 0);
         result = 31 * result + (modelJson != null ? modelJson.hashCode() : 0);
         result = 31 * result + (dataType != null ? dataType.hashCode() : 0);
+        result = 31 * result + (xmlPrefix != null ? xmlPrefix.hashCode() : 0);
+        result = 31 * result + (xmlNamespace != null ? xmlNamespace.hashCode() : 0);
+        result = 31 * result + (xmlName != null ? xmlName.hashCode() : 0);
         result = 31 * result + (classFilename != null ? classFilename.hashCode() : 0);
         result = 31 * result + (unescapedDescription != null ? unescapedDescription.hashCode() : 0);
         result = 31 * result + (discriminator != null ? discriminator.hashCode() : 0);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -54,6 +54,12 @@ public class CodegenProperty implements Cloneable {
     public String enumName;
     public Integer maxItems;
     public Integer minItems;
+	
+    // XML
+    public boolean isXmlAttribute = false;
+    public String xmlPrefix;
+	public String xmlName;
+	public String xmlNamespace;
 
 
     @Override
@@ -125,6 +131,10 @@ public class CodegenProperty implements Cloneable {
         result = prime * result + Objects.hashCode(enumName);
         result = prime * result + ((maxItems == null) ? 0 : maxItems.hashCode());
         result = prime * result + ((minItems == null) ? 0 : minItems.hashCode());
+        result = prime * result + ((isXmlAttribute  ? 13:31));
+        result = prime * result + ((xmlPrefix == null) ? 0 : xmlPrefix.hashCode());
+        result = prime * result + ((xmlName == null) ? 0 : xmlName.hashCode());
+        result = prime * result + ((xmlNamespace == null) ? 0 : xmlNamespace.hashCode());
         return result;
     }
 
@@ -298,6 +308,18 @@ public class CodegenProperty implements Cloneable {
             return false;
         }
         if (this.minItems != other.minItems && (this.minItems == null || !this.minItems.equals(other.minItems))) {
+            return false;
+        }
+        if (!Objects.equals(this.isXmlAttribute, other.isXmlAttribute)) {
+            return false;
+        }
+        if (!Objects.equals(this.xmlPrefix, other.xmlPrefix)) {
+            return false;
+        }
+        if (!Objects.equals(this.xmlName, other.xmlName)) {
+            return false;
+        }
+        if (!Objects.equals(this.xmlNamespace, other.xmlNamespace)) {
             return false;
         }
         return true;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -1292,7 +1292,14 @@ public class DefaultCodegen {
         m.vendorExtensions = model.getVendorExtensions();
 
         if (model instanceof ModelImpl) {
-            m.discriminator = ((ModelImpl) model).getDiscriminator();
+        	ModelImpl modelImpl = (ModelImpl) model;
+            m.discriminator = modelImpl.getDiscriminator();
+            
+            if (modelImpl.getXml() != null) {
+            	m.xmlPrefix = modelImpl.getXml().getPrefix();
+            	m.xmlNamespace = modelImpl.getXml().getNamespace();
+            	m.xmlName = modelImpl.getXml().getName();
+            }
         }
 
         if (model instanceof ArrayModel) {
@@ -1316,8 +1323,14 @@ public class DefaultCodegen {
                 int modelImplCnt = 0; // only one inline object allowed in a ComposedModel
                 for (Model innerModel: ((ComposedModel)model).getAllOf()) {
                     if (innerModel instanceof ModelImpl) {
+                    	ModelImpl modelImpl = (ModelImpl) innerModel;
                         if (m.discriminator == null) {
-                            m.discriminator = ((ModelImpl) innerModel).getDiscriminator();
+                            m.discriminator = modelImpl.getDiscriminator();
+                        }
+                        if (modelImpl.getXml() != null) {
+                        	m.xmlPrefix = modelImpl.getXml().getPrefix();
+                        	m.xmlNamespace = modelImpl.getXml().getNamespace();
+                        	m.xmlName = modelImpl.getXml().getName();
                         }
                         if (modelImplCnt++ > 1) {
                             LOGGER.warn("More than one inline schema specified in allOf:. Only the first one is recognized. All others are ignored.");
@@ -1516,6 +1529,14 @@ public class DefaultCodegen {
         property.jsonSchema = Json.pretty(p);
         if (p.getReadOnly() != null) {
             property.isReadOnly = p.getReadOnly();
+        }
+        if (p.getXml() != null) {
+        	if (p.getXml().getAttribute() != null) {
+        		property.isXmlAttribute = p.getXml().getAttribute();
+        	}
+        	property.xmlPrefix = p.getXml().getPrefix();
+        	property.xmlName = p.getXml().getName();
+        	property.xmlNamespace = p.getXml().getNamespace();
         }
         property.vendorExtensions = p.getVendorExtensions();
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -46,9 +46,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String DEFAULT_LIBRARY = "<default>";
     public static final String DATE_LIBRARY = "dateLibrary";
     public static final String JAVA8_MODE = "java8";
+    public static final String WITH_XML = "withXml";
     public static final String SUPPORT_JAVA6 = "supportJava6";
 
     protected boolean java8Mode = false;
+    protected boolean withXml = false;
     protected String dateLibrary = "joda";
     protected String invokerPackage = "io.swagger";
     protected String groupId = "io.swagger";
@@ -147,6 +149,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 .SERIALIZE_BIG_DECIMAL_AS_STRING_DESC));
         cliOptions.add(CliOption.newBoolean(FULL_JAVA_UTIL, "whether to use fully qualified name for classes under java.util. This option only works for Java API client"));
         cliOptions.add(new CliOption("hideGenerationTimestamp", "hides the timestamp when files were generated"));
+        cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type. This option only works for Java API client"));
 
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use");
         Map<String, String> dateOptions = new HashMap<String, String>();
@@ -315,6 +318,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         additionalProperties.put(FULL_JAVA_UTIL, fullJavaUtil);
         additionalProperties.put("javaUtilPrefix", javaUtilPrefix);
 
+        if (additionalProperties.containsKey(WITH_XML)) {
+        	this.setWithXml(Boolean.valueOf(additionalProperties.get(WITH_XML).toString()));
+        }
+        additionalProperties.put(WITH_XML, withXml);
+        
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);
         additionalProperties.put("modelDocPath", modelDocPath);
@@ -375,6 +383,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             setJava8Mode(Boolean.parseBoolean(additionalProperties.get(JAVA8_MODE).toString()));
             if ( java8Mode ) {
                 additionalProperties.put("java8", "true");
+            }
+        }
+
+        if(additionalProperties.containsKey(WITH_XML)) {
+            setWithXml(Boolean.parseBoolean(additionalProperties.get(WITH_XML).toString()));
+            if ( withXml ) {
+                additionalProperties.put(WITH_XML, "true");
             }
         }
 
@@ -1137,6 +1152,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         this.fullJavaUtil = fullJavaUtil;
     }
 
+    public void setWithXml(boolean withXml) {
+        this.withXml = withXml;
+    }
+    
     public void setDateLibrary(String library) {
         this.dateLibrary = library;
     }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
@@ -212,6 +212,16 @@
       <artifactId>jackson-databind</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+		{{#withXml}}
+
+		<!-- XML Support -->
+		<dependency>
+		  <groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+
+		{{/withXml}}
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-{{^java8}}joda{{/java8}}{{#java8}}jsr310{{/java8}}</artifactId>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -222,6 +222,16 @@
       <artifactId>jackson-databind</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+		{{#withXml}}
+
+		<!-- XML processing: Jackson -->
+		<dependency>
+		  <groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+
+		{{/withXml}}
     {{#java8}}
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -150,6 +150,16 @@
       <artifactId>jackson-databind</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+		{{#withXml}}
+
+		<!-- XML processing: Jackson -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+
+		{{/withXml}}
     {{#java8}}
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -1,5 +1,10 @@
 package {{invokerPackage}};
 
+{{#withXml}}
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+{{/withXml}}
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +22,11 @@ import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+{{#withXml}}
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+{{/withXml}}
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -550,7 +560,19 @@ public class ApiClient {
      * @return RestTemplate
      */
     protected RestTemplate buildRestTemplate() {
+        {{#withXml}}
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<HttpMessageConverter<?>>();
+        messageConverters.add(new MappingJackson2HttpMessageConverter());
+        XmlMapper xmlMapper = new XmlMapper();
+        xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        messageConverters.add(new MappingJackson2XmlHttpMessageConverter(xmlMapper));
+
+        RestTemplate restTemplate = new RestTemplate(messageConverters);
+        {{/withXml}}
+        {{^withXml}}
         RestTemplate restTemplate = new RestTemplate();
+        {{/withXml}}
+
         // This allows us to read the response more than once - Necessary for debugging.
         restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(restTemplate.getRequestFactory()));
         return restTemplate;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -196,7 +196,7 @@
       <artifactId>spring-web</artifactId>
       <version>${spring-web-version}</version>
     </dependency>
-    
+
     <!-- JSON processing: jackson -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -218,6 +218,16 @@
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+		{{#withXml}}
+
+		<!-- XML processing: Jackson -->
+		<dependency>
+		  <groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+
+		{{/withXml}}
     {{#java8}}
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -253,6 +253,16 @@
       <artifactId>jackson-datatype-{{^java8}}joda{{/java8}}{{#java8}}jsr310{{/java8}}</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+		{{#withXml}}
+
+		<!-- XML processing: Jackson -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+
+		{{/withXml}}
     <dependency>
         <groupId>com.typesafe.play</groupId>
         <artifactId>play-java-ws_2.11</artifactId>

--- a/modules/swagger-codegen/src/main/resources/Java/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/model.mustache
@@ -14,6 +14,12 @@ import {{import}};
 {{#serializableModel}}
 import java.io.Serializable;
 {{/serializableModel}}
+{{#jackson}}
+{{#withXml}}
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+{{/withXml}}
+{{/jackson}}
 {{#parcelableModel}}
 import android.os.Parcelable;
 import android.os.Parcel;

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -2,7 +2,7 @@
  * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
  */{{#description}}
 @ApiModel(description = "{{{description}}}"){{/description}}
-{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcelableModel}}implements Parcelable {{#serializableModel}}, Serializable {{/serializableModel}}{{/parcelableModel}}{{^parcelableModel}}{{#serializableModel}}implements Serializable {{/serializableModel}}{{/parcelableModel}}{
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;
@@ -23,6 +23,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     {{/items.isEnum}}
   {{#jackson}}
   @JsonProperty("{{baseName}}")
+	{{#withXml}}@JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"){{/withXml}}
   {{/jackson}}
   {{#gson}}
   @SerializedName("{{baseName}}")
@@ -163,7 +164,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
   {{#parcelableModel}}
   public void writeToParcel(Parcel out, int flags) {
     {{#parent}} super.writeToParcel(out, flags); {{/parent}} {{#vars}}
@@ -186,7 +187,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     {{/isPrimitiveType}}
     {{/vars}}
   }
-  
+
   public int describeContents() {
     return 0;
   }

--- a/modules/swagger-codegen/src/main/resources/Java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pom.mustache
@@ -223,6 +223,16 @@
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+    {{#withXml}}
+
+    <!-- XML processing: Jackson -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>${jackson-version}</version>
+    </dependency>
+
+    {{/withXml}}
     {{#java8}}
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/modules/swagger-codegen/src/main/resources/Java/xmlAnnotation.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/xmlAnnotation.mustache
@@ -1,0 +1,6 @@
+// XML name: {{xmlName}}
+{{#jackson}}
+{{#withXml}}
+{{#withXml}}@JacksonXmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}"){{/withXml}}
+{{/withXml}}
+{{/jackson}}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -9,6 +9,7 @@ import io.swagger.codegen.languages.JavaClientCodegen;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
+import io.swagger.models.Xml;
 import io.swagger.models.parameters.QueryParameter;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.ByteArrayProperty;
@@ -581,6 +582,75 @@ public class JavaModelTest {
         Assert.assertEquals(property.getter, getter);
         Assert.assertEquals(property.setter, setter);
         Assert.assertEquals(property.name, name);
+    }
+
+
+    @Test(description = "test models with xml")
+    public void modelWithXmlTest() {
+        final Model model = new ModelImpl()
+                .description("a sample model")
+                .xml(new Xml()
+                  .prefix("my")
+                  .namespace("xmlNamespace")
+                  .name("customXmlName"))
+                .property("id", new LongProperty())
+                .property("name", new StringProperty()
+                  .example("Tony")
+                  .xml(new Xml()
+                    .attribute(true)
+                    .prefix("my")
+                    .name("myName")))
+                .property("createdAt", new DateTimeProperty()
+                   .xml(new Xml()
+                     .prefix("my")
+                     .namespace("myNamespace")
+                     .name("myCreatedAt")))
+                .required("id")
+                .required("name");
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.xmlPrefix, "my");
+        Assert.assertEquals(cm.xmlName, "customXmlName");
+        Assert.assertEquals(cm.xmlNamespace, "xmlNamespace");
+        Assert.assertEquals(cm.vars.size(), 3);
+
+        final List<CodegenProperty> vars = cm.vars;
+
+        final CodegenProperty property2 = vars.get(1);
+        Assert.assertEquals(property2.baseName, "name");
+        Assert.assertEquals(property2.getter, "getName");
+        Assert.assertEquals(property2.setter, "setName");
+        Assert.assertEquals(property2.datatype, "String");
+        Assert.assertEquals(property2.name, "name");
+        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertEquals(property2.baseType, "String");
+        Assert.assertEquals(property2.example, "Tony");
+        Assert.assertTrue(property2.hasMore);
+        Assert.assertTrue(property2.required);
+        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertTrue(property2.isXmlAttribute);
+        Assert.assertEquals(property2.xmlName, "myName");
+        Assert.assertNull(property2.xmlNamespace);
+
+        final CodegenProperty property3 = vars.get(2);
+        Assert.assertEquals(property3.baseName, "createdAt");
+        Assert.assertEquals(property3.getter, "getCreatedAt");
+        Assert.assertEquals(property3.setter, "setCreatedAt");
+        Assert.assertEquals(property3.datatype, "Date");
+        Assert.assertEquals(property3.name, "createdAt");
+        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.baseType, "Date");
+        Assert.assertFalse(property3.hasMore);
+        Assert.assertFalse(property3.required);
+        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isXmlAttribute);
+        Assert.assertEquals(property3.xmlName, "myCreatedAt");
+        Assert.assertEquals(property3.xmlNamespace, "myNamespace");
+        Assert.assertEquals(property3.xmlPrefix, "my");
     }
 
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JavaOptionsProvider.java
@@ -29,6 +29,7 @@ public class JavaOptionsProvider implements OptionsProvider {
     public static final String LOCAL_PREFIX_VALUE = "tst";
     public static final String SERIALIZABLE_MODEL_VALUE = "false";
     public static final String FULL_JAVA_UTIL_VALUE = "true";
+    public static final String WITH_XML_VALUE = "false";
     public static final String JAVA8_MODE_VALUE = "true";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     //public static final String SUPPORT_JAVA6 = "true";
@@ -66,6 +67,7 @@ public class JavaOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LOCAL_VARIABLE_PREFIX, LOCAL_PREFIX_VALUE)
                 .put(CodegenConstants.SERIALIZABLE_MODEL, SERIALIZABLE_MODEL_VALUE)
                 .put(JavaClientCodegen.FULL_JAVA_UTIL, FULL_JAVA_UTIL_VALUE)
+                .put(JavaClientCodegen.WITH_XML, WITH_XML_VALUE)
                 .put(JavaClientCodegen.JAVA8_MODE, JAVA8_MODE_VALUE)
                 .put(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING, "true")
                 .put(JavaClientCodegen.DATE_LIBRARY, "joda")

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
@@ -38,6 +38,7 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
     public static final String USE_BEANVALIDATION = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String JAVA8_MODE_VALUE = "false";
+    public static final String WITH_XML_VALUE = "false";
 
 
     @Override
@@ -83,6 +84,7 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
             .put(CodegenConstants.LIBRARY, JAXRS_DEFAULT_LIBRARY_VALUE)
             .put(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING, "true")
             .put(JavaClientCodegen.JAVA8_MODE, JAVA8_MODE_VALUE)
+            .put(JavaClientCodegen.WITH_XML, WITH_XML_VALUE)
             //.put(JavaClientCodegen.DATE_LIBRARY, "joda")
             .put("hideGenerationTimestamp", "true")
             .put(JavaCXFServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION)


### PR DESCRIPTION
# Description of the PR

I needed `application/xml` support in a Java client. Thought the best way was to add `withXml` flag and then generate the Java clients accordingly. All Java clients need work, but the **resttemplate** library does its job as is.

`withXml` is respected as one of the `configOptions` for Java clients in your maven plugin:

```xml
	<configOptions>
		<withXml>true</withXml>
		...
```

I've updated the `CodegenModel` and `CodegenProperty` to respect Swagger's **xml** props.