### PR TITLE
[C#] fix issue with API key (query)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/csharp/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/csharp/api.mustache
@@ -262,7 +262,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{#isKeyInQuery}}
             if (!String.IsNullOrEmpty(Configuration.GetApiKeyWithPrefix("{{keyParamName}}")))
             {
-                localVarQueryParams["{{keyParamName}}"] = Configuration.GetApiKeyWithPrefix("{{keyParamName}}");
+                localVarQueryParams.AddRange(Configuration.ApiClient.ParameterToKeyValuePairs("", "{{keyParamName}}", Configuration.GetApiKeyWithPrefix("{{keyParamName}}")));
             }
             {{/isKeyInQuery}}
             {{/isApiKey}}
@@ -278,7 +278,8 @@ namespace {{packageName}}.{{apiPackage}}
             if (!String.IsNullOrEmpty(Configuration.AccessToken))
             {
                 localVarHeaderParams["Authorization"] = "Bearer " + Configuration.AccessToken;
-            }{{/isOAuth}}
+            }
+            {{/isOAuth}}
             {{/authMethods}}
 
             // make the HTTP request
@@ -397,7 +398,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{#isKeyInQuery}}
             if (!String.IsNullOrEmpty(Configuration.GetApiKeyWithPrefix("{{keyParamName}}")))
             {
-                localVarQueryParams["{{keyParamName}}"] = Configuration.GetApiKeyWithPrefix("{{keyParamName}}");
+                localVarQueryParams.AddRange(Configuration.ApiClient.ParameterToKeyValuePairs("", "{{keyParamName}}", Configuration.GetApiKeyWithPrefix("{{keyParamName}}")));
             }
             {{/isKeyInQuery}}
             {{/isApiKey}}

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -583,6 +583,8 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Client'
+      security:
+        - api_key_query: []
   /fake:
     patch:
       tags:
@@ -908,6 +910,10 @@ securityDefinitions:
     type: apiKey
     name: api_key
     in: header
+  api_key_query:
+    type: apiKey
+    name: api_key_query
+    in: query 
   http_basic_test:
     type: basic
 definitions:

--- a/samples/client/petstore/csharp/SwaggerClient/README.md
+++ b/samples/client/petstore/csharp/SwaggerClient/README.md
@@ -175,6 +175,13 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: api_key
 - **Location**: HTTP header
 
+<a name="api_key_query"></a>
+### api_key_query
+
+- **Type**: API key
+- **API key parameter name**: api_key_query
+- **Location**: URL query string
+
 <a name="http_basic_test"></a>
 ### http_basic_test
 

--- a/samples/client/petstore/csharp/SwaggerClient/docs/Fake_classname_tags123Api.md
+++ b/samples/client/petstore/csharp/SwaggerClient/docs/Fake_classname_tags123Api.md
@@ -27,6 +27,11 @@ namespace Example
     {
         public void main()
         {
+            // Configure API key authorization: api_key_query
+            Configuration.Default.AddApiKey("api_key_query", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.AddApiKeyPrefix("api_key_query", "Bearer");
+
             var apiInstance = new Fake_classname_tags123Api();
             var body = new ModelClient(); // ModelClient | client model
 
@@ -57,7 +62,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[api_key_query](../README.md#api_key_query)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/FakeApi.cs
@@ -1355,7 +1355,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["Authorization"] = "Basic " + ApiClient.Base64Encode(Configuration.Username + ":" + Configuration.Password);
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/Fake_classname_tags123Api.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/Fake_classname_tags123Api.cs
@@ -223,6 +223,11 @@ namespace IO.Swagger.Api
                 localVarPostBody = body; // byte array
             }
 
+            // authentication (api_key_query) required
+            if (!String.IsNullOrEmpty(Configuration.GetApiKeyWithPrefix("api_key_query")))
+            {
+                localVarQueryParams.AddRange(Configuration.ApiClient.ParameterToKeyValuePairs("", "api_key_query", Configuration.GetApiKeyWithPrefix("api_key_query")));
+            }
 
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
@@ -298,6 +303,11 @@ namespace IO.Swagger.Api
                 localVarPostBody = body; // byte array
             }
 
+            // authentication (api_key_query) required
+            if (!String.IsNullOrEmpty(Configuration.GetApiKeyWithPrefix("api_key_query")))
+            {
+                localVarQueryParams.AddRange(Configuration.ApiClient.ParameterToKeyValuePairs("", "api_key_query", Configuration.GetApiKeyWithPrefix("api_key_query")));
+            }
 
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await Configuration.ApiClient.CallApiAsync(localVarPath,

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/PetApi.cs
@@ -1144,7 +1144,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["api_key"] = Configuration.GetApiKeyWithPrefix("api_key");
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,

--- a/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClient/src/IO.Swagger/Api/StoreApi.cs
@@ -470,7 +470,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["api_key"] = Configuration.GetApiKeyWithPrefix("api_key");
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/README.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/README.md
@@ -155,6 +155,13 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: api_key
 - **Location**: HTTP header
 
+<a name="api_key_query"></a>
+### api_key_query
+
+- **Type**: API key
+- **API key parameter name**: api_key_query
+- **Location**: URL query string
+
 <a name="http_basic_test"></a>
 ### http_basic_test
 

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/Fake_classname_tags123Api.md
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/docs/Fake_classname_tags123Api.md
@@ -27,6 +27,11 @@ namespace Example
     {
         public void main()
         {
+            // Configure API key authorization: api_key_query
+            Configuration.Default.AddApiKey("api_key_query", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.AddApiKeyPrefix("api_key_query", "Bearer");
+
             var apiInstance = new Fake_classname_tags123Api();
             var body = new ModelClient(); // ModelClient | client model
 
@@ -57,7 +62,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[api_key_query](../README.md#api_key_query)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/FakeApi.cs
@@ -1355,7 +1355,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["Authorization"] = "Basic " + ApiClient.Base64Encode(Configuration.Username + ":" + Configuration.Password);
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/Fake_classname_tags123Api.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/Fake_classname_tags123Api.cs
@@ -223,6 +223,11 @@ namespace IO.Swagger.Api
                 localVarPostBody = body; // byte array
             }
 
+            // authentication (api_key_query) required
+            if (!String.IsNullOrEmpty(Configuration.GetApiKeyWithPrefix("api_key_query")))
+            {
+                localVarQueryParams.AddRange(Configuration.ApiClient.ParameterToKeyValuePairs("", "api_key_query", Configuration.GetApiKeyWithPrefix("api_key_query")));
+            }
 
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
@@ -298,6 +303,11 @@ namespace IO.Swagger.Api
                 localVarPostBody = body; // byte array
             }
 
+            // authentication (api_key_query) required
+            if (!String.IsNullOrEmpty(Configuration.GetApiKeyWithPrefix("api_key_query")))
+            {
+                localVarQueryParams.AddRange(Configuration.ApiClient.ParameterToKeyValuePairs("", "api_key_query", Configuration.GetApiKeyWithPrefix("api_key_query")));
+            }
 
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await Configuration.ApiClient.CallApiAsync(localVarPath,

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/PetApi.cs
@@ -1144,7 +1144,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["api_key"] = Configuration.GetApiKeyWithPrefix("api_key");
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,

--- a/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientNetStandard/src/IO.Swagger/Api/StoreApi.cs
@@ -470,7 +470,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["api_key"] = Configuration.GetApiKeyWithPrefix("api_key");
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/README.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/README.md
@@ -175,6 +175,13 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: api_key
 - **Location**: HTTP header
 
+<a name="api_key_query"></a>
+### api_key_query
+
+- **Type**: API key
+- **API key parameter name**: api_key_query
+- **Location**: URL query string
+
 <a name="http_basic_test"></a>
 ### http_basic_test
 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/Fake_classname_tags123Api.md
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/docs/Fake_classname_tags123Api.md
@@ -27,6 +27,11 @@ namespace Example
     {
         public void main()
         {
+            // Configure API key authorization: api_key_query
+            Configuration.Default.AddApiKey("api_key_query", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.AddApiKeyPrefix("api_key_query", "Bearer");
+
             var apiInstance = new Fake_classname_tags123Api();
             var body = new ModelClient(); // ModelClient | client model
 
@@ -57,7 +62,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[api_key_query](../README.md#api_key_query)
 
 ### HTTP request headers
 

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/FakeApi.cs
@@ -1355,7 +1355,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["Authorization"] = "Basic " + ApiClient.Base64Encode(Configuration.Username + ":" + Configuration.Password);
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/Fake_classname_tags123Api.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/Fake_classname_tags123Api.cs
@@ -223,6 +223,11 @@ namespace IO.Swagger.Api
                 localVarPostBody = body; // byte array
             }
 
+            // authentication (api_key_query) required
+            if (!String.IsNullOrEmpty(Configuration.GetApiKeyWithPrefix("api_key_query")))
+            {
+                localVarQueryParams.AddRange(Configuration.ApiClient.ParameterToKeyValuePairs("", "api_key_query", Configuration.GetApiKeyWithPrefix("api_key_query")));
+            }
 
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
@@ -298,6 +303,11 @@ namespace IO.Swagger.Api
                 localVarPostBody = body; // byte array
             }
 
+            // authentication (api_key_query) required
+            if (!String.IsNullOrEmpty(Configuration.GetApiKeyWithPrefix("api_key_query")))
+            {
+                localVarQueryParams.AddRange(Configuration.ApiClient.ParameterToKeyValuePairs("", "api_key_query", Configuration.GetApiKeyWithPrefix("api_key_query")));
+            }
 
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await Configuration.ApiClient.CallApiAsync(localVarPath,

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/PetApi.cs
@@ -1144,7 +1144,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["api_key"] = Configuration.GetApiKeyWithPrefix("api_key");
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,

--- a/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/SwaggerClientWithPropertyChanged/src/IO.Swagger/Api/StoreApi.cs
@@ -470,7 +470,6 @@ namespace IO.Swagger.Api
                 localVarHeaderParams["api_key"] = Configuration.GetApiKeyWithPrefix("api_key");
             }
 
-
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) Configuration.ApiClient.CallApi(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- Fixed the issue with `ParameterToKeyValuePairs` for query parameters
- Updated petstore-with-fake-endpoints-models-for-testing.yaml with additional test cases to cover the issue moving forward
