### PR TITLE
Async-Scala Strip package name from the class name

### DIFF
--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -273,6 +273,13 @@
             <version>${diffutils-version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.8.47</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
            <groupId>com.atlassian.commonmark</groupId>
            <artifactId>commonmark</artifactId>

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
@@ -20,6 +20,7 @@ import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
+import org.apache.commons.lang3.StringUtils;
 
 public abstract class AbstractScalaCodegen extends DefaultCodegen {
 
@@ -182,6 +183,25 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
     @Override
     public String escapeUnsafeCharacters(String input) {
         return input.replace("*/", "*_/").replace("/*", "/_*");
+    }
+
+    protected String formatIdentifier(String name, boolean capitalized) {
+        String identifier = camelize(sanitizeName(name), true);
+        if (capitalized) {
+            identifier = StringUtils.capitalize(identifier);
+        }
+        if (identifier.matches("[a-zA-Z_$][\\w_$]+") && !isReservedWord(identifier)) {
+            return identifier;
+        }
+        return escapeReservedWord(identifier);
+    }
+
+    protected String stripPackageName(String input) {
+        if(StringUtils.isEmpty(input) || input.lastIndexOf(".") < 0)
+            return input;
+
+        int lastIndexOfDot = input.lastIndexOf(".");
+        return input.substring(lastIndexOfDot + 1);
     }
 
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AkkaScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AkkaScalaClientCodegen.java
@@ -230,17 +230,6 @@ public class AkkaScalaClientCodegen extends AbstractScalaCodegen implements Code
         return super.toOperationId(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, operationId));
     }
 
-    private String formatIdentifier(String name, boolean capitalized) {
-        String identifier = camelize(sanitizeName(name), true);
-        if (capitalized) {
-            identifier = StringUtils.capitalize(identifier);
-        }
-        if (identifier.matches("[a-zA-Z_$][\\w_$]+") && !isReservedWord(identifier)) {
-            return identifier;
-        }
-        return escapeReservedWord(identifier);
-    }
-
     @Override
     public String toParamName(String name) {
         return formatIdentifier(name, false);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AsyncScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AsyncScalaClientCodegen.java
@@ -1,10 +1,6 @@
 package io.swagger.codegen.languages;
 
-import io.swagger.codegen.CliOption;
-import io.swagger.codegen.CodegenConfig;
-import io.swagger.codegen.CodegenConstants;
-import io.swagger.codegen.CodegenType;
-import io.swagger.codegen.SupportingFile;
+import io.swagger.codegen.*;
 
 import java.io.File;
 import java.util.Arrays;
@@ -103,4 +99,15 @@ public class AsyncScalaClientCodegen extends AbstractScalaCodegen implements Cod
         // remove " to avoid code injection
         return input.replace("\"", "");
     }
+
+    @Override
+    public String toModelName(final String name) {
+        return formatIdentifier(stripPackageName(name), true);
+    }
+
+    @Override
+    public String toEnumName(CodegenProperty property) {
+        return formatIdentifier(stripPackageName(property.baseName), true);
+    }
+
 }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/AbstractScalaCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/AbstractScalaCodegenTest.java
