### PR TITLE
Optional model validation in python client

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/model.mustache
@@ -48,11 +48,12 @@ class {{classname}}(object):
     }
 {{/discriminator}}
 
-    def __init__(self{{#vars}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/vars}}):
+    def __init__(self{{#vars}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/vars}}, _validated=True):
         """
         {{classname}} - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
 {{#vars}}
         self._{{name}} = None
 {{/vars}}
@@ -93,6 +94,12 @@ class {{classname}}(object):
         :param {{name}}: The {{name}} of this {{classname}}.
         :type: {{datatype}}
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._{{name}} = {{name}}
+            return
 {{#required}}
         if {{name}} is None:
             raise ValueError("Invalid value for `{{name}}`, must not be `None`")

--- a/samples/client/petstore/python/docs/StoreApi.md
+++ b/samples/client/petstore/python/docs/StoreApi.md
@@ -94,7 +94,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**dict(str, int)**](dict.md)
+**dict(str, int)**
 
 ### Authorization
 

--- a/samples/client/petstore/python/petstore_api/models/additional_properties_class.py
+++ b/samples/client/petstore/python/petstore_api/models/additional_properties_class.py
@@ -40,11 +40,12 @@ class AdditionalPropertiesClass(object):
         'map_of_map_property': 'map_of_map_property'
     }
 
-    def __init__(self, map_property=None, map_of_map_property=None):
+    def __init__(self, map_property=None, map_of_map_property=None, _validated=True):
         """
         AdditionalPropertiesClass - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._map_property = None
         self._map_of_map_property = None
         self.discriminator = None
@@ -73,6 +74,12 @@ class AdditionalPropertiesClass(object):
         :type: dict(str, str)
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._map_property = map_property
+            return
+
         self._map_property = map_property
 
     @property
@@ -93,6 +100,12 @@ class AdditionalPropertiesClass(object):
         :param map_of_map_property: The map_of_map_property of this AdditionalPropertiesClass.
         :type: dict(str, dict(str, str))
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._map_of_map_property = map_of_map_property
+            return
 
         self._map_of_map_property = map_of_map_property
 

--- a/samples/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/client/petstore/python/petstore_api/models/animal.py
@@ -45,11 +45,12 @@ class Animal(object):
         '': 'Cat'
     }
 
-    def __init__(self, class_name=None, color='red'):
+    def __init__(self, class_name=None, color='red', _validated=True):
         """
         Animal - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._class_name = None
         self._color = None
         self.discriminator = 'className'
@@ -76,6 +77,12 @@ class Animal(object):
         :param class_name: The class_name of this Animal.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._class_name = class_name
+            return
         if class_name is None:
             raise ValueError("Invalid value for `class_name`, must not be `None`")
 
@@ -99,6 +106,12 @@ class Animal(object):
         :param color: The color of this Animal.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._color = color
+            return
 
         self._color = color
 

--- a/samples/client/petstore/python/petstore_api/models/animal_farm.py
+++ b/samples/client/petstore/python/petstore_api/models/animal_farm.py
@@ -38,11 +38,12 @@ class AnimalFarm(object):
         
     }
 
-    def __init__(self):
+    def __init__(self, _validated=True):
         """
         AnimalFarm - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.discriminator = None
 
 

--- a/samples/client/petstore/python/petstore_api/models/api_response.py
+++ b/samples/client/petstore/python/petstore_api/models/api_response.py
@@ -42,11 +42,12 @@ class ApiResponse(object):
         'message': 'message'
     }
 
-    def __init__(self, code=None, type=None, message=None):
+    def __init__(self, code=None, type=None, message=None, _validated=True):
         """
         ApiResponse - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._code = None
         self._type = None
         self._message = None
@@ -78,6 +79,12 @@ class ApiResponse(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._code = code
+            return
+
         self._code = code
 
     @property
@@ -99,6 +106,12 @@ class ApiResponse(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._type = type
+            return
+
         self._type = type
 
     @property
@@ -119,6 +132,12 @@ class ApiResponse(object):
         :param message: The message of this ApiResponse.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._message = message
+            return
 
         self._message = message
 

--- a/samples/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
@@ -38,11 +38,12 @@ class ArrayOfArrayOfNumberOnly(object):
         'array_array_number': 'ArrayArrayNumber'
     }
 
-    def __init__(self, array_array_number=None):
+    def __init__(self, array_array_number=None, _validated=True):
         """
         ArrayOfArrayOfNumberOnly - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._array_array_number = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class ArrayOfArrayOfNumberOnly(object):
         :param array_array_number: The array_array_number of this ArrayOfArrayOfNumberOnly.
         :type: list[list[float]]
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._array_array_number = array_array_number
+            return
 
         self._array_array_number = array_array_number
 

--- a/samples/client/petstore/python/petstore_api/models/array_of_number_only.py
+++ b/samples/client/petstore/python/petstore_api/models/array_of_number_only.py
@@ -38,11 +38,12 @@ class ArrayOfNumberOnly(object):
         'array_number': 'ArrayNumber'
     }
 
-    def __init__(self, array_number=None):
+    def __init__(self, array_number=None, _validated=True):
         """
         ArrayOfNumberOnly - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._array_number = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class ArrayOfNumberOnly(object):
         :param array_number: The array_number of this ArrayOfNumberOnly.
         :type: list[float]
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._array_number = array_number
+            return
 
         self._array_number = array_number
 

--- a/samples/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/client/petstore/python/petstore_api/models/array_test.py
@@ -42,11 +42,12 @@ class ArrayTest(object):
         'array_array_of_model': 'array_array_of_model'
     }
 
-    def __init__(self, array_of_string=None, array_array_of_integer=None, array_array_of_model=None):
+    def __init__(self, array_of_string=None, array_array_of_integer=None, array_array_of_model=None, _validated=True):
         """
         ArrayTest - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._array_of_string = None
         self._array_array_of_integer = None
         self._array_array_of_model = None
@@ -78,6 +79,12 @@ class ArrayTest(object):
         :type: list[str]
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._array_of_string = array_of_string
+            return
+
         self._array_of_string = array_of_string
 
     @property
@@ -99,6 +106,12 @@ class ArrayTest(object):
         :type: list[list[int]]
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._array_array_of_integer = array_array_of_integer
+            return
+
         self._array_array_of_integer = array_array_of_integer
 
     @property
@@ -119,6 +132,12 @@ class ArrayTest(object):
         :param array_array_of_model: The array_array_of_model of this ArrayTest.
         :type: list[list[ReadOnlyFirst]]
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._array_array_of_model = array_array_of_model
+            return
 
         self._array_array_of_model = array_array_of_model
 

--- a/samples/client/petstore/python/petstore_api/models/capitalization.py
+++ b/samples/client/petstore/python/petstore_api/models/capitalization.py
@@ -48,11 +48,12 @@ class Capitalization(object):
         'att_name': 'ATT_NAME'
     }
 
-    def __init__(self, small_camel=None, capital_camel=None, small_snake=None, capital_snake=None, sca_eth_flow_points=None, att_name=None):
+    def __init__(self, small_camel=None, capital_camel=None, small_snake=None, capital_snake=None, sca_eth_flow_points=None, att_name=None, _validated=True):
         """
         Capitalization - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._small_camel = None
         self._capital_camel = None
         self._small_snake = None
@@ -93,6 +94,12 @@ class Capitalization(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._small_camel = small_camel
+            return
+
         self._small_camel = small_camel
 
     @property
@@ -113,6 +120,12 @@ class Capitalization(object):
         :param capital_camel: The capital_camel of this Capitalization.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._capital_camel = capital_camel
+            return
 
         self._capital_camel = capital_camel
 
@@ -135,6 +148,12 @@ class Capitalization(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._small_snake = small_snake
+            return
+
         self._small_snake = small_snake
 
     @property
@@ -156,6 +175,12 @@ class Capitalization(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._capital_snake = capital_snake
+            return
+
         self._capital_snake = capital_snake
 
     @property
@@ -176,6 +201,12 @@ class Capitalization(object):
         :param sca_eth_flow_points: The sca_eth_flow_points of this Capitalization.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._sca_eth_flow_points = sca_eth_flow_points
+            return
 
         self._sca_eth_flow_points = sca_eth_flow_points
 
@@ -199,6 +230,12 @@ class Capitalization(object):
         :param att_name: The att_name of this Capitalization.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._att_name = att_name
+            return
 
         self._att_name = att_name
 

--- a/samples/client/petstore/python/petstore_api/models/cat.py
+++ b/samples/client/petstore/python/petstore_api/models/cat.py
@@ -38,11 +38,12 @@ class Cat(object):
         'declawed': 'declawed'
     }
 
-    def __init__(self, declawed=None):
+    def __init__(self, declawed=None, _validated=True):
         """
         Cat - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._declawed = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class Cat(object):
         :param declawed: The declawed of this Cat.
         :type: bool
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._declawed = declawed
+            return
 
         self._declawed = declawed
 

--- a/samples/client/petstore/python/petstore_api/models/category.py
+++ b/samples/client/petstore/python/petstore_api/models/category.py
@@ -40,11 +40,12 @@ class Category(object):
         'name': 'name'
     }
 
-    def __init__(self, id=None, name=None):
+    def __init__(self, id=None, name=None, _validated=True):
         """
         Category - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._id = None
         self._name = None
         self.discriminator = None
@@ -73,6 +74,12 @@ class Category(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._id = id
+            return
+
         self._id = id
 
     @property
@@ -93,6 +100,12 @@ class Category(object):
         :param name: The name of this Category.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._name = name
+            return
 
         self._name = name
 

--- a/samples/client/petstore/python/petstore_api/models/class_model.py
+++ b/samples/client/petstore/python/petstore_api/models/class_model.py
@@ -38,11 +38,12 @@ class ClassModel(object):
         '_class': '_class'
     }
 
-    def __init__(self, _class=None):
+    def __init__(self, _class=None, _validated=True):
         """
         ClassModel - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.__class = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class ClassModel(object):
         :param _class: The _class of this ClassModel.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self.__class = _class
+            return
 
         self.__class = _class
 

--- a/samples/client/petstore/python/petstore_api/models/client.py
+++ b/samples/client/petstore/python/petstore_api/models/client.py
@@ -38,11 +38,12 @@ class Client(object):
         'client': 'client'
     }
 
