### PR TITLE
[TypeScript][Angular2] Add support for "blob" response type

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/api.service.mustache
@@ -83,7 +83,12 @@ export class {{classname}} {
      * {{notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}*/
+{{^isResponseFile}}
     public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+{{/isResponseFile}}
+{{#isResponseFile}}
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}extraHttpRequestParams?: any): Observable<{{#returnType}}{{{returnType}}}|undefined{{/returnType}}{{^returnType}}{}{{/returnType}}> {
+{{/isResponseFile}}
         return this.{{nickname}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}extraHttpRequestParams)
             .map((response: Response) => {
                 if (response.status === 204) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Code generated for typescript-angular2 client in case when return blob 
could also return undefined
typescript compiler error is :
error TS2322: Type 'Observable<Blob | undefined>' is not assignable to type 'Observable<Blob>'.
