### PR TITLE
[Flask] self and None are reserved words (#6111)

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/FlaskConnexionCodegen.java
@@ -69,7 +69,7 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
         typeMapping.put("file", "file");
         typeMapping.put("UUID", "str");
 
-        // from https://docs.python.org/release/2.5.4/ref/keywords.html
+        // from https://docs.python.org/3/reference/lexical_analysis.html#keywords
         setReservedWordsLowerCase(
                 Arrays.asList(
                     // @property
@@ -78,7 +78,7 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
                     "and", "del", "from", "not", "while", "as", "elif", "global", "or", "with",
                     "assert", "else", "if", "pass", "yield", "break", "except", "import",
                     "print", "class", "exec", "in", "raise", "continue", "finally", "is",
-                    "return", "def", "for", "lambda", "try", "self", "None"));
+                    "return", "def", "for", "lambda", "try", "self", "None", "True", "False", "nonlocal"));
 
         // set the output folder here
         outputFolder = "generated-code/connexion";
@@ -92,14 +92,6 @@ public class FlaskConnexionCodegen extends DefaultCodegen implements CodegenConf
          * will use the resource stream to attempt to read the templates.
          */
         embeddedTemplateDir = templateDir = "flaskConnexion";
-
-        // from https://docs.python.org/release/2.5.4/ref/keywords.html
-        setReservedWordsLowerCase(
-                Arrays.asList(
-                        "and", "del", "from", "not", "while", "as", "elif", "global", "or", "with",
-                        "assert", "else", "if", "pass", "yield", "break", "except", "import",
-                        "print", "class", "exec", "in", "raise", "continue", "finally", "is",
-                        "return", "def", "for", "lambda", "try"));
 
         /*
          * Additional Properties.  These values can be passed to the templates and

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -90,7 +90,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         // map uuid to string for the time being
         typeMapping.put("UUID", "str");
 
-        // from https://docs.python.org/release/2.5.4/ref/keywords.html
+        // from https://docs.python.org/3/reference/lexical_analysis.html#keywords
         setReservedWordsLowerCase(
                 Arrays.asList(
                     // local variable name used in API methods (endpoints)
@@ -102,7 +102,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
                     "and", "del", "from", "not", "while", "as", "elif", "global", "or", "with",
                     "assert", "else", "if", "pass", "yield", "break", "except", "import",
                     "print", "class", "exec", "in", "raise", "continue", "finally", "is",
-                    "return", "def", "for", "lambda", "try", "self", "None"));
+                    "return", "def", "for", "lambda", "try", "self", "nonlocal", "None", "True", "False"));
 
         regexModifiers = new HashMap<Character, String>();
         regexModifiers.put('i', "IGNORECASE");


### PR DESCRIPTION
* setReservedWordsLowerCase was called twice, the second time without self and None

* True, False and nonlocal are python3 reserved words

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

issue reference #6111

* setReservedWordsLowerCase was called twice, the second time without self and None

* True, False and nonlocal are python3 reserved words