### PR TITLE
Fix returnBaseType in Map response

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2181,6 +2181,10 @@ public class DefaultCodegen {
                         ArrayProperty ap = (ArrayProperty) responseProperty;
                         CodegenProperty innerProperty = fromProperty("response", ap.getItems());
                         op.returnBaseType = innerProperty.baseType;
+                    } else if (responseProperty instanceof MapProperty) {
+                        MapProperty ap = (MapProperty) responseProperty;
+                        CodegenProperty innerProperty = fromProperty("response", ap.getAdditionalProperties());
+                        op.returnBaseType = innerProperty.baseType;
                     } else {
                         if (cm.complexType != null) {
                             op.returnBaseType = cm.complexType;
@@ -3658,7 +3662,7 @@ public class DefaultCodegen {
      * writes it back to additionalProperties to be usable as a boolean in
      * mustache files.
      *
-     * @param propertyKey
+     * @param propertyKey property key
      * @return property value as boolean
      */
     public boolean convertPropertyToBooleanAndWriteBack(String propertyKey) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/InlineModelResolver.java
@@ -400,8 +400,8 @@ public class InlineModelResolver {
     /**
      * Make a RefProperty
      * 
-     * @param ref
-     * @param property
+     * @param ref new property name
+     * @param property Property
      * @return
      */
     public Property makeRefProperty(String ref, Property property) {
@@ -413,8 +413,8 @@ public class InlineModelResolver {
     /**
      * Copy vendor extensions from Property to another Property
      * 
-     * @param source
-     * @param target
+     * @param source soruce property
+     * @param target target property
      */
     public void copyVendorExtensions(Property source, AbstractProperty target) {
         Map<String, Object> vendorExtensions = source.getVendorExtensions();


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fix returnBaseType in Map response  (which was not handled before)
