### PR TITLE
Kotlin: Use packageName option for all classes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/KotlinClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/KotlinClientCodegen.java
@@ -200,6 +200,10 @@ public class KotlinClientCodegen extends DefaultCodegen implements CodegenConfig
 
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             this.setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
+            if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE))
+                this.setModelPackage(packageName + ".models");
+            if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE))
+                this.setApiPackage(packageName + ".apis");
         } else {
             additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         }


### PR DESCRIPTION
Use the optional packageName parameter for model and api classes,
additionally to the infrastructure classes.

Fixes #6364

### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ]x Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR fixes #6364 by using the packageName option to build the package name for the api and model classes unless these are not explicitly set.