### PR TITLE
Moving instantiationTypes, typeMappings, languageSpecificPrimitives, additionalProperties, and reservedWordsMappings out of configOptions and converting it into a list, rather than being a comma-separated string.

### DIFF
--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -20,6 +20,12 @@ import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyInstantiat
 import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyLanguageSpecificPrimitivesCsv;
 import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyTypeMappingsKvp;
 import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyReservedWordsMappingsKvp;
+import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyAdditionalPropertiesKvpList;
+import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyImportMappingsKvpList;
+import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyInstantiationTypesKvpList;
+import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyLanguageSpecificPrimitivesCsvList;
+import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyTypeMappingsKvpList;
+import static io.swagger.codegen.config.CodegenConfiguratorUtils.applyReservedWordsMappingsKvpList;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.File;
@@ -461,50 +467,32 @@ public class CodeGenMojo extends AbstractMojo {
 
         //Apply Instantiation Types
         if (instantiationTypes != null && !configOptions.containsKey("instantiation-types")) {
-            String instantiationTypesAsString = instantiationTypes.toString();
-            applyInstantiationTypesKvp(
-                    instantiationTypesAsString.substring(0, instantiationTypesAsString.length() - 1),
-                    configurator);
+            applyInstantiationTypesKvpList(instantiationTypes, configurator);
         }
 
         //Apply Import Mappings
         if (importMappings != null && !configOptions.containsKey("import-mappings")) {
-            String importMappingsAsString = importMappings.toString();
-            applyImportMappingsKvp(
-                    importMappingsAsString.substring(0, importMappingsAsString.length() - 1),
-                    configurator);
+            applyImportMappingsKvpList(importMappings, configurator);
         }
 
         //Apply Type Mappings
         if (typeMappings != null && !configOptions.containsKey("type-mappings")) {
-            String typeMappingsAsString = typeMappings.toString();
-            applyTypeMappingsKvp(
-                    typeMappingsAsString.substring(0, typeMappingsAsString.length() - 1),
-                    configurator);
+            applyTypeMappingsKvpList(typeMappings, configurator);
         }
 
         //Apply Language Specific Primitives
         if (languageSpecificPrimitives != null && !configOptions.containsKey("language-specific-primitives")) {
-            String languageSpecificPrimitivesAsString = languageSpecificPrimitives.toString();
-            applyLanguageSpecificPrimitivesCsv(
-                    languageSpecificPrimitivesAsString.substring(0,languageSpecificPrimitivesAsString.length() - 1),
-                    configurator);
+            applyLanguageSpecificPrimitivesCsvList(languageSpecificPrimitives, configurator);
         }
 
         //Apply Additional Properties
         if (additionalProperties != null && !configOptions.containsKey("additional-properties")) {
-            String additionalPropertiesAsString = additionalProperties.toString();
-            applyAdditionalPropertiesKvp(
-                    additionalPropertiesAsString.substring(0, additionalPropertiesAsString.length() - 1),
-                    configurator);
+            applyAdditionalPropertiesKvpList(additionalProperties, configurator);
         }
 
         //Apply Reserved Words Mappings
         if (reservedWordsMappings != null && !configOptions.containsKey("reserved-words-mappings")) {
-            String reservedWordsMappingsAsString = reservedWordsMappings.toString();
-            applyReservedWordsMappingsKvp(
-                    reservedWordsMappingsAsString.substring(0, reservedWordsMappingsAsString.length() - 1),
-                    configurator);
+            applyReservedWordsMappingsKvpList(reservedWordsMappings, configurator);
         }
 
         if (environmentVariables != null) {

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -185,7 +185,7 @@ public class CodeGenMojo extends AbstractMojo {
     private Map<?, ?> configOptions;
 
     /**
-     * A map of classes and the import that should be used for that class
+     * A map of types and the types they should be instantiated as
      */
     @Parameter(name = "instantiationTypes")
     private List<String> instantiationTypes;
@@ -197,25 +197,25 @@ public class CodeGenMojo extends AbstractMojo {
     private List<String> importMappings;
 
     /**
-     * A map of classes and the import that should be used for that class
+     * A map of swagger spec types and the generated code types to use for them
      */
     @Parameter(name = "typeMappings")
     private List<String> typeMappings;
 
     /**
-     * A map of classes and the import that should be used for that class
+     * A map of additional language specific primitive types
      */
     @Parameter(name = "languageSpecificPrimitives")
     private List<String> languageSpecificPrimitives;
 
     /**
-     * A map of classes and the import that should be used for that class
+     * A map of additional properties that can be referenced by the mustache templates
      */
     @Parameter(name = "additionalProperties")
     private List<String> additionalProperties;
 
     /**
-     * A map of classes and the import that should be used for that class
+     * A map of reserved names and how they should be escaped
      */
     @Parameter(name = "reservedWordsMappings")
     private List<String> reservedWordsMappings;    

--- a/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
+++ b/modules/swagger-codegen-maven-plugin/src/main/java/io/swagger/codegen/plugin/CodeGenMojo.java
@@ -178,8 +178,41 @@ public class CodeGenMojo extends AbstractMojo {
     @Parameter(name = "configOptions")
     private Map<?, ?> configOptions;
 
+    /**
+     * A map of classes and the import that should be used for that class
+     */
+    @Parameter(name = "instantiationTypes")
+    private List<String> instantiationTypes;
+
+    /**
+     * A map of classes and the import that should be used for that class
+     */
     @Parameter(name = "importMappings")
     private List<String> importMappings;
+
+    /**
+     * A map of classes and the import that should be used for that class
+     */
+    @Parameter(name = "typeMappings")
+    private List<String> typeMappings;
+
+    /**
+     * A map of classes and the import that should be used for that class
+     */
+    @Parameter(name = "languageSpecificPrimitives")
+    private List<String> languageSpecificPrimitives;
+
+    /**
+     * A map of classes and the import that should be used for that class
+     */
+    @Parameter(name = "additionalProperties")
+    private List<String> additionalProperties;
+
+    /**
+     * A map of classes and the import that should be used for that class
+     */
+    @Parameter(name = "reservedWordsMappings")
+    private List<String> reservedWordsMappings;    
 
     /**
      * Generate the apis
@@ -390,41 +423,87 @@ public class CodeGenMojo extends AbstractMojo {
         System.setProperty("withXml", withXml.toString());
 
         if (configOptions != null) {
-
-            if (configOptions.containsKey("instantiation-types")) {
+            // Retained for backwards-compataibility with configOptions -> instantiation-types
+            if (instantiationTypes == null && configOptions.containsKey("instantiation-types")) {
                 applyInstantiationTypesKvp(configOptions.get("instantiation-types").toString(),
                         configurator);
             }
 
+            // Retained for backwards-compataibility with configOptions -> import-mappings
             if (importMappings == null && configOptions.containsKey("import-mappings")) {
                 applyImportMappingsKvp(configOptions.get("import-mappings").toString(),
                         configurator);
             }
 
-            if (configOptions.containsKey("type-mappings")) {
+            // Retained for backwards-compataibility with configOptions -> type-mappings
+            if (typeMappings == null && configOptions.containsKey("type-mappings")) {
                 applyTypeMappingsKvp(configOptions.get("type-mappings").toString(), configurator);
             }
 
-            if (configOptions.containsKey("language-specific-primitives")) {
+            // Retained for backwards-compataibility with configOptions -> language-specific-primitives
+            if (languageSpecificPrimitives == null && configOptions.containsKey("language-specific-primitives")) {
                 applyLanguageSpecificPrimitivesCsv(configOptions
                         .get("language-specific-primitives").toString(), configurator);
             }
 
-            if (configOptions.containsKey("additional-properties")) {
+            // Retained for backwards-compataibility with configOptions -> additional-properties
+            if (additionalProperties == null && configOptions.containsKey("additional-properties")) {
                 applyAdditionalPropertiesKvp(configOptions.get("additional-properties").toString(),
                         configurator);
             }
 
-            if (configOptions.containsKey("reserved-words-mappings")) {
+            // Retained for backwards-compataibility with configOptions -> reserved-words-mappings
+            if (reservedWordsMappings == null && configOptions.containsKey("reserved-words-mappings")) {
                 applyReservedWordsMappingsKvp(configOptions.get("reserved-words-mappings")
                         .toString(), configurator);
             }
         }
 
+        //Apply Instantiation Types
+        if (instantiationTypes != null && !configOptions.containsKey("instantiation-types")) {
+            String instantiationTypesAsString = instantiationTypes.toString();
+            applyInstantiationTypesKvp(
+                    instantiationTypesAsString.substring(0, instantiationTypesAsString.length() - 1),
+                    configurator);
+        }
+
+        //Apply Import Mappings
         if (importMappings != null && !configOptions.containsKey("import-mappings")) {
             String importMappingsAsString = importMappings.toString();
             applyImportMappingsKvp(
                     importMappingsAsString.substring(0, importMappingsAsString.length() - 1),
+                    configurator);
+        }
+
+        //Apply Type Mappings
+        if (typeMappings != null && !configOptions.containsKey("type-mappings")) {
+            String typeMappingsAsString = typeMappings.toString();
+            applyTypeMappingsKvp(
+                    typeMappingsAsString.substring(0, typeMappingsAsString.length() - 1),
+                    configurator);
+        }
+
+        //Apply Language Specific Primitives
+        if (languageSpecificPrimitives != null && !configOptions.containsKey("language-specific-primitives")) {
+            String languageSpecificPrimitivesAsString = languageSpecificPrimitives.toString();
+            applyLanguageSpecificPrimitivesCsv(
+                    languageSpecificPrimitivesAsString.substring(0,languageSpecificPrimitivesAsString.length() - 1),
+                    configurator);
+        }
+
+        //Apply Additional Properties
+        if (additionalProperties != null && !configOptions.containsKey("additional-properties")) {
+            String additionalPropertiesAsString = additionalProperties.toString();
+            applyAdditionalPropertiesKvp(
+                    additionalPropertiesAsString.substring(0, additionalPropertiesAsString.length() - 1),
+                    configurator);
+        }
+
+        //Apply Reserved Words Mappings
+        if (reservedWordsMappings != null && !configOptions.containsKey("reserved-words-mappings")) {
+            String reservedWordsMappingsAsString = reservedWordsMappings.toString();
+            applyReservedWordsMappingsKvp(
+                    reservedWordsMappingsAsString.substring(0, reservedWordsMappingsAsString.length() - 1),
                     configurator);
         }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

In the same vein as (and following the pattern established by) https://github.com/swagger-api/swagger-codegen/pull/5384 this converts `instantiation-types`, `type-mappings`, `language-specific-primitives`, `additional-properties`, and `reserved-words-mappings` to lists and moves them outside of configOptions, while still maintaining backwards compatibility. Fixes #6062

This adds support to having configuration like this (same example from https://github.com/swagger-api/swagger-codegen/pull/5384 converted to show type mappings):

```
<configuration>
    <typeMappings>
        <param>json_mymodel=com.mypackage.MyModel</param>
        <param>json_anothermodel=com.mypackage.AnotherModel</param>
    </typeMappings>
</configuration>
```