### PR TITLE
[Java] Play! framework + retrofit2 client exception converter, bug fixes

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3263,9 +3263,16 @@ public class DefaultCodegen {
         p = Pattern.compile("(-)(.)");
         m = p.matcher(word);
         while (m.find()) {
-            word = m.replaceFirst(m.group(2).toUpperCase());
+            String original = m.group(2);
+            String upperCase = original.toUpperCase();
+            if (original.equals(upperCase)) {
+                word = word.replaceFirst("_", "");
+            } else {
+                word = m.replaceFirst(upperCase);
+            }
             m = p.matcher(word);
         }
+
 
         if (lowercaseFirstLetter && word.length() > 0) {
             word = word.substring(0, 1).toLowerCase() + word.substring(1);

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3255,14 +3255,6 @@ public class DefaultCodegen {
         p = Pattern.compile("(_)(.)");
         m = p.matcher(word);
         while (m.find()) {
-            word = m.replaceFirst(m.group(2).toUpperCase());
-            m = p.matcher(word);
-        }
-
-        // Remove all hyphens (hyphen-case to camelCase)
-        p = Pattern.compile("(-)(.)");
-        m = p.matcher(word);
-        while (m.find()) {
             String original = m.group(2);
             String upperCase = original.toUpperCase();
             if (original.equals(upperCase)) {
@@ -3273,6 +3265,13 @@ public class DefaultCodegen {
             m = p.matcher(word);
         }
 
+        // Remove all hyphens (hyphen-case to camelCase)
+        p = Pattern.compile("(-)(.)");
+        m = p.matcher(word);
+        while (m.find()) {
+            word = m.replaceFirst(m.group(2).toUpperCase());
+            m = p.matcher(word);
+        }
 
         if (lowercaseFirstLetter && word.length() > 0) {
             word = word.substring(0, 1).toLowerCase() + word.substring(1);

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play25/Play25CallAdapterFactory.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/play25/Play25CallAdapterFactory.mustache
@@ -9,11 +9,22 @@ import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 /**
  * Creates {@link CallAdapter} instances that convert {@link Call} into {@link java.util.concurrent.CompletionStage}
  */
 public class Play25CallAdapterFactory extends CallAdapter.Factory {
+
+    private Function<RuntimeException, RuntimeException> exceptionConverter = Function.identity();
+
+    public Play25CallAdapterFactory() {
+    }
+
+    public Play25CallAdapterFactory(
+            Function<RuntimeException, RuntimeException> exceptionConverter) {
+        this.exceptionConverter = exceptionConverter;
+    }
 
     @Override
     public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
@@ -49,7 +60,7 @@ public class Play25CallAdapterFactory extends CallAdapter.Factory {
             includeResponse = true;
         }
 
-        return new ValueAdapter(resultType, includeResponse);
+        return new ValueAdapter(resultType, includeResponse, exceptionConverter);
     }
 
     /**
@@ -59,10 +70,13 @@ public class Play25CallAdapterFactory extends CallAdapter.Factory {
 
         private final Type responseType;
         private final boolean includeResponse;
+        private Function<RuntimeException, RuntimeException> exceptionConverter;
 
-        ValueAdapter(Type responseType, boolean includeResponse) {
+        ValueAdapter(Type responseType, boolean includeResponse,
+                     Function<RuntimeException, RuntimeException> exceptionConverter) {
             this.responseType = responseType;
             this.includeResponse = includeResponse;
+            this.exceptionConverter = exceptionConverter;
         }
 
         @Override
@@ -85,7 +99,7 @@ public class Play25CallAdapterFactory extends CallAdapter.Factory {
                             promise.complete(response.body());
                         }
                     } else {
-                        promise.completeExceptionally(new HttpException(response));
+                        promise.completeExceptionally(exceptionConverter.apply(new HttpException(response)));
                     }
                 }
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -32,6 +32,7 @@ public class CodegenTest {
         Assert.assertEquals(codegen.camelize(".foo"), "Foo");
         Assert.assertEquals(codegen.camelize(".foo.bar"), "FooBar");
         Assert.assertEquals(codegen.camelize("foo$bar"), "Foo$bar");
+        Assert.assertEquals(codegen.camelize("foo_$bar"), "Foo$bar");
         Assert.assertEquals(codegen.camelize("foo_bar"), "FooBar");
         Assert.assertEquals(codegen.camelize("foo_bar_baz"), "FooBarBaz");
         Assert.assertEquals(codegen.camelize("foo/bar.baz"), "FooBarBaz");

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -33,6 +33,7 @@ public class CodegenTest {
         Assert.assertEquals(codegen.camelize(".foo.bar"), "FooBar");
         Assert.assertEquals(codegen.camelize("foo$bar"), "Foo$bar");
         Assert.assertEquals(codegen.camelize("foo_$bar"), "Foo$bar");
+        
         Assert.assertEquals(codegen.camelize("foo_bar"), "FooBar");
         Assert.assertEquals(codegen.camelize("foo_bar_baz"), "FooBarBaz");
         Assert.assertEquals(codegen.camelize("foo/bar.baz"), "FooBarBaz");

--- a/samples/client/petstore/java/retrofit2-play24/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/AnotherFakeApi.md
@@ -1,0 +1,54 @@
+# AnotherFakeApi
+
+All URIs are relative to *http://petstore.swagger.io:80/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**testSpecialTags**](AnotherFakeApi.md#testSpecialTags) | **PATCH** another-fake/dummy | To test special tags
+
+
+<a name="testSpecialTags"></a>
+# **testSpecialTags**
+> Client testSpecialTags(body)
+
+To test special tags
+
+To test special tags
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.AnotherFakeApi;
+
+
+AnotherFakeApi apiInstance = new AnotherFakeApi();
+Client body = new Client(); // Client | client model
+try {
+    Client result = apiInstance.testSpecialTags(body);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling AnotherFakeApi#testSpecialTags");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**Client**](Client.md)| client model |
+
+### Return type
+
+[**Client**](Client.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/io/swagger/client/api/AnotherFakeApi.java
@@ -1,0 +1,37 @@
+package io.swagger.client.api;
+
+import io.swagger.client.CollectionFormats.*;
+
+
+
+import retrofit2.Call;
+import retrofit2.http.*;
+
+import okhttp3.RequestBody;
+
+import io.swagger.client.model.Client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import play.libs.F;
+import retrofit2.Response;
+
+public interface AnotherFakeApi {
+  /**
+   * To test special tags
+   * To test special tags
+   * @param body client model (required)
+   * @return Call&lt;Client&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @PATCH("another-fake/dummy")
+  F.Promise<Response<Client>> testSpecialTags(
+    @retrofit2.http.Body Client body
+  );
+
+}

--- a/samples/client/petstore/java/retrofit2-play24/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
@@ -1,0 +1,37 @@
+package io.swagger.client.api;
+
+import io.swagger.client.ApiClient;
+import io.swagger.client.model.Client;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * API tests for AnotherFakeApi
+ */
+public class AnotherFakeApiTest {
+
+    private AnotherFakeApi api;
+
+    @Before
+    public void setup() {
+        api = new ApiClient().createService(AnotherFakeApi.class);
+    }
+
+    /**
+     * To test special tags
+     *
+     * To test special tags
+     */
+    @Test
+    public void testSpecialTagsTest() {
+        Client body = null;
+        // Client response = api.testSpecialTags(body);
+
+        // TODO: test validations
+    }
+}

--- a/samples/client/petstore/java/retrofit2-play25/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/AnotherFakeApi.md
@@ -1,0 +1,54 @@
+# AnotherFakeApi
+
+All URIs are relative to *http://petstore.swagger.io:80/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**testSpecialTags**](AnotherFakeApi.md#testSpecialTags) | **PATCH** another-fake/dummy | To test special tags
+
+
+<a name="testSpecialTags"></a>
+# **testSpecialTags**
+> Client testSpecialTags(body)
+
+To test special tags
+
+To test special tags
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.AnotherFakeApi;
+
+
+AnotherFakeApi apiInstance = new AnotherFakeApi();
+Client body = new Client(); // Client | client model
+try {
+    Client result = apiInstance.testSpecialTags(body);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling AnotherFakeApi#testSpecialTags");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**Client**](Client.md)| client model |
+
+### Return type
+
+[**Client**](Client.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/io/swagger/client/Play25CallAdapterFactory.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/io/swagger/client/Play25CallAdapterFactory.java
@@ -9,11 +9,22 @@ import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 /**
  * Creates {@link CallAdapter} instances that convert {@link Call} into {@link java.util.concurrent.CompletionStage}
  */
 public class Play25CallAdapterFactory extends CallAdapter.Factory {
+
+    private Function<RuntimeException, RuntimeException> exceptionConverter = Function.identity();
+
+    public Play25CallAdapterFactory() {
+    }
+
+    public Play25CallAdapterFactory(
+            Function<RuntimeException, RuntimeException> exceptionConverter) {
+        this.exceptionConverter = exceptionConverter;
+    }
 
     @Override
     public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
@@ -49,7 +60,7 @@ public class Play25CallAdapterFactory extends CallAdapter.Factory {
             includeResponse = true;
         }
 
-        return new ValueAdapter(resultType, includeResponse);
+        return new ValueAdapter(resultType, includeResponse, exceptionConverter);
     }
 
     /**
@@ -59,10 +70,13 @@ public class Play25CallAdapterFactory extends CallAdapter.Factory {
 
         private final Type responseType;
         private final boolean includeResponse;
+        private Function<RuntimeException, RuntimeException> exceptionConverter;
 
-        ValueAdapter(Type responseType, boolean includeResponse) {
+        ValueAdapter(Type responseType, boolean includeResponse,
+                     Function<RuntimeException, RuntimeException> exceptionConverter) {
             this.responseType = responseType;
             this.includeResponse = includeResponse;
+            this.exceptionConverter = exceptionConverter;
         }
 
         @Override
@@ -85,7 +99,7 @@ public class Play25CallAdapterFactory extends CallAdapter.Factory {
                             promise.complete(response.body());
                         }
                     } else {
-                        promise.completeExceptionally(new HttpException(response));
+                        promise.completeExceptionally(exceptionConverter.apply(new HttpException(response)));
                     }
                 }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/io/swagger/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/io/swagger/client/api/AnotherFakeApi.java
@@ -1,0 +1,37 @@
+package io.swagger.client.api;
+
+import io.swagger.client.CollectionFormats.*;
+
+
+
+import retrofit2.Call;
+import retrofit2.http.*;
+
+import okhttp3.RequestBody;
+
+import io.swagger.client.model.Client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import java.util.concurrent.*;
+import retrofit2.Response;
+
+public interface AnotherFakeApi {
+  /**
+   * To test special tags
+   * To test special tags
+   * @param body client model (required)
+   * @return Call&lt;Client&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @PATCH("another-fake/dummy")
+  CompletionStage<Response<Client>> testSpecialTags(
+    @retrofit2.http.Body Client body
+  );
+
+}

--- a/samples/client/petstore/java/retrofit2-play25/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
@@ -1,0 +1,37 @@
+package io.swagger.client.api;
+
+import io.swagger.client.ApiClient;
+import io.swagger.client.model.Client;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * API tests for AnotherFakeApi
+ */
+public class AnotherFakeApiTest {
+
+    private AnotherFakeApi api;
+
+    @Before
+    public void setup() {
+        api = new ApiClient().createService(AnotherFakeApi.class);
+    }
+
+    /**
+     * To test special tags
+     *
+     * To test special tags
+     */
+    @Test
+    public void testSpecialTagsTest() {
+        Client body = null;
+        // Client response = api.testSpecialTags(body);
+
+        // TODO: test validations
+    }
+}

--- a/samples/client/petstore/java/retrofit2/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/AnotherFakeApi.md
@@ -1,0 +1,54 @@
+# AnotherFakeApi
+
+All URIs are relative to *http://petstore.swagger.io:80/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**testSpecialTags**](AnotherFakeApi.md#testSpecialTags) | **PATCH** another-fake/dummy | To test special tags
+
+
+<a name="testSpecialTags"></a>
+# **testSpecialTags**
+> Client testSpecialTags(body)
+
+To test special tags
+
+To test special tags
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.AnotherFakeApi;
+
+
+AnotherFakeApi apiInstance = new AnotherFakeApi();
+Client body = new Client(); // Client | client model
+try {
+    Client result = apiInstance.testSpecialTags(body);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling AnotherFakeApi#testSpecialTags");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**Client**](Client.md)| client model |
+
+### Return type
+
+[**Client**](Client.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+

--- a/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/io/swagger/client/api/AnotherFakeApi.java
@@ -1,0 +1,33 @@
+package io.swagger.client.api;
+
+import io.swagger.client.CollectionFormats.*;
+
+import retrofit2.Call;
+import retrofit2.http.*;
+
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+
+import io.swagger.client.model.Client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public interface AnotherFakeApi {
+  /**
+   * To test special tags
+   * To test special tags
+   * @param body client model (required)
+   * @return Call&lt;Client&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @PATCH("another-fake/dummy")
+  Call<Client> testSpecialTags(
+    @retrofit2.http.Body Client body
+  );
+
+}

--- a/samples/client/petstore/java/retrofit2/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/retrofit2/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
@@ -1,0 +1,37 @@
+package io.swagger.client.api;
+
+import io.swagger.client.ApiClient;
+import io.swagger.client.model.Client;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * API tests for AnotherFakeApi
+ */
+public class AnotherFakeApiTest {
+
+    private AnotherFakeApi api;
+
+    @Before
+    public void setup() {
+        api = new ApiClient().createService(AnotherFakeApi.class);
+    }
+
+    /**
+     * To test special tags
+     *
+     * To test special tags
+     */
+    @Test
+    public void testSpecialTagsTest() {
+        Client body = null;
+        // Client response = api.testSpecialTags(body);
+
+        // TODO: test validations
+    }
+}

--- a/samples/client/petstore/java/retrofit2rx/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/AnotherFakeApi.md
@@ -1,0 +1,54 @@
+# AnotherFakeApi
+
+All URIs are relative to *http://petstore.swagger.io:80/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**testSpecialTags**](AnotherFakeApi.md#testSpecialTags) | **PATCH** another-fake/dummy | To test special tags
+
+
+<a name="testSpecialTags"></a>
+# **testSpecialTags**
+> Client testSpecialTags(body)
+
+To test special tags
+
+To test special tags
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.AnotherFakeApi;
+
+
+AnotherFakeApi apiInstance = new AnotherFakeApi();
+Client body = new Client(); // Client | client model
+try {
+    Client result = apiInstance.testSpecialTags(body);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling AnotherFakeApi#testSpecialTags");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**Client**](Client.md)| client model |
+
+### Return type
+
+[**Client**](Client.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/io/swagger/client/api/AnotherFakeApi.java
@@ -1,0 +1,33 @@
+package io.swagger.client.api;
+
+import io.swagger.client.CollectionFormats.*;
+
+import rx.Observable;
+import retrofit2.http.*;
+
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+
+import io.swagger.client.model.Client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public interface AnotherFakeApi {
+  /**
+   * To test special tags
+   * To test special tags
+   * @param body client model (required)
+   * @return Call&lt;Client&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @PATCH("another-fake/dummy")
+  Observable<Client> testSpecialTags(
+    @retrofit2.http.Body Client body
+  );
+
+}

--- a/samples/client/petstore/java/retrofit2rx/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
@@ -1,0 +1,37 @@
+package io.swagger.client.api;
+
+import io.swagger.client.ApiClient;
+import io.swagger.client.model.Client;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * API tests for AnotherFakeApi
+ */
+public class AnotherFakeApiTest {
+
+    private AnotherFakeApi api;
+
+    @Before
+    public void setup() {
+        api = new ApiClient().createService(AnotherFakeApi.class);
+    }
+
+    /**
+     * To test special tags
+     *
+     * To test special tags
+     */
+    @Test
+    public void testSpecialTagsTest() {
+        Client body = null;
+        // Client response = api.testSpecialTags(body);
+
+        // TODO: test validations
+    }
+}

--- a/samples/client/petstore/java/retrofit2rx2/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/AnotherFakeApi.md
@@ -1,0 +1,54 @@
+# AnotherFakeApi
+
+All URIs are relative to *http://petstore.swagger.io:80/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**testSpecialTags**](AnotherFakeApi.md#testSpecialTags) | **PATCH** another-fake/dummy | To test special tags
+
+
+<a name="testSpecialTags"></a>
+# **testSpecialTags**
+> Client testSpecialTags(body)
+
+To test special tags
+
+To test special tags
+
+### Example
+```java
+// Import classes:
+//import io.swagger.client.ApiException;
+//import io.swagger.client.api.AnotherFakeApi;
+
+
+AnotherFakeApi apiInstance = new AnotherFakeApi();
+Client body = new Client(); // Client | client model
+try {
+    Client result = apiInstance.testSpecialTags(body);
+    System.out.println(result);
+} catch (ApiException e) {
+    System.err.println("Exception when calling AnotherFakeApi#testSpecialTags");
+    e.printStackTrace();
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | [**Client**](Client.md)| client model |
+
+### Return type
+
+[**Client**](Client.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/io/swagger/client/api/AnotherFakeApi.java
@@ -1,0 +1,33 @@
+package io.swagger.client.api;
+
+import io.swagger.client.CollectionFormats.*;
+
+import io.reactivex.Observable;
+import retrofit2.http.*;
+
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+
+import io.swagger.client.model.Client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public interface AnotherFakeApi {
+  /**
+   * To test special tags
+   * To test special tags
+   * @param body client model (required)
+   * @return Call&lt;Client&gt;
+   */
+  @Headers({
+    "Content-Type:application/json"
+  })
+  @PATCH("another-fake/dummy")
+  Observable<Client> testSpecialTags(
+    @retrofit2.http.Body Client body
+  );
+
+}

--- a/samples/client/petstore/java/retrofit2rx2/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/test/java/io/swagger/client/api/AnotherFakeApiTest.java
@@ -1,0 +1,37 @@
+package io.swagger.client.api;
+
+import io.swagger.client.ApiClient;
+import io.swagger.client.model.Client;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * API tests for AnotherFakeApi
+ */
+public class AnotherFakeApiTest {
+
+    private AnotherFakeApi api;
+
+    @Before
+    public void setup() {
+        api = new ApiClient().createService(AnotherFakeApi.class);
+    }
+
+    /**
+     * To test special tags
+     *
+     * To test special tags
+     */
+    @Test
+    public void testSpecialTagsTest() {
+        Client body = null;
+        // Client response = api.testSpecialTags(body);
+
+        // TODO: test validations
+    }
+}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

- added exception converter that can be used to convert from retrofit2.HttpException to custom API exception
- fixed underscore removal code bug (didnt work correctly when the dollar symbol ($) was present)

