### PR TITLE
Pre-calculate type aliases before processing models

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -619,7 +619,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String getAlias(String name) {
-        if (typeAliases.containsKey(name)) {
+        if (typeAliases != null && typeAliases.containsKey(name)) {
             return typeAliases.get(name);
         }
         return name;

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1402,12 +1402,6 @@ definitions:
     - "placed"
     - "approved"
     - "delivered"
-  OuterNumber:
-    type: number
-  OuterString:
-    type: string
-  OuterBoolean:
-    type: boolean
   OuterComposite:
     type: object
     properties:
@@ -1417,6 +1411,12 @@ definitions:
         $ref: '#/definitions/OuterString'
       my_boolean:
         $ref: '#/definitions/OuterBoolean'
+  OuterNumber:
+    type: number
+  OuterString:
+    type: string
+  OuterBoolean:
+    type: boolean
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'


### PR DESCRIPTION
A type alias in this context is where a model is simply another name for a
primitive type, such as `MyString` in the following model definitions:

    MyList:
      type: array
      items:
        $ref: '#/definitions/MyString'
    MyString:
      type: string

It is valid to use a type alias as a property in another object or array model,
even if the object/array is defined before the alias is, as in the example
above. However, the current alias logic only looks "back" in list of previously
defined models, meaning that `MyList` would not know that `MyString` is an
alias. This change fixes the incorrect behavior by pre-calculating the list of
aliases before any models are processed. It also changes the test endpoint to
verify the correct behavior even when an object is defined before an alias it
uses.

### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This is a fix for Issue #6379. The problem was that the list of potential alias types was being built up as the models were being generated, and so a composite type (like an object or array) would only be aware of aliases defined above it in the spec. This change pre-calculates all the aliases before processing the first model definition. I have tested it by changing the test spec to use a definition pattern similar to the one in the bug report, and the same client code is generated either way.

