### PR TITLE
represent swagger enums as union of literal types

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/modelEnum.mustache
@@ -1,7 +1,1 @@
-export enum {{classname}} {
-{{#allowableValues}}
-{{#enumVars}}
-    {{{name}}} = <any> {{{value}}}{{^-last}},{{/-last}}
-{{/enumVars}}
-{{/allowableValues}}
-}
+export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/modelEnum.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/modelEnum.mustache
@@ -1,1 +1,2 @@
 export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
+

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -16,13 +16,7 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 export namespace {{classname}} {
 {{#vars}}
     {{#isEnum}}
-    export enum {{enumName}} {
-    {{#allowableValues}}
-        {{#enumVars}}
-        {{{name}}} = <any> {{{value}}}{{^-last}},{{/-last}}
-        {{/enumVars}}
-    {{/allowableValues}}
-    }
+    export type {{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
     {{/isEnum}}
 {{/vars}}
 }{{/hasEnums}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -19,4 +19,5 @@ export namespace {{classname}} {
     export type {{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
     {{/isEnum}}
 {{/vars}}
-}{{/hasEnums}}
+}{{/hasEnums}}i
+

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -19,5 +19,5 @@ export namespace {{classname}} {
     export type {{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
     {{/isEnum}}
 {{/vars}}
-}{{/hasEnums}}i
+}{{/hasEnums}}
 

--- a/samples/client/petstore/typescript-angular-v2/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/model/order.ts
@@ -33,9 +33,5 @@ export interface Order {
 
 }
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
 }

--- a/samples/client/petstore/typescript-angular-v2/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/model/pet.ts
@@ -35,9 +35,5 @@ export interface Pet {
 
 }
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
 }

--- a/samples/client/petstore/typescript-angular-v2/npm/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/model/order.ts
@@ -33,9 +33,5 @@ export interface Order {
 
 }
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
 }

--- a/samples/client/petstore/typescript-angular-v2/npm/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/model/pet.ts
@@ -35,9 +35,5 @@ export interface Pet {
 
 }
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
 }

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/model/Order.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/model/Order.ts
@@ -33,9 +33,5 @@ export interface Order {
 
 }
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
 }

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/model/Pet.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/model/Pet.ts
@@ -35,9 +35,5 @@ export interface Pet {
 
 }
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
 }

--- a/samples/client/petstore/typescript-angular-v4/npm/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/model/order.ts
@@ -33,9 +33,5 @@ export interface Order {
 
 }
 export namespace Order {
-    export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
-    }
+    export type StatusEnum = 'placed' | 'approved' | 'delivered';
 }

--- a/samples/client/petstore/typescript-angular-v4/npm/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/model/pet.ts
@@ -35,9 +35,5 @@ export interface Pet {
 
 }
 export namespace Pet {
-    export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
-    }
+    export type StatusEnum = 'available' | 'pending' | 'sold';
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR changes the angular-typescript generator to emit a union of literals for swagger enums, e.g.:

    export type StatusEnum = 'open' | 'inProgress' | 'resolved' | 'closed';

or
    
    export type ResponseCode = 200 | 404;

enabling their easy use in angular templates, structural subtyping
among enums (in particular, different instances of the same enum
are now mutually assignable), improving type safety by preventing
incorrect widening, and permitting numeric enum values
(albeit without descriptive names)

Fixes #6206, #5146, #3500