-    def __init__(self, client=None):
+    def __init__(self, client=None, _validated=True):
         """
         Client - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._client = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class Client(object):
         :param client: The client of this Client.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._client = client
+            return
 
         self._client = client
 

--- a/samples/client/petstore/python/petstore_api/models/dog.py
+++ b/samples/client/petstore/python/petstore_api/models/dog.py
@@ -38,11 +38,12 @@ class Dog(object):
         'breed': 'breed'
     }
 
-    def __init__(self, breed=None):
+    def __init__(self, breed=None, _validated=True):
         """
         Dog - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._breed = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class Dog(object):
         :param breed: The breed of this Dog.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._breed = breed
+            return
 
         self._breed = breed
 

--- a/samples/client/petstore/python/petstore_api/models/enum_arrays.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_arrays.py
@@ -40,11 +40,12 @@ class EnumArrays(object):
         'array_enum': 'array_enum'
     }
 
-    def __init__(self, just_symbol=None, array_enum=None):
+    def __init__(self, just_symbol=None, array_enum=None, _validated=True):
         """
         EnumArrays - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._just_symbol = None
         self._array_enum = None
         self.discriminator = None
@@ -72,6 +73,12 @@ class EnumArrays(object):
         :param just_symbol: The just_symbol of this EnumArrays.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._just_symbol = just_symbol
+            return
         allowed_values = [">=", "$"]
         if just_symbol not in allowed_values:
             raise ValueError(
@@ -99,6 +106,12 @@ class EnumArrays(object):
         :param array_enum: The array_enum of this EnumArrays.
         :type: list[str]
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._array_enum = array_enum
+            return
         allowed_values = ["fish", "crab"]
         if not set(array_enum).issubset(set(allowed_values)):
             raise ValueError(

--- a/samples/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_class.py
@@ -44,11 +44,12 @@ class EnumClass(object):
         
     }
 
-    def __init__(self):
+    def __init__(self, _validated=True):
         """
         EnumClass - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.discriminator = None
 
 

