### PR TITLE
[kotlin] Fix causing NoClassDefFoundError at runtime on Android device

### DIFF
--- a/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/swagger-codegen/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -60,9 +60,9 @@ open class ApiClient(val baseUrl: String) {
         var urlBuilder = httpUrl.newBuilder()
                 .addPathSegments(requestConfig.path.trimStart('/'))
 
-        requestConfig.query.forEach { k, v ->
-            v.forEach { queryValue ->
-                urlBuilder = urlBuilder.addQueryParameter(k,queryValue)
+        requestConfig.query.forEach { query ->
+            query.value.forEach { queryValue ->
+                urlBuilder = urlBuilder.addQueryParameter(query.key, queryValue)
             }
         }
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/io/swagger/client/infrastructure/ApiClient.kt
@@ -60,9 +60,9 @@ open class ApiClient(val baseUrl: String) {
         var urlBuilder = httpUrl.newBuilder()
                 .addPathSegments(requestConfig.path.trimStart('/'))
 
-        requestConfig.query.forEach { k, v ->
-            v.forEach { queryValue ->
-                urlBuilder = urlBuilder.addQueryParameter(k,queryValue)
+        requestConfig.query.forEach { query ->
+            query.value.forEach { queryValue ->
+                urlBuilder = urlBuilder.addQueryParameter(query.key, queryValue)
             }
         }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

I faced with the following exception at runtime on Android Device(API 19) by using generated api client.

```
E/AndroidRuntime(32762): java.lang.NoClassDefFoundError: io.swagger.client.infrastructure.ApiClient$request$1
E/AndroidRuntime(32762): 	at io.swagger.client.apis.InventoryApi.deleteInventory(InventoryApi.kt:294)
```

Finally I was approached an incompatible forEach syntax on ApiClient. Please review this whether is appropriate or not.

<img width="945" alt="2017-10-12 10 11 59" src="https://user-images.githubusercontent.com/2027132/31477495-3d0d7c9a-af47-11e7-9c98-8f6f402e76af.png">
