### PR TITLE
[Swift4] Allow for custom dateformatter to be used

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift4/CodableHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/CodableHelper.mustache
@@ -21,7 +21,7 @@ open class CodableHelper {
         if let df = self.dateformatter {
             decoder.dateDecodingStrategy = .formatted(df)
         } else {
-            decoder.dateDecodingStrategy = .deferredToDate
+            decoder.dataDecodingStrategy = .base64
             if #available(iOS 10.0, *) {
                 decoder.dateDecodingStrategy = .iso8601
             }

--- a/modules/swagger-codegen/src/main/resources/swift4/CodableHelper.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/CodableHelper.mustache
@@ -11,14 +11,20 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
+    open static var dateformatter: DateFormatter?
+
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
         let decoder = JSONDecoder()
-        decoder.dataDecodingStrategy = .base64
-        if #available(iOS 10.0, *) {
-            decoder.dateDecodingStrategy = .iso8601
+        if let df = self.dateformatter {
+            decoder.dateDecodingStrategy = .formatted(df)
+        } else {
+            decoder.dateDecodingStrategy = .deferredToDate
+            if #available(iOS 10.0, *) {
+                decoder.dateDecodingStrategy = .iso8601
+            }
         }
 
         do {

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -21,7 +21,7 @@ open class CodableHelper {
         if let df = self.dateformatter {
             decoder.dateDecodingStrategy = .formatted(df)
         } else {
-            decoder.dateDecodingStrategy = .deferredToDate
+            decoder.dataDecodingStrategy = .base64
             if #available(iOS 10.0, *) {
                 decoder.dateDecodingStrategy = .iso8601
             }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -11,14 +11,20 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
+    open static var dateformatter: DateFormatter?
+
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
         let decoder = JSONDecoder()
-        decoder.dataDecodingStrategy = .base64
-        if #available(iOS 10.0, *) {
-            decoder.dateDecodingStrategy = .iso8601
+        if let df = self.dateformatter {
+            decoder.dateDecodingStrategy = .formatted(df)
+        } else {
+            decoder.dateDecodingStrategy = .deferredToDate
+            if #available(iOS 10.0, *) {
+                decoder.dateDecodingStrategy = .iso8601
+            }
         }
 
         do {

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -21,7 +21,7 @@ open class CodableHelper {
         if let df = self.dateformatter {
             decoder.dateDecodingStrategy = .formatted(df)
         } else {
-            decoder.dateDecodingStrategy = .deferredToDate
+            decoder.dataDecodingStrategy = .base64
             if #available(iOS 10.0, *) {
                 decoder.dateDecodingStrategy = .iso8601
             }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -11,14 +11,20 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
+    open static var dateformatter: DateFormatter?
+
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
         let decoder = JSONDecoder()
-        decoder.dataDecodingStrategy = .base64
-        if #available(iOS 10.0, *) {
-            decoder.dateDecodingStrategy = .iso8601
+        if let df = self.dateformatter {
+            decoder.dateDecodingStrategy = .formatted(df)
+        } else {
+            decoder.dateDecodingStrategy = .deferredToDate
+            if #available(iOS 10.0, *) {
+                decoder.dateDecodingStrategy = .iso8601
+            }
         }
 
         do {

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -21,7 +21,7 @@ open class CodableHelper {
         if let df = self.dateformatter {
             decoder.dateDecodingStrategy = .formatted(df)
         } else {
-            decoder.dateDecodingStrategy = .deferredToDate
+            decoder.dataDecodingStrategy = .base64
             if #available(iOS 10.0, *) {
                 decoder.dateDecodingStrategy = .iso8601
             }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/CodableHelper.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/Swaggers/CodableHelper.swift
@@ -11,14 +11,20 @@ public typealias EncodeResult = (data: Data?, error: Error?)
 
 open class CodableHelper {
 
+    open static var dateformatter: DateFormatter?
+
     open class func decode<T>(_ type: T.Type, from data: Data) -> (decodableObj: T?, error: Error?) where T : Decodable {
         var returnedDecodable: T? = nil
         var returnedError: Error? = nil
 
         let decoder = JSONDecoder()
-        decoder.dataDecodingStrategy = .base64
-        if #available(iOS 10.0, *) {
-            decoder.dateDecodingStrategy = .iso8601
+        if let df = self.dateformatter {
+            decoder.dateDecodingStrategy = .formatted(df)
+        } else {
+            decoder.dateDecodingStrategy = .deferredToDate
+            if #available(iOS 10.0, *) {
+                decoder.dateDecodingStrategy = .iso8601
+            }
         }
 
         do {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

Setting a custom date format to be used on decoding. 

My server response date uses the format `YYYY-MM-DD'T'HH:mm:ss.sssZ`, I needed a way to set DateFormatter on the decoding of the data models. Suggest allowing for a custom DateFormat to be used in `CodableHelper`. 

Usage:
```
// Custom Date
let dateFormat = DateFormatter()
dateFormat.dateFormat = "YYYY-MM-DD'T'HH:mm:ss.sssZ" // "2017-10-12T17:03:21.000Z"
CodableHelper.dateformatter = dateFormat
```
Suggested code change in `CodableHelper`
```
// Allow for custom date formatter to be used
open static var dateformatter: DateFormatter?

// Check if formatter is set, else fallback to default values
let decoder = JSONDecoder()
if let df = self.dateformatter {
    decoder.dateDecodingStrategy = .formatted(df)
} else {
    decoder.dateDecodingStrategy = .deferredToDate
    if #available(iOS 10.0, *) {
        decoder.dateDecodingStrategy = .iso8601
    }
}
```

Also changed the `dateDecodingStrategy` from '.base64' to '.deferredToDate` from issue #6576.

