### PR TITLE
[TypeScript Fetch] Optional URL query parameters not sent anymore

### DIFF
--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
@@ -90,11 +90,12 @@ export const {{classname}}FetchParamCreator = {
             .replace(`{${"{{baseName}}"}}`, `${ params["{{paramName}}"] }`){{/pathParams}};
         let urlObj = url.parse(baseUrl, true);
 {{#hasQueryParams}}
-        urlObj.query = {{#supportsES6}}Object.{{/supportsES6}}assign({}, urlObj.query, {
-            {{#queryParams}}
-            "{{baseName}}": params["{{paramName}}"],
-            {{/queryParams}}
-        });
+    urlObj.query =  {{#supportsES6}}Object.{{/supportsES6}}assign({}, urlObj.query)
+    {{#queryParams}}
+        if (params["{{paramName}}"] !== undefined) {
+            urlObj.query["{{baseName}}"] = params["{{paramName}}"];
+        }
+    {{/queryParams}}
 {{/hasQueryParams}}
         let fetchOptions: RequestInit = {{#supportsES6}}Object.{{/supportsES6}}assign({}, { method: "{{httpMethod}}" }, options);
 

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
@@ -90,7 +90,7 @@ export const {{classname}}FetchParamCreator = {
             .replace(`{${"{{baseName}}"}}`, `${ params["{{paramName}}"] }`){{/pathParams}};
         let urlObj = url.parse(baseUrl, true);
 {{#hasQueryParams}}
-        urlObj.query =  {{#supportsES6}}Object.{{/supportsES6}}assign({}, urlObj.query)
+        urlObj.query =  {{#supportsES6}}Object.{{/supportsES6}}assign({}, urlObj.query);
     {{#queryParams}}
         if (params["{{paramName}}"] !== undefined) {
             urlObj.query["{{baseName}}"] = params["{{paramName}}"];

--- a/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/TypeScript-Fetch/api.mustache
@@ -90,7 +90,7 @@ export const {{classname}}FetchParamCreator = {
             .replace(`{${"{{baseName}}"}}`, `${ params["{{paramName}}"] }`){{/pathParams}};
         let urlObj = url.parse(baseUrl, true);
 {{#hasQueryParams}}
-    urlObj.query =  {{#supportsES6}}Object.{{/supportsES6}}assign({}, urlObj.query)
+        urlObj.query =  {{#supportsES6}}Object.{{/supportsES6}}assign({}, urlObj.query)
     {{#queryParams}}
         if (params["{{paramName}}"] !== undefined) {
             urlObj.query["{{baseName}}"] = params["{{paramName}}"];

--- a/samples/client/petstore-security-test/typescript-fetch/api.ts
+++ b/samples/client/petstore-security-test/typescript-fetch/api.ts
@@ -67,7 +67,7 @@ export const FakeApiFetchParamCreator = {
             "test code inject */ &#39; &quot; &#x3D;end -- \r\n \n \r": params["test code inject * &#39; &quot; &#x3D;end  rn n r"],
         });
         if (contentTypeHeader) {
-            fetchOptions.headers = contentTypeHeader;
+            fetchOptions.headers = assign({}, contentTypeHeader, fetchOptions.headers);
         }
         return {
             url: url.format(urlObj),

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -148,9 +148,10 @@ export const PetApiFetchParamCreator = {
     findPetsByStatus(params: {  "status"?: Array<string>; }, options?: any): FetchArgs {
         const baseUrl = `/pet/findByStatus`;
         let urlObj = url.parse(baseUrl, true);
-        urlObj.query = assign({}, urlObj.query, {
-            "status": params["status"],
-        });
+    urlObj.query =  assign({}, urlObj.query)
+        if (params["status"] !== undefined) {
+            urlObj.query["status"] = params["status"];
+        }
         let fetchOptions: RequestInit = assign({}, { method: "GET" }, options);
 
         let contentTypeHeader: Dictionary<string> = {};
@@ -170,9 +171,10 @@ export const PetApiFetchParamCreator = {
     findPetsByTags(params: {  "tags"?: Array<string>; }, options?: any): FetchArgs {
         const baseUrl = `/pet/findByTags`;
         let urlObj = url.parse(baseUrl, true);
-        urlObj.query = assign({}, urlObj.query, {
-            "tags": params["tags"],
-        });
+    urlObj.query =  assign({}, urlObj.query)
+        if (params["tags"] !== undefined) {
+            urlObj.query["tags"] = params["tags"];
+        }
         let fetchOptions: RequestInit = assign({}, { method: "GET" }, options);
 
         let contentTypeHeader: Dictionary<string> = {};
@@ -970,10 +972,13 @@ export const UserApiFetchParamCreator = {
     loginUser(params: {  "username"?: string; "password"?: string; }, options?: any): FetchArgs {
         const baseUrl = `/user/login`;
         let urlObj = url.parse(baseUrl, true);
-        urlObj.query = assign({}, urlObj.query, {
-            "username": params["username"],
-            "password": params["password"],
-        });
+    urlObj.query =  assign({}, urlObj.query)
+        if (params["username"] !== undefined) {
+            urlObj.query["username"] = params["username"];
+        }
+        if (params["password"] !== undefined) {
+            urlObj.query["password"] = params["password"];
+        }
         let fetchOptions: RequestInit = assign({}, { method: "GET" }, options);
 
         let contentTypeHeader: Dictionary<string> = {};

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -148,7 +148,7 @@ export const PetApiFetchParamCreator = {
     findPetsByStatus(params: {  "status"?: Array<string>; }, options?: any): FetchArgs {
         const baseUrl = `/pet/findByStatus`;
         let urlObj = url.parse(baseUrl, true);
-        urlObj.query =  assign({}, urlObj.query)
+        urlObj.query =  assign({}, urlObj.query);
         if (params["status"] !== undefined) {
             urlObj.query["status"] = params["status"];
         }
@@ -171,7 +171,7 @@ export const PetApiFetchParamCreator = {
     findPetsByTags(params: {  "tags"?: Array<string>; }, options?: any): FetchArgs {
         const baseUrl = `/pet/findByTags`;
         let urlObj = url.parse(baseUrl, true);
-        urlObj.query =  assign({}, urlObj.query)
+        urlObj.query =  assign({}, urlObj.query);
         if (params["tags"] !== undefined) {
             urlObj.query["tags"] = params["tags"];
         }
@@ -972,7 +972,7 @@ export const UserApiFetchParamCreator = {
     loginUser(params: {  "username"?: string; "password"?: string; }, options?: any): FetchArgs {
         const baseUrl = `/user/login`;
         let urlObj = url.parse(baseUrl, true);
-        urlObj.query =  assign({}, urlObj.query)
+        urlObj.query =  assign({}, urlObj.query);
         if (params["username"] !== undefined) {
             urlObj.query["username"] = params["username"];
         }

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -148,7 +148,7 @@ export const PetApiFetchParamCreator = {
     findPetsByStatus(params: {  "status"?: Array<string>; }, options?: any): FetchArgs {
         const baseUrl = `/pet/findByStatus`;
         let urlObj = url.parse(baseUrl, true);
-    urlObj.query =  assign({}, urlObj.query)
+        urlObj.query =  assign({}, urlObj.query)
         if (params["status"] !== undefined) {
             urlObj.query["status"] = params["status"];
         }
@@ -171,7 +171,7 @@ export const PetApiFetchParamCreator = {
     findPetsByTags(params: {  "tags"?: Array<string>; }, options?: any): FetchArgs {
         const baseUrl = `/pet/findByTags`;
         let urlObj = url.parse(baseUrl, true);
-    urlObj.query =  assign({}, urlObj.query)
+        urlObj.query =  assign({}, urlObj.query)
         if (params["tags"] !== undefined) {
             urlObj.query["tags"] = params["tags"];
         }
@@ -972,7 +972,7 @@ export const UserApiFetchParamCreator = {
     loginUser(params: {  "username"?: string; "password"?: string; }, options?: any): FetchArgs {
         const baseUrl = `/user/login`;
         let urlObj = url.parse(baseUrl, true);
-    urlObj.query =  assign({}, urlObj.query)
+        urlObj.query =  assign({}, urlObj.query)
         if (params["username"] !== undefined) {
             urlObj.query["username"] = params["username"];
         }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
This prevents empty URL parameters from being sent, e.g. `http://some-api/endpoint?param=SOMETHING?v=` will now be `http://some-api/endpoint?param=SOMETHING`.
Solution suggested by @TiFu. Fixes #6003.

Can somebody please verify whether this is still working as intended: https://github.com/swagger-api/swagger-codegen/compare/master...roberterdin:master#diff-89eaac82e75bf2e3698813ad62b26691L70
I don't know if it is covered by the tests and if the browser tests are being executed with maven. 
