### PR TITLE
[Java][Jersey2] Use jersey 2.6 for JDK6

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -283,8 +283,11 @@
   </dependencies>
   <properties>
     <swagger-core-version>1.5.15</swagger-core-version>
+    {{^supportJava6}}
     <jersey-version>2.25.1</jersey-version>
+    {{/supportJava6}}
     {{#supportJava6}}
+    <jersey-version>2.6</jersey-version>
     <commons_io_version>2.5</commons_io_version>
     <commons_lang3_version>3.6</commons_lang3_version>
     {{/supportJava6}}

--- a/samples/client/petstore/java/jersey2-java6/pom.xml
+++ b/samples/client/petstore/java/jersey2-java6/pom.xml
@@ -247,7 +247,7 @@
   </dependencies>
   <properties>
     <swagger-core-version>1.5.15</swagger-core-version>
-    <jersey-version>2.25.1</jersey-version>
+    <jersey-version>2.6</jersey-version>
     <commons_io_version>2.5</commons_io_version>
     <commons_lang3_version>3.6</commons_lang3_version>
     <jackson-version>2.6.4</jackson-version>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

To fix https://github.com/swagger-api/swagger-codegen/issues/6154
