### PR TITLE
Fix Erlang auth method code generation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
+++ b/modules/swagger-codegen/src/main/resources/erlang-server/handler.mustache
@@ -71,6 +71,7 @@ allowed_methods(Req, State) ->
         State :: state()
     }.
 {{#operations}}{{#operation}}
+{{#authMethods}}
 is_authorized(
     Req0,
     State = #state{
@@ -78,7 +79,6 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
-{{#authMethods}}
   {{#isApiKey}}
     From = {{#isKeyInQuery}}qs_val{{/isKeyInQuery}}{{#isKeyInHeader}}header{{/isKeyInHeader}},
     Result = {{packageName}}_auth:authorize_api_key(
@@ -93,6 +93,10 @@ is_authorized(
         {false, AuthHeader, Req} ->  {{false, AuthHeader}, Req, State}
     end;
   {{/isApiKey}}
+{{/authMethods}}
+{{^authMethods}}
+is_authorized(Req, State) ->
+    {true, Req, State};
 {{/authMethods}}
 {{/operation}}{{/operations}}
 is_authorized(Req, State) ->

--- a/samples/server/petstore/erlang-server/src/swagger_store_handler.erl
+++ b/samples/server/petstore/erlang-server/src/swagger_store_handler.erl
@@ -102,6 +102,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -130,6 +131,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -138,6 +140,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(Req, State) ->
     {{false, <<"">>}, Req, State}.

--- a/samples/server/petstore/erlang-server/src/swagger_user_handler.erl
+++ b/samples/server/petstore/erlang-server/src/swagger_user_handler.erl
@@ -134,6 +134,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -142,6 +143,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -150,6 +152,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -158,6 +161,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -166,6 +170,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -174,6 +179,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -182,6 +188,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(
     Req0,
@@ -190,6 +197,7 @@ is_authorized(
         logic_handler = LogicHandler
     }
 ) ->
+    {true, Req0, State};
 
 is_authorized(Req, State) ->
     {{false, <<"">>}, Req, State}.


### PR DESCRIPTION
Broken code is generated when no authentication methods are supplied
in the API schema. Fix this by providing code to fall back to.
