### PR TITLE
[Haskell] Add haskell-http-client to Shippable CI

### DIFF
--- a/pom.xml.shippable
+++ b/pom.xml.shippable
@@ -839,6 +839,7 @@
             <modules>
                 <!-- clients -->
                 <module>samples/client/petstore/elixir</module>
+                <module>samples/client/petstore/haskell-http-client</module>
             </modules>
         </profile>
     </profiles>

--- a/shippable.yml
+++ b/shippable.yml
@@ -7,7 +7,11 @@ build:
   cache: true
   cache_dir_list:
     - $HOME/.m2
+    - $SHIPPABLE_REPO_DIR/samples/client/petstore/haskell-http-client/.stack-work
   ci:
+    - sudo apt-get update -qq
+    # install stack
+    - curl -sSL https://get.haskellstack.org/ | sh
     # install elixir
     - wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb
     - sudo apt-get update


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Add haskell-http-client to Shippable CI
