### PR TITLE
[python] Fix body check in rest.py

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/asyncio/rest.mustache
@@ -115,7 +115,7 @@ class RESTClientObject:
             if query_params:
                 url += '?' + urlencode(query_params)
             if re.search('json', headers['Content-Type'], re.IGNORECASE):
-                if body:
+                if body is not None:
                     body = json.dumps(body)
                 args["data"] = body
             elif headers['Content-Type'] == 'application/x-www-form-urlencoded':

--- a/modules/swagger-codegen/src/main/resources/python/rest.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/rest.mustache
@@ -132,7 +132,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,


### PR DESCRIPTION
Checking for "trueness" here is not sufficient.  An empty list has a truth
value of false so it will not be encoded as json and sent as the request
body as it should.  Instead we need to check explicitly if body is None.

