### PR TITLE
[objc] Convert boolean query params to true/false (#6139)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-body.mustache
@@ -92,7 +92,14 @@ NSInteger k{{classname}}MissingParamErrorCode = 234513;
         {{#collectionFormat}}
         queryParams[@"{{baseName}}"] = [[{{classPrefix}}QueryParamCollection alloc] initWithValuesAndFormat: {{paramName}} format: @"{{collectionFormat}}"];
         {{/collectionFormat}}
-        {{^collectionFormat}}queryParams[@"{{baseName}}"] = {{paramName}};{{/collectionFormat}}
+        {{^collectionFormat}}
+        {{#isBoolean}}
+        queryParams[@"{{baseName}}"] = [{{paramName}} isEqual:@(YES)] ? @"true" : @"false";
+        {{/isBoolean}}
+        {{^isBoolean}}
+        queryParams[@"{{baseName}}"] = {{paramName}};
+        {{/isBoolean}}
+        {{/collectionFormat}}
     }
     {{/queryParams}}
     NSMutableDictionary* headerParams = [NSMutableDictionary dictionaryWithDictionary:self.apiClient.configuration.defaultHeaders];


### PR DESCRIPTION
Change booleans in query parameters from 0/1 to true/false to
match Swagger UI behaviour

### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
https://github.com/swagger-api/swagger-codegen/issues/6139

Boolean properties when sent as query string parameters are being sent as either 0 or 1.

```
?isEnabled=1
?isEnabled=0
```
To match Swagger-UI behaviour it should send true or false instead

```
?isEnabled=true
?isEnabled=false
```