### PR TITLE
[TypeScript][Angular] Better support for "Accept", "Content-Type"

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -175,6 +175,11 @@ export class {{classname}} {
             '{{{mediaType}}}'{{#hasMore}},{{/hasMore}}
             {{/consumes}}
         ];
+
+        if (consumes != null) {
+            headers.set('Content-Type', produces.join(';'));
+        }
+
         let canConsumeForm = this.canConsumeForm(consumes);
         let useForm = false;
 {{#formParams}}
@@ -193,6 +198,10 @@ export class {{classname}} {
             '{{{mediaType}}}'{{#hasMore}},{{/hasMore}}
             {{/produces}}
         ];
+
+        if (produces != null) {
+            headers.set('Accept', produces.join(';'));
+        }
 
 {{#authMethods}}
         // authentication ({{name}}) required

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -176,7 +176,7 @@ export class {{classname}} {
             {{/consumes}}
         ];
 
-        if ((consumes != null) && (consumes.length > 0)) {
+        if (consumes != null && consumes.length > 0) {
             headers.set('Content-Type', consumes.join(';'));
         }
 
@@ -199,7 +199,7 @@ export class {{classname}} {
             {{/produces}}
         ];
 
-        if ((produces != null) && (produces.length > 0)) {
+        if (produces != null && produces.length > 0) {
             headers.set('Accept', produces.join(';'));
         }
 

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -78,6 +78,11 @@ export class {{classname}} {
         return false;
     }
 
+    public isJsonMime(mime: string): boolean {
+        const jsonMime: RegExp = new RegExp('(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$');
+        return mime != null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
 {{#operation}}
     /**
      * {{&notes}}
@@ -177,7 +182,7 @@ export class {{classname}} {
         ];
 
         if (consumes != null && consumes.length > 0) {
-            headers.set('Content-Type', consumes.join(';'));
+            headers.set('Content-Type', consumes.filter(item => this.isJsonMime(item)).join(";"));
         }
 
         let canConsumeForm = this.canConsumeForm(consumes);
@@ -200,7 +205,7 @@ export class {{classname}} {
         ];
 
         if (produces != null && produces.length > 0) {
-            headers.set('Accept', produces.join(';'));
+            headers.set('Accept', produces.filter(item => this.isJsonMime(item)).join(';'));
         }
 
 {{#authMethods}}

--- a/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/api.service.mustache
@@ -176,8 +176,8 @@ export class {{classname}} {
             {{/consumes}}
         ];
 
-        if (consumes != null) {
-            headers.set('Content-Type', produces.join(';'));
+        if ((consumes != null) && (consumes.length > 0)) {
+            headers.set('Content-Type', consumes.join(';'));
         }
 
         let canConsumeForm = this.canConsumeForm(consumes);
@@ -199,7 +199,7 @@ export class {{classname}} {
             {{/produces}}
         ];
 
-        if (produces != null) {
+        if ((produces != null) && (produces.length > 0)) {
             headers.set('Accept', produces.join(';'));
         }
 

--- a/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
@@ -230,6 +230,10 @@ export class PetService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -285,6 +289,10 @@ export class PetService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -334,6 +342,10 @@ export class PetService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -385,6 +397,10 @@ export class PetService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -432,6 +448,10 @@ export class PetService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
             headers.set('api_key', this.configuration.apiKeys["api_key"]);
@@ -473,6 +493,10 @@ export class PetService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -523,6 +547,11 @@ export class PetService {
         let consumes: string[] = [
             'application/x-www-form-urlencoded'
         ];
+
+        if ((consumes != null) && (consumes.length > 0)) {
+            headers.set('Content-Type', consumes.join(';'));
+        }
+
         let canConsumeForm = this.canConsumeForm(consumes);
         let useForm = false;
         let formParams = new (useForm ? FormData : URLSearchParams as any)() as {
@@ -534,6 +563,10 @@ export class PetService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -590,6 +623,11 @@ export class PetService {
         let consumes: string[] = [
             'multipart/form-data'
         ];
+
+        if ((consumes != null) && (consumes.length > 0)) {
+            headers.set('Content-Type', consumes.join(';'));
+        }
+
         let canConsumeForm = this.canConsumeForm(consumes);
         let useForm = false;
         useForm = canConsumeForm;
@@ -601,6 +639,10 @@ export class PetService {
         let produces: string[] = [
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required

--- a/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
@@ -160,6 +160,10 @@ export class StoreService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -190,6 +194,10 @@ export class StoreService {
         let produces: string[] = [
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -234,6 +242,10 @@ export class StoreService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -270,6 +282,10 @@ export class StoreService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');

--- a/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
@@ -225,6 +225,10 @@ export class UserService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         headers.set('Content-Type', 'application/json');
 
@@ -265,6 +269,10 @@ export class UserService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         headers.set('Content-Type', 'application/json');
 
@@ -304,6 +312,10 @@ export class UserService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');
@@ -346,6 +358,10 @@ export class UserService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -383,6 +399,10 @@ export class UserService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -434,6 +454,10 @@ export class UserService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -465,6 +489,10 @@ export class UserService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -508,6 +536,10 @@ export class UserService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');

--- a/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
@@ -230,6 +230,10 @@ export class PetService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -285,6 +289,10 @@ export class PetService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -334,6 +342,10 @@ export class PetService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -385,6 +397,10 @@ export class PetService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -432,6 +448,10 @@ export class PetService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
             headers.set('api_key', this.configuration.apiKeys["api_key"]);
@@ -473,6 +493,10 @@ export class PetService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -523,6 +547,11 @@ export class PetService {
         let consumes: string[] = [
             'application/x-www-form-urlencoded'
         ];
+
+        if ((consumes != null) && (consumes.length > 0)) {
+            headers.set('Content-Type', consumes.join(';'));
+        }
+
         let canConsumeForm = this.canConsumeForm(consumes);
         let useForm = false;
         let formParams = new (useForm ? FormData : URLSearchParams as any)() as {
@@ -534,6 +563,10 @@ export class PetService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -590,6 +623,11 @@ export class PetService {
         let consumes: string[] = [
             'multipart/form-data'
         ];
+
+        if ((consumes != null) && (consumes.length > 0)) {
+            headers.set('Content-Type', consumes.join(';'));
+        }
+
         let canConsumeForm = this.canConsumeForm(consumes);
         let useForm = false;
         useForm = canConsumeForm;
@@ -601,6 +639,10 @@ export class PetService {
         let produces: string[] = [
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required

--- a/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
@@ -160,6 +160,10 @@ export class StoreService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -190,6 +194,10 @@ export class StoreService {
         let produces: string[] = [
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -234,6 +242,10 @@ export class StoreService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -270,6 +282,10 @@ export class StoreService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');

--- a/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
@@ -225,6 +225,10 @@ export class UserService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         headers.set('Content-Type', 'application/json');
 
@@ -265,6 +269,10 @@ export class UserService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         headers.set('Content-Type', 'application/json');
 
@@ -304,6 +312,10 @@ export class UserService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');
@@ -346,6 +358,10 @@ export class UserService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -383,6 +399,10 @@ export class UserService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -434,6 +454,10 @@ export class UserService {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -465,6 +489,10 @@ export class UserService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -508,6 +536,10 @@ export class UserService {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
@@ -231,6 +231,10 @@ export class PetService implements PetServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -286,6 +290,10 @@ export class PetService implements PetServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -335,6 +343,10 @@ export class PetService implements PetServiceInterface {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -386,6 +398,10 @@ export class PetService implements PetServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (petstore_auth) required
         // oauth required
         if (this.configuration.accessToken) {
@@ -433,6 +449,10 @@ export class PetService implements PetServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
             headers.set('api_key', this.configuration.apiKeys["api_key"]);
@@ -474,6 +494,10 @@ export class PetService implements PetServiceInterface {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -524,6 +548,11 @@ export class PetService implements PetServiceInterface {
         let consumes: string[] = [
             'application/x-www-form-urlencoded'
         ];
+
+        if ((consumes != null) && (consumes.length > 0)) {
+            headers.set('Content-Type', consumes.join(';'));
+        }
+
         let canConsumeForm = this.canConsumeForm(consumes);
         let useForm = false;
         let formParams = new (useForm ? FormData : URLSearchParams as any)() as {
@@ -535,6 +564,10 @@ export class PetService implements PetServiceInterface {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required
@@ -591,6 +624,11 @@ export class PetService implements PetServiceInterface {
         let consumes: string[] = [
             'multipart/form-data'
         ];
+
+        if ((consumes != null) && (consumes.length > 0)) {
+            headers.set('Content-Type', consumes.join(';'));
+        }
+
         let canConsumeForm = this.canConsumeForm(consumes);
         let useForm = false;
         useForm = canConsumeForm;
@@ -602,6 +640,10 @@ export class PetService implements PetServiceInterface {
         let produces: string[] = [
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (petstore_auth) required
         // oauth required

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
@@ -161,6 +161,10 @@ export class StoreService implements StoreServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -191,6 +195,10 @@ export class StoreService implements StoreServiceInterface {
         let produces: string[] = [
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
         // authentication (api_key) required
         if (this.configuration.apiKeys["api_key"]) {
@@ -235,6 +243,10 @@ export class StoreService implements StoreServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -271,6 +283,10 @@ export class StoreService implements StoreServiceInterface {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
@@ -226,6 +226,10 @@ export class UserService implements UserServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         headers.set('Content-Type', 'application/json');
 
@@ -266,6 +270,10 @@ export class UserService implements UserServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         headers.set('Content-Type', 'application/json');
 
@@ -305,6 +313,10 @@ export class UserService implements UserServiceInterface {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');
@@ -347,6 +359,10 @@ export class UserService implements UserServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -384,6 +400,10 @@ export class UserService implements UserServiceInterface {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -435,6 +455,10 @@ export class UserService implements UserServiceInterface {
             'application/json'
         ];
 
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
+
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -466,6 +490,10 @@ export class UserService implements UserServiceInterface {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         let requestOptions: RequestOptionsArgs = new RequestOptions({
@@ -509,6 +537,10 @@ export class UserService implements UserServiceInterface {
             'application/xml',
             'application/json'
         ];
+
+        if ((produces != null) && (produces.length > 0)) {
+            headers.set('Accept', produces.join(';'));
+        }
 
             
         headers.set('Content-Type', 'application/json');


### PR DESCRIPTION
### Description of the PR

fix for issue https://github.com/swagger-api/swagger-codegen/issues/6006

checks if the produces or consumes list is null or empty and adds the corresponding headers (Accept, Content-Type), with the value being a list seperated by semicolon, according to http-spec.