--- a/samples/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_test.py
@@ -44,11 +44,12 @@ class EnumTest(object):
         'outer_enum': 'outerEnum'
     }
 
-    def __init__(self, enum_string=None, enum_integer=None, enum_number=None, outer_enum=None):
+    def __init__(self, enum_string=None, enum_integer=None, enum_number=None, outer_enum=None, _validated=True):
         """
         EnumTest - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._enum_string = None
         self._enum_integer = None
         self._enum_number = None
@@ -82,6 +83,12 @@ class EnumTest(object):
         :param enum_string: The enum_string of this EnumTest.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._enum_string = enum_string
+            return
         allowed_values = ["UPPER", "lower", ""]
         if enum_string not in allowed_values:
             raise ValueError(
@@ -109,6 +116,12 @@ class EnumTest(object):
         :param enum_integer: The enum_integer of this EnumTest.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._enum_integer = enum_integer
+            return
         allowed_values = [1, -1]
         if enum_integer not in allowed_values:
             raise ValueError(
@@ -136,6 +149,12 @@ class EnumTest(object):
         :param enum_number: The enum_number of this EnumTest.
         :type: float
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._enum_number = enum_number
+            return
         allowed_values = [1.1, -1.2]
         if enum_number not in allowed_values:
             raise ValueError(
@@ -163,6 +182,12 @@ class EnumTest(object):
         :param outer_enum: The outer_enum of this EnumTest.
         :type: OuterEnum
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._outer_enum = outer_enum
+            return
 
         self._outer_enum = outer_enum
 

--- a/samples/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python/petstore_api/models/format_test.py
@@ -62,11 +62,12 @@ class FormatTest(object):
         'password': 'password'
     }
 
-    def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None):
+    def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None, _validated=True):
         """
         FormatTest - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._integer = None
         self._int32 = None
         self._int64 = None
