### PR TITLE
[Elixir] Improve Elixir Client about primitive type spec

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ElixirClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ElixirClientCodegen.java
@@ -590,9 +590,26 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
                 buildTypespec(param.items, sb);
                 sb.append("}");
             } else if (param.isPrimitiveType) {
-                // <type>.t
-                sb.append(param.dataType);
-                sb.append(".t");
+                // <type>() OR <type>.t
+
+                // Primitive types in Elixir
+                // https://hexdocs.pm/elixir/1.5.2/typespecs.html#types-and-their-syntax
+                //
+                // NOTE: List, Tuple and Map are declared as primitive in a variable `languageSpecificPrimitives`.
+                HashMap map = new HashMap<String, String>();
+                map.put("Integer", "integer()");
+                map.put("Float", "float()");
+                map.put("Boolean", "boolean()");
+                map.put("String", "String.t");
+                map.put("List", "list()");
+                map.put("Atom", "atom()");
+                map.put("Map", "map()");
+                map.put("Tuple", "tuple()");
+                map.put("PID", "pid()");
+                map.put("DateTime", "DateTime.t");
+
+                String dataType = (String) map.get(param.dataType);
+                sb.append(dataType);
             } else if (param.isFile) {
                 sb.append("String.t");
             } else {

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/fake.ex
@@ -177,7 +177,7 @@ defmodule SwaggerPetstore.Api.Fake do
   {:ok, %{}} on success
   {:error, info} on failure
   """
-  @spec test_endpoint_parameters(Tesla.Env.client, Float.t, Float.t, String.t, String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_endpoint_parameters(Tesla.Env.client, float(), float(), String.t, String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_endpoint_parameters(connection, number, double, pattern_without_delimiter, byte, opts \\ []) do
     optional_params = %{
       :"integer" => :form,

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/pet.ex
@@ -53,7 +53,7 @@ defmodule SwaggerPetstore.Api.Pet do
   {:ok, %{}} on success
   {:error, info} on failure
   """
-  @spec delete_pet(Tesla.Env.client, Integer.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec delete_pet(Tesla.Env.client, integer(), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def delete_pet(connection, pet_id, opts \\ []) do
     optional_params = %{
       :"api_key" => :headers
@@ -134,7 +134,7 @@ defmodule SwaggerPetstore.Api.Pet do
   {:ok, %SwaggerPetstore.Model.Pet{}} on success
   {:error, info} on failure
   """
-  @spec get_pet_by_id(Tesla.Env.client, Integer.t, keyword()) :: {:ok, SwaggerPetstore.Model.Pet.t} | {:error, Tesla.Env.t}
+  @spec get_pet_by_id(Tesla.Env.client, integer(), keyword()) :: {:ok, SwaggerPetstore.Model.Pet.t} | {:error, Tesla.Env.t}
   def get_pet_by_id(connection, pet_id, _opts \\ []) do
     %{}
     |> method(:get)
@@ -187,7 +187,7 @@ defmodule SwaggerPetstore.Api.Pet do
   {:ok, %{}} on success
   {:error, info} on failure
   """
-  @spec update_pet_with_form(Tesla.Env.client, Integer.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec update_pet_with_form(Tesla.Env.client, integer(), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def update_pet_with_form(connection, pet_id, opts \\ []) do
     optional_params = %{
       :"name" => :form,
@@ -219,7 +219,7 @@ defmodule SwaggerPetstore.Api.Pet do
   {:ok, %SwaggerPetstore.Model.ApiResponse{}} on success
   {:error, info} on failure
   """
-  @spec upload_file(Tesla.Env.client, Integer.t, keyword()) :: {:ok, SwaggerPetstore.Model.ApiResponse.t} | {:error, Tesla.Env.t}
+  @spec upload_file(Tesla.Env.client, integer(), keyword()) :: {:ok, SwaggerPetstore.Model.ApiResponse.t} | {:error, Tesla.Env.t}
   def upload_file(connection, pet_id, opts \\ []) do
     optional_params = %{
       :"additionalMetadata" => :form,

--- a/samples/client/petstore/elixir/lib/swagger_petstore/api/store.ex
+++ b/samples/client/petstore/elixir/lib/swagger_petstore/api/store.ex
@@ -75,7 +75,7 @@ defmodule SwaggerPetstore.Api.Store do
   {:ok, %SwaggerPetstore.Model.Order{}} on success
   {:error, info} on failure
   """
-  @spec get_order_by_id(Tesla.Env.client, Integer.t, keyword()) :: {:ok, SwaggerPetstore.Model.Order.t} | {:error, Tesla.Env.t}
+  @spec get_order_by_id(Tesla.Env.client, integer(), keyword()) :: {:ok, SwaggerPetstore.Model.Order.t} | {:error, Tesla.Env.t}
   def get_order_by_id(connection, order_id, _opts \\ []) do
     %{}
     |> method(:get)


### PR DESCRIPTION
Fix following dialyzer warnings in the sample:

```
:0: Unknown type 'Elixir.Float':t/0
:0: Unknown type 'Elixir.Integer':t/0
```

You can check dialyzer warnings following like:

```
% git clone https://github.com/jeremyjh/dialyxir
% cd dialyxir
% MIX_ENV=prod mix do compile, archive.build, archive.install
% cd ../swagger-codegen/samples/client/petstore/elixir
% mix do deps.get, dialyzer
```