### PR TITLE
WIP:feat(nodejs): add support for response headers

### DIFF
--- a/modules/swagger-codegen/src/main/resources/nodejs/controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/nodejs/controller.mustache
@@ -9,12 +9,23 @@ module.exports.{{nickname}} = function {{nickname}} (req, res, next) {
   {{#allParams}}
   var {{paramName}} = req.swagger.params['{{baseName}}'].value;
   {{/allParams}}
+  var responseHeaders = [];
+  var header = {};
+  var responseHeaderSchema;
+  {{#responses}}
+  {{#headers}}
+  responseHeaderSchema = {{{jsonSchema}}};
+  header.name = '{{name}}';
+  header.value = responseHeaderSchema.default;
+  responseHeaders.push(header);
+  {{/headers}}
+  {{/responses}}
   {{classname}}.{{nickname}}({{#allParams}}{{paramName}}{{#hasMore}},{{/hasMore}}{{/allParams}})
     .then(function (response) {
-      utils.writeJson(res, response);
+      utils.writeJson(res, response, null, responseHeaders);
     })
     .catch(function (response) {
-      utils.writeJson(res, response);
+      utils.writeJson(res, response, null, responseHeaders);
     });
 };
 {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/nodejs/writer.mustache
+++ b/modules/swagger-codegen/src/main/resources/nodejs/writer.mustache
@@ -7,9 +7,10 @@ exports.respondWithCode = function(code, payload) {
   return new ResponsePayload(code, payload);
 }
 
-var writeJson = exports.writeJson = function(response, arg1, arg2) {
+var writeJson = exports.writeJson = function(response, arg1, arg2, arg3) {
   var code;
   var payload;
+  var headers;
 
   if(arg1 && arg1 instanceof ResponsePayload) {
     writeJson(response, arg1.payload, arg1.code);
@@ -24,6 +25,14 @@ var writeJson = exports.writeJson = function(response, arg1, arg2) {
       code = arg1;
     }
   }
+  
+  if(arg3){
+    headers = arg3;
+	for(var i = 0; i < headers.length; i++){
+      response.setHeader(headers[i].name, headers[i].value);
+    }
+  }
+  
   if(code && arg1) {
     payload = arg1;
   }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Response headers defined in swagger file are returned by the nodejs server.

Closes #6424 

Tested with the following yaml:
```yaml
swagger: '2.0'
info:
  description: >-
    This is a sample server Petstore server.  You can find out more about    
    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
    #swagger](http://swagger.io/irc/).      For this sample, you can use the api
    key `special-key` to test the authorization     filters.
  version: 1.0.0
  title: Swagger Petstore
  termsOfService: 'http://swagger.io/terms/'
  contact:
    email: apiteam@swagger.io
  license:
    name: Apache 2.0
    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
host: petstore.swagger.io
basePath: /v2
tags:
  - name: pet
    description: Everything about your Pets
    externalDocs:
      description: Find out more
      url: 'http://swagger.io'
schemes:
  - http
paths:
  /pet/responsewithheader:
    get:
      tags:
        - pet
      produces:
        - application/xml
        - application/json
      responses:
        '200':
          headers:
            MyHeader:
              type: string
              default: '*'
          description: successful operation
  /pet/response:
    get:
      tags:
        - pet
      produces:
        - application/xml
        - application/json
      responses:
        '200':
          description: successful operation

```