@@ -123,6 +124,12 @@ class FormatTest(object):
         :param integer: The integer of this FormatTest.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._integer = integer
+            return
         if integer is not None and integer > 100:
             raise ValueError("Invalid value for `integer`, must be a value less than or equal to `100`")
         if integer is not None and integer < 10:
@@ -148,6 +155,12 @@ class FormatTest(object):
         :param int32: The int32 of this FormatTest.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._int32 = int32
+            return
         if int32 is not None and int32 > 200:
             raise ValueError("Invalid value for `int32`, must be a value less than or equal to `200`")
         if int32 is not None and int32 < 20:
@@ -174,6 +187,12 @@ class FormatTest(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._int64 = int64
+            return
+
         self._int64 = int64
 
     @property
@@ -194,6 +213,12 @@ class FormatTest(object):
         :param number: The number of this FormatTest.
         :type: float
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._number = number
+            return
         if number is None:
             raise ValueError("Invalid value for `number`, must not be `None`")
         if number is not None and number > 543.2:
@@ -221,6 +246,12 @@ class FormatTest(object):
         :param float: The float of this FormatTest.
         :type: float
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._float = float
+            return
         if float is not None and float > 987.6:
             raise ValueError("Invalid value for `float`, must be a value less than or equal to `987.6`")
         if float is not None and float < 54.3:
@@ -246,6 +277,12 @@ class FormatTest(object):
         :param double: The double of this FormatTest.
         :type: float
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._double = double
+            return
         if double is not None and double > 123.4:
             raise ValueError("Invalid value for `double`, must be a value less than or equal to `123.4`")
         if double is not None and double < 67.8:
@@ -271,6 +308,12 @@ class FormatTest(object):
         :param string: The string of this FormatTest.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._string = string
+            return
         if string is not None and not re.search('[a-z]', string, flags=re.IGNORECASE):
             raise ValueError("Invalid value for `string`, must be a follow pattern or equal to `/[a-z]/i`")
 
@@ -294,6 +337,12 @@ class FormatTest(object):
         :param byte: The byte of this FormatTest.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._byte = byte
+            return
         if byte is None:
             raise ValueError("Invalid value for `byte`, must not be `None`")
         if byte is not None and not re.search('^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$', byte):
@@ -320,6 +369,12 @@ class FormatTest(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._binary = binary
+            return
+
         self._binary = binary
 
     @property
@@ -340,6 +395,12 @@ class FormatTest(object):
         :param date: The date of this FormatTest.
         :type: date
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._date = date
+            return
         if date is None:
             raise ValueError("Invalid value for `date`, must not be `None`")
 
@@ -364,6 +425,12 @@ class FormatTest(object):
         :type: datetime
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._date_time = date_time
+            return
+
         self._date_time = date_time
 
     @property
@@ -385,6 +452,12 @@ class FormatTest(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._uuid = uuid
+            return
+
         self._uuid = uuid
 
     @property
@@ -405,6 +478,12 @@ class FormatTest(object):
         :param password: The password of this FormatTest.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._password = password
+            return
         if password is None:
             raise ValueError("Invalid value for `password`, must not be `None`")
         if password is not None and len(password) > 64:

--- a/samples/client/petstore/python/petstore_api/models/has_only_read_only.py
+++ b/samples/client/petstore/python/petstore_api/models/has_only_read_only.py
@@ -40,11 +40,12 @@ class HasOnlyReadOnly(object):
         'foo': 'foo'
     }
 
-    def __init__(self, bar=None, foo=None):
+    def __init__(self, bar=None, foo=None, _validated=True):
         """
         HasOnlyReadOnly - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._bar = None
         self._foo = None
         self.discriminator = None
@@ -73,6 +74,12 @@ class HasOnlyReadOnly(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._bar = bar
+            return
+
         self._bar = bar
 
     @property
@@ -93,6 +100,12 @@ class HasOnlyReadOnly(object):
         :param foo: The foo of this HasOnlyReadOnly.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._foo = foo
+            return
 
         self._foo = foo
 

--- a/samples/client/petstore/python/petstore_api/models/list.py
+++ b/samples/client/petstore/python/petstore_api/models/list.py
@@ -38,11 +38,12 @@ class List(object):
         '_123_list': '123-list'
     }
 
-    def __init__(self, _123_list=None):
+    def __init__(self, _123_list=None, _validated=True):
         """
         List - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.__123_list = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class List(object):
         :param _123_list: The _123_list of this List.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self.__123_list = _123_list
+            return
 
         self.__123_list = _123_list
 

--- a/samples/client/petstore/python/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python/petstore_api/models/map_test.py
@@ -40,11 +40,12 @@ class MapTest(object):
         'map_of_enum_string': 'map_of_enum_string'
     }
 
-    def __init__(self, map_map_of_string=None, map_of_enum_string=None):
+    def __init__(self, map_map_of_string=None, map_of_enum_string=None, _validated=True):
         """
         MapTest - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._map_map_of_string = None
         self._map_of_enum_string = None
         self.discriminator = None
@@ -73,6 +74,12 @@ class MapTest(object):
         :type: dict(str, dict(str, str))
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._map_map_of_string = map_map_of_string
+            return
+
         self._map_map_of_string = map_map_of_string
 
     @property
@@ -93,6 +100,12 @@ class MapTest(object):
         :param map_of_enum_string: The map_of_enum_string of this MapTest.
         :type: dict(str, str)
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._map_of_enum_string = map_of_enum_string
+            return
         allowed_values = ["UPPER", "lower"]
         if not set(map_of_enum_string.keys()).issubset(set(allowed_values)):
             raise ValueError(

--- a/samples/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -42,11 +42,12 @@ class MixedPropertiesAndAdditionalPropertiesClass(object):
         'map': 'map'
     }
 
-    def __init__(self, uuid=None, date_time=None, map=None):
+    def __init__(self, uuid=None, date_time=None, map=None, _validated=True):
         """
         MixedPropertiesAndAdditionalPropertiesClass - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._uuid = None
         self._date_time = None
         self._map = None
@@ -78,6 +79,12 @@ class MixedPropertiesAndAdditionalPropertiesClass(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._uuid = uuid
+            return
+
         self._uuid = uuid
 
     @property
@@ -99,6 +106,12 @@ class MixedPropertiesAndAdditionalPropertiesClass(object):
         :type: datetime
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._date_time = date_time
+            return
+
         self._date_time = date_time
 
     @property
@@ -119,6 +132,12 @@ class MixedPropertiesAndAdditionalPropertiesClass(object):
         :param map: The map of this MixedPropertiesAndAdditionalPropertiesClass.
         :type: dict(str, Animal)
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._map = map
+            return
 
         self._map = map
 

--- a/samples/client/petstore/python/petstore_api/models/model_200_response.py
+++ b/samples/client/petstore/python/petstore_api/models/model_200_response.py
@@ -40,11 +40,12 @@ class Model200Response(object):
         '_class': 'class'
     }
 
-    def __init__(self, name=None, _class=None):
+    def __init__(self, name=None, _class=None, _validated=True):
         """
         Model200Response - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._name = None
         self.__class = None
         self.discriminator = None
@@ -73,6 +74,12 @@ class Model200Response(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._name = name
+            return
+
         self._name = name
 
     @property
@@ -93,6 +100,12 @@ class Model200Response(object):
         :param _class: The _class of this Model200Response.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self.__class = _class
+            return
 
         self.__class = _class
 

--- a/samples/client/petstore/python/petstore_api/models/model_return.py
+++ b/samples/client/petstore/python/petstore_api/models/model_return.py
@@ -38,11 +38,12 @@ class ModelReturn(object):
         '_return': 'return'
     }
 
-    def __init__(self, _return=None):
+    def __init__(self, _return=None, _validated=True):
         """
         ModelReturn - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.__return = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class ModelReturn(object):
         :param _return: The _return of this ModelReturn.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self.__return = _return
+            return
 
         self.__return = _return
 

--- a/samples/client/petstore/python/petstore_api/models/name.py
+++ b/samples/client/petstore/python/petstore_api/models/name.py
@@ -44,11 +44,12 @@ class Name(object):
         '_123_number': '123Number'
     }
 
