### PR TITLE
[Scala] Strip package name from the class name

### DIFF
--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -278,6 +278,12 @@
            <artifactId>commonmark</artifactId>
            <version>0.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.8.47</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
     <repositories>

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractScalaCodegen.java
@@ -20,6 +20,7 @@ import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
+import org.apache.commons.lang3.StringUtils;
 
 public abstract class AbstractScalaCodegen extends DefaultCodegen {
 
@@ -31,18 +32,18 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
         super();
 
         languageSpecificPrimitives.addAll(Arrays.asList(
-                        "String",
-                        "boolean",
-                        "Boolean",
-                        "Double",
-                        "Int",
-                        "Long",
-                        "Float",
-                        "Object",
-                        "Any",
-                        "List",
-                        "Seq",
-                        "Map"));
+                "String",
+                "boolean",
+                "Boolean",
+                "Double",
+                "Int",
+                "Long",
+                "Float",
+                "Object",
+                "Any",
+                "List",
+                "Seq",
+                "Map"));
 
         cliOptions.add(new CliOption(CodegenConstants.MODEL_PACKAGE, CodegenConstants.MODEL_PACKAGE_DESC));
         cliOptions.add(new CliOption(CodegenConstants.API_PACKAGE, CodegenConstants.API_PACKAGE_DESC));
@@ -67,8 +68,8 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
     }
 
     @Override
-    public String escapeReservedWord(String name) {           
-        if(this.reservedWordsMappings().containsKey(name)) {
+    public String escapeReservedWord(String name) {
+        if (this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
         }
         return "_" + name;
@@ -93,7 +94,7 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
         } else if (p instanceof MapProperty) {
             MapProperty mp = (MapProperty) p;
             Property inner = mp.getAdditionalProperties();
-    
+
             return getSwaggerType(p) + "[String, " + getTypeDeclaration(inner) + "]";
         }
         return super.getTypeDeclaration(p);
@@ -184,4 +185,22 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
         return input.replace("*/", "*_/").replace("/*", "/_*");
     }
 
+    protected String formatIdentifier(String name, boolean capitalized) {
+        String identifier = camelize(sanitizeName(name), true);
+        if (capitalized) {
+            identifier = StringUtils.capitalize(identifier);
+        }
+        if (identifier.matches("[a-zA-Z_$][\\w_$]+") && !isReservedWord(identifier)) {
+            return identifier;
+        }
+        return escapeReservedWord(identifier);
+    }
+
+    protected String stripPackageName(String input) {
+        if (StringUtils.isEmpty(input) || input.lastIndexOf(".") < 0)
+            return input;
+
+        int lastIndexOfDot = input.lastIndexOf(".");
+        return input.substring(lastIndexOfDot + 1);
+    }
 }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AkkaScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AkkaScalaClientCodegen.java
@@ -230,17 +230,6 @@ public class AkkaScalaClientCodegen extends AbstractScalaCodegen implements Code
         return super.toOperationId(CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, operationId));
     }
 
