### PR TITLE
Updated feign library dependency to io.github.openfeign

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -113,9 +113,9 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
-    compile "com.netflix.feign:feign-core:$feign_version"
-    compile "com.netflix.feign:feign-jackson:$feign_version"
-    compile "com.netflix.feign:feign-slf4j:$feign_version"
+    compile "io.github.openfeign:feign-core:$feign_version"
+    compile "io.github.openfeign:feign-jackson:$feign_version"
+    compile "io.github.openfeign:feign-slf4j:$feign_version"
     compile "io.github.openfeign.form:feign-form:$feign_form_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/build.sbt.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/build.sbt.mustache
@@ -10,9 +10,9 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.9" % "compile",
-      "com.netflix.feign" % "feign-core" % "9.4.0" % "compile",
-      "com.netflix.feign" % "feign-jackson" % "9.4.0" % "compile",
-      "com.netflix.feign" % "feign-slf4j" % "9.4.0" % "compile",
+      "io.github.openfeign" % "feign-core" % "9.4.0" % "compile",
+      "io.github.openfeign" % "feign-jackson" % "9.4.0" % "compile",
+      "io.github.openfeign" % "feign-slf4j" % "9.4.0" % "compile",
       "io.github.openfeign.form" % "feign-form" % "2.1.0" % "compile",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.8.7" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.8.7" % "compile",

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -105,9 +105,9 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
-    compile "com.netflix.feign:feign-core:$feign_version"
-    compile "com.netflix.feign:feign-jackson:$feign_version"
-    compile "com.netflix.feign:feign-slf4j:$feign_version"
+    compile "io.github.openfeign:feign-core:$feign_version"
+    compile "io.github.openfeign:feign-jackson:$feign_version"
+    compile "io.github.openfeign:feign-slf4j:$feign_version"
     compile "io.github.openfeign.form:feign-form:$feign_form_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/samples/client/petstore/java/feign/build.sbt
+++ b/samples/client/petstore/java/feign/build.sbt
@@ -10,9 +10,9 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.9" % "compile",
-      "com.netflix.feign" % "feign-core" % "9.4.0" % "compile",
-      "com.netflix.feign" % "feign-jackson" % "9.4.0" % "compile",
-      "com.netflix.feign" % "feign-slf4j" % "9.4.0" % "compile",
+      "io.github.openfeign" % "feign-core" % "9.4.0" % "compile",
+      "io.github.openfeign" % "feign-jackson" % "9.4.0" % "compile",
+      "io.github.openfeign" % "feign-slf4j" % "9.4.0" % "compile",
       "io.github.openfeign.form" % "feign-form" % "2.1.0" % "compile",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.8.7" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.8.7" % "compile",


### PR DESCRIPTION
Changed groupId from “com.netflix.feign” to “io.github.openfeign” from
gradle and sbt mustache templates.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR
Fixes #6397 by changing groupId in gradle and sbt mustache templates.

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)