-    def __init__(self, name=None, snake_case=None, _property=None, _123_number=None):
+    def __init__(self, name=None, snake_case=None, _property=None, _123_number=None, _validated=True):
         """
         Name - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._name = None
         self._snake_case = None
         self.__property = None
@@ -81,6 +82,12 @@ class Name(object):
         :param name: The name of this Name.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._name = name
+            return
         if name is None:
             raise ValueError("Invalid value for `name`, must not be `None`")
 
@@ -105,6 +112,12 @@ class Name(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._snake_case = snake_case
+            return
+
         self._snake_case = snake_case
 
     @property
@@ -126,6 +139,12 @@ class Name(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self.__property = _property
+            return
+
         self.__property = _property
 
     @property
@@ -146,6 +165,12 @@ class Name(object):
         :param _123_number: The _123_number of this Name.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self.__123_number = _123_number
+            return
 
         self.__123_number = _123_number
 

--- a/samples/client/petstore/python/petstore_api/models/number_only.py
+++ b/samples/client/petstore/python/petstore_api/models/number_only.py
@@ -38,11 +38,12 @@ class NumberOnly(object):
         'just_number': 'JustNumber'
     }
 
-    def __init__(self, just_number=None):
+    def __init__(self, just_number=None, _validated=True):
         """
         NumberOnly - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._just_number = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class NumberOnly(object):
         :param just_number: The just_number of this NumberOnly.
         :type: float
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._just_number = just_number
+            return
 
         self._just_number = just_number
 

