### PR TITLE
[Java] Handle Long in enum correctly

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -1016,9 +1016,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String toEnumValue(String value, String datatype) {
-        if ("Integer".equals(datatype) || "Long".equals(datatype) ||
-            "Double".equals(datatype)) {
+        if ("Integer".equals(datatype) || "Double".equals(datatype)) {
             return value;
+        } else if ("Long".equals(datatype)) {
+            // add l to number, e.g. 2048 => 2048l
+            return value + "l";
         } else if ("Float".equals(datatype)) {
             // add f to number, e.g. 3.14 => 3.14f
             return value + "f";

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/model/FormatTest.java
@@ -13,15 +13,18 @@
 
 package io.swagger.client.model;
 
+import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-
-import javax.validation.Valid;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.util.Objects;
 import java.util.UUID;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
 
 /**
  * FormatTest


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

When used as an enum value, long values (those marked with format: int64 in an OAS spec) were not being suffixed with l. This means autoboxing (as Long is used in place of long) fails, preventing the code from compiling.

Sample broken before this change (build with  `-l java -Dmodels` or you'll get an NPE as there are no paths) and fixed after the change.

```
swagger: 2.0
definitions:
  BrokenEnum:
    type: object
    properties:
      long_value:
        enum:
          - 1
          - 2
        type: integer
        format: int64
```
Resolves #6338 

Note: I ran java-petstore-all.sh to update the samples - I'm unsure which one exactly the plain `java` language maps to, nor whether to just test everything since model changes can in theory affect them all.