### PR TITLE
Fix regular expression to escape forward slash 

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -607,7 +607,7 @@ public class DefaultCodegen {
      * @return properly-escaped pattern
      */
     public String toRegularExpression(String pattern) {
-        return escapeText(addRegularExpressionDelimiter(pattern));
+        return addRegularExpressionDelimiter(escapeText(pattern));
     }
 
     /**
@@ -3573,9 +3573,14 @@ public class DefaultCodegen {
      * @return the pattern with delimiter
      */
     public String addRegularExpressionDelimiter(String pattern) {
-        if (pattern != null && !pattern.matches("^/.*")) {
-            return "/" + pattern + "/";
+        if (StringUtils.isEmpty(pattern)) {
+            return pattern;
         }
+
+        if (!pattern.matches("^/.*")) {
+            return "/" + pattern.replaceAll("/", "\\\\/") + "/";
+        }
+
         return pattern;
     }
 

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -274,7 +274,7 @@ double = 1.2 # Float | None
 
 pattern_without_delimiter = "pattern_without_delimiter_example" # String | None
 
-byte = "B" # String | None
+byte = "byte_example" # String | None
 
 opts = { 
   integer: 56, # Integer | None

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -198,6 +198,10 @@ module Petstore
         invalid_properties.push("invalid value for 'byte', byte cannot be nil.")
       end
 
+      if @byte !~ Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
+        invalid_properties.push("invalid value for 'byte', must conform to the pattern /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/.")
+      end
+
       if @date.nil?
         invalid_properties.push("invalid value for 'date', date cannot be nil.")
       end
@@ -233,6 +237,7 @@ module Petstore
       return false if !@double.nil? && @double < 67.8
       return false if !@string.nil? && @string !~ Regexp.new(/[a-z]/i)
       return false if @byte.nil?
+      return false if @byte !~ Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
       return false if @date.nil?
       return false if @password.nil?
       return false if @password.to_s.length > 64
@@ -327,6 +332,20 @@ module Petstore
       end
 
       @string = string
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] byte Value to be assigned
+    def byte=(byte)
+      if byte.nil?
+        fail ArgumentError, "byte cannot be nil"
+      end
+
+      if byte !~ Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
+        fail ArgumentError, "invalid value for 'byte', must conform to the pattern /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/."
+      end
+
+      @byte = byte
     end
 
     # Custom attribute writer method with validation


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

"/" (forward slash) is not escaped when adding delimiters "/" to regular expressions. This PR aims to fix that as byte array (base64 string) now has a `pattern` after upgrading to newer version of Swagger Core.
