### PR TITLE
[Typescript-jQuery] Tentative fix for #6505

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-jquery/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-jquery/api.mustache
@@ -58,7 +58,6 @@ export class {{classname}} {
 {{#hasFormParams}}
         let formParams = new FormData();
         let reqHasFile = false;
-
 {{/hasFormParams}}
 {{#allParams}}
 {{#required}}

--- a/samples/client/petstore/typescript-jquery/default/api/PetApi.ts
+++ b/samples/client/petstore/typescript-jquery/default/api/PetApi.ts
@@ -420,7 +420,6 @@ export class PetApi {
         let headerParams: any = {};
         let formParams = new FormData();
         let reqHasFile = false;
-
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
@@ -500,7 +499,6 @@ export class PetApi {
         let headerParams: any = {};
         let formParams = new FormData();
         let reqHasFile = false;
-
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');

--- a/samples/client/petstore/typescript-jquery/npm/api/PetApi.ts
+++ b/samples/client/petstore/typescript-jquery/npm/api/PetApi.ts
@@ -420,7 +420,6 @@ export class PetApi {
         let headerParams: any = {};
         let formParams = new FormData();
         let reqHasFile = false;
-
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
@@ -500,7 +499,6 @@ export class PetApi {
         let headerParams: any = {};
         let formParams = new FormData();
         let reqHasFile = false;
-
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This is a tentative fix for https://github.com/swagger-api/swagger-codegen/issues/6505

The downside of this fix is that we "concatenate" all formData of type "file" into one called "files". So if there is 4 file parameters, and the first is required and the 3 others are not, then we will validate that "files" is required. If there is only one formData of type "file", we don't concatenate or change the name.

But I don't think there is a perfect solution in this case. Let me know what you think.
