### PR TITLE
[JavaPlayFramework ]Update the Java Play Framework generator to version 2.6.3

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/application.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/application.mustache
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 {{#handleExceptions}}
 play.http.errorHandler="swagger.ErrorHandler"
 {{/handleExceptions}}
@@ -44,7 +46,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -67,6 +69,11 @@ play.modules {
     {{^useInterfaces}}
     disabled += "Module"
     {{/useInterfaces}}
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -268,7 +275,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -282,7 +290,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/build.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/build.mustache
@@ -4,11 +4,12 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
 {{#useSwaggerUI}}
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.10-1"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.1.5"
 {{/useSwaggerUI}}
 {{#useBeanValidation}}
 libraryDependencies += "javax.validation" % "validation-api" % "1.1.0.Final"
 {{/useBeanValidation}}
+libraryDependencies += guice

--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/buildproperties.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/buildproperties.mustache
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/plugins.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/plugins.mustache
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/routes.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/routes.mustache
@@ -19,4 +19,5 @@ GET     /api                        controllers.ApiDocController.api
 {{/apiInfo}}
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework-controller-only/build.sbt
+++ b/samples/server/petstore/java-play-framework-controller-only/build.sbt
@@ -4,7 +4,8 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.10-1"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.1.5"
 libraryDependencies += "javax.validation" % "validation-api" % "1.1.0.Final"
+libraryDependencies += guice

--- a/samples/server/petstore/java-play-framework-controller-only/conf/application.conf
+++ b/samples/server/petstore/java-play-framework-controller-only/conf/application.conf
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 play.http.errorHandler="swagger.ErrorHandler"
 
 ## Akka
@@ -42,7 +44,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -60,6 +62,11 @@ play.modules {
 # explicitly below.
 # If there are any built-in modules that you want to disable, you can list them here.
     disabled += "Module"
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -261,7 +268,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -275,7 +283,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/samples/server/petstore/java-play-framework-controller-only/conf/routes
+++ b/samples/server/petstore/java-play-framework-controller-only/conf/routes
@@ -32,4 +32,5 @@ GET     /v2/user/logout                     controllers.UserApiController.logout
 PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework-controller-only/project/build.properties
+++ b/samples/server/petstore/java-play-framework-controller-only/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/samples/server/petstore/java-play-framework-controller-only/project/plugins.sbt
+++ b/samples/server/petstore/java-play-framework-controller-only/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/samples/server/petstore/java-play-framework-fake-endpoints/build.sbt
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/build.sbt
@@ -4,7 +4,8 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.10-1"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.1.5"
 libraryDependencies += "javax.validation" % "validation-api" % "1.1.0.Final"
+libraryDependencies += guice

--- a/samples/server/petstore/java-play-framework-fake-endpoints/conf/application.conf
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/conf/application.conf
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 play.http.errorHandler="swagger.ErrorHandler"
 
 ## Akka
@@ -42,7 +44,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -59,6 +61,11 @@ play.modules {
 # in the root package (the "app" directory), or you can define them
 # explicitly below.
 # If there are any built-in modules that you want to disable, you can list them here.
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -260,7 +267,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -274,7 +282,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/samples/server/petstore/java-play-framework-fake-endpoints/conf/routes
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/conf/routes
@@ -45,4 +45,5 @@ GET     /v2/user/logout                     controllers.UserApiController.logout
 PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework-fake-endpoints/project/build.properties
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/samples/server/petstore/java-play-framework-fake-endpoints/project/plugins.sbt
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/samples/server/petstore/java-play-framework-no-bean-validation/build.sbt
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/build.sbt
@@ -4,6 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.10-1"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.1.5"
+libraryDependencies += guice

--- a/samples/server/petstore/java-play-framework-no-bean-validation/conf/application.conf
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/conf/application.conf
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 play.http.errorHandler="swagger.ErrorHandler"
 
 ## Akka
@@ -42,7 +44,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -59,6 +61,11 @@ play.modules {
 # in the root package (the "app" directory), or you can define them
 # explicitly below.
 # If there are any built-in modules that you want to disable, you can list them here.
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -260,7 +267,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -274,7 +282,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/samples/server/petstore/java-play-framework-no-bean-validation/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/conf/routes
@@ -32,4 +32,5 @@ GET     /v2/user/logout                     controllers.UserApiController.logout
 PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework-no-bean-validation/project/build.properties
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/samples/server/petstore/java-play-framework-no-bean-validation/project/plugins.sbt
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/samples/server/petstore/java-play-framework-no-exception-handling/build.sbt
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/build.sbt
@@ -4,7 +4,8 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.10-1"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.1.5"
 libraryDependencies += "javax.validation" % "validation-api" % "1.1.0.Final"
+libraryDependencies += guice

--- a/samples/server/petstore/java-play-framework-no-exception-handling/conf/application.conf
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/conf/application.conf
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 
 ## Akka
 # https://www.playframework.com/documentation/latest/ScalaAkka#Configuration
@@ -41,7 +43,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -58,6 +60,11 @@ play.modules {
 # in the root package (the "app" directory), or you can define them
 # explicitly below.
 # If there are any built-in modules that you want to disable, you can list them here.
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -259,7 +266,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -273,7 +281,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/samples/server/petstore/java-play-framework-no-exception-handling/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/conf/routes
@@ -32,4 +32,5 @@ GET     /v2/user/logout                     controllers.UserApiController.logout
 PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework-no-exception-handling/project/build.properties
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/samples/server/petstore/java-play-framework-no-exception-handling/project/plugins.sbt
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/samples/server/petstore/java-play-framework-no-interface/build.sbt
+++ b/samples/server/petstore/java-play-framework-no-interface/build.sbt
@@ -4,7 +4,8 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.10-1"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.1.5"
 libraryDependencies += "javax.validation" % "validation-api" % "1.1.0.Final"
+libraryDependencies += guice

--- a/samples/server/petstore/java-play-framework-no-interface/conf/application.conf
+++ b/samples/server/petstore/java-play-framework-no-interface/conf/application.conf
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 play.http.errorHandler="swagger.ErrorHandler"
 
 ## Akka
@@ -42,7 +44,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -60,6 +62,11 @@ play.modules {
 # explicitly below.
 # If there are any built-in modules that you want to disable, you can list them here.
     disabled += "Module"
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -261,7 +268,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -275,7 +283,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/samples/server/petstore/java-play-framework-no-interface/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-interface/conf/routes
@@ -32,4 +32,5 @@ GET     /v2/user/logout                     controllers.UserApiController.logout
 PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework-no-interface/logs/application.log
+++ b/samples/server/petstore/java-play-framework-no-interface/logs/application.log
@@ -1,1 +1,19 @@
-2017-08-09 12:45:42,656 [INFO] from play.api.Play in ForkJoinPool-1-worker-1 - Application started (Dev)
+2017-08-22 11:19:05,148 [INFO] from play.api.http.EnabledFilters in play-dev-mode-akka.actor.default-dispatcher-4 - Enabled Filters (see <https://www.playframework.com/documentation/latest/Filters>):
+
+    play.filters.csrf.CSRFFilter
+    play.filters.headers.SecurityHeadersFilter
+    play.filters.hosts.AllowedHostsFilter
+
+2017-08-22 11:19:05,151 [INFO] from play.api.Play in play-dev-mode-akka.actor.default-dispatcher-4 - Application started (Dev)
+2017-08-22 11:19:05,274 [WARN] from play.api.mvc.DefaultJWTCookieDataCodec in play-dev-mode-akka.actor.default-dispatcher-4 - decode: cookie has invalid signature! message = JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.
+2017-08-22 11:19:05,275 [INFO] from play.api.mvc.DefaultJWTCookieDataCodec in play-dev-mode-akka.actor.default-dispatcher-4 - The JWT signature in the cookie does not match the locally computed signature with the server.
+This usually indicates the browser has a leftover cookie from another Play application,
+so clearing cookies may resolve this error message.
+2017-08-22 11:19:12,122 [WARN] from play.api.mvc.DefaultJWTCookieDataCodec in play-dev-mode-akka.actor.default-dispatcher-4 - decode: cookie has invalid signature! message = JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.
+2017-08-22 11:19:12,122 [INFO] from play.api.mvc.DefaultJWTCookieDataCodec in play-dev-mode-akka.actor.default-dispatcher-4 - The JWT signature in the cookie does not match the locally computed signature with the server.
+This usually indicates the browser has a leftover cookie from another Play application,
+so clearing cookies may resolve this error message.
+2017-08-22 11:19:12,173 [WARN] from play.api.mvc.DefaultJWTCookieDataCodec in play-dev-mode-akka.actor.default-dispatcher-4 - decode: cookie has invalid signature! message = JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.
+2017-08-22 11:19:12,173 [INFO] from play.api.mvc.DefaultJWTCookieDataCodec in play-dev-mode-akka.actor.default-dispatcher-4 - The JWT signature in the cookie does not match the locally computed signature with the server.
+This usually indicates the browser has a leftover cookie from another Play application,
+so clearing cookies may resolve this error message.

--- a/samples/server/petstore/java-play-framework-no-interface/project/build.properties
+++ b/samples/server/petstore/java-play-framework-no-interface/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/samples/server/petstore/java-play-framework-no-interface/project/plugins.sbt
+++ b/samples/server/petstore/java-play-framework-no-interface/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/build.sbt
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/build.sbt
@@ -4,6 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
 libraryDependencies += "javax.validation" % "validation-api" % "1.1.0.Final"
+libraryDependencies += guice

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/conf/application.conf
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/conf/application.conf
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 play.http.errorHandler="swagger.ErrorHandler"
 
 ## Akka
@@ -42,7 +44,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -59,6 +61,11 @@ play.modules {
 # in the root package (the "app" directory), or you can define them
 # explicitly below.
 # If there are any built-in modules that you want to disable, you can list them here.
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -260,7 +267,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -274,7 +282,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/conf/routes
@@ -31,4 +31,5 @@ GET     /v2/user/logout                     controllers.UserApiController.logout
 PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/project/build.properties
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/project/plugins.sbt
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/build.sbt
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/build.sbt
@@ -4,7 +4,8 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.10-1"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.1.5"
 libraryDependencies += "javax.validation" % "validation-api" % "1.1.0.Final"
+libraryDependencies += guice

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/conf/application.conf
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/conf/application.conf
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 play.http.errorHandler="swagger.ErrorHandler"
 
 ## Akka
@@ -42,7 +44,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -59,6 +61,11 @@ play.modules {
 # in the root package (the "app" directory), or you can define them
 # explicitly below.
 # If there are any built-in modules that you want to disable, you can list them here.
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -260,7 +267,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -274,7 +282,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/conf/routes
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/conf/routes
@@ -32,4 +32,5 @@ GET     /v2/user/logout                     controllers.UserApiController.logout
 PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/project/build.properties
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/project/plugins.sbt
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/samples/server/petstore/java-play-framework/build.sbt
+++ b/samples/server/petstore/java-play-framework/build.sbt
@@ -4,7 +4,8 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.10-1"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.1.5"
 libraryDependencies += "javax.validation" % "validation-api" % "1.1.0.Final"
+libraryDependencies += guice

--- a/samples/server/petstore/java-play-framework/conf/application.conf
+++ b/samples/server/petstore/java-play-framework/conf/application.conf
@@ -15,6 +15,8 @@
 # HOCON will fall back to substituting environment variable:
 #mykey = ${JAVA_HOME}
 
+play.filters.headers.contentSecurityPolicy=null
+
 play.http.errorHandler="swagger.ErrorHandler"
 
 ## Akka
@@ -42,7 +44,7 @@ akka {
 # ~~~~~
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules
@@ -59,6 +61,11 @@ play.modules {
 # in the root package (the "app" directory), or you can define them
 # explicitly below.
 # If there are any built-in modules that you want to disable, you can list them here.
+}
+
+play.assets {
+path = "/public"
+urlPrefix = "/assets"
 }
 
 ## IDE
@@ -260,7 +267,8 @@ csrf {
 # ~~~~~
 # Defines security headers that prevent XSS attacks.
 # If enabled, then all options are set to the below configuration by default:
-headers {
+play.filters.headers {
+
 # The X-Frame-Options header. If null, the header is not set.
 #frameOptions = "DENY"
 
@@ -274,7 +282,13 @@ headers {
 #permittedCrossDomainPolicies = "master-only"
 
 # The Content-Security-Policy header. If null, the header is not set.
-#contentSecurityPolicy = "default-src 'self'"
+contentSecurityPolicy = "default-src 'self'"
+
+# The Referrer-Policy header. If null, the header is not set.
+#referrerPolicy = "origin-when-cross-origin, strict-origin-when-cross-origin"
+
+# If true, allow an action to use .withHeaders to replace one or more of the above headers
+#allowActionSpecificHeaders = false
 }
 
 ## Allowed hosts filter configuration

--- a/samples/server/petstore/java-play-framework/conf/routes
+++ b/samples/server/petstore/java-play-framework/conf/routes
@@ -32,4 +32,5 @@ GET     /v2/user/logout                     controllers.UserApiController.logout
 PUT     /v2/user/:username                     controllers.UserApiController.updateUser(username: String)
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+GET /assets/*file           controllers.Assets.at(file)
+GET /versionedAssets/*file  controllers.Assets.versioned(file)

--- a/samples/server/petstore/java-play-framework/project/build.properties
+++ b/samples/server/petstore/java-play-framework/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/samples/server/petstore/java-play-framework/project/plugins.sbt
+++ b/samples/server/petstore/java-play-framework/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This fix issue https://github.com/swagger-api/swagger-codegen/issues/6096
All samples runs fine except, as always, the "fake endpoint" one which has never compile 100% yet because of unsupported cases.

@wing328 I have file this PR against branche 3.0.0 because it contains breaking changes. Let me know if it's ok.

