### PR TITLE
[ObjC] fix NPE when getting swagger type

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -24,7 +24,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     public static final String GIT_REPO_URL = "gitRepoURL";
     public static final String DEFAULT_LICENSE = "Proprietary";
     public static final String CORE_DATA = "coreData";
-    
+
     protected Set<String> foundationClasses = new HashSet<String>();
     protected String podName = "SwaggerClient";
     protected String podVersion = "1.0.0";
@@ -41,7 +41,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     protected String apiFilesPath = "Api/";
 
     protected boolean generateCoreData = false;
-    
+
     protected Set<String> advancedMapingTypes = new HashSet<String>();
 
     public ObjcClientCodegen() {
@@ -255,7 +255,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("Object-body.mustache",  coreFileFolder(), classPrefix + "Object.m"));
         supportingFiles.add(new SupportingFile("QueryParamCollection-header.mustache",  coreFileFolder(), classPrefix + "QueryParamCollection.h"));
         supportingFiles.add(new SupportingFile("QueryParamCollection-body.mustache",  coreFileFolder(), classPrefix + "QueryParamCollection.m"));
-        supportingFiles.add(new SupportingFile("ApiClient-header.mustache",  coreFileFolder(), classPrefix + "ApiClient.h")); 
+        supportingFiles.add(new SupportingFile("ApiClient-header.mustache",  coreFileFolder(), classPrefix + "ApiClient.h"));
         supportingFiles.add(new SupportingFile("ApiClient-body.mustache",  coreFileFolder(), classPrefix + "ApiClient.m"));
         supportingFiles.add(new SupportingFile("JSONRequestSerializer-body.mustache",  coreFileFolder(), classPrefix + "JSONRequestSerializer.m"));
         supportingFiles.add(new SupportingFile("JSONRequestSerializer-header.mustache",  coreFileFolder(), classPrefix + "JSONRequestSerializer.h"));
@@ -314,7 +314,6 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
 
         // TODO avoid using toLowerCase as typeMapping should be case-sensitive
