### PR TITLE
[JAVA-VERTX] make Vertx client support running on different contexts

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -40,10 +40,11 @@ public class ApiClient {
     private static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
 
     private final Vertx vertx;
+    private final JsonObject config;
+    private final String identifier;
 
     private MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
     private Map<String, Authentication> authentications;
-    private WebClient webClient;
     private String basePath = "{{{basePath}}}";
     private DateFormat dateFormat;
     private ObjectMapper objectMapper;
@@ -84,9 +85,8 @@ public class ApiClient {
         // Configurations
         this.basePath = config.getString("basePath", this.basePath);
         this.downloadsDir = config.getString("downloadsDir", this.downloadsDir);
-
-        // Build WebClient
-        this.webClient = buildWebClient(vertx, config);
+        this.config = config;
+        this.identifier = UUID.randomUUID().toString();
     }
 
     public Vertx getVertx() {
@@ -102,13 +102,14 @@ public class ApiClient {
         return this;
     }
 
-    public WebClient getWebClient() {
+    public synchronized WebClient getWebClient() {
+        String webClientIdentifier = "web-client-" + identifier;
+        WebClient webClient = Vertx.currentContext().get(webClientIdentifier);
+        if (webClient == null) {
+            webClient = buildWebClient(vertx, config);
+            Vertx.currentContext().put(webClientIdentifier, webClient);
+        }
         return webClient;
-    }
-
-    public ApiClient setWebClient(WebClient webClient) {
-        this.webClient = webClient;
-        return this;
     }
 
     public String getBasePath() {
@@ -428,7 +429,7 @@ public class ApiClient {
         }
 
         HttpMethod httpMethod = HttpMethod.valueOf(method);
-        HttpRequest<Buffer> request = webClient.requestAbs(httpMethod, basePath + path);
+        HttpRequest<Buffer> request = getWebClient().requestAbs(httpMethod, basePath + path);
 
         if (httpMethod == HttpMethod.PATCH) {
             request.putHeader("X-HTTP-Method-Override", "PATCH");

--- a/samples/client/petstore/java/vertx/docs/StoreApi.md
+++ b/samples/client/petstore/java/vertx/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/AdditionalPropertiesClass.java
@@ -127,6 +127,6 @@ public class AdditionalPropertiesClass {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Animal.java
@@ -115,6 +115,6 @@ public class Animal {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/AnimalFarm.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/AnimalFarm.java
@@ -60,6 +60,6 @@ public class AnimalFarm extends ArrayList<Animal> {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ArrayOfArrayOfNumberOnly.java
@@ -96,6 +96,6 @@ public class ArrayOfArrayOfNumberOnly {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ArrayOfNumberOnly.java
@@ -96,6 +96,6 @@ public class ArrayOfNumberOnly {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ArrayTest.java
@@ -158,6 +158,6 @@ public class ArrayTest {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Capitalization.java
@@ -200,6 +200,6 @@ public class Capitalization {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Cat.java
@@ -87,6 +87,6 @@ public class Cat extends Animal {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Category.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Category.java
@@ -108,6 +108,6 @@ public class Category {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ClassModel.java
@@ -86,6 +86,6 @@ public class ClassModel {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Client.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Client.java
@@ -85,6 +85,6 @@ public class Client {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Dog.java
@@ -87,6 +87,6 @@ public class Dog extends Animal {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/EnumArrays.java
@@ -188,6 +188,6 @@ public class EnumArrays {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/EnumTest.java
@@ -262,6 +262,6 @@ public class EnumTest {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/FormatTest.java
@@ -375,6 +375,6 @@ public class FormatTest {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/HasOnlyReadOnly.java
@@ -90,6 +90,6 @@ public class HasOnlyReadOnly {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/MapTest.java
@@ -162,6 +162,6 @@ public class MapTest {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -145,6 +145,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Model200Response.java
@@ -109,6 +109,6 @@ public class Model200Response {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ModelApiResponse.java
@@ -131,6 +131,6 @@ public class ModelApiResponse {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ModelReturn.java
@@ -86,6 +86,6 @@ public class ModelReturn {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Name.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Name.java
@@ -137,6 +137,6 @@ public class Name {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/NumberOnly.java
@@ -86,6 +86,6 @@ public class NumberOnly {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Order.java
@@ -238,6 +238,6 @@ public class Order {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/OuterComposite.java
@@ -132,6 +132,6 @@ public class OuterComposite {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Pet.java
@@ -254,6 +254,6 @@ public class Pet {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/ReadOnlyFirst.java
@@ -99,6 +99,6 @@ public class ReadOnlyFirst {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/SpecialModelName.java
@@ -85,6 +85,6 @@ public class SpecialModelName {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/Tag.java
@@ -108,6 +108,6 @@ public class Tag {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/User.java
+++ b/samples/client/petstore/java/vertx/src/main/java/io/swagger/client/model/User.java
@@ -246,6 +246,6 @@ public class User {
     }
     return o.toString().replace("\n", "\n    ");
   }
-  
+
 }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Current generated VertX clients do not support running on different contexts (e.g.: verticles), which means we cannot have a singleton client, and must instead instantiate new ones for each context.

This PR adds support to singleton Vertx clients.
This is achieved by having the generated API client instantiate WebClient for the context it is running in, and cache it within the context, to avoid having to recreate it on each invocation.