--- a/samples/client/petstore/python/petstore_api/models/order.py
+++ b/samples/client/petstore/python/petstore_api/models/order.py
@@ -48,11 +48,12 @@ class Order(object):
         'complete': 'complete'
     }
 
-    def __init__(self, id=None, pet_id=None, quantity=None, ship_date=None, status=None, complete=False):
+    def __init__(self, id=None, pet_id=None, quantity=None, ship_date=None, status=None, complete=False, _validated=True):
         """
         Order - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._id = None
         self._pet_id = None
         self._quantity = None
@@ -93,6 +94,12 @@ class Order(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._id = id
+            return
+
         self._id = id
 
     @property
@@ -113,6 +120,12 @@ class Order(object):
         :param pet_id: The pet_id of this Order.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._pet_id = pet_id
+            return
 
         self._pet_id = pet_id
 
@@ -135,6 +148,12 @@ class Order(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._quantity = quantity
+            return
+
         self._quantity = quantity
 
     @property
@@ -155,6 +174,12 @@ class Order(object):
         :param ship_date: The ship_date of this Order.
         :type: datetime
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._ship_date = ship_date
+            return
 
         self._ship_date = ship_date
 
@@ -178,6 +203,12 @@ class Order(object):
         :param status: The status of this Order.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._status = status
+            return
         allowed_values = ["placed", "approved", "delivered"]
         if status not in allowed_values:
             raise ValueError(
@@ -205,6 +236,12 @@ class Order(object):
         :param complete: The complete of this Order.
         :type: bool
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._complete = complete
+            return
 
         self._complete = complete
 

--- a/samples/client/petstore/python/petstore_api/models/outer_boolean.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_boolean.py
@@ -38,11 +38,12 @@ class OuterBoolean(object):
         
     }
 
-    def __init__(self):
+    def __init__(self, _validated=True):
         """
         OuterBoolean - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.discriminator = None
 
 

