### PR TITLE
fix(codegen, nodejs-server): correct reponse.end

### DIFF
--- a/modules/swagger-codegen/src/main/resources/nodejs/writer.mustache
+++ b/modules/swagger-codegen/src/main/resources/nodejs/writer.mustache
@@ -39,5 +39,5 @@ var writeJson = exports.writeJson = function(response, arg1, arg2) {
     payload = JSON.stringify(payload, null, 2);
   }
   response.writeHead(code, {'Content-Type': 'application/json'});
-  response.end(payload, code);
+  response.end(payload);
 }


### PR DESCRIPTION
Don't send code with response.end because it's already set in writeHead.

Fixes #6292

