### PR TITLE
RxJava2CallAdapterFactory is now in Retrofit2 adapters

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -26,7 +26,7 @@ import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
 {{/useRxJava}}
 {{#useRxJava2}}
-import com.jakewharton.retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 {{/useRxJava2}}
 import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;


### PR DESCRIPTION
Very simple update, I have to do it manually after every generation using 2.3.0-SNAPSHOT.

Adapting RxJava2CallAdapterFactory to the latest version of Retrofi2, now it is implemented inside 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'.