### PR TITLE
golang: trailing whitespace fails gofmt

### DIFF
--- a/modules/swagger-codegen/src/main/resources/go/partial_header.mustache
+++ b/modules/swagger-codegen/src/main/resources/go/partial_header.mustache
@@ -1,4 +1,4 @@
-/* 
+/*
  {{#appName}}
  * {{{appName}}}
  *


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR
The generated comments have a trailing whitespace, which several format related tools check for.

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

