### PR TITLE
allow accessToken to be specified by string or function; restores PR #4361

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular2/configuration.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular2/configuration.mustache
@@ -2,7 +2,7 @@ export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;
     password?: string;
-    accessToken?: string;
+    accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

fix for typescript-angular2's configuration.mustache -- PR #4361 had opened this up to be able to be specified by string or function; one of the recent changes seems to have stepped on this in that the interface passed to the constructor only allows for string, hence static initialization is problematic. 