### PR TITLE
[Java] fix a bug whereby OAuth intercept method calls itself forever

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/auth/OAuth.mustache
@@ -112,7 +112,7 @@ public class OAuth implements Interceptor {
             Response response = chain.proceed(rb.build());
     
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
                     return retryingIntercept( chain, false );
                 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/auth/OAuth.mustache
@@ -73,6 +73,10 @@ public class OAuth implements Interceptor {
     public Response intercept(Chain chain)
             throws IOException {
 
+        return retryingIntercept(chain, true);
+    }
+
+    private Response retryingIntercept(Chain chain, boolean updateTokenAndRetryOnAuthorizationFailure) throws IOException {
         Request request = chain.request();
 
         // If the request already have an authorization (eg. Basic auth), do nothing
@@ -107,11 +111,10 @@ public class OAuth implements Interceptor {
             //Execute the request
             Response response = chain.proceed(rb.build());
     
-            // 401 most likely indicates that access token has expired.
-            // Time to refresh and resend the request
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) ) {
+            // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
-                    return intercept( chain );
+                    return retryingIntercept( chain, false );
                 }
             }
             return response;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/auth/OAuth.mustache
@@ -112,7 +112,7 @@ public class OAuth implements Interceptor {
             Response response = chain.proceed(rb.build());
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
                     return retryingIntercept( chain, false );
                 }

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/auth/OAuth.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/auth/OAuth.mustache
@@ -73,6 +73,10 @@ public class OAuth implements Interceptor {
     public Response intercept(Chain chain)
             throws IOException {
 
+        return retryingIntercept(chain, true);
+    }
+
+    private Response retryingIntercept(Chain chain, boolean updateTokenAndRetryOnAuthorizationFailure) throws IOException {
         Request request = chain.request();
 
         // If the request already have an authorization (eg. Basic auth), do nothing
@@ -107,11 +111,10 @@ public class OAuth implements Interceptor {
             //Execute the request
             Response response = chain.proceed(rb.build());
 
-            // 401 most likely indicates that access token has expired.
-            // Time to refresh and resend the request
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) ) {
+            // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
-                    return intercept( chain );
+                    return retryingIntercept( chain, false );
                 }
             }
             return response;

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/auth/OAuth.java
@@ -112,7 +112,7 @@ public class OAuth implements Interceptor {
             Response response = chain.proceed(rb.build());
     
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
                     return retryingIntercept( chain, false );
                 }

--- a/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/io/swagger/client/auth/OAuth.java
@@ -73,6 +73,10 @@ public class OAuth implements Interceptor {
     public Response intercept(Chain chain)
             throws IOException {
 
+        return retryingIntercept(chain, true);
+    }
+
+    private Response retryingIntercept(Chain chain, boolean updateTokenAndRetryOnAuthorizationFailure) throws IOException {
         Request request = chain.request();
 
         // If the request already have an authorization (eg. Basic auth), do nothing
@@ -107,11 +111,10 @@ public class OAuth implements Interceptor {
             //Execute the request
             Response response = chain.proceed(rb.build());
     
-            // 401 most likely indicates that access token has expired.
-            // Time to refresh and resend the request
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) ) {
+            // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
-                    return intercept( chain );
+                    return retryingIntercept( chain, false );
                 }
             }
             return response;

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -112,7 +112,7 @@ public class OAuth implements Interceptor {
             Response response = chain.proceed(rb.build());
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
                     return retryingIntercept( chain, false );
                 }

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -73,6 +73,10 @@ public class OAuth implements Interceptor {
     public Response intercept(Chain chain)
             throws IOException {
 
+        return retryingIntercept(chain, true);
+    }
+
+    private Response retryingIntercept(Chain chain, boolean updateTokenAndRetryOnAuthorizationFailure) throws IOException {
         Request request = chain.request();
 
         // If the request already have an authorization (eg. Basic auth), do nothing
@@ -107,11 +111,10 @@ public class OAuth implements Interceptor {
             //Execute the request
             Response response = chain.proceed(rb.build());
 
-            // 401 most likely indicates that access token has expired.
-            // Time to refresh and resend the request
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) ) {
+            // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
-                    return intercept( chain );
+                    return retryingIntercept( chain, false );
                 }
             }
             return response;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/auth/OAuth.java
@@ -112,7 +112,7 @@ public class OAuth implements Interceptor {
             Response response = chain.proceed(rb.build());
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
                     return retryingIntercept( chain, false );
                 }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/auth/OAuth.java
@@ -73,6 +73,10 @@ public class OAuth implements Interceptor {
     public Response intercept(Chain chain)
             throws IOException {
 
+        return retryingIntercept(chain, true);
+    }
+
+    private Response retryingIntercept(Chain chain, boolean updateTokenAndRetryOnAuthorizationFailure) throws IOException {
         Request request = chain.request();
 
         // If the request already have an authorization (eg. Basic auth), do nothing
@@ -107,11 +111,10 @@ public class OAuth implements Interceptor {
             //Execute the request
             Response response = chain.proceed(rb.build());
 
-            // 401 most likely indicates that access token has expired.
-            // Time to refresh and resend the request
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) ) {
+            // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
-                    return intercept( chain );
+                    return retryingIntercept( chain, false );
                 }
             }
             return response;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -112,7 +112,7 @@ public class OAuth implements Interceptor {
             Response response = chain.proceed(rb.build());
 
             // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED || response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
                     return retryingIntercept( chain, false );
                 }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/auth/OAuth.java
@@ -73,6 +73,10 @@ public class OAuth implements Interceptor {
     public Response intercept(Chain chain)
             throws IOException {
 
+        return retryingIntercept(chain, true);
+    }
+
+    private Response retryingIntercept(Chain chain, boolean updateTokenAndRetryOnAuthorizationFailure) throws IOException {
         Request request = chain.request();
 
         // If the request already have an authorization (eg. Basic auth), do nothing
@@ -107,11 +111,10 @@ public class OAuth implements Interceptor {
             //Execute the request
             Response response = chain.proceed(rb.build());
 
-            // 401 most likely indicates that access token has expired.
-            // Time to refresh and resend the request
-            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) ) {
+            // 401/403 most likely indicates that access token has expired. Unless it happens two times in a row.
+            if ( response != null && (response.code() == HTTP_UNAUTHORIZED | response.code() == HTTP_FORBIDDEN) && updateTokenAndRetryOnAuthorizationFailure ) {
                 if (updateAccessToken(requestAccessToken)) {
-                    return intercept( chain );
+                    return retryingIntercept( chain, false );
                 }
             }
             return response;


### PR DESCRIPTION
When the response is 401 or 403, the interceptor assumes that it is because of token so it keeps retrying the request with new token. However if the response status is due to the fact that authorization to the api endpoint failed, and not due to invalid token, then a recursive operation of updating token and re-requesting the failed request happens.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

For second point, I committed the files affected by my change. There were many generated files by the shell scripts which I ignored. Ran maven integration tests and they pass.

### Description of the PR

This PR fixes the bug described in https://github.com/swagger-api/swagger-codegen/issues/6288 (and above too)

The fix is to not retry making the api request when receiving 401 (or 403) for a second time, and just return the 401 (or 403) response.