### PR TITLE
[Java][Client] Add javax.validation.validation-api dependency for Bean Validation API support to Jersey 2

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -273,6 +273,15 @@
       <version>${commons_io_version}</version>
     </dependency>
     {{/supportJava6}}
+    {{#useBeanValidation}}
+    <!-- Bean Validation API support -->
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>1.1.0.Final</version>
+      <scope>provided</scope>
+    </dependency>
+    {{/useBeanValidation}}
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Add `javax.validation.validation-api` dependency for Bean Validation API support to `pom.mustache` under jersey2