### PR TITLE
[Java] Fix okhttp-gson datetime converter compilation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/JSON.mustache
@@ -13,6 +13,7 @@ import com.google.gson.stream.JsonWriter;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.ISODateTimeFormat;
 {{/joda}}
 {{#threetenbp}}
@@ -132,11 +133,12 @@ public class JSON {
      */
     public static class DateTimeTypeAdapter extends TypeAdapter<DateTime> {
 
-        private final DateTimeFormatter parseFormatter = ISODateTimeFormat.dateOptionalTimeParser();
-        private final DateTimeFormatter printFormatter = ISODateTimeFormat.dateTime();
+        private DateTimeFormatter formatter;
 
         public DateTimeTypeAdapter() {
-            this(ISODateTimeFormat.dateTime().withOffsetParsed());
+            this(new DateTimeFormatterBuilder()
+                .append(ISODateTimeFormat.dateTime().getPrinter(), ISODateTimeFormat.dateOptionalTimeParser().getParser())
+                .toFormatter());
         }
 
         public DateTimeTypeAdapter(DateTimeFormatter formatter) {
@@ -152,7 +154,7 @@ public class JSON {
             if (date == null) {
                 out.nullValue();
             } else {
-                out.value(printFormatter.print(date));
+                out.value(formatter.print(date));
             }
         }
 
@@ -164,7 +166,7 @@ public class JSON {
                     return null;
                 default:
                     String date = in.nextString();
-                    return parseFormatter.parseDateTime(date);
+                    return formatter.parseDateTime(date);
             }
         }
     }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/JSON.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/JSON.mustache
@@ -13,6 +13,7 @@ import com.google.gson.stream.JsonWriter;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.ISODateTimeFormat;
 {{/joda}}
 {{#threetenbp}}
@@ -91,7 +92,9 @@ public class JSON {
         private DateTimeFormatter formatter;
 
         public DateTimeTypeAdapter() {
-            this(ISODateTimeFormat.dateTime().withOffsetParsed());
+            this(new DateTimeFormatterBuilder()
+                .append(ISODateTimeFormat.dateTime().getPrinter(), ISODateTimeFormat.dateOptionalTimeParser().getParser())
+                .toFormatter());
         }
 
         public DateTimeTypeAdapter(DateTimeFormatter formatter) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This commit https://github.com/swagger-api/swagger-codegen/commit/f1e237f76fc7ee8c731e77569c5628da5dff85d8 seemed to have introduce unprompted new properties to the `DateTimeTypeAdaptor`. While this technically changes the intended behavior of having two separate date time formatters for parsing and printing, I can't see reverting this breaking anything since the generated code in its current state cannot compile.