--- a/samples/client/petstore/python/petstore_api/models/outer_composite.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_composite.py
@@ -42,11 +42,12 @@ class OuterComposite(object):
         'my_boolean': 'my_boolean'
     }
 
-    def __init__(self, my_number=None, my_string=None, my_boolean=None):
+    def __init__(self, my_number=None, my_string=None, my_boolean=None, _validated=True):
         """
         OuterComposite - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._my_number = None
         self._my_string = None
         self._my_boolean = None
@@ -78,6 +79,12 @@ class OuterComposite(object):
         :type: OuterNumber
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._my_number = my_number
+            return
+
         self._my_number = my_number
 
     @property
@@ -99,6 +106,12 @@ class OuterComposite(object):
         :type: OuterString
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._my_string = my_string
+            return
+
         self._my_string = my_string
 
     @property
@@ -119,6 +132,12 @@ class OuterComposite(object):
         :param my_boolean: The my_boolean of this OuterComposite.
         :type: OuterBoolean
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._my_boolean = my_boolean
+            return
 
         self._my_boolean = my_boolean
 

--- a/samples/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_enum.py
@@ -44,11 +44,12 @@ class OuterEnum(object):
         
     }
 
-    def __init__(self):
+    def __init__(self, _validated=True):
         """
         OuterEnum - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.discriminator = None
 
 

--- a/samples/client/petstore/python/petstore_api/models/outer_number.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_number.py
@@ -38,11 +38,12 @@ class OuterNumber(object):
         
     }
 
-    def __init__(self):
+    def __init__(self, _validated=True):
         """
         OuterNumber - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.discriminator = None
 
 

--- a/samples/client/petstore/python/petstore_api/models/outer_string.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_string.py
@@ -38,11 +38,12 @@ class OuterString(object):
         
     }
 
-    def __init__(self):
+    def __init__(self, _validated=True):
         """
         OuterString - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self.discriminator = None
 
 

--- a/samples/client/petstore/python/petstore_api/models/pet.py
+++ b/samples/client/petstore/python/petstore_api/models/pet.py
@@ -48,11 +48,12 @@ class Pet(object):
         'status': 'status'
     }
 
-    def __init__(self, id=None, category=None, name=None, photo_urls=None, tags=None, status=None):
+    def __init__(self, id=None, category=None, name=None, photo_urls=None, tags=None, status=None, _validated=True):
         """
         Pet - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._id = None
         self._category = None
         self._name = None
@@ -91,6 +92,12 @@ class Pet(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._id = id
+            return
+
         self._id = id
 
     @property
@@ -112,6 +119,12 @@ class Pet(object):
         :type: Category
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._category = category
+            return
+
         self._category = category
 
     @property
@@ -132,6 +145,12 @@ class Pet(object):
         :param name: The name of this Pet.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._name = name
+            return
         if name is None:
             raise ValueError("Invalid value for `name`, must not be `None`")
 
@@ -155,6 +174,12 @@ class Pet(object):
         :param photo_urls: The photo_urls of this Pet.
         :type: list[str]
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._photo_urls = photo_urls
+            return
         if photo_urls is None:
             raise ValueError("Invalid value for `photo_urls`, must not be `None`")
 
@@ -179,6 +204,12 @@ class Pet(object):
         :type: list[Tag]
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._tags = tags
+            return
+
         self._tags = tags
 
     @property
@@ -201,6 +232,12 @@ class Pet(object):
         :param status: The status of this Pet.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._status = status
+            return
         allowed_values = ["available", "pending", "sold"]
         if status not in allowed_values:
             raise ValueError(

--- a/samples/client/petstore/python/petstore_api/models/read_only_first.py
+++ b/samples/client/petstore/python/petstore_api/models/read_only_first.py
@@ -40,11 +40,12 @@ class ReadOnlyFirst(object):
         'baz': 'baz'
     }
 
-    def __init__(self, bar=None, baz=None):
+    def __init__(self, bar=None, baz=None, _validated=True):
         """
         ReadOnlyFirst - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._bar = None
         self._baz = None
         self.discriminator = None