@@ -1,0 +1,80 @@
+package io.swagger.codegen.languages;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class AbstractScalaCodegenTest {
+
+    private AbstractScalaCodegen abstractScalaCodegen;
+
+    @BeforeTest
+    public void setup() {
+        this.abstractScalaCodegen = new FakeScalaCodeGen();
+    }
+
+    @Test
+    public void shouldCamelCase() {
+        String className = "models.WebsiteBodyModel";
+
+        String result = abstractScalaCodegen.formatIdentifier(className, false);
+
+        Assert.assertTrue("modelsWebsiteBodyModel".equals(result));
+    }
+
+    @Test
+    public void shouldCamelCaseAndUpperCase() {
+        String className = "models.WebsiteBodyModel";
+
+        String result = abstractScalaCodegen.formatIdentifier(className, true);
+
+        Assert.assertTrue("ModelsWebsiteBodyModel".equals(result));
+    }
+
+    @Test
+    public void shouldEscapeReservedWords() {
+        String className = "ReservedWord";
+
+        String result = abstractScalaCodegen.formatIdentifier(className, true);
+
+        Assert.assertTrue("_ReservedWord".equals(result));
+    }
+
+    @Test
+    public void shouldReturnSameInputWhenNull() {
+        String result = abstractScalaCodegen.stripPackageName(null);
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnSameInputWhenEmpty() {
+        String input = "";
+        String result = abstractScalaCodegen.stripPackageName(input);
+
+        Assert.assertSame(result, input);
+    }
+
+    @Test
+    public void shouldReturnSameInputWhenValid() {
+        String input = "WebsiteBodyModel";
+        String result = abstractScalaCodegen.stripPackageName(input);
+
+        Assert.assertSame(result, input);
+    }
+
+    @Test
+    public void shouldStripPackageName() {
+        String input = "models.WebsiteBodyModel";
+        String result = abstractScalaCodegen.stripPackageName(input);
+
+        Assert.assertEquals(result, "WebsiteBodyModel");
+    }
+
+    private class FakeScalaCodeGen extends AbstractScalaCodegen {
+        public FakeScalaCodeGen() {
+            super();
+            this.reservedWords.add("reservedword");
+        }
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/AkkaScalaCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/AkkaScalaCodegenTest.java
@@ -1,0 +1,24 @@
+package io.swagger.codegen.languages;
+
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class AkkaScalaCodegenTest {
+
+    @Test
+    public void shouldCallFormatIdentifierOnGetModelName() {
+        String className = "models.WebsiteBodyModel";
+
+        AkkaScalaClientCodegen akkaScalaClientCodegen = new AkkaScalaClientCodegen();
+        AkkaScalaClientCodegen akkaScalaClientCodegenSpy = Mockito.spy(akkaScalaClientCodegen);
+
+        akkaScalaClientCodegenSpy.toModelName(className);
+
+        verify(akkaScalaClientCodegenSpy, times(1)).formatIdentifier(anyString(), anyBoolean());
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/AsyncScalaClientCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/AsyncScalaClientCodegenTest.java
@@ -1,0 +1,50 @@
+package io.swagger.codegen.languages;
+
+import io.swagger.codegen.CodegenProperty;
+import junit.framework.Assert;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class AsyncScalaClientCodegenTest {
+
+    private AsyncScalaClientCodegen asyncScalaClientCodegen;
+
+    @BeforeTest
+    public void setup() {
+        this.asyncScalaClientCodegen = new AsyncScalaClientCodegen();
+    }
+
+    @Test
+    public void shouldCallFormatIdentifierOnGetModelName() {
+        String className = "models.WebsiteBodyModel";
+
+        AsyncScalaClientCodegen asyncScalaClientCodegenSpy = Mockito.spy(asyncScalaClientCodegen);
+
+        String result = asyncScalaClientCodegenSpy.toModelName(className);
+
+        verify(asyncScalaClientCodegenSpy, times(1)).stripPackageName(anyString());
+        verify(asyncScalaClientCodegenSpy, times(1)).formatIdentifier(anyString(), anyBoolean());
+        Assert.assertEquals("WebsiteBodyModel", result);
+    }
+
+    @Test
+    public void shouldCallFormatIdentifierOnToEnumName() {
+        String className = "models.WebsiteBodyModel";
+
+        AsyncScalaClientCodegen asyncScalaClientCodegenSpy = Mockito.spy(asyncScalaClientCodegen);
+
+        CodegenProperty property = new CodegenProperty();
+        property.baseName = className;
+        String result = asyncScalaClientCodegenSpy.toEnumName(property);
+
+        verify(asyncScalaClientCodegenSpy, times(1)).stripPackageName(anyString());
+        verify(asyncScalaClientCodegenSpy, times(1)).formatIdentifier(anyString(), anyBoolean());
+        Assert.assertEquals("WebsiteBodyModel", result);
+    }
+}


### PR DESCRIPTION
This goal of this PR is to fix this [issue](https://github.com/swagger-api/swagger-codegen/issues/6234).

In fact, When generating a client using Async-scala module, the class name of the generated models contains the package like this "models.WebsiteBodyModel" which causes compilation errors.


