### PR TITLE
[CPPREST] Fixed multipart files upload implementation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/api-source.mustache
@@ -221,9 +221,6 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
         throw ApiException(415, U("{{classname}}->{{operationId}} does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
     {{#authMethods}}
     // authentication ({{name}}) required
     {{#isApiKey}}

--- a/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
+++ b/modules/swagger-codegen/src/main/resources/cpprest/apiclient-source.mustache
@@ -100,10 +100,10 @@ pplx::task<web::http::http_response> ApiClient::callApi(
             uploadData.add(ModelBase::toHttpContent(kvp.first, kvp.second));
         }
         std::stringstream data;
-        postBody->writeTo(data);
+        uploadData.writeTo(data);
         auto bodyString = data.str();
         auto length = bodyString.size();
-        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, contentType);
+        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, U("multipart/form-data; boundary=") + uploadData.getBoundary());
     }
     else
     {

--- a/samples/client/petstore/cpprest/ApiClient.cpp
+++ b/samples/client/petstore/cpprest/ApiClient.cpp
@@ -112,10 +112,10 @@ pplx::task<web::http::http_response> ApiClient::callApi(
             uploadData.add(ModelBase::toHttpContent(kvp.first, kvp.second));
         }
         std::stringstream data;
-        postBody->writeTo(data);
+        uploadData.writeTo(data);
         auto bodyString = data.str();
         auto length = bodyString.size();
-        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, contentType);
+        request.set_body(concurrency::streams::bytestream::open_istream(std::move(bodyString)), length, U("multipart/form-data; boundary=") + uploadData.getBoundary());
     }
     else
     {

--- a/samples/client/petstore/cpprest/api/PetApi.cpp
+++ b/samples/client/petstore/cpprest/api/PetApi.cpp
@@ -118,9 +118,6 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> body)
         throw ApiException(415, U("PetApi->addPet does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
@@ -224,9 +221,6 @@ pplx::task<void> PetApi::deletePet(int64_t petId, utility::string_t apiKey)
         throw ApiException(415, U("PetApi->deletePet does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
@@ -328,9 +322,6 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
     {
         throw ApiException(415, U("PetApi->findPetsByStatus does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
@@ -459,9 +450,6 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
         throw ApiException(415, U("PetApi->findPetsByTags does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
@@ -585,9 +573,6 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
     {
         throw ApiException(415, U("PetApi->getPetById does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
     // authentication (api_key) required
     {
@@ -732,9 +717,6 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> body)
         throw ApiException(415, U("PetApi->updatePet does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
@@ -843,9 +825,6 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, utility::string_t name
         throw ApiException(415, U("PetApi->updatePetWithForm does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
@@ -952,9 +931,6 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, utili
     {
         throw ApiException(415, U("PetApi->uploadFile does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config

--- a/samples/client/petstore/cpprest/api/StoreApi.cpp
+++ b/samples/client/petstore/cpprest/api/StoreApi.cpp
@@ -98,9 +98,6 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId)
         throw ApiException(415, U("StoreApi->deleteOrder does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
 
     return m_ApiClient->callApi(path, U("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
@@ -195,9 +192,6 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
     {
         throw ApiException(415, U("StoreApi->getInventory does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
     // authentication (api_key) required
     {
@@ -326,9 +320,6 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
     {
         throw ApiException(415, U("StoreApi->getOrderById does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
 
     return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
@@ -462,9 +453,6 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> b
     {
         throw ApiException(415, U("StoreApi->placeOrder does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
 
     return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)

--- a/samples/client/petstore/cpprest/api/UserApi.cpp
+++ b/samples/client/petstore/cpprest/api/UserApi.cpp
@@ -116,9 +116,6 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> body)
         throw ApiException(415, U("UserApi->createUser does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
 
     return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
@@ -240,9 +237,6 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
     {
         throw ApiException(415, U("UserApi->createUsersWithArrayInput does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
 
     return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
@@ -366,9 +360,6 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
         throw ApiException(415, U("UserApi->createUsersWithListInput does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
 
     return m_ApiClient->callApi(path, U("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
@@ -466,9 +457,6 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username)
         throw ApiException(415, U("UserApi->deleteUser does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
 
     return m_ApiClient->callApi(path, U("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
@@ -565,9 +553,6 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
     {
         throw ApiException(415, U("UserApi->getUserByName does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
 
     return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
@@ -696,9 +681,6 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
         throw ApiException(415, U("UserApi->loginUser does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
 
     return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
@@ -818,9 +800,6 @@ pplx::task<void> UserApi::logoutUser()
         throw ApiException(415, U("UserApi->logoutUser does not consume any supported media type"));
     }
 
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
-
 
     return m_ApiClient->callApi(path, U("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
     .then([=](web::http::http_response response)
@@ -936,9 +915,6 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
     {
         throw ApiException(415, U("UserApi->updateUser does not consume any supported media type"));
     }
-
-    //Set the request content type in the header.
-    headerParams[U("Content-Type")] = requestHttpContentType;
 
 
     return m_ApiClient->callApi(path, U("PUT"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)

--- a/samples/client/petstore/cpprest/model/Pet.h
+++ b/samples/client/petstore/cpprest/model/Pet.h
@@ -22,10 +22,10 @@
 
 #include "ModelBase.h"
 
-#include "Tag.h"
-#include <cpprest/details/basic_types.h>
 #include "Category.h"
+#include <cpprest/details/basic_types.h>
 #include <vector>
+#include "Tag.h"
 
 namespace io {
 namespace swagger {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

Before this PR, file upload functionality was completely broken. I have fixed the segmentation fault due to the use of null `postBody` instead of `uploadData` (I believe, it was just a typo) and `Content-Type` didn't include the `boundary` marker.