### PR TITLE
[php] Fixed typo in codedocs (Swaagger -> Swagger)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/model.mustache
@@ -8,7 +8,7 @@
  *
  * @category Class
  * @package  {{invokerPackage}}
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Model/ModelReturn.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Animal.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/AnimalFarm.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/AnimalFarm.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/ApiResponse.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/ArrayTest.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Capitalization.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Cat.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Category.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/ClassModel.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Client.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Dog.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumArrays.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumClass.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumClass.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/EnumTest.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/FormatTest.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/HasOnlyReadOnly.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/MapTest.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Model200Response.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/ModelList.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/ModelReturn.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Name.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/NumberOnly.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Order.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterBoolean.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterBoolean.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterComposite.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterEnum.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterEnum.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterNumber.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterNumber.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterString.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/OuterString.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Pet.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/ReadOnlyFirst.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/SpecialModelName.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/Tag.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Model/User.php
@@ -6,7 +6,7 @@
  *
  * @category Class
  * @package  Swagger\Client
- * @author   Swaagger Codegen team
+ * @author   Swagger Codegen team
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 


### PR DESCRIPTION
The mustache template has a typo in the PHP codedoc block.
This PR fixes the template and the resulting sample petstore code files.