-    private String formatIdentifier(String name, boolean capitalized) {
-        String identifier = camelize(sanitizeName(name), true);
-        if (capitalized) {
-            identifier = StringUtils.capitalize(identifier);
-        }
-        if (identifier.matches("[a-zA-Z_$][\\w_$]+") && !isReservedWord(identifier)) {
-            return identifier;
-        }
-        return escapeReservedWord(identifier);
-    }
-
     @Override
     public String toParamName(String name) {
         return formatIdentifier(name, false);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaClientCodegen.java
@@ -1,10 +1,6 @@
 package io.swagger.codegen.languages;
 
-import io.swagger.codegen.CliOption;
-import io.swagger.codegen.CodegenConfig;
-import io.swagger.codegen.CodegenConstants;
-import io.swagger.codegen.CodegenType;
-import io.swagger.codegen.SupportingFile;
+import io.swagger.codegen.*;
 
 import java.io.File;
 import java.util.Arrays;
@@ -210,7 +206,7 @@ public class ScalaClientCodegen extends AbstractScalaCodegen implements CodegenC
 
     @Override
     public String toModelName(final String name) {
-        final String sanitizedName = sanitizeName(modelNamePrefix + name + modelNameSuffix);
+        final String sanitizedName = sanitizeName(modelNamePrefix + this.stripPackageName(name) + modelNameSuffix);
     
         // camelize the model name
         // phone_number => PhoneNumber
@@ -231,6 +227,11 @@ public class ScalaClientCodegen extends AbstractScalaCodegen implements CodegenC
         }
     
         return camelizedName;
+    }
+
+    @Override
+    public String toEnumName(CodegenProperty property) {
+        return formatIdentifier(stripPackageName(property.baseName), true);
     }
 
     @Override

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/AbstractScalaCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/AbstractScalaCodegenTest.java
@@ -1,0 +1,80 @@
+package io.swagger.codegen.languages;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+public class AbstractScalaCodegenTest {
+
+    private AbstractScalaCodegen abstractScalaCodegen;
+
+    @BeforeTest
+    public void setup() {
+        this.abstractScalaCodegen = new FakeScalaCodeGen();
+    }
+
+    @Test
+    public void shouldCamelCase() {
+        String className = "models.WebsiteBodyModel";
+
+        String result = abstractScalaCodegen.formatIdentifier(className, false);
+
+        Assert.assertTrue("modelsWebsiteBodyModel".equals(result));
+    }
+
+    @Test
+    public void shouldCamelCaseAndUpperCase() {
+        String className = "models.WebsiteBodyModel";
+
+        String result = abstractScalaCodegen.formatIdentifier(className, true);
+
+        Assert.assertTrue("ModelsWebsiteBodyModel".equals(result));
+    }
+
+    @Test
+    public void shouldEscapeReservedWords() {
+        String className = "ReservedWord";
+
+        String result = abstractScalaCodegen.formatIdentifier(className, true);
+
+        Assert.assertTrue("_ReservedWord".equals(result));
+    }
+
+    @Test
+    public void shouldReturnSameInputWhenNull() {
+        String result = abstractScalaCodegen.stripPackageName(null);
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnSameInputWhenEmpty() {
+        String input = "";
+        String result = abstractScalaCodegen.stripPackageName(input);
+
+        Assert.assertSame(result, input);
+    }
+
+    @Test
+    public void shouldReturnSameInputWhenValid() {
+        String input = "WebsiteBodyModel";
+        String result = abstractScalaCodegen.stripPackageName(input);
+
+        Assert.assertSame(result, input);
+    }
+
+    @Test
+    public void shouldStripPackageName() {
+        String input = "models.WebsiteBodyModel";
+        String result = abstractScalaCodegen.stripPackageName(input);
+
+        Assert.assertEquals(result, "WebsiteBodyModel");
+    }
+
+    private class FakeScalaCodeGen extends AbstractScalaCodegen {
+        public FakeScalaCodeGen() {
+            super();
+            this.reservedWords.add("reservedword");
+        }
+    }
+}

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/ScalaCodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/languages/ScalaCodegenTest.java
@@ -1,0 +1,46 @@
+package io.swagger.codegen.languages;
+
+import io.swagger.codegen.CodegenProperty;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ScalaCodegenTest {
+
+    private ScalaClientCodegen scalaClientCodegen;
+
+    @BeforeTest
+    public void setup() {
+        this.scalaClientCodegen = new ScalaClientCodegen();
+    }
+
+    @Test
+    public void shouldCallFormatIdentifierOnGetModelName() {
+        String className = "models.WebsiteBodyModel";
+
+        ScalaClientCodegen scalaClientCodegenSpy = Mockito.spy(this.scalaClientCodegen);
+
+        String result = scalaClientCodegenSpy.toModelName(className);
+
+        verify(scalaClientCodegenSpy, times(1)).stripPackageName(anyString());
+        Assert.assertEquals("WebsiteBodyModel", result);
+    }
+
+    @Test
+    public void shouldCallFormatIdentifierOnToEnumName() {
+        String className = "models.WebsiteBodyModel";
+        ScalaClientCodegen scalaClientCodegenSpy = Mockito.spy(this.scalaClientCodegen);
+        CodegenProperty property = new CodegenProperty();
+        property.baseName = className;
+        String result = scalaClientCodegenSpy.toEnumName(property);
+        verify(scalaClientCodegenSpy, times(1)).stripPackageName(anyString());
+        verify(scalaClientCodegenSpy, times(1)).formatIdentifier(anyString(), anyBoolean());
+        Assert.assertEquals("WebsiteBodyModel", result);
+    }
+}


### PR DESCRIPTION
This goal of this PR is to fix this [issue](https://github.com/swagger-api/swagger-codegen/issues/6234).

In fact, When generating a client using scala module, the class name of the generated models contains the package like this "models.WebsiteBodyModel" which causes compilation errors.

This PR replaces this old one: https://github.com/swagger-api/swagger-codegen/pull/6235