@@ -73,6 +74,12 @@ class ReadOnlyFirst(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._bar = bar
+            return
+
         self._bar = bar
 
     @property
@@ -93,6 +100,12 @@ class ReadOnlyFirst(object):
         :param baz: The baz of this ReadOnlyFirst.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._baz = baz
+            return
 
         self._baz = baz
 

--- a/samples/client/petstore/python/petstore_api/models/special_model_name.py
+++ b/samples/client/petstore/python/petstore_api/models/special_model_name.py
@@ -38,11 +38,12 @@ class SpecialModelName(object):
         'special_property_name': '$special[property.name]'
     }
 
-    def __init__(self, special_property_name=None):
+    def __init__(self, special_property_name=None, _validated=True):
         """
         SpecialModelName - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._special_property_name = None
         self.discriminator = None
 
@@ -67,6 +68,12 @@ class SpecialModelName(object):
         :param special_property_name: The special_property_name of this SpecialModelName.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._special_property_name = special_property_name
+            return
 
         self._special_property_name = special_property_name
 

--- a/samples/client/petstore/python/petstore_api/models/tag.py
+++ b/samples/client/petstore/python/petstore_api/models/tag.py
@@ -40,11 +40,12 @@ class Tag(object):
         'name': 'name'
     }
 
-    def __init__(self, id=None, name=None):
+    def __init__(self, id=None, name=None, _validated=True):
         """
         Tag - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._id = None
         self._name = None
         self.discriminator = None
@@ -73,6 +74,12 @@ class Tag(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._id = id
+            return
+
         self._id = id
 
     @property
@@ -93,6 +100,12 @@ class Tag(object):
         :param name: The name of this Tag.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._name = name
+            return
 
         self._name = name
 

--- a/samples/client/petstore/python/petstore_api/models/user.py
+++ b/samples/client/petstore/python/petstore_api/models/user.py
@@ -52,11 +52,12 @@ class User(object):
         'user_status': 'userStatus'
     }
 
-    def __init__(self, id=None, username=None, first_name=None, last_name=None, email=None, password=None, phone=None, user_status=None):
+    def __init__(self, id=None, username=None, first_name=None, last_name=None, email=None, password=None, phone=None, user_status=None, _validated=True):
         """
         User - a model defined in Swagger
         """
 
+        self._is_model_validated = _validated
         self._id = None
         self._username = None
         self._first_name = None
@@ -103,6 +104,12 @@ class User(object):
         :type: int
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._id = id
+            return
+
         self._id = id
 
     @property
@@ -123,6 +130,12 @@ class User(object):
         :param username: The username of this User.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._username = username
+            return
 
         self._username = username
 
@@ -145,6 +158,12 @@ class User(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._first_name = first_name
+            return
+
         self._first_name = first_name
 
     @property
@@ -165,6 +184,12 @@ class User(object):
         :param last_name: The last_name of this User.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._last_name = last_name
+            return
 
         self._last_name = last_name
 
@@ -187,6 +212,12 @@ class User(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._email = email
+            return
+
         self._email = email
 
     @property
@@ -208,6 +239,12 @@ class User(object):
         :type: str
         """
 
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._password = password
+            return
+
         self._password = password
 
     @property
@@ -228,6 +265,12 @@ class User(object):
         :param phone: The phone of this User.
         :type: str
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._phone = phone
+            return
 
         self._phone = phone
 
@@ -251,6 +294,12 @@ class User(object):
         :param user_status: The user_status of this User.
         :type: int
         """
+
+        if not self._is_model_validated:
+            # If this model was built without validation, then simply set the
+            # value here and quickly return, skipping all possible validation
+            self._user_status = user_status
+            return
 
         self._user_status = user_status
 

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -141,7 +141,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR introduces a new parameter _validated, which defaults to True (backwards compatible) in the generated python models for the python client. When set to False, all value setters in the model object will bypass validation.

This becomes particularly useful when attempting to send wrong values to the API on purpose. For instance, with the intention of testing API error responses.

The problem is referenced in issue #6371

