### PR TITLE
[C#] skip pattern check for byte array in C# API client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/modelGeneric.mustache
@@ -241,13 +241,15 @@ this.{{name}} = {{name}};
 
             {{/minimum}}
             {{#pattern}}
+            {{^isByteArray}}
             // {{{name}}} ({{{datatype}}}) pattern
             Regex regex{{{name}}} = new Regex(@"{{{vendorExtensions.x-regex}}}"{{#vendorExtensions.x-modifiers}}{{#-first}}, {{/-first}}RegexOptions.{{{.}}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}});
             if (false == regex{{{name}}}.Match(this.{{{name}}}).Success)
             {
-                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must match a pattern of {{{pattern}}}.", new [] { "{{{name}}}" });
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must match a pattern of " + regex{{{name}}}, new [] { "{{{name}}}" });
             }
 
+            {{/isByteArray}}
             {{/pattern}}
             {{/hasValidation}}
             {{/vars}}

--- a/samples/client/petstore/csharp/SwaggerClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/FakeApi.md
@@ -344,7 +344,7 @@ namespace Example
             var number = 3.4;  // decimal? | None
             var _double = 1.2;  // double? | None
             var patternWithoutDelimiter = patternWithoutDelimiter_example;  // string | None
-            var _byte = B;  // byte[] | None
+            var _byte = _byte_example;  // byte[] | None
             var integer = 56;  // int? | None (optional) 
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789;  // long? | None (optional) 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Model/FormatTest.cs
@@ -415,7 +415,7 @@ namespace IO.Swagger.Model
             Regex regex_String = new Regex(@"[a-z]", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
             if (false == regex_String.Match(this._String).Success)
             {
-                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for _String, must match a pattern of /[a-z]/i.", new [] { "_String" });
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for _String, must match a pattern of " + regex_String, new [] { "_String" });
             }
 
             // Password (string) maxLength

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/FakeApi.md
@@ -344,7 +344,7 @@ namespace Example
             var number = 3.4;  // decimal? | None
             var _double = 1.2;  // double? | None
             var patternWithoutDelimiter = patternWithoutDelimiter_example;  // string | None
-            var _byte = B;  // byte[] | None
+            var _byte = _byte_example;  // byte[] | None
             var integer = 56;  // int? | None (optional) 
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789;  // long? | None (optional) 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/FakeApi.md
@@ -344,7 +344,7 @@ namespace Example
             var number = 3.4;  // decimal? | None
             var _double = 1.2;  // double? | None
             var patternWithoutDelimiter = patternWithoutDelimiter_example;  // string | None
-            var _byte = B;  // byte[] | None
+            var _byte = _byte_example;  // byte[] | None
             var integer = 56;  // int? | None (optional) 
             var int32 = 56;  // int? | None (optional) 
             var int64 = 789;  // long? | None (optional) 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Model/FormatTest.cs
@@ -438,7 +438,7 @@ namespace IO.Swagger.Model
             Regex regex_String = new Regex(@"[a-z]", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
             if (false == regex_String.Match(this._String).Success)
             {
-                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for _String, must match a pattern of /[a-z]/i.", new [] { "_String" });
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for _String, must match a pattern of " + regex_String, new [] { "_String" });
             }
 
             // Password (string) maxLength


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Skip the regular expression validation for byte array, which causes compilation errors.
