### PR TITLE
Fix Xcode Documentation Issue

### DIFF
--- a/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
+++ b/modules/swagger-codegen/src/main/resources/objc/api-header.mustache
@@ -22,7 +22,7 @@ extern NSInteger k{{classname}}MissingParamErrorCode;
 /// {{/allParams}}{{#responses}}
 ///  code:{{{code}}} message:"{{{message}}}"{{#hasMore}},{{/hasMore}}{{/responses}}
 ///
-/// @return {{{returnType}}}
+/// @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
 -(NSURLSessionTask*) {{#vendorExtensions.x-objc-operationId}}{{vendorExtensions.x-objc-operationId}}{{/vendorExtensions.x-objc-operationId}}{{^vendorExtensions.x-objc-operationId}}{{nickname}}{{#hasParams}}With{{vendorExtensions.firstParamAltName}}{{/hasParams}}{{^hasParams}}WithCompletionHandler: {{/hasParams}}{{/vendorExtensions.x-objc-operationId}}{{#allParams}}{{#secondaryParam}}
     {{paramName}}{{/secondaryParam}}: ({{{dataType}}}) {{paramName}}{{/allParams}}
     {{#hasParams}}completionHandler: {{/hasParams}}(void (^)({{#returnBaseType}}{{{returnType}}} output, {{/returnBaseType}}NSError* error)) handler;


### PR DESCRIPTION
Allow documentation to specify void when no
return type is available

Remove Xcode warnings:
```
Documentation Issue
Empty paragraph passed to '@return' command
```

### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

