### PR TITLE
[PHP][Symfony] Generate valid PHP code

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php-symfony/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/api.mustache
@@ -18,7 +18,7 @@
 
 namespace {{apiPackage}};
 
-{{#operations}}{{#imports}}use {{this}};
+{{#operations}}{{#imports}}use {{import}};
 {{/imports}}
 
 /**
@@ -56,7 +56,7 @@ interface {{classname}}
      *
     {{/description}}
     {{#allParams}}
-     * @param  {{vendorExtensions.x-simpleName}} ${{paramName}}  {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{dataType}} ${{paramName}}  {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
     {{/allParams}}
      *
     {{#responses}}
@@ -64,7 +64,7 @@ interface {{classname}}
      * @throws {{vendorExtensions.x-symfonyExceptionSimple}}  {{message}}
     {{/vendorExtensions.x-symfonyExceptionSimple}}
     {{^vendorExtensions.x-symfonyExceptionSimple}}
-     * @return {{^dataType}}void{{/dataType}}{{#dataType}}{{vendorExtensions.x-simpleName}}{{/dataType}}  {{message}}
+     * @return {{^dataType}}void{{/dataType}}{{#dataType}}{{dataType}}{{/dataType}}  {{message}}
      *
     {{/vendorExtensions.x-symfonyExceptionSimple}}
     {{/responses}}

--- a/modules/swagger-codegen/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/api_controller.mustache
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use {{apiPackage}}\{{classname}};
-{{#imports}}use {{this}};
+{{#imports}}use {{import}};
 {{/imports}}
 
 /**
@@ -179,11 +179,9 @@ class {{controllerName}} extends Controller
             return new Response('', 204);
             {{/returnType}}
         {{#responses}}
-        {{#vendorExtensions.x-symfonyExceptionSimple}}
-        } catch ({{vendorExtensions.x-symfonyExceptionSimple}} $exception) {
+        } catch (HttpException $exception) {
             // {{message}}
             return $this->createErrorResponse($exception);
-        {{/vendorExtensions.x-symfonyExceptionSimple}}
         {{/responses}}
         } catch (Exception $fallthrough) {
             return $this->createErrorResponse(new HttpException(500, 'An unsuspected error occurred.', $fallthrough));

--- a/modules/swagger-codegen/src/main/resources/php-symfony/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/model.mustache
@@ -20,9 +20,8 @@
  */
 
 namespace {{modelPackage}};
-{{^isEnum}}
 
-use \ArrayAccess;
+{{^isEnum}}
 {{#useStatements}}use {{this}};
 {{/useStatements}}
 {{/isEnum}}

--- a/modules/swagger-codegen/src/main/resources/php-symfony/model_generic.mustache
+++ b/modules/swagger-codegen/src/main/resources/php-symfony/model_generic.mustache
@@ -1,4 +1,4 @@
-class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}implements ModelInterface, ArrayAccess
+class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}implements ModelInterface, \ArrayAccess
 {
     const DISCRIMINATOR = {{#discriminator}}'{{discriminator}}'{{/discriminator}}{{^discriminator}}null{{/discriminator}};
 

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SymfonyServerOptionsProvider.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/options/SymfonyServerOptionsProvider.java
@@ -49,6 +49,7 @@ public class SymfonyServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.ARTIFACT_VERSION, ARTIFACT_VERSION_VALUE)
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
+                .put(SymfonyServerCodegen.PHP_LEGACY_SUPPORT, "true")
                 .build();
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR
We were experiencing syntax issues when generating the Petstore example. See some of the examples below:

### StoreApiInterface.php
namespace Swagger\Server\Api;
use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
use Swagger\Server\Model\Order;
**use maparray&lt;string,int&gt;;**
use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

### UserApiInterface.php
public function createUsersWithArrayInput(**User[]** $body);
public function createUsersWithListInput(**User[]** $body);

### PetApiInterface.php
namespace Swagger\Server\Api;

use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
use Swagger\Server\Model\Pet;
use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
use Swagger\Server\Model\ApiResponse;
**use string[];**
use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;

public function findPetsByStatus(**string[]** $status);
public function findPetsByTags(**string[]** $tags);

This PR should fix #5985