### PR TITLE
Fixed issues 6099 and 6100

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaPlayFrameworkCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaPlayFrameworkCodegen.java
@@ -181,7 +181,7 @@ public class JavaPlayFrameworkCodegen extends AbstractJavaCodegen implements Bea
             apiTemplateFiles.put("newApi.mustache", "ControllerImp.java");
         }
         if (this.useInterfaces) {
-            apiTemplateFiles.put("newApiInterface.mustache", "ControllerImpInterface.java");
+            apiTemplateFiles.put("newApiInterface.mustache", "ControllerInterface.java");
         }
 
         additionalProperties.put("javaVersion", "1.8");

--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApi.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApi.mustache
@@ -13,7 +13,7 @@ import javax.validation.constraints.*;
 {{/useBeanValidation}}
 {{>generatedAnnotation}}
 {{#operations}}
-public class {{classname}}ControllerImp {{#useInterfaces}}implements {{classname}}ControllerImpInterface{{/useInterfaces}} {
+public class {{classname}}ControllerImp {{#useInterfaces}}implements {{classname}}ControllerInterface{{/useInterfaces}} {
 {{#operation}}
     {{#useInterfaces}}@Override{{/useInterfaces}}
     public {{>returnTypes}} {{operationId}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{>formParams}}{{>headerParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {{#handleExceptions}}throws Exception{{/handleExceptions}} {

--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApiController.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApiController.mustache
@@ -27,12 +27,12 @@ import swagger.SwaggerUtils.ApiAction;
 {{#operations}}
 public class {{classname}}Controller extends Controller {
 
-    private final {{classname}}ControllerImp imp;
+    private final {{classname}}ControllerInterface api;
     private final ObjectMapper mapper;
 
     @Inject
-    private {{classname}}Controller({{classname}}ControllerImp imp) {
-        this.imp = imp;
+    private {{classname}}Controller({{classname}}ControllerInterface api) {
+        this.api = api;
         mapper = new ObjectMapper();
     }
 
@@ -129,7 +129,7 @@ public class {{classname}}Controller extends Controller {
         }{{/required}}
         {{/collectionFormat}}
         {{/headerParams}}
-        {{#returnType}}{{>returnTypesNoVoid}} obj = {{/returnType}}imp.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+        {{#returnType}}{{>returnTypesNoVoid}} obj = {{/returnType}}api.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
         {{#returnType}}{{^isResponseFile}}JsonNode result = mapper.valueToTree(obj);
         return ok(result);{{/isResponseFile}}{{#isResponseFile}}return ok(obj);{{/isResponseFile}}{{/returnType}}
         {{^returnType}}return ok();{{/returnType}}

--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApiInterface.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApiInterface.mustache
@@ -13,7 +13,7 @@ import javax.validation.constraints.*;
 {{/useBeanValidation}}
 
 {{#operations}}
-public interface {{classname}}ControllerImpInterface {
+public interface {{classname}}ControllerInterface {
 {{#operation}}
     {{>returnTypes}} {{operationId}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{>formParams}}{{>headerParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {{#handleExceptions}}throws Exception{{/handleExceptions}};
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixed the dependency injection in the Controllers on JavaPlayFramework #6100 
Fixed the name of the interfaces on JavaPlayFramework #6099 

