### PR TITLE
[Java] Escape descriptions in javadocs

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/modelEnum.mustache
@@ -11,7 +11,7 @@ import com.google.gson.stream.JsonWriter;
 {{/gson}}
 
 /**
- * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{{description}}}{{/description}}
+ * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
  */
 {{#gson}}
 @JsonAdapter({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)

--- a/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pojo.mustache
@@ -80,7 +80,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/isReadOnly}}
    /**
   {{#description}}
-   * {{{description}}}
+   * {{description}}
   {{/description}}
   {{^description}}
    * Get {{name}}

--- a/samples/client/petstore-security-test/java/okhttp-gson/src/main/java/io/swagger/client/model/ModelReturn.java
+++ b/samples/client/petstore-security-test/java/okhttp-gson/src/main/java/io/swagger/client/model/ModelReturn.java
@@ -38,7 +38,7 @@ public class ModelReturn {
   }
 
    /**
-   * property description  *_/ ' \" =end -- \\r\\n \\n \\r
+   * property description  *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
    * @return _return
   **/
   @ApiModelProperty(value = "property description  *_/ ' \" =end -- \\r\\n \\n \\r")


### PR DESCRIPTION
The [java8 doclint](http://openjdk.java.net/jeps/172) rejects unescaped
HTML chars such as `<`, making some generated clients unbuildable with
java8. Seems a few property descriptions were using the `{{{` instead
of `{{` preventing those HTML chars from being escaped properly.

