### PR TITLE
Add additional cli option and properties to swift3 for Objective-C compatibility

### DIFF
--- a/bin/swift3-petstore-objcCompatible.json
+++ b/bin/swift3-petstore-objcCompatible.json
@@ -1,0 +1,7 @@
+{
+  "podSummary": "PetstoreClient",
+  "podHomepage": "https://github.com/swagger-api/swagger-codegen",
+  "podAuthors": "",
+  "projectName": "PetstoreClient",
+  "objcCompatible": true
+}

--- a/bin/swift3-petstore-objcCompatible.sh
+++ b/bin/swift3-petstore-objcCompatible.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+SCRIPT="$0"
+
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+
+if [ ! -d "${APP_DIR}" ]; then
+  APP_DIR=`dirname "$SCRIPT"`/..
+  APP_DIR=`cd "${APP_DIR}"; pwd`
+fi
+
+executable="./modules/swagger-codegen-cli/target/swagger-codegen-cli.jar"
+
+if [ ! -f "$executable" ]
+then
+  mvn clean package
+fi
+
+# if you've executed sbt assembly previously it will use that instead.
+export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+ags="generate -v -t modules/swagger-codegen/src/main/resources/swift3 -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c ./bin/swift3-petstore-objcCompatible.json -o samples/client/petstore/swift3/objcCompatible $@"
+
+java $JAVA_OPTS -jar $executable $ags

--- a/modules/swagger-codegen/src/main/resources/swift3/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/model.mustache
@@ -44,7 +44,12 @@ open class {{classname}}: {{#parent}}{{{parent}}}{{/parent}}{{^parent}}JSONEncod
 {{/isEnum}}
 {{^isEnum}}
     {{#description}}/** {{description}} */
-    {{/description}}public var {{name}}: {{{datatype}}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}
+    {{/description}}public var {{name}}: {{{datatype}}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{#objcCompatible}}{{#vendorExtensions.x-swift-optional-scalar}}
+    public var {{name}}Num: NSNumber? {
+        get {
+            return {{name}}.map({ return NSNumber(value: $0) })
+        }
+    }{{/vendorExtensions.x-swift-optional-scalar}}{{/objcCompatible}}
 {{/isEnum}}
 {{/vars}}
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Swift3OptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/Swift3OptionsProvider.java
@@ -13,6 +13,7 @@ public class Swift3OptionsProvider implements OptionsProvider {
     public static final String PROJECT_NAME_VALUE = "Swagger";
     public static final String RESPONSE_AS_VALUE = "test";
     public static final String UNWRAP_REQUIRED_VALUE = "true";
+    public static final String OBJC_COMPATIBLE_VALUE = "false";
     public static final String LENIENT_TYPE_CAST_VALUE = "false";
     public static final String POD_SOURCE_VALUE = "{ :git => 'git@github.com:swagger-api/swagger-mustache.git'," +
             " :tag => 'v1.0.0-SNAPSHOT' }";
@@ -42,6 +43,7 @@ public class Swift3OptionsProvider implements OptionsProvider {
                 .put(Swift3Codegen.PROJECT_NAME, PROJECT_NAME_VALUE)
                 .put(Swift3Codegen.RESPONSE_AS, RESPONSE_AS_VALUE)
                 .put(Swift3Codegen.UNWRAP_REQUIRED, UNWRAP_REQUIRED_VALUE)
+                .put(Swift3Codegen.OBJC_COMPATIBLE, OBJC_COMPATIBLE_VALUE)
                 .put(Swift3Codegen.LENIENT_TYPE_CAST, LENIENT_TYPE_CAST_VALUE)
                 .put(Swift3Codegen.POD_SOURCE, POD_SOURCE_VALUE)
                 .put(CodegenConstants.POD_VERSION, POD_VERSION_VALUE)

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3OptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/swift3/Swift3OptionsTest.java
@@ -33,6 +33,8 @@ public class Swift3OptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setUnwrapRequired(Boolean.valueOf(Swift3OptionsProvider.UNWRAP_REQUIRED_VALUE));
             times = 1;
+            clientCodegen.setObjcCompatible(Boolean.valueOf(Swift3OptionsProvider.OBJC_COMPATIBLE_VALUE));
+            times = 1;
             clientCodegen.setLenientTypeCast(Boolean.valueOf(Swift3OptionsProvider.LENIENT_TYPE_CAST_VALUE));
             times = 1;
         }};


### PR DESCRIPTION
### Description of the PR

Currently, in the swift3 language, if you have an optional integer, number, or boolean property in a model, then the generated swift3 model class might look like:

```
class SomeModel {
    var someInt: Int?
    var someFloat: Float?
    var someDouble: Double?
    var someBool: Bool?
}
```

This works fine if you are accessing this model only from Swift code. However, it is very common for iOS codebases to contain both Swift AND Objective-C. If you need to access this model from Objective-C, then those 4 properties are not accessible, since Optional scalars do not translate to Objective-C.

Therefore, in the swift3 language, we want to add some code for Objective-C compatibility:

1. We add a "objcCompatible" boolean command-line option. If objcCompatible=true, then this enables some additional code generation to make these types of properties accessible from Objective-C. If objcCompatible=false, then the generated code is exactly as it currently is. The default is objcCompatible=false.

2. If objCompatible=true, then for these types of Objective-C-inaccessible properties (Optional scalars), then we add a "x-swift-optional-scalar=true" vendor extension in the CodegenProperty.

3. Then, in the model.mustache template, if we see x-swift-optional-scalar=true, then we add an additional computed property which returns an optional NSNumber.

So, for example, when objcCompatible=false (the default case), then the generated code for the "declawed" property of the Cat model looks like:

```
open class Cat: Animal {

    public var declawed: Bool?

    ...
```

But when objcCompatible=true, then it looks like:

```
open class Cat: Animal {

    public var declawed: Bool?
    public var declawedNum: NSNumber? {
        get {
            return declawed.map({ return NSNumber(value: $0) })
        }
    }

   ...
```

### To Do

There is remaining work to do for Objective-C compatibility, particularly around enums. The only Swift enums which are visible from Objective-C are enums where the rawValue is an Int. But hopefully now that we have this cli option, then the remaining work should be template-only changes.

I also need to file a PR to merge this changes to the swift4 language as well.

### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.
