### PR TITLE
[JaxrsResteasy] Fix EAP dependencies for Java 8

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/JacksonConfig.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/JacksonConfig.mustache
@@ -9,7 +9,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+{{#java8}}
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+{{/java8}}
+{{^java8}}
 import com.fasterxml.jackson.datatype.joda.JodaModule;
+{{/java8}}
 
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
@@ -25,9 +30,9 @@ public class JacksonConfig implements ContextResolver<ObjectMapper> {
 {{#java8}}        
         this.objectMapper.registerModule(new JavaTimeModule());
 {{/java8}}
-{{#joda}}
+{{^java8}}
         this.objectMapper.registerModule(new JodaModule());
-{{/joda}}
+{{/java8}}
 
         // sample to convert any DateTime to readable timestamps
         //this.objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/gradle.mustache
@@ -15,10 +15,16 @@ dependencies {
     providedCompile 'javax.annotation:javax.annotation-api:1.2'
     providedCompile 'org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec:1.0.0.Final'
     compile         'org.jboss.resteasy:resteasy-jackson2-provider:3.0.11.Final'
-{{#joda}}
-    compile         'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.4.1'
+{{#useBeanValidation}}
+    providedCompile 'javax.validation:validation-api:1.1.0.Final'
+{{/useBeanValidation}}
+{{^java8}}
+    compile         'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.3'
     compile         'joda-time:joda-time:2.7'
-{{/joda}}
+{{/java8}}
+{{#java8}}
+    compile         'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.6.3'
+{{/java8}}
     testCompile     'junit:junit:4.12',
                     'org.hamcrest:hamcrest-core:1.3'
 }

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
@@ -99,16 +99,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-            <version>2.4.1</version>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.7</version>
-        </dependency>
-        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
             <version>${swagger-core-version}</version>
@@ -140,27 +130,32 @@
             </exclusions>
         </dependency>
 {{#useBeanValidation}}
-    <!-- Bean Validation API support -->
-    <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>1.1.0.Final</version>
-        <scope>provided</scope>
-    </dependency>
-{{/useBeanValidation}}        
-{{#joda}}      
-    <dependency>
-          <groupId>com.fasterxml.jackson.datatype</groupId>
-          <artifactId>jackson-datatype-joda</artifactId>
-          <version>2.1.1</version>
-    </dependency> 
-{{/joda}}
-{{#java8}}     
-     <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.6.3</version>
-    </dependency>
+        <!-- Bean Validation API support -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+{{/useBeanValidation}}
+{{^java8}}
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+{{/java8}}
+{{#java8}}
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.6.3</version>
+        </dependency>
 {{/java8}}
         
     </dependencies>

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/build.gradle
@@ -15,7 +15,8 @@ dependencies {
     providedCompile 'javax.annotation:javax.annotation-api:1.2'
     providedCompile 'org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec:1.0.0.Final'
     compile         'org.jboss.resteasy:resteasy-jackson2-provider:3.0.11.Final'
-    compile         'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.4.1'
+    providedCompile 'javax.validation:validation-api:1.1.0.Final'
+    compile         'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.3'
     compile         'joda-time:joda-time:2.7'
     testCompile     'junit:junit:4.12',
                     'org.hamcrest:hamcrest-core:1.3'

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/pom.xml
@@ -99,16 +99,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-            <version>2.4.1</version>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.7</version>
-        </dependency>
-        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
             <version>${swagger-core-version}</version>
@@ -139,18 +129,23 @@
                 </exclusion>
             </exclusions>
         </dependency>
-    <!-- Bean Validation API support -->
-    <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>1.1.0.Final</version>
-        <scope>provided</scope>
-    </dependency>
-    <dependency>
-          <groupId>com.fasterxml.jackson.datatype</groupId>
-          <artifactId>jackson-datatype-joda</artifactId>
-          <version>2.1.1</version>
-    </dependency> 
+        <!-- Bean Validation API support -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>2.6.3</version>
+        </dependency>
         
     </dependencies>
     <repositories>

--- a/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
+++ b/samples/server/petstore/jaxrs-resteasy/eap/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     providedCompile 'javax.annotation:javax.annotation-api:1.2'
     providedCompile 'org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec:1.0.0.Final'
     compile         'org.jboss.resteasy:resteasy-jackson2-provider:3.0.11.Final'
+    providedCompile 'javax.validation:validation-api:1.1.0.Final'
+    compile         'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.6.3'
+    compile         'joda-time:joda-time:2.7'
     testCompile     'junit:junit:4.12',
                     'org.hamcrest:hamcrest-core:1.3'
 }

--- a/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
+++ b/samples/server/petstore/jaxrs-resteasy/eap/pom.xml
@@ -99,16 +99,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-            <version>2.4.1</version>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.7</version>
-        </dependency>
-        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
             <version>${swagger-core-version}</version>
@@ -139,13 +129,23 @@
                 </exclusion>
             </exclusions>
         </dependency>
-    <!-- Bean Validation API support -->
-    <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>1.1.0.Final</version>
-        <scope>provided</scope>
-    </dependency>
+        <!-- Bean Validation API support -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>2.6.3</version>
+        </dependency>
         
     </dependencies>
     <repositories>

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/main/java/io/swagger/api/JacksonConfig.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/main/java/io/swagger/api/JacksonConfig.java
@@ -22,6 +22,7 @@ public class JacksonConfig implements ContextResolver<ObjectMapper> {
     public JacksonConfig() throws Exception {
         this.objectMapper = new ObjectMapper();
         
+        this.objectMapper.registerModule(new JodaModule());
 
         // sample to convert any DateTime to readable timestamps
         //this.objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

* Depend on Joda by default, like the default JAX-RS server.
* If Java 8 is specified add Jackson JSR-310 dependency and import
  in the JacksonConfig.