### PR TITLE
#5958 [JAVA-RESTEASY] Add servialVersionId to generated model class w…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pojo.mustache
@@ -3,6 +3,9 @@ import io.swagger.annotations.*;
 {{#description}}@ApiModel(description="{{{description}}}"){{/description}}
 {{>generatedAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+{{#serializableModel}}
+  private static final long serialVersionUID = 1L;
+{{/serializableModel}}
   {{#vars}}{{#isEnum}}
 
 {{>enumClass}}{{/isEnum}}{{#items.isEnum}}{{#items}}

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pojo.mustache
@@ -3,6 +3,9 @@ import io.swagger.annotations.*;
 {{#description}}@ApiModel(description="{{{description}}}"){{/description}}
 {{>generatedAnnotation}}
 public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+{{#serializableModel}}
+  private static final long serialVersionUID = 1L;
+{{/serializableModel}}
   {{#vars}}{{#isEnum}}{{^isContainer}}
 
 {{>enumClass}}{{/isContainer}}{{/isEnum}}{{#items.isEnum}}{{#items}}


### PR DESCRIPTION
### PR  for #5958 

Fix [JAVA-RESTEASY] generated codes with serializableModel=true classes have no servialVersionId. Test with swagger-codegen-cli.

PR for v2.3.0

