### PR TITLE
Add class prefix to tag with numbers

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3502,7 +3502,7 @@ public class DefaultCodegen {
 
         // tag starts with numbers
         if (tag.matches("^\\d.*")) {
-            tag = "_" + tag;
+            tag = "Class" + tag;
         }
 
         return tag;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -1229,11 +1229,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         additionalProperties.put(propertyKey, value);
     }
 
-    @Override
-    public String sanitizeTag(String tag) {
-        return camelize(sanitizeName(tag));
-    }
-
     /**
      * Output the Getter name for boolean property, e.g. isActive
      *

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/CodegenTest.java
@@ -17,11 +17,12 @@ public class CodegenTest {
     public void sanitizeTagTest() {
         final DefaultCodegen codegen = new DefaultCodegen();
         Assert.assertEquals(codegen.sanitizeTag("foo"), "Foo");
+        Assert.assertEquals(codegen.sanitizeTag("$foo!"), "Foo");
         Assert.assertEquals(codegen.sanitizeTag("foo bar"), "FooBar");
         Assert.assertEquals(codegen.sanitizeTag("foo_bar"), "FooBar");
         Assert.assertEquals(codegen.sanitizeTag("foo1 bar2"), "Foo1Bar2");
         Assert.assertEquals(codegen.sanitizeTag("foo bar 1"), "FooBar1");
-        Assert.assertEquals(codegen.sanitizeTag("1foo"), "_1foo");
+        Assert.assertEquals(codegen.sanitizeTag("1foo"), "Class1foo");
     }
 
     @Test(description = "test camelize")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

To fix https://github.com/swagger-api/swagger-codegen/issues/6482

- add class prefix to tag with numbers
- update Java generator to use default tag naming
