### PR TITLE
[Bash ] Bugfix: Path replacement regex not working

### DIFF
--- a/modules/swagger-codegen/src/main/resources/bash/client.mustache
+++ b/modules/swagger-codegen/src/main/resources/bash/client.mustache
@@ -407,8 +407,8 @@ build_request_path() {
     fi
 
     # First replace all path parameters in the path
-    local path_regex="(.*)(\\{$pparam\\})(.*)"
     for pparam in "${path_params[@]}"; do
+        local path_regex="(.*)(\\{$pparam\\})(.*)"
         if [[ $path_template =~ $path_regex ]]; then
             path_template=${BASH_REMATCH[1]}${operation_parameters[$pparam]}${BASH_REMATCH[3]}
         fi

--- a/samples/client/petstore/bash/petstore-cli
+++ b/samples/client/petstore/bash/petstore-cli
@@ -509,8 +509,8 @@ build_request_path() {
     fi
 
     # First replace all path parameters in the path
-    local path_regex="(.*)(\\{$pparam\\})(.*)"
     for pparam in "${path_params[@]}"; do
+        local path_regex="(.*)(\\{$pparam\\})(.*)"
         if [[ $path_template =~ $path_regex ]]; then
             path_template=${BASH_REMATCH[1]}${operation_parameters[$pparam]}${BASH_REMATCH[3]}
         fi


### PR DESCRIPTION
A previous change to make the regex a variable to allow proper linting
resulted in the regexp not having access to the value associated with
the variable and the path variable not being replaced.

Moves the regexp variable inside the for loop to allow the value to be
used and the path variable to be replaced with the provided value.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

