### PR TITLE
Global namespaces for ruby basic types

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -274,7 +274,7 @@ module {{moduleName}}
         data = {}
         form_params.each do |key, value|
           case value
-          when File, Array, nil
+          when ::File, ::Array, nil
             # let typhoeus handle File, Array and nil parameters
             data[key] = value
           else


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

File here will be overriden by generated class File if swagger.yml contains the definition named File. Using global namespace can fix it

