### PR TITLE
Added not null check in code generator.

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2578,9 +2578,9 @@ public class DefaultCodegen {
                 // recursively add import
                 CodegenProperty innerCp = cp;
                 while(innerCp != null) {
-                	if(innerCp.complexType != null) {
-                		imports.add(innerCp.complexType);
-                	}
+                    if(innerCp.complexType != null) {
+                        imports.add(innerCp.complexType);
+                    }
                     innerCp = innerCp.items;
                 }
 

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2578,7 +2578,9 @@ public class DefaultCodegen {
                 // recursively add import
                 CodegenProperty innerCp = cp;
                 while(innerCp != null) {
-                    imports.add(innerCp.complexType);
+                	if(innerCp.complexType != null) {
+                		imports.add(innerCp.complexType);
+                	}
                     innerCp = innerCp.items;
                 }
 


### PR DESCRIPTION
### Description of the PR
When generating client libs for the EVE Online ESI API a null pointer exception occured preventing the libs from being build.

### Reproduce the error
git clone https://github.com/swagger-api/swagger-codegen
cd swagger-codegen
mvn clean package
java -jar modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
  -i https://esi.tech.ccp.is/latest/swagger.json \
  -l java \
  -o samples/client/eve-online-esi-api/java

### Fix
I traced the root cause of the null pointer exception and prevented it by a not-null-check when adding the object in question.

**Caution: I have absolutely no idea what the code were I implemented the fix does!!!**
Please check the fix for any side effects. I only tested the fix with the petstore and eve specs and both can build their client libs.