### PR TITLE
[Java] Support custom ok-http authenticators

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -92,13 +92,21 @@ public class ApiClient {
         // Set default User-Agent.
         setUserAgent("{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}Swagger-Codegen/{{{artifactVersion}}}/java{{/httpUserAgent}}");
 
-        // Setup authentications (key: authentication name, value: authentication).
+        // Prevent the authentications from being modified.
+        authentications = Collections.unmodifiableMap(getClientAuthentications());
+    }
+
+    /**
+     * Get authentications to be used by this API client.
+     *
+     * @return authentications (key: authentication name, value: authentication).
+     */
+    protected Map<String, Authentication> getClientAuthentications() {
         authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}
         authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
-        // Prevent the authentications from being modified.
-        authentications = Collections.unmodifiableMap(authentications);
+        return authentications;
     }
 
     /**


### PR DESCRIPTION


### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Users who want to supply custom authenticators can subclass `ApiClient` and override `getClientAuthenticators`.

Waiting on https://github.com/swagger-api/swagger-codegen/pull/6256 to update petstore samples.
