### PR TITLE
[TypeScript] rename Angular, Angular2 generators

### DIFF
--- a/bin/typescript-angular-petstore.sh
+++ b/bin/typescript-angular-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l typescript-angular -o samples/client/petstore/typescript-angular"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.json -l typescript-angularjs -o samples/client/petstore/typescript-angular"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular2-petstore-all.sh
+++ b/bin/typescript-angular2-petstore-all.sh
@@ -28,13 +28,13 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 echo "Typescript Petstore API client (default)"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular2 -o samples/client/petstore/typescript-angular2/default --additional-properties ngVersion=2"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular2/default --additional-properties ngVersion=2"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript Petstore API client (npm setting)"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular2 -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular2/npm --additional-properties ngVersion=2"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular2/npm --additional-properties ngVersion=2"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript Petstore API client (with interfaces generated)"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular2 -o samples/client/petstore/typescript-angular2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular2-petstore-interfaces.sh
+++ b/bin/typescript-angular2-petstore-interfaces.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular2 -o samples/client/petstore/typescript-angular2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular2-petstore-with-npm.sh
+++ b/bin/typescript-angular2-petstore-with-npm.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular2 -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular2/npm --additional-properties ngVersion=2"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular2/npm --additional-properties ngVersion=2"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular2-petstore.sh
+++ b/bin/typescript-angular2-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular2 -o samples/client/petstore/typescript-angular2/default --additional-properties ngVersion=2"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular2/default --additional-properties ngVersion=2"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular4-petstore-with-npm.sh
+++ b/bin/typescript-angular4-petstore-with-npm.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular2 -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular4/npm --additional-properties ngVersion=4"
+ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular4/npm --additional-properties ngVersion=4"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/typescript-angular.bat
+++ b/bin/windows/typescript-angular.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -l typescript-angular -o samples\client\petstore\typescript-angular
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -l typescript-angularjs -o samples\client\petstore\typescript-angular
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/typescript-angular2-interfaces.bat
+++ b/bin/windows/typescript-angular2-interfaces.bat
@@ -1,0 +1,10 @@
+set executable=.\modules\swagger-codegen-cli\target\swagger-codegen-cli.jar
+
+If Not Exist %executable% (
+  mvn clean package
+)
+
+REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -c bin\typescript-petstore-npm.json -l typescript-angular -o samples\client\petstore\typescript-angular2\with-interfaces -D withInterfaces=true --additional-properties ngVersion=2
+
+java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/typescript-angular2-petstore-all.bat
+++ b/bin/windows/typescript-angular2-petstore-all.bat
@@ -1,0 +1,3 @@
+call .\bin\windows\typescript-angular2-with-npm.bat
+call .\bin\windows\typescript-angular2-interfaces.bat
+call .\bin\windows\typescript-angular2.bat

--- a/bin/windows/typescript-angular2-with-npm.bat
+++ b/bin/windows/typescript-angular2-with-npm.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -c bin\typescript-petstore-npm.json -l typescript-angular2 -o samples\client\petstore\typescript-angular2\npm
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -c bin\typescript-petstore-npm.json -l typescript-angular -o samples\client\petstore\typescript-angular2\npm
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/bin/windows/typescript-angular2.bat
+++ b/bin/windows/typescript-angular2.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -l typescript-angular2 -o samples\client\petstore\typescript-angular2\default
+set ags=generate -i modules\swagger-codegen\src\test\resources\2_0\petstore.yaml -l typescript-angular -o samples\client\petstore\typescript-angular2\default
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngular2ClientCodegen.java
@@ -66,7 +66,7 @@ public class TypeScriptAngular2ClientCodegen extends AbstractTypeScriptClientCod
 
     @Override
     public String getName() {
-        return "typescript-angular2";
+        return "typescript-angular";
     }
 
     @Override

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -10,7 +10,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public String getName() {
-        return "typescript-angular";
+        return "typescript-angularjs";
     }
 
     @Override

--- a/samples/client/petstore/typescript-angular2/npm/package.json
+++ b/samples/client/petstore/typescript-angular2/npm/package.json
@@ -35,6 +35,6 @@
     "typescript": "^2.1.5"
   },
   "publishConfig": {
-    "registry": "https://skimdb.npmjs.com/registry"
+    "registry":"https://skimdb.npmjs.com/registry"
   }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- renamed typescript-angular to typescript-angularjs in 2.3.0
- renamed typescript-angular2 to typescript-angular in 2.3.0
- updated shell scripts, batch files

Closes https://github.com/swagger-api/swagger-codegen/issues/5570