### PR TITLE
[PHP] Fix #6474: Bug with 'format: date' when using --model-name-prefix

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PhpClientCodegen.java
@@ -117,6 +117,7 @@ public class PhpClientCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("string", "string");
         typeMapping.put("byte", "int");
         typeMapping.put("boolean", "bool");
+        typeMapping.put("date", "\\DateTime");
         typeMapping.put("Date", "\\DateTime");
         typeMapping.put("DateTime", "\\DateTime");
         typeMapping.put("file", "\\SplFileObject");

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/php/PhpModelTest.java
@@ -1,12 +1,14 @@
 package io.swagger.codegen.php;
 
 import io.swagger.codegen.CodegenModel;
+import io.swagger.codegen.CodegenOperation;
 import io.swagger.codegen.CodegenProperty;
 import io.swagger.codegen.DefaultCodegen;
 import io.swagger.codegen.languages.PhpClientCodegen;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.DateTimeProperty;
@@ -344,5 +346,17 @@ public class PhpModelTest {
         Assert.assertEquals(codegen.toEnumVarName("hello", null), "HELLO");
     }
 
+    @Test(description = "returns DateTime when using `--model-name-prefix`")
+    public void dateTest() {
+        final Swagger model =  new SwaggerParser().read("src/test/resources/2_0/datePropertyTest.json");
+        final DefaultCodegen codegen = new PhpClientCodegen();
+        codegen.setModelNamePrefix("foo");
 
+        final String path = "/tests/dateResponse";
+        final Operation p = model.getPaths().get(path).getPost();
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, model.getDefinitions());
+
+        Assert.assertEquals(op.returnType, "\\DateTime");
+        Assert.assertEquals(op.bodyParam.dataType, "\\DateTime");
+    }
 }

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Model/FormatTest.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Model/FormatTest.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **string** | **string** |  | [optional] 
 **byte** | **string** |  | 
 **binary** | **string** |  | [optional] 
-**date** | [**\DateTime**](Date.md) |  | 
+**date** | [**\DateTime**](\DateTime.md) |  | 
 **date_time** | [**\DateTime**](\DateTime.md) |  | [optional] 
 **uuid** | **string** |  | [optional] 
 **password** | **string** |  | 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Fixes issue #6474.

