### PR TITLE
Fix unexpected text error in javadoc by replacing url with html tag

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api.mustache
@@ -57,7 +57,7 @@ public class {{classname}} {
    {{/isDeprecated}}
    {{#externalDocs}}
    * {{description}}
-   * @see {{url}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/api.mustache
@@ -32,7 +32,7 @@ public interface {{classname}} extends ApiClient.Api {
 {{/returnType}}
 {{#externalDocs}}
   * {{description}}
-  * @see {{url}}
+  * @see <a href="{{url}}">{{summary}} Documentation</a>
 {{/externalDocs}}
    */
   @RequestLine("{{httpMethod}} {{{path}}}{{#hasQueryParams}}?{{/hasQueryParams}}{{#queryParams}}{{baseName}}={{=<% %>=}}{<%paramName%>}<%={{ }}=%>{{#hasMore}}&{{/hasMore}}{{/queryParams}}")
@@ -70,7 +70,7 @@ public interface {{classname}} extends ApiClient.Api {
       {{/returnType}}
       {{#externalDocs}}
    * {{description}}
-   * @see {{url}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
       {{/externalDocs}}
    */
   @RequestLine("{{httpMethod}} {{{path}}}?{{#queryParams}}{{baseName}}={{=<% %>=}}{<%paramName%>}<%={{ }}=%>{{#hasMore}}&{{/hasMore}}{{/queryParams}}")

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -54,7 +54,7 @@ public class {{classname}} {
    {{/isDeprecated}}
    {{#externalDocs}}
    * {{description}}
-   * @see {{url}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -72,7 +72,7 @@ public class {{classname}} {
      * @throws ApiException If fail to serialize the request body object
         {{#externalDocs}}
      * {{description}}
-     * @see {{url}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
         {{/externalDocs}}
      */
     public com.squareup.okhttp.Call {{operationId}}Call({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
@@ -177,7 +177,7 @@ public class {{classname}} {
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
         {{#externalDocs}}
      * {{description}}
-     * @see {{url}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
         {{/externalDocs}}
      */
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
@@ -193,7 +193,7 @@ public class {{classname}} {
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
         {{#externalDocs}}
      * {{description}}
-     * @see {{url}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
         {{/externalDocs}}
      */
     public ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
@@ -211,7 +211,7 @@ public class {{classname}} {
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
         {{#externalDocs}}
      * {{description}}
-     * @see {{url}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
         {{/externalDocs}}
      */
     public com.squareup.okhttp.Call {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{localVariablePrefix}}callback) throws ApiException {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/api.mustache
@@ -50,7 +50,7 @@ public class {{classname}} {
    {{/isDeprecated}}
    {{#externalDocs}}
    * {{description}}
-   * @see {{url}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
    {{/externalDocs}}
    */
   public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/api.mustache
@@ -57,7 +57,7 @@ public class {{classname}} {
 {{/returnType}}     * @throws RestClientException if an error occurs while attempting to invoke the API
 {{#externalDocs}}
     * {{description}}
-    * @see {{url}}
+    * @see <a href="{{url}}">{{summary}} Documentation</a>
 {{/externalDocs}}
      */
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws RestClientException {

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/api.mustache
@@ -31,7 +31,7 @@ public interface {{classname}} {
 {{/returnType}}
 {{#externalDocs}}
    * {{description}}
-   * @see {{url}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
 {{/externalDocs}}
    */
   {{#formParams}}{{#-first}}
@@ -50,7 +50,7 @@ public interface {{classname}} {
    * @param cb callback method
 {{#externalDocs}}
    * {{description}}
-   * @see {{url}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
 {{/externalDocs}}
    */
   {{#formParams}}{{#-first}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
@@ -42,7 +42,7 @@ public interface {{classname}} {
    * @return Call&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Object{{/returnType}}&gt;
 {{#externalDocs}}
    * {{description}}
-   * @see {{url}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
 {{/externalDocs}}
    */
   {{#formParams}}

--- a/samples/client/petstore/java/jersey1/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey1/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/jersey2-java6/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/jersey2-java8/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/jersey2/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/StoreApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/okhttp-gson/docs/StoreApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/resteasy/docs/StoreApi.md
+++ b/samples/client/petstore/java/resteasy/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/StoreApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/resttemplate/docs/StoreApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/StoreApi.md
@@ -95,7 +95,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/retrofit2/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/StoreApi.md
@@ -95,7 +95,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/retrofit2rx/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/StoreApi.md
@@ -95,7 +95,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/StoreApi.md
@@ -95,7 +95,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

