### PR TITLE
Fixed typo in the Abstract Eiffel class.

### DIFF
--- a/bin/eiffel-petstore.sh
+++ b/bin/eiffel-petstore.sh
@@ -26,6 +26,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l eiffel -o samples/client/petstore/eiffel/"
+args="$@ generate -i modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l eiffel -o samples/client/petstore/eiffel/"
 
-java $JAVA_OPTS -jar $executable $ags
+java $JAVA_OPTS -jar $executable $args

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/EiffelClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/EiffelClientCodegen.java
@@ -1,16 +1,19 @@
 package io.swagger.codegen.languages;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.swagger.codegen.CodegenConstants;
+import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.SupportingFile;
 
-public class EiffelClientCodegen extends AbstractEiffelCogegen {
+public class EiffelClientCodegen extends AbstractEiffelCodegen {
     static Logger LOGGER = LoggerFactory.getLogger(EiffelClientCodegen.class);
 
     protected String libraryTarget = "swagger_eiffel_client";
@@ -42,10 +45,9 @@ public class EiffelClientCodegen extends AbstractEiffelCogegen {
         super();
         uuid = UUID.randomUUID();
         uuidTest = UUID.randomUUID();
-        ;
         outputFolder = "generated-code/Eiffel";
         modelDocTemplateFiles.put("model_doc.mustache", ".md");
-        modelTemplateFiles.put("model.mustache", ".e");
+        modelTemplateFiles.put("model_generic.mustache", ".e");
         apiTemplateFiles.put("api.mustache", ".e");
         apiTestTemplateFiles.put("test/api_test.mustache", ".e");
         apiDocTemplateFiles.put("api_doc.mustache", ".md");
@@ -155,6 +157,53 @@ public class EiffelClientCodegen extends AbstractEiffelCogegen {
     public void setPackageVersion(String packageVersion) {
         this.packageVersion = packageVersion;
     }
+    
 
+    @Override
+    public String toEnumName(CodegenProperty property) {
+        return sanitizeName(property.name).toUpperCase() + "_ENUM";
+    }
+
+    @Override
+    public String toEnumVarName(String value, String datatype) {
+        if (value.length() == 0) {
+            return "EMPTY";
+        }
+
+        // for symbol, e.g. $, #
+        if (getSymbolName(value) != null) {
+            return getSymbolName(value).toUpperCase();
+        }
+
+        // number
+        if ("INTEGER_32".equals(datatype) || "INTEGER_64".equals(datatype) ||
+            "REAL_32".equals(datatype) || "REAL_64".equals(datatype)) {
+            String varName = "NUMBER_" + value;
+            varName = varName.replaceAll("-", "MINUS_");
+            varName = varName.replaceAll("\\+", "PLUS_");
+            varName = varName.replaceAll("\\.", "_DOT_");
+            return varName;
+        }
+
+        // string
+        String var = value.replaceAll("\\W+", "_").toLowerCase();
+        if (var.matches("\\d.*")) {
+            return "val_" + var;
+        } else if (var.startsWith("_")){
+            return "val" + var;
+        } else {
+            return "val_" + var;
+        }
+    }
+
+    @Override
+    public String toEnumValue(String value, String datatype) {
+        if ("INTEGER_32".equals(datatype) || "INTEGER_64".equals(datatype) ||
+            "REAL_32".equals(datatype) || "REAL_64".equals(datatype)) {
+            return value;
+        } else {
+            return "\"" + escapeText(value) + "\"";
+        }
+    }    
 
 }

--- a/modules/swagger-codegen/src/main/resources/Eiffel/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Eiffel/api.mustache
@@ -36,6 +36,7 @@ feature -- API Access
 			{{#queryParams}}
 			l_request.fill_query_params(api_client.parameter_to_tuple("{{#collectionFormat}}{{{collectionFormat}}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}));
 			{{/queryParams}}
+
 			{{#headerParams}}
 			if attached {{paramName}} as l_{{paramName}} then
 				l_request.add_header(l_{{paramName}}.out,"{{baseName}}");

--- a/modules/swagger-codegen/src/main/resources/Eiffel/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/Eiffel/api_client.mustache
@@ -123,7 +123,7 @@ feature -- Helper: OAuth Authentication
 
 feature -- Query Parameter Helpers
 
-	parameter_to_tuple (a_collection_format, a_name: STRING; a_value: ANY): LIST [TUPLE [name: STRING; value: STRING]]
+	parameter_to_tuple (a_collection_format, a_name: STRING; a_value: detachable ANY): LIST [TUPLE [name: STRING; value: STRING]]
 			-- A list of tuples with name and valule.
 			-- collectionFormat collection format (e.g. csv, tsv)
 			-- name Name
@@ -175,7 +175,12 @@ feature -- Query Parameter Helpers
 				end
 			else
 				create {ARRAYED_LIST [TUPLE [name: STRING; value: STRING]]} Result.make (1)
-				Result.force ([a_name,a_value.out])
+				if attached a_value then
+					Result.force ([a_name,a_value.out])
+				else
+					Result.force ([a_name,""])
+				end
+
 			end
 		end
 

--- a/modules/swagger-codegen/src/main/resources/Eiffel/ecf.mustache
+++ b/modules/swagger-codegen/src/main/resources/Eiffel/ecf.mustache
@@ -19,6 +19,7 @@
 		<library name="http_client" location="$ISE_LIBRARY\contrib\library\network\http_client\http_client-safe.ecf"/>
 		<library name="time" location="$ISE_LIBRARY\library\time\time-safe.ecf"/>
 		<library name="uri" location="$ISE_LIBRARY\library\text\uri\uri-safe.ecf"/>
+		<library name="uuid" location="$ISE_LIBRARY\library\uuid\uuid.ecf"/>
 		<cluster name="client" location=".\src" recursive="true"/>
 	</target>
 </system>

--- a/modules/swagger-codegen/src/main/resources/Eiffel/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/Eiffel/model.mustache
@@ -1,7 +1,3 @@
-{{>noteinfo}}
-{{#models}}
-{{#model}}
-
 class {{classname}} 
 
 inherit
@@ -18,7 +14,12 @@ inherit
 {{#parent}}
   {{{parent}}} 
       rename
-          out as out_{{{parentSchema}}} 
+          out as out_{{{parentSchema}}},
+          is_equal as is_equal_{{{parentSchema}}},
+          copy as copy_{{{parentSchema}}}
+      select
+          is_equal_{{{parentSchema}}},
+          copy_{{{parentSchema}}}     
       end   
 {{/parent}}
 
@@ -103,5 +104,3 @@ feature -- Change Element
         {{/vars}}
       end
 end
-{{/model}}
-{{/models}}

--- a/modules/swagger-codegen/src/main/resources/Eiffel/model_enum.mustache
+++ b/modules/swagger-codegen/src/main/resources/Eiffel/model_enum.mustache
@@ -1,0 +1,36 @@
+class {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}
+
+feature -- Access
+
+  value: detachable {{dataType}}
+      -- enumerated value.
+    note
+            option: stable
+    attribute
+    end
+
+feature -- Enum
+
+ {{#allowableValues}}
+ {{#enumVars}}
+ {{{name}}}: {{classname}}
+    once
+      create Result
+      Result.set_value ({{{value}}}){{^-last}}{{/-last}}{{#-last}}{{/-last}}
+    end
+
+  {{/enumVars}}
+ {{/allowableValues}}
+
+feature -- Element Change
+
+  set_value (a_val: like value)
+      -- Set `value' with `a_value'.
+    do
+      value := a_val
+    ensure
+      value_set: value = a_val
+    end
+
+
+end

--- a/modules/swagger-codegen/src/main/resources/Eiffel/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/Eiffel/model_generic.mustache
@@ -1,0 +1,7 @@
+{{>noteinfo}}
+{{#models}}
+{{#model}}
+{{#isEnum}}{{>model_enum}}{{/isEnum}}{{^isEnum}}{{>model}}{{/isEnum}}
+{{/model}}
+{{/models}}
+

--- a/modules/swagger-codegen/src/main/resources/Eiffel/test/ecf_test.mustache
+++ b/modules/swagger-codegen/src/main/resources/Eiffel/test/ecf_test.mustache
@@ -16,6 +16,8 @@
 		<library name="json" location="$ISE_LIBRARY\contrib\library\text\parser\json\library\json-safe.ecf" readonly="false"/>
 		<library name="testing" location="$ISE_LIBRARY\library\testing\testing-safe.ecf"/>
 		<library name="api_client" location="..\api_client.ecf" readonly="false"/>
+		<library name="time" location="$ISE_LIBRARY\library\time\time-safe.ecf"/>
+		<library name="uuid" location="$ISE_LIBRARY\library\uuid\uuid.ecf"/>
 		<cluster name="test" location=".\" recursive="true"/>
 	</target>
 </system>

--- a/samples/client/petstore/eiffel/api_client.ecf
+++ b/samples/client/petstore/eiffel/api_client.ecf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-16-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-16-0 http://www.eiffel.com/developers/xml/configuration-1-16-0.xsd" name="swagger_eiffel_client" uuid="1eca0519-e046-46a8-9a4a-e7b165399022" library_target="swagger_eiffel_client">	
+<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-16-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-16-0 http://www.eiffel.com/developers/xml/configuration-1-16-0.xsd" name="swagger_eiffel_client" uuid="e892c29a-3caa-456b-bc97-f488bba434b9" library_target="swagger_eiffel_client">	
 	<target name="swagger_eiffel_client">
 		<root all_classes="true"/>
 		<file_rule>
@@ -19,6 +19,7 @@
 		<library name="http_client" location="$ISE_LIBRARY\contrib\library\network\http_client\http_client-safe.ecf"/>
 		<library name="time" location="$ISE_LIBRARY\library\time\time-safe.ecf"/>
 		<library name="uri" location="$ISE_LIBRARY\library\text\uri\uri-safe.ecf"/>
+		<library name="uuid" location="$ISE_LIBRARY\library\uuid\uuid.ecf"/>
 		<cluster name="client" location=".\src" recursive="true"/>
 	</target>
 </system>

--- a/samples/client/petstore/eiffel/test/api_test.ecf
+++ b/samples/client/petstore/eiffel/test/api_test.ecf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-16-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-16-0 http://www.eiffel.com/developers/xml/configuration-1-16-0.xsd" name="test" 	uuid="852c8325-690a-42c3-b22e-21a39d723d98">
+<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-16-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-16-0 http://www.eiffel.com/developers/xml/configuration-1-16-0.xsd" name="test" 	uuid="28bb8709-c181-416f-8c3e-9eea7157da9f">
 	<target name="test">
 		<root feature="make" class="APPLICATION"/>
 		<file_rule>
@@ -16,6 +16,8 @@
 		<library name="json" location="$ISE_LIBRARY\contrib\library\text\parser\json\library\json-safe.ecf" readonly="false"/>
 		<library name="testing" location="$ISE_LIBRARY\library\testing\testing-safe.ecf"/>
 		<library name="api_client" location="..\api_client.ecf" readonly="false"/>
+		<library name="time" location="$ISE_LIBRARY\library\time\time-safe.ecf"/>
+		<library name="uuid" location="$ISE_LIBRARY\library\uuid\uuid.ecf"/>
 		<cluster name="test" location=".\" recursive="true"/>
 	</target>
 </system>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR added Enum support and fixes
Fixed typo in the Abstract Eiffel class.
Fixed typo in shell script
Added support for Outer Enums, inner enums not supported.
Added missing UUID library in ecf configuration template.
Improved Model inheritance.

