### PR TITLE
Fix swagger-api/swagger-codegen#6345. Wrap optional JSDoc parameter (…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/api.mustache
@@ -27,7 +27,7 @@
    * <description></description>
    * @alias module:<#invokerPackage><&invokerPackage>/</invokerPackage><#apiPackage><apiPackage>/</apiPackage><classname>
    * @class
-   * @param {module:<#invokerPackage><&invokerPackage>/</invokerPackage>ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:<#invokerPackage><&invokerPackage>/</invokerPackage>ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:<#invokerPackage><&invokerPackage>/</invokerPackage>ApiClient#instance} if unspecified.
    */
 </emitJSDoc>  var exports = function(apiClient) {

--- a/modules/swagger-codegen/src/main/resources/Javascript/es6/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/es6/api.mustache
@@ -17,7 +17,7 @@ export default class <classname> {
     * <description></description>
     * @alias module:<#invokerPackage><&invokerPackage>/</invokerPackage><#apiPackage><apiPackage>/</apiPackage><classname>
     * @class
-    * @param {module:<#invokerPackage><&invokerPackage>/</invokerPackage>ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:<#invokerPackage><&invokerPackage>/</invokerPackage>ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:<#invokerPackage><&invokerPackage>/</invokerPackage>ApiClient#instance} if unspecified.
     */</emitJSDoc>
     constructor(apiClient) {

--- a/samples/client/petstore-security-test/javascript/src/api/FakeApi.js
+++ b/samples/client/petstore-security-test/javascript/src/api/FakeApi.js
@@ -41,7 +41,7 @@
    * Constructs a new FakeApi. 
    * @alias module:api/FakeApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/FakeApi.js
@@ -30,7 +30,7 @@ export default class FakeApi {
     * Constructs a new FakeApi. 
     * @alias module:api/FakeApi
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-es6/src/api/Fake_classname_tags123Api.js
+++ b/samples/client/petstore/javascript-es6/src/api/Fake_classname_tags123Api.js
@@ -26,7 +26,7 @@ export default class Fake_classname_tags123Api {
     * Constructs a new Fake_classname_tags123Api. 
     * @alias module:api/Fake_classname_tags123Api
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-es6/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/PetApi.js
@@ -27,7 +27,7 @@ export default class PetApi {
     * Constructs a new PetApi. 
     * @alias module:api/PetApi
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-es6/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/StoreApi.js
@@ -26,7 +26,7 @@ export default class StoreApi {
     * Constructs a new StoreApi. 
     * @alias module:api/StoreApi
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-es6/src/api/UserApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/UserApi.js
@@ -26,7 +26,7 @@ export default class UserApi {
     * Constructs a new UserApi. 
     * @alias module:api/UserApi
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
@@ -30,7 +30,7 @@ export default class FakeApi {
     * Constructs a new FakeApi. 
     * @alias module:api/FakeApi
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-promise-es6/src/api/Fake_classname_tags123Api.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/Fake_classname_tags123Api.js
@@ -26,7 +26,7 @@ export default class Fake_classname_tags123Api {
     * Constructs a new Fake_classname_tags123Api. 
     * @alias module:api/Fake_classname_tags123Api
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-promise-es6/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/PetApi.js
@@ -27,7 +27,7 @@ export default class PetApi {
     * Constructs a new PetApi. 
     * @alias module:api/PetApi
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-promise-es6/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/StoreApi.js
@@ -26,7 +26,7 @@ export default class StoreApi {
     * Constructs a new StoreApi. 
     * @alias module:api/StoreApi
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-promise-es6/src/api/UserApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/UserApi.js
@@ -26,7 +26,7 @@ export default class UserApi {
     * Constructs a new UserApi. 
     * @alias module:api/UserApi
     * @class
-    * @param {module:ApiClient} apiClient Optional API client implementation to use,
+    * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
     * default to {@link module:ApiClient#instance} if unspecified.
     */
     constructor(apiClient) {

--- a/samples/client/petstore/javascript-promise/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/FakeApi.js
@@ -41,7 +41,7 @@
    * Constructs a new FakeApi. 
    * @alias module:api/FakeApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript-promise/src/api/Fake_classname_tags123Api.js
+++ b/samples/client/petstore/javascript-promise/src/api/Fake_classname_tags123Api.js
@@ -41,7 +41,7 @@
    * Constructs a new Fake_classname_tags123Api. 
    * @alias module:api/Fake_classname_tags123Api
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript-promise/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/PetApi.js
@@ -41,7 +41,7 @@
    * Constructs a new PetApi. 
    * @alias module:api/PetApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript-promise/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/StoreApi.js
@@ -41,7 +41,7 @@
    * Constructs a new StoreApi. 
    * @alias module:api/StoreApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript-promise/src/api/UserApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/UserApi.js
@@ -41,7 +41,7 @@
    * Constructs a new UserApi. 
    * @alias module:api/UserApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript/src/api/FakeApi.js
@@ -41,7 +41,7 @@
    * Constructs a new FakeApi. 
    * @alias module:api/FakeApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript/src/api/Fake_classname_tags123Api.js
+++ b/samples/client/petstore/javascript/src/api/Fake_classname_tags123Api.js
@@ -41,7 +41,7 @@
    * Constructs a new Fake_classname_tags123Api. 
    * @alias module:api/Fake_classname_tags123Api
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript/src/api/PetApi.js
+++ b/samples/client/petstore/javascript/src/api/PetApi.js
@@ -41,7 +41,7 @@
    * Constructs a new PetApi. 
    * @alias module:api/PetApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript/src/api/StoreApi.js
@@ -41,7 +41,7 @@
    * Constructs a new StoreApi. 
    * @alias module:api/StoreApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {

--- a/samples/client/petstore/javascript/src/api/UserApi.js
+++ b/samples/client/petstore/javascript/src/api/UserApi.js
@@ -41,7 +41,7 @@
    * Constructs a new UserApi. 
    * @alias module:api/UserApi
    * @class
-   * @param {module:ApiClient} apiClient Optional API client implementation to use,
+   * @param {module:ApiClient} [apiClient] Optional API client implementation to use,
    * default to {@link module:ApiClient#instance} if unspecified.
    */
   var exports = function(apiClient) {


### PR DESCRIPTION
…apiClient) in square brackets

### PR checklist

- [✓] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [✓] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [✓] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

apiClient JSDoc optional parameter wrapped in square brackets.
