### PR TITLE
#6012 - fixed mustache template for lumen server

### DIFF
--- a/modules/swagger-codegen/src/main/resources/lumen/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/lumen/api.mustache
@@ -33,37 +33,37 @@ use Illuminate\Support\Facades\Request;
         {{#pathParams}}
         {{#hasValidation}}
         {{#maxLength}}
-        if (strlen(${{paramName}}]) > {{maxLength}}) {
+        if (strlen(${{paramName}}) > {{maxLength}}) {
             throw new \InvalidArgumentException('invalid length for ${{paramName}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
         }
         {{/maxLength}}
         {{#minLength}}
-        if (strlen(${{paramName}}]) < {{minLength}}) {
+        if (strlen(${{paramName}}) < {{minLength}}) {
             throw new \InvalidArgumentException('invalid length for ${{paramName}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
         }
         {{/minLength}}
         {{#maximum}}
-        if (${{paramName}}] >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}) {
+        if (${{paramName}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}) {
             throw new \InvalidArgumentException('invalid value for ${{paramName}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');
         }
         {{/maximum}}
         {{#minimum}}
-        if (${{paramName}}] <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}) {
+        if (${{paramName}} <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}) {
             throw new \InvalidArgumentException('invalid value for ${{paramName}} when calling {{classname}}.{{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.');
         }
         {{/minimum}}
         {{#pattern}}
-        if (!preg_match("{{{pattern}}}", ${{paramName}}])) {
+        if (!preg_match("{{{pattern}}}", ${{paramName}})) {
             throw new \InvalidArgumentException('invalid value for ${{paramName}} when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}.');
         }
         {{/pattern}}
         {{#maxItems}}
-        if (count(${{paramName}}]) > {{maxItems}}) {
+        if (count(${{paramName}}) > {{maxItems}}) {
             throw new \InvalidArgumentException('invalid length for ${{paramName}} when calling {{classname}}.{{operationId}}, number of items must be less than or equal to {{maxItems}}.');
         }
         {{/maxItems}}
         {{#minItems}}
-        if (count(${{paramName}}]) < {{minItems}}) {
+        if (count(${{paramName}}) < {{minItems}}) {
             throw new \InvalidArgumentException('invalid length for ${{paramName}} when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
         }
         {{/minItems}}

--- a/samples/server/petstore/lumen/lib/app/Http/Controllers/FakeApi.php
+++ b/samples/server/petstore/lumen/lib/app/Http/Controllers/FakeApi.php
@@ -91,8 +91,8 @@ class FakeApi extends Controller
         if (!isset($input['pattern_without_delimiter'])) {
             throw new \InvalidArgumentException('Missing the required parameter $pattern_without_delimiter when calling testEndpointParameters');
         }
-        if (!preg_match("/^[A-Z].", $input['pattern_without_delimiter'])) {
-            throw new \InvalidArgumentException('invalid value for $pattern_without_delimiter when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z]..');
+        if (!preg_match("/^[A-Z].*/", $input['pattern_without_delimiter'])) {
+            throw new \InvalidArgumentException('invalid value for $pattern_without_delimiter when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z].*/.');
         }
         $pattern_without_delimiter = $input['pattern_without_delimiter'];
 

--- a/samples/server/petstore/lumen/lib/app/Http/Controllers/StoreApi.php
+++ b/samples/server/petstore/lumen/lib/app/Http/Controllers/StoreApi.php
@@ -103,10 +103,10 @@ class StoreApi extends Controller
         $input = Request::all();
 
         //path params validation
-        if ($order_id] > 5) {
+        if ($order_id > 5) {
             throw new \InvalidArgumentException('invalid value for $order_id when calling StoreApi.getOrderById, must be smaller than or equal to 5.');
         }
-        if ($order_id] < 1) {
+        if ($order_id < 1) {
             throw new \InvalidArgumentException('invalid value for $order_id when calling StoreApi.getOrderById, must be bigger than or equal to 1.');
         }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [X] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixes issue #6012
I've removed all superfluous closing brackets, that would produce syntactical errors, from mustache template. I also regenerated the lumen samples to ensure that the fix will produce correct code.
