### PR TITLE
[Java] Interpret consumes '*/*' as 'application/json'

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/ApiClient.mustache
@@ -519,10 +519,10 @@ public class ApiClient {
    *
    * @param contentTypes The Content-Type array to select from
    * @return The Content-Type header to use. If the given array is empty,
-   *   JSON will be used.
+   *   or matches "any", JSON will be used.
    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
+    if (contentTypes.length == 0 || contentTypes[0].equals("*/*")) {
       return "application/json";
     }
     for (String contentType : contentTypes) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

I'm having trouble with the `./bin/java-petstore-all.sh` script since it's introducing a lot of changes unrelated to this change, even when I run against `upstream/master` with no changes staged. It seems like at some point changes to the templates were not checked in alongside their changes to the petstore examples.

### Description of the PR

Servers can describe their desired (consumed) content type for an operation as "*/*", which the current swagger API sends as the content type for any request against that operation. This is troublesome because "*/*" provides no info to the server as to what is being sent. Given that swagger already defaults to "application/json", this seems appropriate.
