### PR TITLE
Fix Java Play server generator when path variables aren't camelCase

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaPlayFrameworkCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaPlayFrameworkCodegen.java
@@ -10,6 +10,8 @@ import io.swagger.util.Json;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class JavaPlayFrameworkCodegen extends AbstractJavaCodegen implements BeanValidationFeatures {
 
@@ -264,8 +266,12 @@ public class JavaPlayFrameworkCodegen extends AbstractJavaCodegen implements Bea
                     }
                 }
 
-                if (operation.path.contains("{")) {
-                    operation.path = operation.path.replace("{", ":").replace("}", "");
+                Pattern pathVariableMatcher = Pattern.compile("\\{(.+)}");
+                Matcher match = pathVariableMatcher.matcher(operation.path);
+                while (match.find()) {
+                    String completeMatch = match.group();
+                    String replacement = ":" + camelize(match.group(1), true);
+                    operation.path = operation.path.replace(completeMatch, replacement);
                 }
 
                 if (operation.returnType != null) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixes #6085

