### PR TITLE
[typescript-angular] add customized encoder to use '+' char in query parameter #6306

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -84,6 +84,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         supportingFiles.add(new SupportingFile("rxjs-operators.mustache", getIndexDirectory(), "rxjs-operators.ts"));        
         supportingFiles.add(new SupportingFile("configuration.mustache", getIndexDirectory(), "configuration.ts"));
         supportingFiles.add(new SupportingFile("variables.mustache", getIndexDirectory(), "variables.ts"));
+        supportingFiles.add(new SupportingFile("encoder.mustache", getIndexDirectory(), "encoder.ts"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
 

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -15,6 +15,7 @@ import { {{classname}} } from '../{{filename}}';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 {{#withInterfaces}}
 import { {{classname}}Interface }                            from './{{classname}}Interface';
 {{/withInterfaces}}
@@ -118,7 +119,7 @@ export class {{classname}} {
         const path = this.basePath + '{{{path}}}'{{#pathParams}}
                     .replace('${' + '{{baseName}}' + '}', String({{paramName}})){{/pathParams}};
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 {{#allParams}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/encoder.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/encoder.mustache
@@ -1,0 +1,17 @@
+import { QueryEncoder } from "@angular/http";
+
+/**
+* CustomQueryEncoderHelper
+* Fix plus sign (+) not encoding, so sent as blank space
+* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+*/
+export class CustomQueryEncoderHelper extends QueryEncoder {
+    encodeKey(k: string): string {
+        k = super.encodeKey(k);
+        return k.replace(/\+/gi, '%2B');
+    }
+    encodeValue(v: string): string {
+        v = super.encodeValue(v);
+        return v.replace(/\+/gi, '%2B');
+    }
+}

--- a/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
@@ -25,6 +25,7 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -215,7 +216,7 @@ export class PetService {
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -266,7 +267,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -316,7 +317,7 @@ export class PetService {
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet/findByStatus';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'status' is not null or undefined
@@ -366,7 +367,7 @@ export class PetService {
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet/findByTags';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'tags' is not null or undefined
@@ -417,7 +418,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -459,7 +460,7 @@ export class PetService {
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -511,7 +512,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -578,7 +579,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}/uploadImage'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
@@ -24,6 +24,7 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -145,7 +146,7 @@ export class StoreService {
         const path = this.basePath + '/store/order/${orderId}'
                     .replace('${' + 'orderId' + '}', String(orderId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'orderId' is not null or undefined
@@ -181,7 +182,7 @@ export class StoreService {
     public getInventoryWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/store/inventory';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 
@@ -219,7 +220,7 @@ export class StoreService {
         const path = this.basePath + '/store/order/${orderId}'
                     .replace('${' + 'orderId' + '}', String(orderId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'orderId' is not null or undefined
@@ -256,7 +257,7 @@ export class StoreService {
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/store/order';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
@@ -24,6 +24,7 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -210,7 +211,7 @@ export class UserService {
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -250,7 +251,7 @@ export class UserService {
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/createWithArray';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -290,7 +291,7 @@ export class UserService {
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/createWithList';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -331,7 +332,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -369,7 +370,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -407,7 +408,7 @@ export class UserService {
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/login';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -455,7 +456,7 @@ export class UserService {
     public logoutUserWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/logout';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 
@@ -490,7 +491,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/encoder.ts
@@ -1,0 +1,17 @@
+import { QueryEncoder } from "@angular/http";
+
+/**
+* CustomQueryEncoderHelper
+* Fix plus sign (+) not encoding, so sent as blank space
+* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+*/
+export class CustomQueryEncoderHelper extends QueryEncoder {
+    encodeKey(k: string): string {
+        k = super.encodeKey(k);
+        return k.replace(/\+/gi, '%2B');
+    }
+    encodeValue(v: string): string {
+        v = super.encodeValue(v);
+        return v.replace(/\+/gi, '%2B');
+    }
+}

--- a/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
@@ -25,6 +25,7 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -215,7 +216,7 @@ export class PetService {
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -266,7 +267,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -316,7 +317,7 @@ export class PetService {
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet/findByStatus';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'status' is not null or undefined
@@ -366,7 +367,7 @@ export class PetService {
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet/findByTags';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'tags' is not null or undefined
@@ -417,7 +418,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -459,7 +460,7 @@ export class PetService {
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -511,7 +512,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -578,7 +579,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}/uploadImage'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
@@ -24,6 +24,7 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -145,7 +146,7 @@ export class StoreService {
         const path = this.basePath + '/store/order/${orderId}'
                     .replace('${' + 'orderId' + '}', String(orderId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'orderId' is not null or undefined
@@ -181,7 +182,7 @@ export class StoreService {
     public getInventoryWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/store/inventory';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 
@@ -219,7 +220,7 @@ export class StoreService {
         const path = this.basePath + '/store/order/${orderId}'
                     .replace('${' + 'orderId' + '}', String(orderId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'orderId' is not null or undefined
@@ -256,7 +257,7 @@ export class StoreService {
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/store/order';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
@@ -24,6 +24,7 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -210,7 +211,7 @@ export class UserService {
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -250,7 +251,7 @@ export class UserService {
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/createWithArray';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -290,7 +291,7 @@ export class UserService {
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/createWithList';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -331,7 +332,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -369,7 +370,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -407,7 +408,7 @@ export class UserService {
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/login';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -455,7 +456,7 @@ export class UserService {
     public logoutUserWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/logout';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 
@@ -490,7 +491,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/encoder.ts
@@ -1,0 +1,17 @@
+import { QueryEncoder } from "@angular/http";
+
+/**
+* CustomQueryEncoderHelper
+* Fix plus sign (+) not encoding, so sent as blank space
+* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+*/
+export class CustomQueryEncoderHelper extends QueryEncoder {
+    encodeKey(k: string): string {
+        k = super.encodeKey(k);
+        return k.replace(/\+/gi, '%2B');
+    }
+    encodeValue(v: string): string {
+        v = super.encodeValue(v);
+        return v.replace(/\+/gi, '%2B');
+    }
+}

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
@@ -25,6 +25,7 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 import { PetServiceInterface }                            from './PetServiceInterface';
 
 
@@ -216,7 +217,7 @@ export class PetService implements PetServiceInterface {
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -267,7 +268,7 @@ export class PetService implements PetServiceInterface {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -317,7 +318,7 @@ export class PetService implements PetServiceInterface {
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet/findByStatus';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'status' is not null or undefined
@@ -367,7 +368,7 @@ export class PetService implements PetServiceInterface {
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet/findByTags';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'tags' is not null or undefined
@@ -418,7 +419,7 @@ export class PetService implements PetServiceInterface {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -460,7 +461,7 @@ export class PetService implements PetServiceInterface {
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -512,7 +513,7 @@ export class PetService implements PetServiceInterface {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -579,7 +580,7 @@ export class PetService implements PetServiceInterface {
         const path = this.basePath + '/pet/${petId}/uploadImage'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
@@ -24,6 +24,7 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 import { StoreServiceInterface }                            from './StoreServiceInterface';
 
 
@@ -146,7 +147,7 @@ export class StoreService implements StoreServiceInterface {
         const path = this.basePath + '/store/order/${orderId}'
                     .replace('${' + 'orderId' + '}', String(orderId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'orderId' is not null or undefined
@@ -182,7 +183,7 @@ export class StoreService implements StoreServiceInterface {
     public getInventoryWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/store/inventory';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 
@@ -220,7 +221,7 @@ export class StoreService implements StoreServiceInterface {
         const path = this.basePath + '/store/order/${orderId}'
                     .replace('${' + 'orderId' + '}', String(orderId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'orderId' is not null or undefined
@@ -257,7 +258,7 @@ export class StoreService implements StoreServiceInterface {
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/store/order';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
@@ -24,6 +24,7 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 import { UserServiceInterface }                            from './UserServiceInterface';
 
 
@@ -211,7 +212,7 @@ export class UserService implements UserServiceInterface {
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -251,7 +252,7 @@ export class UserService implements UserServiceInterface {
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/createWithArray';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -291,7 +292,7 @@ export class UserService implements UserServiceInterface {
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/createWithList';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -332,7 +333,7 @@ export class UserService implements UserServiceInterface {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -370,7 +371,7 @@ export class UserService implements UserServiceInterface {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -408,7 +409,7 @@ export class UserService implements UserServiceInterface {
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/login';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -456,7 +457,7 @@ export class UserService implements UserServiceInterface {
     public logoutUserWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/logout';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 
@@ -491,7 +492,7 @@ export class UserService implements UserServiceInterface {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/encoder.ts
@@ -1,0 +1,17 @@
+import { QueryEncoder } from "@angular/http";
+
+/**
+* CustomQueryEncoderHelper
+* Fix plus sign (+) not encoding, so sent as blank space
+* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+*/
+export class CustomQueryEncoderHelper extends QueryEncoder {
+    encodeKey(k: string): string {
+        k = super.encodeKey(k);
+        return k.replace(/\+/gi, '%2B');
+    }
+    encodeValue(v: string): string {
+        v = super.encodeValue(v);
+        return v.replace(/\+/gi, '%2B');
+    }
+}

--- a/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
@@ -25,6 +25,7 @@ import { Pet } from '../model/pet';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -215,7 +216,7 @@ export class PetService {
     public addPetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -266,7 +267,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -316,7 +317,7 @@ export class PetService {
     public findPetsByStatusWithHttpInfo(status: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet/findByStatus';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'status' is not null or undefined
@@ -366,7 +367,7 @@ export class PetService {
     public findPetsByTagsWithHttpInfo(tags: Array<string>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet/findByTags';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'tags' is not null or undefined
@@ -417,7 +418,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -459,7 +460,7 @@ export class PetService {
     public updatePetWithHttpInfo(body: Pet, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/pet';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -511,7 +512,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined
@@ -578,7 +579,7 @@ export class PetService {
         const path = this.basePath + '/pet/${petId}/uploadImage'
                     .replace('${' + 'petId' + '}', String(petId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'petId' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
@@ -24,6 +24,7 @@ import { Order } from '../model/order';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -73,7 +74,7 @@ export class StoreService {
     }
 
     /**
-     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
@@ -104,7 +105,7 @@ export class StoreService {
     }
 
     /**
-     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
@@ -145,7 +146,7 @@ export class StoreService {
         const path = this.basePath + '/store/order/${orderId}'
                     .replace('${' + 'orderId' + '}', String(orderId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'orderId' is not null or undefined
@@ -181,7 +182,7 @@ export class StoreService {
     public getInventoryWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/store/inventory';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 
@@ -219,7 +220,7 @@ export class StoreService {
         const path = this.basePath + '/store/order/${orderId}'
                     .replace('${' + 'orderId' + '}', String(orderId));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'orderId' is not null or undefined
@@ -256,7 +257,7 @@ export class StoreService {
     public placeOrderWithHttpInfo(body: Order, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/store/order';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
@@ -24,6 +24,7 @@ import { User } from '../model/user';
 
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
+import { CustomQueryEncoderHelper }                          from '../encoder';
 
 
 @Injectable()
@@ -210,7 +211,7 @@ export class UserService {
     public createUserWithHttpInfo(body: User, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -250,7 +251,7 @@ export class UserService {
     public createUsersWithArrayInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/createWithArray';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -290,7 +291,7 @@ export class UserService {
     public createUsersWithListInputWithHttpInfo(body: Array<User>, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/createWithList';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'body' is not null or undefined
@@ -331,7 +332,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -369,7 +370,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -407,7 +408,7 @@ export class UserService {
     public loginUserWithHttpInfo(username: string, password: string, extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/login';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined
@@ -455,7 +456,7 @@ export class UserService {
     public logoutUserWithHttpInfo(extraHttpRequestParams?: any): Observable<Response> {
         const path = this.basePath + '/user/logout';
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
 
@@ -490,7 +491,7 @@ export class UserService {
         const path = this.basePath + '/user/${username}'
                     .replace('${' + 'username' + '}', String(username));
 
-        let queryParameters = new URLSearchParams();
+        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
         let headers = new Headers(this.defaultHeaders.toJSON()); // https://github.com/angular/angular/issues/6845
 
         // verify required parameter 'username' is not null or undefined

--- a/samples/client/petstore/typescript-angular-v4/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/configuration.ts
@@ -2,18 +2,18 @@ export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;
     password?: string;
-    accessToken?: string;
+    accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
 }
 
 export class Configuration {
-    apiKeys: {[ key: string ]: string};
-    username: string;
-    password: string;
-    accessToken: string | (() => string);
-    basePath: string;
-    withCredentials: boolean;
+    apiKeys?: {[ key: string ]: string};
+    username?: string;
+    password?: string;
+    accessToken?: string | (() => string);
+    basePath?: string;
+    withCredentials?: boolean;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;

--- a/samples/client/petstore/typescript-angular-v4/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/encoder.ts
@@ -1,0 +1,17 @@
+import { QueryEncoder } from "@angular/http";
+
+/**
+* CustomQueryEncoderHelper
+* Fix plus sign (+) not encoding, so sent as blank space
+* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+*/
+export class CustomQueryEncoderHelper extends QueryEncoder {
+    encodeKey(k: string): string {
+        k = super.encodeKey(k);
+        return k.replace(/\+/gi, '%2B');
+    }
+    encodeValue(v: string): string {
+        v = super.encodeValue(v);
+        return v.replace(/\+/gi, '%2B');
+    }
+}

--- a/samples/client/petstore/typescript-angular-v4/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v4/npm/package.json
@@ -35,6 +35,6 @@
     "typescript": "^2.1.5"
   },
   "publishConfig": {
-    "registry": "https://skimdb.npmjs.com/registry"
+    "registry":"https://skimdb.npmjs.com/registry"
   }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- Issue #6306 
- Add customized query encoder to use '+' character in query parameter

