### PR TITLE
[Java][JAX-RS] Fix pom in jaxrs-cxf-cdi

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>[1.5.3,2)</version>
+            <version>[1.5.3,1.5.16]</version>
         </dependency>
         
 {{#useBeanValidation}}

--- a/samples/server/petstore/jaxrs-cxf-cdi/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-cdi/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>[1.5.3,2)</version>
+            <version>[1.5.3,1.5.16]</version>
         </dependency>
         
        <!-- Bean Validation API support -->


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Update JAXRS-CXF-CDI pom.xml to avoid downloading the latest pre-release of io.swagger annotation lib.
