### PR TITLE
[ANDROID][volley] Handle UnsupportedEncodingException in invokeAPI

### DIFF
--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/apiInvoker.mustache
@@ -373,7 +373,7 @@ public class ApiInvoker {
         return "no data";
       }
     } catch (UnsupportedEncodingException ex) {
-      throw new ApiException();
+      throw new ApiException(0, "UnsupportedEncodingException");
     }
   }
 
@@ -384,7 +384,7 @@ public class ApiInvoker {
         mRequestQueue.add(request);
       }
     } catch (UnsupportedEncodingException ex) {
-      throw new ApiException();
+      throw new ApiException(0, "UnsupportedEncodingException");
     }
   }
 

--- a/modules/swagger-codegen/src/main/resources/android/libraries/volley/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/libraries/volley/apiInvoker.mustache
@@ -363,24 +363,32 @@ public class ApiInvoker {
   }
 
   public String invokeAPI(String host, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, String[] authNames) throws ApiException, InterruptedException, ExecutionException, TimeoutException {
-    RequestFuture<String> future = RequestFuture.newFuture();
-    Request request = createRequest(host, path, method, queryParams, body, headerParams, formParams, contentType, authNames, future, future);
-    if(request != null) {
-       mRequestQueue.add(request);
-       return future.get(connectionTimeout, TimeUnit.SECONDS);
-    } else {
-      return "no data";
+    try {
+      RequestFuture<String> future = RequestFuture.newFuture();
+      Request request = createRequest(host, path, method, queryParams, body, headerParams, formParams, contentType, authNames, future, future);
+      if(request != null) {
+         mRequestQueue.add(request);
+         return future.get(connectionTimeout, TimeUnit.SECONDS);
+      } else {
+        return "no data";
+      }
+    } catch (UnsupportedEncodingException ex) {
+      throw new ApiException();
     }
   }
 
   public void invokeAPI(String host, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, String[] authNames, Response.Listener<String> stringRequest, Response.ErrorListener errorListener) throws ApiException {
-    Request request = createRequest(host, path, method, queryParams, body, headerParams, formParams, contentType, authNames, stringRequest, errorListener);
-    if (request != null) {
-      mRequestQueue.add(request);
+    try {
+      Request request = createRequest(host, path, method, queryParams, body, headerParams, formParams, contentType, authNames, stringRequest, errorListener);
+      if (request != null) {
+        mRequestQueue.add(request);
+      }
+    } catch (UnsupportedEncodingException ex) {
+      throw new ApiException();
     }
   }
 
-  public Request<String> createRequest(String host, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, String[] authNames, Response.Listener<String> stringRequest, Response.ErrorListener errorListener) throws ApiException {
+  public Request<String> createRequest(String host, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, String[] authNames, Response.Listener<String> stringRequest, Response.ErrorListener errorListener) throws ApiException, UnsupportedEncodingException {
     StringBuilder b = new StringBuilder();
     b.append("?");
 

--- a/samples/client/petstore/android/volley/docs/StoreApi.md
+++ b/samples/client/petstore/android/volley/docs/StoreApi.md
@@ -80,7 +80,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**Map&lt;String, Integer&gt;**](Map.md)
+**Map&lt;String, Integer&gt;**
 
 ### Authorization
 

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java
@@ -365,24 +365,32 @@ public class ApiInvoker {
   }
 
   public String invokeAPI(String host, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, String[] authNames) throws ApiException, InterruptedException, ExecutionException, TimeoutException {
-    RequestFuture<String> future = RequestFuture.newFuture();
-    Request request = createRequest(host, path, method, queryParams, body, headerParams, formParams, contentType, authNames, future, future);
-    if(request != null) {
-       mRequestQueue.add(request);
-       return future.get(connectionTimeout, TimeUnit.SECONDS);
-    } else {
-      return "no data";
+    try {
+      RequestFuture<String> future = RequestFuture.newFuture();
+      Request request = createRequest(host, path, method, queryParams, body, headerParams, formParams, contentType, authNames, future, future);
+      if(request != null) {
+         mRequestQueue.add(request);
+         return future.get(connectionTimeout, TimeUnit.SECONDS);
+      } else {
+        return "no data";
+      }
+    } catch (UnsupportedEncodingException ex) {
+      throw new ApiException();
     }
   }
 
   public void invokeAPI(String host, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, String[] authNames, Response.Listener<String> stringRequest, Response.ErrorListener errorListener) throws ApiException {
-    Request request = createRequest(host, path, method, queryParams, body, headerParams, formParams, contentType, authNames, stringRequest, errorListener);
-    if (request != null) {
-      mRequestQueue.add(request);
+    try {
+      Request request = createRequest(host, path, method, queryParams, body, headerParams, formParams, contentType, authNames, stringRequest, errorListener);
+      if (request != null) {
+        mRequestQueue.add(request);
+      }
+    } catch (UnsupportedEncodingException ex) {
+      throw new ApiException();
     }
   }
 
-  public Request<String> createRequest(String host, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, String[] authNames, Response.Listener<String> stringRequest, Response.ErrorListener errorListener) throws ApiException {
+  public Request<String> createRequest(String host, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> formParams, String contentType, String[] authNames, Response.Listener<String> stringRequest, Response.ErrorListener errorListener) throws ApiException, UnsupportedEncodingException {
     StringBuilder b = new StringBuilder();
     b.append("?");
 

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java
@@ -375,7 +375,7 @@ public class ApiInvoker {
         return "no data";
       }
     } catch (UnsupportedEncodingException ex) {
-      throw new ApiException();
+      throw new ApiException(0, "UnsupportedEncodingException");
     }
   }
 
@@ -386,7 +386,7 @@ public class ApiInvoker {
         mRequestQueue.add(request);
       }
     } catch (UnsupportedEncodingException ex) {
-      throw new ApiException();
+      throw new ApiException(0, "UnsupportedEncodingException");
     }
   }
 

--- a/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/StoreApi.java
+++ b/samples/client/petstore/android/volley/src/main/java/io/swagger/client/api/StoreApi.java
@@ -214,7 +214,7 @@ public class StoreApi {
     try {
       String localVarResponse = apiInvoker.invokeAPI (basePath, path, "GET", queryParams, postBody, headerParams, formParams, contentType, authNames);
       if (localVarResponse != null) {
-         return (Map<String, Integer>) ApiInvoker.deserialize(localVarResponse, "map", Map.class);
+         return (Map<String, Integer>) ApiInvoker.deserialize(localVarResponse, "map", Integer.class);
       } else {
          return null;
       }
@@ -280,7 +280,7 @@ public class StoreApi {
           @Override
           public void onResponse(String localVarResponse) {
             try {
-              responseListener.onResponse((Map<String, Integer>) ApiInvoker.deserialize(localVarResponse,  "map", Map.class));
+              responseListener.onResponse((Map<String, Integer>) ApiInvoker.deserialize(localVarResponse,  "map", Integer.class));
             } catch (ApiException exception) {
                errorListener.onErrorResponse(new VolleyError(exception));
             }


### PR DESCRIPTION
PR for Issue #6432 

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
The constructor of StringEntity can throw UnsupportedEncodingException, which is not catch nor thrown by createRequest method.
Therefore the build of android client fails with:

ApiInvoker.java:448: error: unreported exception UnsupportedEncodingException; must be caught or declared to be thrown

This commit adds a try ... catch on UnsupportedEncodingException in invokeAPI methods and declare this exception to be thrown in createRequest

