### PR TITLE
Add useTags option to JavaJersey server codegen

### DIFF
--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/jaxrs/JaxRSServerOptionsTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/jaxrs/JaxRSServerOptionsTest.java
@@ -75,6 +75,8 @@ public class JaxRSServerOptionsTest extends AbstractOptionsTest {
             clientCodegen.setSupportJava6(false);
             times = 1;
             clientCodegen.setUseBeanValidation(Boolean.valueOf(JaxRSServerOptionsProvider.USE_BEANVALIDATION));
+            times = 1;           
+            clientCodegen.setUseTags(Boolean.valueOf(JaxRSServerOptionsProvider.USE_TAGS));
             times = 1;
         }};
     }

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/JaxRSServerOptionsProvider.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.swagger.codegen.CodegenConstants;
 import io.swagger.codegen.languages.JavaCXFServerCodegen;
 import io.swagger.codegen.languages.JavaClientCodegen;
+import io.swagger.codegen.languages.JavaJerseyServerCodegen;
 
 import java.util.Map;
 
@@ -39,6 +40,7 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String JAVA8_MODE_VALUE = "false";
     public static final String WITH_XML_VALUE = "false";
+    public static final String USE_TAGS = "useTags";
 
 
     @Override
@@ -89,7 +91,8 @@ public class JaxRSServerOptionsProvider implements OptionsProvider {
             .put("hideGenerationTimestamp", "true")
             .put(JavaCXFServerCodegen.USE_BEANVALIDATION, USE_BEANVALIDATION)
             .put("serverPort", "2345")
-            .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE);
+            .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
+            .put(JavaJerseyServerCodegen.USE_TAGS, USE_TAGS);
 
         return builder.build();
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Adds a useTags additional property to the Java Jersey JaxRS server codegen. Allows for generation to create sevice/factories according to specified tags rather than root of URL stem.

#6218

