### PR TITLE
[Java Play Framework] Fix a small error of using paramName instead of baseName

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApiController.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApiController.mustache
@@ -78,7 +78,7 @@ public class {{classname}}Controller extends Controller {
         }
         {{/collectionFormat}}
         {{^collectionFormat}}
-        String value{{paramName}} = request().getQueryString("{{paramName}}");
+        String value{{paramName}} = request().getQueryString("{{baseName}}");
         {{{dataType}}} {{paramName}};
         {{^required}}
         if (value{{paramName}} != null) {

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/FakeApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/FakeApiController.java
@@ -230,7 +230,7 @@ public class FakeApiController extends Controller {
             //noinspection UseBulkOperation
             enumQueryStringArray.add(curParam);
         }
-        String valueenumQueryString = request().getQueryString("enumQueryString");
+        String valueenumQueryString = request().getQueryString("enum_query_string");
         String enumQueryString;
         if (valueenumQueryString != null) {
             enumQueryString = valueenumQueryString;
@@ -238,7 +238,7 @@ public class FakeApiController extends Controller {
         } else {
             enumQueryString = "-efg";
         }
-        String valueenumQueryInteger = request().getQueryString("enumQueryInteger");
+        String valueenumQueryInteger = request().getQueryString("enum_query_integer");
         Integer enumQueryInteger;
         if (valueenumQueryInteger != null) {
             enumQueryInteger = Integer.parseInt(valueenumQueryInteger);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Small bug of using the wrong mustache param when getting query parameters.