-
         if (typeMapping.containsKey(swaggerType.toLowerCase())) {
             type = typeMapping.get(swaggerType.toLowerCase());
             if (languageSpecificPrimitives.contains(type) && !foundationClasses.contains(type)) {
@@ -355,7 +354,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
             Property inner = mp.getAdditionalProperties();
 
             String innerTypeDeclaration = getTypeDeclaration(inner);
-            
+
             if (innerTypeDeclaration.endsWith("*")) {
                 innerTypeDeclaration = innerTypeDeclaration.substring(0, innerTypeDeclaration.length() - 1);
             }
@@ -471,17 +470,17 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     public String apiDocFileFolder() {
         return (outputFolder + "/" + apiDocPath).replace("/", File.separator);
     }
- 
+
     @Override
     public String modelDocFileFolder() {
         return (outputFolder + "/" + modelDocPath).replace("/", File.separator);
     }
- 
+
     @Override
     public String toModelDocFilename(String name) {
         return toModelName(name);
     }
- 
+
     @Override
     public String toApiDocFilename(String name) {
         return toApiName(name);
@@ -551,9 +550,9 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
      * those terms here.  This logic is only called if a variable matches the reserved words
      *
      * @return the escaped term
-     */    
+     */
     @Override
-    public String escapeReservedWord(String name) {           
+    public String escapeReservedWord(String name) {
         if(this.reservedWordsMappings().containsKey(name)) {
             return this.reservedWordsMappings().get(name);
         }

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ObjcClientCodegen.java
@@ -308,6 +308,13 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
     public String getSwaggerType(Property p) {
         String swaggerType = super.getSwaggerType(p);
         String type = null;
+
+        if (swaggerType == null) {
+            swaggerType = ""; // set swagger type to empty string if null
+        }
+
+        // TODO avoid using toLowerCase as typeMapping should be case-sensitive
+
         if (typeMapping.containsKey(swaggerType.toLowerCase())) {
             type = typeMapping.get(swaggerType.toLowerCase());
             if (languageSpecificPrimitives.contains(type) && !foundationClasses.contains(type)) {

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGPetApi.h
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGPetApi.h
@@ -30,7 +30,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 /// 
 ///  code:405 message:"Invalid input"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) addPetWithBody: (SWGPet*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -43,7 +43,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 /// 
 ///  code:400 message:"Invalid pet value"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) deletePetWithPetId: (NSNumber*) petId
     apiKey: (NSString*) apiKey
     completionHandler: (void (^)(NSError* error)) handler;
@@ -98,7 +98,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 ///  code:404 message:"Pet not found",
 ///  code:405 message:"Validation exception"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) updatePetWithBody: (SWGPet*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -112,7 +112,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 /// 
 ///  code:405 message:"Invalid input"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) updatePetWithFormWithPetId: (NSString*) petId
     name: (NSString*) name
     status: (NSString*) status
@@ -128,7 +128,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) uploadFileWithPetId: (NSNumber*) petId
     additionalMetadata: (NSString*) additionalMetadata
     file: (NSURL*) file

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGStoreApi.h
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGStoreApi.h
@@ -31,7 +31,7 @@ extern NSInteger kSWGStoreApiMissingParamErrorCode;
 ///  code:400 message:"Invalid ID supplied",
 ///  code:404 message:"Order not found"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) deleteOrderWithOrderId: (NSString*) orderId
     completionHandler: (void (^)(NSError* error)) handler;
 

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGUserApi.h
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Api/SWGUserApi.h
@@ -30,7 +30,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) createUserWithBody: (SWGUser*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -42,7 +42,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) createUsersWithArrayInputWithBody: (NSArray<SWGUser>*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -54,7 +54,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) createUsersWithListInputWithBody: (NSArray<SWGUser>*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -67,7 +67,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 ///  code:400 message:"Invalid username supplied",
 ///  code:404 message:"User not found"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) deleteUserWithUsername: (NSString*) username
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -107,7 +107,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) logoutUserWithCompletionHandler: 
     (void (^)(NSError* error)) handler;
 
@@ -121,7 +121,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 ///  code:400 message:"Invalid user supplied",
 ///  code:404 message:"User not found"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) updateUserWithUsername: (NSString*) username
     body: (SWGUser*) body
     completionHandler: (void (^)(NSError* error)) handler;

--- a/samples/client/petstore/objc/default/SwaggerClient/Api/SWGPetApi.h
+++ b/samples/client/petstore/objc/default/SwaggerClient/Api/SWGPetApi.h
@@ -30,7 +30,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 /// 
 ///  code:405 message:"Invalid input"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) addPetWithBody: (SWGPet*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -43,7 +43,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 /// 
 ///  code:400 message:"Invalid pet value"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) deletePetWithPetId: (NSNumber*) petId
     apiKey: (NSString*) apiKey
     completionHandler: (void (^)(NSError* error)) handler;
@@ -98,7 +98,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 ///  code:404 message:"Pet not found",
 ///  code:405 message:"Validation exception"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) updatePetWithBody: (SWGPet*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -112,7 +112,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 /// 
 ///  code:405 message:"Invalid input"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) updatePetWithFormWithPetId: (NSString*) petId
     name: (NSString*) name
     status: (NSString*) status
@@ -128,7 +128,7 @@ extern NSInteger kSWGPetApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) uploadFileWithPetId: (NSNumber*) petId
     additionalMetadata: (NSString*) additionalMetadata
     file: (NSURL*) file

--- a/samples/client/petstore/objc/default/SwaggerClient/Api/SWGStoreApi.h
+++ b/samples/client/petstore/objc/default/SwaggerClient/Api/SWGStoreApi.h
@@ -31,7 +31,7 @@ extern NSInteger kSWGStoreApiMissingParamErrorCode;
 ///  code:400 message:"Invalid ID supplied",
 ///  code:404 message:"Order not found"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) deleteOrderWithOrderId: (NSString*) orderId
     completionHandler: (void (^)(NSError* error)) handler;
 

--- a/samples/client/petstore/objc/default/SwaggerClient/Api/SWGUserApi.h
+++ b/samples/client/petstore/objc/default/SwaggerClient/Api/SWGUserApi.h
@@ -30,7 +30,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) createUserWithBody: (SWGUser*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -42,7 +42,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) createUsersWithArrayInputWithBody: (NSArray<SWGUser>*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -54,7 +54,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) createUsersWithListInputWithBody: (NSArray<SWGUser>*) body
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -67,7 +67,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 ///  code:400 message:"Invalid username supplied",
 ///  code:404 message:"User not found"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) deleteUserWithUsername: (NSString*) username
     completionHandler: (void (^)(NSError* error)) handler;
 
@@ -107,7 +107,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 /// 
 ///  code:0 message:"successful operation"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) logoutUserWithCompletionHandler: 
     (void (^)(NSError* error)) handler;
 
@@ -121,7 +121,7 @@ extern NSInteger kSWGUserApiMissingParamErrorCode;
 ///  code:400 message:"Invalid user supplied",
 ///  code:404 message:"User not found"
 ///
-/// @return 
+/// @return void
 -(NSURLSessionTask*) updateUserWithUsername: (NSString*) username
     body: (SWGUser*) body
     completionHandler: (void (^)(NSError* error)) handler;

--- a/samples/client/petstore/objc/default/docs/SWGStoreApi.md
+++ b/samples/client/petstore/objc/default/docs/SWGStoreApi.md
@@ -97,7 +97,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**NSDictionary<NSString*, NSNumber*>***](NSDictionary.md)
+**NSDictionary<NSString*, NSNumber*>***
 
 ### Authorization
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Similar to https://github.com/swagger-api/swagger-codegen/pull/6462 but for ObjC
