### PR TITLE
[Python][Flask] Upgraded connxion to 1.1.15 (now supports multi collection format arrays)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/flaskConnexion/requirements.mustache
+++ b/modules/swagger-codegen/src/main/resources/flaskConnexion/requirements.mustache
@@ -1,4 +1,4 @@
-connexion == 1.1.9
+connexion == 1.1.15
 python_dateutil == 2.6.0
 {{#supportPython2}}
 typing == 3.5.2.2

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -141,7 +141,7 @@ class RESTClientObject(object):
                     url += '?' + urlencode(query_params)
                 if re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
-                    if body:
+                    if body is not None:
                         request_body = json.dumps(body)
                     r = self.pool_manager.request(method, url,
                                                   body=request_body,

--- a/samples/server/petstore/flaskConnexion/requirements.txt
+++ b/samples/server/petstore/flaskConnexion/requirements.txt
@@ -1,3 +1,3 @@
-connexion == 1.1.9
+connexion == 1.1.15
 python_dateutil == 2.6.0
 setuptools >= 21.0.0


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Updating the version of connexion from 1.1.9 to 1.1.15, to support arrays with the multi collection format.