### PR TITLE
[objc] Initialize default BOOL with @(YES)/@(NO). (#5982)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -640,9 +640,9 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
             BooleanProperty dp = (BooleanProperty) p;
             if (dp.getDefault() != null) {
                 if (dp.getDefault().toString().equalsIgnoreCase("false"))
-                    return "@0";
+                    return "@(NO)";
                 else
-                    return "@1";
+                    return "@(YES)";
             }
         } else if (p instanceof DateProperty) {
             // TODO


### PR DESCRIPTION
This will prevent submitting integer numbers instead of booleans
when posting objects to the REST API.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Default values for Bool convert into numbers.
Bool are stored as NSNumber, setting a default value to 'false' or 'true' on specification file generates the following lines:

```
property = @0 //false
property = @1 //true
```
this converts into a __NSCFNumber instead of __NSCFBoolean

When posting to the backend this will post an integer instead of a boolean and the REST API will complain.

Generating instead the following code:

```
property = @(NO) //false
property = @(YES) //true
```

it would create an __NSCFBoolean and would not fail when posting the object to the server wrapped into a JSONDictionary
