### PR TITLE
[New Generator] Rust API client generator

### DIFF
--- a/samples/client/petstore/rust/.gitignore
+++ b/samples/client/petstore/rust/.gitignore
@@ -1,0 +1,3 @@
+/target/
+**/*.rs.bk
+Cargo.lock

--- a/samples/client/petstore/rust/Cargo.toml
+++ b/samples/client/petstore/rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "petstore-client"
+version = "0.1.0"
+authors = ["Vladimir Pouzanov <farcaller@gmail.com>"]
+
+[dependencies]
+serde = "*"
+serde_derive = "*"
+serde_yaml = "*"
+serde_json = "*"
+base64 = "*"
+futures = "*"
+hyper = "*"
+url = "*"
+
+[dev-dependencies]
+tokio-core = "*"

--- a/samples/client/petstore/rust/examples/client.rs
+++ b/samples/client/petstore/rust/examples/client.rs
@@ -1,0 +1,44 @@
+extern crate petstore_client;
+extern crate hyper;
+extern crate tokio_core;
+extern crate futures;
+
+use hyper::Client;
+use hyper::client::HttpConnector;
+use tokio_core::reactor::Core;
+use futures::{Future};
+
+fn main() {
+    let mut core = Core::new().expect("failed to init core");
+    let handle = core.handle();
+
+    let http_connector = HttpConnector::new(4, &handle);
+
+    let client = Client::configure().connector(http_connector).build(&handle);
+    let api = "http://localhost:8080/v2";
+
+    let mut new_pet = petstore_client::models::Pet::new("barker".to_owned(), vec![]);
+    new_pet.set_id(1337);
+
+    let work = petstore_client::apis::add_pet(api, &client, &new_pet)
+    .and_then(|_| {
+        petstore_client::apis::update_pet_with_form(
+            api,
+            &client,
+            1337,
+            "barko",
+            "escaped")
+    })
+    .and_then(|_| {
+        petstore_client::apis::get_pet_by_id(
+            api,
+            &client,
+            1337)
+    })
+    .and_then(|pet| {
+        println!("pet: {:?}", pet);
+        futures::future::ok(())
+    });
+
+    core.run(work).expect("failed to run core");
+}

--- a/samples/client/petstore/rust/examples/client.rs
+++ b/samples/client/petstore/rust/examples/client.rs
@@ -15,12 +15,16 @@ fn main() {
     let http_connector = HttpConnector::new(4, &handle);
 
     let client = Client::configure().connector(http_connector).build(&handle);
-    let api = "http://localhost:8080/v2";
+    let api = "http://petstore.swagger.io:80/v2";
 
-    let mut new_pet = petstore_client::models::Pet::new("barker".to_owned(), vec![]);
-    new_pet.set_id(1337);
+    let new_pet = petstore_client::models::Pet::new("barker".to_owned(), vec![]).with_id(1337);
 
-    let work = petstore_client::apis::add_pet(api, &client, &new_pet)
+    let apicli = petstore_client::apis::client::APIClient::new(
+        petstore_client::apis::configuration::Configuration::new(
+            Client::configure().connector(HttpConnector::new(4, &handle)).build(&handle)));
+
+    let work = apicli.pet_api().add_pet(&new_pet)
+    // petstore_client::apis::add_pet(api, &client, &new_pet)
     .and_then(|_| {
         petstore_client::apis::update_pet_with_form(
             api,

--- a/samples/client/petstore/rust/src/apis/add_pet_api.rs
+++ b/samples/client/petstore/rust/src/apis/add_pet_api.rs
@@ -1,0 +1,27 @@
+use hyper;
+use serde_json;
+use futures::{Future, Stream};
+use futures;
+
+use super::models;
+use super::Error;
+
+pub fn add_pet<C: hyper::client::Connect>(
+    prefix: &str,
+    cli: &hyper::client::Client<C>,
+    pet: &models::Pet,
+    ) -> Box<Future<Item = (), Error = Error>> {
+    let mut req = hyper::Request::new(
+        hyper::Method::Post,
+        format!("{}/pet", prefix).parse().unwrap());
+    let serialized = serde_json::to_string(pet).unwrap();
+    req.headers_mut().set(hyper::header::ContentType::json());
+    req.headers_mut().set(hyper::header::ContentLength(serialized.len() as u64));
+    req.set_body(serialized);
+
+    Box::new(
+        cli.request(req).and_then(|res| { res.body().concat2() })
+        .map_err(|e| Error::from(e))
+        .and_then(|_| futures::future::ok(()))
+    )
+}

--- a/samples/client/petstore/rust/src/apis/client.rs
+++ b/samples/client/petstore/rust/src/apis/client.rs
@@ -1,0 +1,26 @@
+use std::rc::Rc;
+
+use hyper;
+use super::configuration::Configuration;
+use super::pet_api;
+
+pub struct APIClient<C: hyper::client::Connect> {
+  configuration: Rc<Configuration<C>>,
+
+  pet_api: Box<pet_api::PetAPI>,
+}
+
+impl<C: hyper::client::Connect> APIClient<C> {
+  pub fn new(configuration: Configuration<C>) -> APIClient<C> {
+    let rc = Rc::new(configuration);
+    
+    APIClient {
+      configuration: rc.clone(),
+      pet_api: Box::new(pet_api::PetAPIImpl::new(rc.clone())),
+    }
+  }
+
+  pub fn pet_api(&self) -> &pet_api::PetAPI {
+    self.pet_api.as_ref()
+  }
+}

--- a/samples/client/petstore/rust/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/src/apis/configuration.rs
@@ -1,0 +1,15 @@
+use hyper;
+
+pub struct Configuration<C: hyper::client::Connect> {
+  pub base_path: String,
+  pub client: hyper::client::Client<C>,
+}
+
+impl<C: hyper::client::Connect> Configuration<C> {
+  pub fn new(client: hyper::client::Client<C>) -> Configuration<C> {
+    Configuration {
+      base_path: "http://petstore.swagger.io:80/v2".to_owned(),
+      client: client,
+    }
+  }
+}

--- a/samples/client/petstore/rust/src/apis/get_pet_by_id_api.rs
+++ b/samples/client/petstore/rust/src/apis/get_pet_by_id_api.rs
@@ -1,0 +1,23 @@
+use hyper;
+use serde_json;
+use futures::{Future, Stream};
+
+use super::models;
+use super::Error;
+
+pub fn get_pet_by_id<C: hyper::client::Connect>(
+    prefix: &str,
+    cli: &hyper::client::Client<C>,
+    pet_id: i64,
+    ) -> Box<Future<Item = models::Pet, Error = Error>> {
+    Box::new(
+        cli.get(format!("{}/pet/{}", prefix, pet_id).parse().unwrap())
+
+        .and_then(|res| { res.body().concat2() }).map_err(|e| Error::from(e))
+        
+        .and_then(|body| {
+            let parsed: Result<models::Pet, _> = serde_json::from_slice(&body);
+            parsed.map_err(|e| Error::from(e))
+        }).map_err(|e| Error::from(e))
+    )
+}

--- a/samples/client/petstore/rust/src/apis/mod.rs
+++ b/samples/client/petstore/rust/src/apis/mod.rs
@@ -1,0 +1,31 @@
+use hyper;
+use serde_json;
+
+#[derive(Debug)]
+pub enum Error {
+    Hyper(hyper::Error),
+    Serde(serde_json::Error),
+}
+
+impl From<hyper::Error> for Error {
+    fn from(e: hyper::Error) -> Self {
+        return Error::Hyper(e)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        return Error::Serde(e)
+    }
+}
+
+use super::models;
+
+mod get_pet_by_id_api;
+pub use self::get_pet_by_id_api::get_pet_by_id;
+
+mod update_pet_with_form_api;
+pub use self::update_pet_with_form_api::update_pet_with_form;
+
+mod add_pet_api;
+pub use self::add_pet_api::add_pet;

--- a/samples/client/petstore/rust/src/apis/mod.rs
+++ b/samples/client/petstore/rust/src/apis/mod.rs
@@ -29,3 +29,9 @@ pub use self::update_pet_with_form_api::update_pet_with_form;
 
 mod add_pet_api;
 pub use self::add_pet_api::add_pet;
+
+pub mod configuration;
+pub mod client;
+
+mod pet_api;
+pub use self::pet_api::PetAPI;

--- a/samples/client/petstore/rust/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/src/apis/pet_api.rs
@@ -1,0 +1,44 @@
+use std::rc::Rc;
+use std::borrow::Borrow;
+
+use hyper;
+use serde_json;
+use futures;
+use futures::{Future, Stream};
+
+use super::{Error, configuration, models};
+
+pub trait PetAPI {
+    fn add_pet(&self, pet: &models::Pet) -> Box<Future<Item = (), Error = Error>>;
+}
+
+pub struct PetAPIImpl<C: hyper::client::Connect> {
+    configuration: Rc<configuration::Configuration<C>>,
+}
+
+impl<C: hyper::client::Connect> PetAPIImpl<C> {
+    pub fn new(configuration: Rc<configuration::Configuration<C>>) -> PetAPIImpl<C> {
+        PetAPIImpl {
+            configuration: configuration,
+        }
+    }
+}
+
+impl<C: hyper::client::Connect>PetAPI for PetAPIImpl<C> {
+    fn add_pet(&self, pet: &models::Pet) -> Box<Future<Item = (), Error = Error>> {
+        let configuration: &configuration::Configuration<C> = self.configuration.borrow();
+        let mut req = hyper::Request::new(
+            hyper::Method::Post,
+            format!("{}/pet", configuration.base_path).parse().unwrap());
+        let serialized = serde_json::to_string(pet).unwrap();
+        req.headers_mut().set(hyper::header::ContentType::json());
+        req.headers_mut().set(hyper::header::ContentLength(serialized.len() as u64));
+        req.set_body(serialized);
+
+        Box::new(
+            configuration.client.request(req).and_then(|res| { res.body().concat2() })
+            .map_err(|e| Error::from(e))
+            .and_then(|_| futures::future::ok(()))
+        )
+    }
+}

--- a/samples/client/petstore/rust/src/apis/update_pet_with_form_api.rs
+++ b/samples/client/petstore/rust/src/apis/update_pet_with_form_api.rs
@@ -1,0 +1,31 @@
+use hyper;
+use futures::{Future, Stream};
+use url;
+use futures;
+
+use super::Error;
+
+pub fn update_pet_with_form<C: hyper::client::Connect>(
+    prefix: &str,
+    cli: &hyper::client::Client<C>,
+    pet_id: i64,
+    name: &str,
+    status: &str,
+    ) -> Box<Future<Item = (), Error = Error>> {
+    let mut req = hyper::Request::new(
+        hyper::Method::Post,
+        format!("{}/pet/{}", prefix, pet_id).parse().unwrap());
+    let body = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("name", name)
+        .append_pair("status", status)
+        .finish();
+    req.headers_mut().set(hyper::header::ContentType::form_url_encoded());
+    req.headers_mut().set(hyper::header::ContentLength(body.len() as u64));
+    req.set_body(body);
+
+    Box::new(
+        cli.request(req).and_then(|res| { res.body().concat2() })
+        .map_err(|e| Error::from(e))
+        .and_then(|_| futures::future::ok(()))
+    )
+}

--- a/samples/client/petstore/rust/src/lib.rs
+++ b/samples/client/petstore/rust/src/lib.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate serde_derive;
+
+extern crate hyper;
+extern crate serde_json;
+extern crate futures;
+extern crate url;
+
+pub mod apis;
+pub mod models;

--- a/samples/client/petstore/rust/src/models/category.rs
+++ b/samples/client/petstore/rust/src/models/category.rs
@@ -1,0 +1,8 @@
+/// Pet catehgry
+///
+/// A category for a pet
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Category {
+    id: Option<i64>,
+    name: Option<String>,
+}

--- a/samples/client/petstore/rust/src/models/mod.rs
+++ b/samples/client/petstore/rust/src/models/mod.rs
@@ -1,0 +1,8 @@
+mod pet;
+pub use self::pet::Pet;
+
+mod category;
+pub use self::category::Category;
+
+mod tag;
+pub use self::tag::Tag;

--- a/samples/client/petstore/rust/src/models/pet.rs
+++ b/samples/client/petstore/rust/src/models/pet.rs
@@ -26,4 +26,9 @@ impl Pet {
   pub fn set_id(&mut self, id: i64) {
     self.id = Some(id);
   }
+
+  pub fn with_id(mut self, id: i64) -> Pet {
+    self.id = Some(id);
+    self
+  }
 }

--- a/samples/client/petstore/rust/src/models/pet.rs
+++ b/samples/client/petstore/rust/src/models/pet.rs
@@ -1,0 +1,29 @@
+/// a Pet
+///
+/// A pet for sale in the pet store
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Pet {
+    id: Option<i64>,
+    category: Option<super::Category>,
+    name: String,
+    #[serde(rename = "photoUrls")] photo_urls: Vec<String>,
+    tags: Vec<super::Tag>,
+    status: Option<String>,
+}
+
+impl Pet {
+  pub fn new(name: String, photo_urls: Vec<String>) -> Pet {
+    Pet {
+      id: None,
+      category: None,
+      name: name,
+      photo_urls: photo_urls,
+      tags: Vec::new(),
+      status: None,
+    }
+  }
+
+  pub fn set_id(&mut self, id: i64) {
+    self.id = Some(id);
+  }
+}

--- a/samples/client/petstore/rust/src/models/tag.rs
+++ b/samples/client/petstore/rust/src/models/tag.rs
@@ -1,0 +1,8 @@
+/// Pet Tag
+///
+/// A tag for a pet
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Tag {
+    id: Option<i64>,
+    name: Option<String>,
+}


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Tracking PR for Rust client implementation.

The first commit adds a subset of apis requested in #5905.