### PR TITLE
Ruby Enums: Fix for issue #4848

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/partial_model_enum_class.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/partial_model_enum_class.mustache
@@ -1,4 +1,13 @@
   class {{classname}}
     {{#allowableValues}}{{#enumVars}}
     {{{name}}} = {{{value}}}.freeze{{/enumVars}}{{/allowableValues}}
+
+    # Builds the enum from string
+    # @param [String] The enum value in the form of the string
+    # @return [String] The enum value
+    def build_from_hash(value)
+      consantValues = {{classname}}.constants.select{|c| c.to_s == value}
+      raise "Invalid ENUM value #{value} for class #{{{classname}}}" if consantValues.empty?
+      value
+    end
   end


### PR DESCRIPTION
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Fixes issue with ENUM generation for ruby issue #4848 

