### PR TITLE
Fix #6201: Typescript-Angular2 produces invalid import for self-referencing model

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -268,19 +268,21 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         for (Object _mo : models) {
             Map<String, Object> mo = (Map<String, Object>) _mo;
             CodegenModel cm = (CodegenModel) mo.get("model");
-            mo.put("tsImports", toTsImports(cm.imports));
+            mo.put("tsImports", toTsImports(cm,cm.imports));
         }
         
         return result;
     }
 
-    private List<Map<String, String>> toTsImports(Set<String> imports) {
+    private List<Map<String, String>> toTsImports(CodegenModel cm, Set<String> imports) {
             List<Map<String, String>> tsImports = new ArrayList<>();
             for(String im : imports) {
+                if(!im.equals(cm.classname)) {
                     HashMap<String, String> tsImport = new HashMap<>();
                     tsImport.put("classname", im);
                     tsImport.put("filename", toModelFilename(im));
                     tsImports.add(tsImport);
+                }
             }
             return tsImports;
     }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR
Naive fix for Issue #6201 . Does not address any other languages.