### PR TITLE
[Java Play Framework] Add required exception when a required parameters is not provided

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApiController.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApiController.mustache
@@ -52,25 +52,35 @@ public class {{classname}}Controller extends Controller {
         {{^collectionFormat}}
         JsonNode node{{paramName}} = request().body().asJson();
         {{{dataType}}} {{paramName}};
-        {{^required}}
         if (node{{paramName}} != null) {
-            {{paramName}} = mapper.readValue(node{{paramName}}.toString(), {{#isContainer}}new TypeReference<{{{dataType}}}>(){}{{/isContainer}}{{^isContainer}}{{{dataType}}}.class{{/isContainer}});{{/required}}
-        {{#required}}{{paramName}} = mapper.readValue(node{{paramName}}.toString(), {{#isContainer}}new TypeReference<{{{dataType}}}>(){}{{/isContainer}}{{^isContainer}}{{{dataType}}}.class{{/isContainer}});{{/required}}{{#useBeanValidation}}
-        {{#isListContainer}}for ({{{baseType}}} curItem : {{paramName}}) {
-            curItem.validate();
-        }{{/isListContainer}}{{#isMapContainer}}for (Map.Entry<String, {{{baseType}}}> entry : {{paramName}}.entrySet()) {
-            entry.getValue().validate();
-        }
-        {{/isMapContainer}}{{^isContainer}}{{paramName}}.validate();{{/isContainer}}{{/useBeanValidation}}
-        {{^required}}
+            {{paramName}} = mapper.readValue(node{{paramName}}.toString(), {{#isContainer}}new TypeReference<{{{dataType}}}>(){}{{/isContainer}}{{^isContainer}}{{{dataType}}}.class{{/isContainer}});
+            {{#useBeanValidation}}
+            {{#isListContainer}}for ({{{baseType}}} curItem : {{paramName}}) {
+                curItem.validate();
+            }{{/isListContainer}}{{#isMapContainer}}for (Map.Entry<String, {{{baseType}}}> entry : {{paramName}}.entrySet()) {
+                entry.getValue().validate();
+            }
+            {{/isMapContainer}}{{^isContainer}}{{paramName}}.validate();{{/isContainer}}
+            {{/useBeanValidation}}
         } else {
+            {{#required}}
+            throw new IllegalArgumentException("'{{baseName}}' parameter is required");
+            {{/required}}
+            {{^required}}
             {{paramName}} = null;
-        }{{/required}}
+            {{/required}}
+        }
         {{/collectionFormat}}
         {{/bodyParams}}
         {{#queryParams}}
         {{#collectionFormat}}
-        List<String> {{paramName}}List = SwaggerUtils.parametersToList("{{collectionFormat}}", request().queryString().get("{{baseName}}"));
+        String[] {{paramName}}Array = request().queryString().get("{{baseName}}");
+        {{#required}}
+        if ({{paramName}}Array == null) {
+            throw new IllegalArgumentException("'{{baseName}}' parameter is required");
+        }
+        {{/required}}
+        List<String> {{paramName}}List = SwaggerUtils.parametersToList("{{collectionFormat}}", {{paramName}}Array);
         {{{dataType}}} {{paramName}} = new Array{{{dataType}}}();
         for (String curParam : {{paramName}}List) {
             //noinspection UseBulkOperation
@@ -80,14 +90,16 @@ public class {{classname}}Controller extends Controller {
         {{^collectionFormat}}
         String value{{paramName}} = request().getQueryString("{{baseName}}");
         {{{dataType}}} {{paramName}};
-        {{^required}}
         if (value{{paramName}} != null) {
-            {{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};{{/required}}
-        {{#required}}{{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};{{/required}}
-        {{^required}}
+            {{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};
         } else {
+            {{#required}}
+            throw new IllegalArgumentException("'{{baseName}}' parameter is required");
+            {{/required}}
+            {{^required}}
             {{paramName}} = {{>paramDefaultValue}};
-        }{{/required}}
+            {{/required}}
+        }
         {{/collectionFormat}}
         {{/queryParams}}
         {{#formParams}}
@@ -95,13 +107,19 @@ public class {{classname}}Controller extends Controller {
         {{{dataType}}} {{paramName}} = request().body().asMultipartFormData().getFile("{{baseName}}");
         {{#required}}
         if (({{paramName}} == null || ((File) {{paramName}}.getFile()).length() == 0)) {
-            throw new RuntimeException("File cannot be empty");
+            throw new IllegalArgumentException("'{{baseName}}' file cannot be empty");
         }
         {{/required}}
         {{/notFile}}
         {{#notFile}}
         {{#collectionFormat}}
-        List<String> {{paramName}}List = SwaggerUtils.parametersToList("{{collectionFormat}}", request().body().asMultipartFormData().asFormUrlEncoded().get("{{baseName}}"));
+        String[] {{paramName}}Array = request().body().asMultipartFormData().asFormUrlEncoded().get("{{baseName}}");
+        {{#required}}
+        if ({{paramName}}Array == null) {
+            throw new IllegalArgumentException("'{{baseName}}' parameter is required");
+        }
+        {{/required}}
+        List<String> {{paramName}}List = SwaggerUtils.parametersToList("{{collectionFormat}}", {{paramName}}Array);
         {{{dataType}}} {{paramName}} = new Array{{{dataType}}}();
         for (String curParam : {{paramName}}List) {
             //noinspection UseBulkOperation
@@ -111,20 +129,28 @@ public class {{classname}}Controller extends Controller {
         {{^collectionFormat}}
         String value{{paramName}} = (request().body().asMultipartFormData().asFormUrlEncoded().get("{{baseName}}"))[0];
         {{{dataType}}} {{paramName}};
-        {{^required}}
         if (value{{paramName}} != null) {
-            {{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};{{/required}}
-        {{#required}}{{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};{{/required}}
-        {{^required}}
+            {{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};
         } else {
+            {{#required}}
+            throw new IllegalArgumentException("'{{baseName}}' parameter is required");
+            {{/required}}
+            {{^required}}
             {{paramName}} = {{>paramDefaultValue}};
-        }{{/required}}
+            {{/required}}
+        }
         {{/collectionFormat}}
         {{/notFile}}
         {{/formParams}}
         {{#headerParams}}
         {{#collectionFormat}}
-        List<String> {{paramName}}List = SwaggerUtils.parametersToList("{{collectionFormat}}", request().headers().get("{{baseName}}"));
+        String[] {{paramName}}Array = request().headers().get("{{baseName}}");
+        {{#required}}
+        if ({{paramName}}Array == null) {
+            throw new IllegalArgumentException("'{{baseName}}' parameter is required");
+        }
+        {{/required}}
+        List<String> {{paramName}}List = SwaggerUtils.parametersToList("{{collectionFormat}}", {{paramName}}Array);
         {{{dataType}}} {{paramName}} = new Array{{{dataType}}}();
         for (String curParam : {{paramName}}List) {
             //noinspection UseBulkOperation
@@ -134,14 +160,16 @@ public class {{classname}}Controller extends Controller {
         {{^collectionFormat}}
         String value{{paramName}} = request().getHeader("{{baseName}}");
         {{{dataType}}} {{paramName}};
-        {{^required}}
         if (value{{paramName}} != null) {
-            {{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};{{/required}}
-        {{#required}}{{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};{{/required}}
-        {{^required}}
+            {{paramName}} = {{>conversionBegin}}value{{paramName}}{{>conversionEnd}};
         } else {
+            {{#required}}
+            throw new IllegalArgumentException("'{{baseName}}' parameter is required");
+            {{/required}}
+            {{^required}}
             {{paramName}} = {{>paramDefaultValue}};
-        }{{/required}}
+            {{/required}}
+        }
         {{/collectionFormat}}
         {{/headerParams}}
         {{^controllerOnly}}

--- a/samples/server/petstore/java-play-framework-controller-only/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-controller-only/app/controllers/PetApiController.java
@@ -36,10 +36,12 @@ public class PetApiController extends Controller {
     public Result addPet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         return ok();
     }
 
@@ -49,7 +51,6 @@ public class PetApiController extends Controller {
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;
-        
         } else {
             apiKey = null;
         }
@@ -58,7 +59,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByStatus() throws Exception {
-        List<String> statusList = SwaggerUtils.parametersToList("csv", request().queryString().get("status"));
+        String[] statusArray = request().queryString().get("status");
+        if (statusArray == null) {
+            throw new IllegalArgumentException("'status' parameter is required");
+        }
+        List<String> statusList = SwaggerUtils.parametersToList("csv", statusArray);
         List<String> status = new ArrayList<String>();
         for (String curParam : statusList) {
             //noinspection UseBulkOperation
@@ -69,7 +74,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByTags() throws Exception {
-        List<String> tagsList = SwaggerUtils.parametersToList("csv", request().queryString().get("tags"));
+        String[] tagsArray = request().queryString().get("tags");
+        if (tagsArray == null) {
+            throw new IllegalArgumentException("'tags' parameter is required");
+        }
+        List<String> tagsList = SwaggerUtils.parametersToList("csv", tagsArray);
         List<String> tags = new ArrayList<String>();
         for (String curParam : tagsList) {
             //noinspection UseBulkOperation
@@ -87,10 +96,12 @@ public class PetApiController extends Controller {
     public Result updatePet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         return ok();
     }
 
@@ -100,7 +111,6 @@ public class PetApiController extends Controller {
         String name;
         if (valuename != null) {
             name = valuename;
-        
         } else {
             name = null;
         }
@@ -108,7 +118,6 @@ public class PetApiController extends Controller {
         String status;
         if (valuestatus != null) {
             status = valuestatus;
-        
         } else {
             status = null;
         }
@@ -121,7 +130,6 @@ public class PetApiController extends Controller {
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
             additionalMetadata = valueadditionalMetadata;
-        
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-controller-only/app/controllers/StoreApiController.java
+++ b/samples/server/petstore/java-play-framework-controller-only/app/controllers/StoreApiController.java
@@ -50,10 +50,12 @@ public class StoreApiController extends Controller {
     public Result placeOrder() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Order body;
-
-        body = mapper.readValue(nodebody.toString(), Order.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Order.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         return ok();
     }
 }

--- a/samples/server/petstore/java-play-framework-controller-only/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-controller-only/app/controllers/UserApiController.java
@@ -35,10 +35,12 @@ public class UserApiController extends Controller {
     public Result createUser() throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         return ok();
     }
 
@@ -46,12 +48,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithArrayInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         return ok();
     }
 
@@ -59,12 +63,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithListInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         return ok();
     }
 
@@ -82,14 +88,18 @@ public class UserApiController extends Controller {
     public Result loginUser() throws Exception {
         String valueusername = request().getQueryString("username");
         String username;
-
-        username = valueusername;
-
+        if (valueusername != null) {
+            username = valueusername;
+        } else {
+            throw new IllegalArgumentException("'username' parameter is required");
+        }
         String valuepassword = request().getQueryString("password");
         String password;
-
-        password = valuepassword;
-
+        if (valuepassword != null) {
+            password = valuepassword;
+        } else {
+            throw new IllegalArgumentException("'password' parameter is required");
+        }
         return ok();
     }
 
@@ -102,10 +112,12 @@ public class UserApiController extends Controller {
     public Result updateUser(String username) throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         return ok();
     }
 }

--- a/samples/server/petstore/java-play-framework-controller-only/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-controller-only/public/swagger.json
@@ -9,7 +9,7 @@
       "email" : "apiteam@swagger.io"
     },
     "license" : {
-      "name" : "Apache 2.0",
+      "name" : "Apache-2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/Module.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/Module.java
@@ -6,6 +6,7 @@ public class Module extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(AnotherFakeApiControllerImpInterface.class).to(AnotherFakeApiControllerImp.class);
         bind(FakeApiControllerImpInterface.class).to(FakeApiControllerImp.class);
         bind(FakeClassnameTags123ApiControllerImpInterface.class).to(FakeClassnameTags123ApiControllerImp.class);
         bind(PetApiControllerImpInterface.class).to(PetApiControllerImp.class);

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/AnotherFakeApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/AnotherFakeApiController.java
@@ -20,20 +20,20 @@ import javax.validation.constraints.*;
 import swagger.SwaggerUtils.ApiAction;
 
 
-public class FakeClassnameTags123ApiController extends Controller {
+public class AnotherFakeApiController extends Controller {
 
-    private final FakeClassnameTags123ApiControllerImpInterface imp;
+    private final AnotherFakeApiControllerImpInterface imp;
     private final ObjectMapper mapper;
 
     @Inject
-    private FakeClassnameTags123ApiController(FakeClassnameTags123ApiControllerImpInterface imp) {
+    private AnotherFakeApiController(AnotherFakeApiControllerImpInterface imp) {
         this.imp = imp;
         mapper = new ObjectMapper();
     }
 
 
     @ApiAction
-    public Result testClassname() throws Exception {
+    public Result testSpecialTags() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Client body;
         if (nodebody != null) {
@@ -42,7 +42,7 @@ public class FakeClassnameTags123ApiController extends Controller {
         } else {
             throw new IllegalArgumentException("'body' parameter is required");
         }
-        Client obj = imp.testClassname(body);
+        Client obj = imp.testSpecialTags(body);
         obj.validate();
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/AnotherFakeApiControllerImp.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/AnotherFakeApiControllerImp.java
@@ -1,0 +1,19 @@
+package controllers;
+
+import apimodels.Client;
+
+import play.mvc.Http;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.io.FileInputStream;
+import javax.validation.constraints.*;
+
+public class AnotherFakeApiControllerImp implements AnotherFakeApiControllerImpInterface {
+    @Override
+    public Client testSpecialTags(Client body) throws Exception {
+        //Do your magic!!!
+        return new Client();
+    }
+
+}

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/AnotherFakeApiControllerImpInterface.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/AnotherFakeApiControllerImpInterface.java
@@ -1,0 +1,16 @@
+package controllers;
+
+import apimodels.Client;
+
+import play.mvc.Http;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import javax.validation.constraints.*;
+
+@SuppressWarnings("RedundantThrows")
+public interface AnotherFakeApiControllerImpInterface {
+    Client testSpecialTags(Client body) throws Exception;
+
+}

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/FakeApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/FakeApiController.java
@@ -42,8 +42,7 @@ public class FakeApiController extends Controller {
         Boolean body;
         if (nodebody != null) {
             body = mapper.readValue(nodebody.toString(), Boolean.class);
-        
-        body.validate();
+            body.validate();
         } else {
             body = null;
         }
@@ -58,8 +57,7 @@ public class FakeApiController extends Controller {
         OuterComposite body;
         if (nodebody != null) {
             body = mapper.readValue(nodebody.toString(), OuterComposite.class);
-        
-        body.validate();
+            body.validate();
         } else {
             body = null;
         }
@@ -75,8 +73,7 @@ public class FakeApiController extends Controller {
         BigDecimal body;
         if (nodebody != null) {
             body = mapper.readValue(nodebody.toString(), BigDecimal.class);
-        
-        body.validate();
+            body.validate();
         } else {
             body = null;
         }
@@ -92,8 +89,7 @@ public class FakeApiController extends Controller {
         String body;
         if (nodebody != null) {
             body = mapper.readValue(nodebody.toString(), String.class);
-        
-        body.validate();
+            body.validate();
         } else {
             body = null;
         }
@@ -106,10 +102,12 @@ public class FakeApiController extends Controller {
     public Result testClientModel() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Client body;
-
-        body = mapper.readValue(nodebody.toString(), Client.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Client.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         Client obj = imp.testClientModel(body);
         obj.validate();
         JsonNode result = mapper.valueToTree(obj);
@@ -122,7 +120,6 @@ public class FakeApiController extends Controller {
         Integer integer;
         if (valueinteger != null) {
             integer = Integer.parseInt(valueinteger);
-        
         } else {
             integer = null;
         }
@@ -130,7 +127,6 @@ public class FakeApiController extends Controller {
         Integer int32;
         if (valueint32 != null) {
             int32 = Integer.parseInt(valueint32);
-        
         } else {
             int32 = null;
         }
@@ -138,51 +134,55 @@ public class FakeApiController extends Controller {
         Long int64;
         if (valueint64 != null) {
             int64 = Long.parseLong(valueint64);
-        
         } else {
             int64 = null;
         }
         String valuenumber = (request().body().asMultipartFormData().asFormUrlEncoded().get("number"))[0];
         BigDecimal number;
-
-        number = Float.parseFloat(valuenumber);
-
+        if (valuenumber != null) {
+            number = Float.parseFloat(valuenumber);
+        } else {
+            throw new IllegalArgumentException("'number' parameter is required");
+        }
         String value_float = (request().body().asMultipartFormData().asFormUrlEncoded().get("float"))[0];
         Float _float;
         if (value_float != null) {
             _float = Float.parseFloat(value_float);
-        
         } else {
             _float = null;
         }
         String value_double = (request().body().asMultipartFormData().asFormUrlEncoded().get("double"))[0];
         Double _double;
-
-        _double = Double.parseDouble(value_double);
-
+        if (value_double != null) {
+            _double = Double.parseDouble(value_double);
+        } else {
+            throw new IllegalArgumentException("'double' parameter is required");
+        }
         String valuestring = (request().body().asMultipartFormData().asFormUrlEncoded().get("string"))[0];
         String string;
         if (valuestring != null) {
             string = valuestring;
-        
         } else {
             string = null;
         }
         String valuepatternWithoutDelimiter = (request().body().asMultipartFormData().asFormUrlEncoded().get("pattern_without_delimiter"))[0];
         String patternWithoutDelimiter;
-
-        patternWithoutDelimiter = valuepatternWithoutDelimiter;
-
+        if (valuepatternWithoutDelimiter != null) {
+            patternWithoutDelimiter = valuepatternWithoutDelimiter;
+        } else {
+            throw new IllegalArgumentException("'pattern_without_delimiter' parameter is required");
+        }
         String value_byte = (request().body().asMultipartFormData().asFormUrlEncoded().get("byte"))[0];
         byte[] _byte;
-
-        _byte = value_byte;
-
+        if (value_byte != null) {
+            _byte = value_byte;
+        } else {
+            throw new IllegalArgumentException("'byte' parameter is required");
+        }
         String valuebinary = (request().body().asMultipartFormData().asFormUrlEncoded().get("binary"))[0];
         byte[] binary;
         if (valuebinary != null) {
             binary = valuebinary;
-        
         } else {
             binary = null;
         }
@@ -190,7 +190,6 @@ public class FakeApiController extends Controller {
         LocalDate date;
         if (valuedate != null) {
             date = valuedate;
-        
         } else {
             date = null;
         }
@@ -198,7 +197,6 @@ public class FakeApiController extends Controller {
         OffsetDateTime dateTime;
         if (valuedateTime != null) {
             dateTime = OffsetDateTime.parse(valuedateTime);
-        
         } else {
             dateTime = null;
         }
@@ -206,7 +204,6 @@ public class FakeApiController extends Controller {
         String password;
         if (valuepassword != null) {
             password = valuepassword;
-        
         } else {
             password = null;
         }
@@ -214,7 +211,6 @@ public class FakeApiController extends Controller {
         String paramCallback;
         if (valueparamCallback != null) {
             paramCallback = valueparamCallback;
-        
         } else {
             paramCallback = null;
         }
@@ -224,7 +220,8 @@ public class FakeApiController extends Controller {
 
     @ApiAction
     public Result testEnumParameters() throws Exception {
-        List<String> enumQueryStringArrayList = SwaggerUtils.parametersToList("csv", request().queryString().get("enum_query_string_array"));
+        String[] enumQueryStringArrayArray = request().queryString().get("enum_query_string_array");
+        List<String> enumQueryStringArrayList = SwaggerUtils.parametersToList("csv", enumQueryStringArrayArray);
         List<String> enumQueryStringArray = new ArrayList<String>();
         for (String curParam : enumQueryStringArrayList) {
             //noinspection UseBulkOperation
@@ -234,7 +231,6 @@ public class FakeApiController extends Controller {
         String enumQueryString;
         if (valueenumQueryString != null) {
             enumQueryString = valueenumQueryString;
-        
         } else {
             enumQueryString = "-efg";
         }
@@ -242,11 +238,11 @@ public class FakeApiController extends Controller {
         Integer enumQueryInteger;
         if (valueenumQueryInteger != null) {
             enumQueryInteger = Integer.parseInt(valueenumQueryInteger);
-        
         } else {
             enumQueryInteger = null;
         }
-        List<String> enumFormStringArrayList = SwaggerUtils.parametersToList("csv", request().body().asMultipartFormData().asFormUrlEncoded().get("enum_form_string_array"));
+        String[] enumFormStringArrayArray = request().body().asMultipartFormData().asFormUrlEncoded().get("enum_form_string_array");
+        List<String> enumFormStringArrayList = SwaggerUtils.parametersToList("csv", enumFormStringArrayArray);
         List<String> enumFormStringArray = new ArrayList<String>();
         for (String curParam : enumFormStringArrayList) {
             //noinspection UseBulkOperation
@@ -256,7 +252,6 @@ public class FakeApiController extends Controller {
         String enumFormString;
         if (valueenumFormString != null) {
             enumFormString = valueenumFormString;
-        
         } else {
             enumFormString = "-efg";
         }
@@ -264,11 +259,11 @@ public class FakeApiController extends Controller {
         Double enumQueryDouble;
         if (valueenumQueryDouble != null) {
             enumQueryDouble = Double.parseDouble(valueenumQueryDouble);
-        
         } else {
             enumQueryDouble = null;
         }
-        List<String> enumHeaderStringArrayList = SwaggerUtils.parametersToList("csv", request().headers().get("enum_header_string_array"));
+        String[] enumHeaderStringArrayArray = request().headers().get("enum_header_string_array");
+        List<String> enumHeaderStringArrayList = SwaggerUtils.parametersToList("csv", enumHeaderStringArrayArray);
         List<String> enumHeaderStringArray = new ArrayList<String>();
         for (String curParam : enumHeaderStringArrayList) {
             //noinspection UseBulkOperation
@@ -278,7 +273,6 @@ public class FakeApiController extends Controller {
         String enumHeaderString;
         if (valueenumHeaderString != null) {
             enumHeaderString = valueenumHeaderString;
-        
         } else {
             enumHeaderString = "-efg";
         }
@@ -290,14 +284,18 @@ public class FakeApiController extends Controller {
     public Result testJsonFormData() throws Exception {
         String valueparam = (request().body().asMultipartFormData().asFormUrlEncoded().get("param"))[0];
         String param;
-
-        param = valueparam;
-
+        if (valueparam != null) {
+            param = valueparam;
+        } else {
+            throw new IllegalArgumentException("'param' parameter is required");
+        }
         String valueparam2 = (request().body().asMultipartFormData().asFormUrlEncoded().get("param2"))[0];
         String param2;
-
-        param2 = valueparam2;
-
+        if (valueparam2 != null) {
+            param2 = valueparam2;
+        } else {
+            throw new IllegalArgumentException("'param2' parameter is required");
+        }
         imp.testJsonFormData(param, param2);
         return ok();
     }

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/PetApiController.java
@@ -38,10 +38,12 @@ public class PetApiController extends Controller {
     public Result addPet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.addPet(body);
         return ok();
     }
@@ -52,7 +54,6 @@ public class PetApiController extends Controller {
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;
-        
         } else {
             apiKey = null;
         }
@@ -62,7 +63,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByStatus() throws Exception {
-        List<String> statusList = SwaggerUtils.parametersToList("csv", request().queryString().get("status"));
+        String[] statusArray = request().queryString().get("status");
+        if (statusArray == null) {
+            throw new IllegalArgumentException("'status' parameter is required");
+        }
+        List<String> statusList = SwaggerUtils.parametersToList("csv", statusArray);
         List<String> status = new ArrayList<String>();
         for (String curParam : statusList) {
             //noinspection UseBulkOperation
@@ -78,7 +83,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByTags() throws Exception {
-        List<String> tagsList = SwaggerUtils.parametersToList("csv", request().queryString().get("tags"));
+        String[] tagsArray = request().queryString().get("tags");
+        if (tagsArray == null) {
+            throw new IllegalArgumentException("'tags' parameter is required");
+        }
+        List<String> tagsList = SwaggerUtils.parametersToList("csv", tagsArray);
         List<String> tags = new ArrayList<String>();
         for (String curParam : tagsList) {
             //noinspection UseBulkOperation
@@ -104,10 +113,12 @@ public class PetApiController extends Controller {
     public Result updatePet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updatePet(body);
         return ok();
     }
@@ -118,7 +129,6 @@ public class PetApiController extends Controller {
         String name;
         if (valuename != null) {
             name = valuename;
-        
         } else {
             name = null;
         }
@@ -126,7 +136,6 @@ public class PetApiController extends Controller {
         String status;
         if (valuestatus != null) {
             status = valuestatus;
-        
         } else {
             status = null;
         }
@@ -140,7 +149,6 @@ public class PetApiController extends Controller {
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
             additionalMetadata = valueadditionalMetadata;
-        
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/StoreApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/StoreApiController.java
@@ -58,10 +58,12 @@ public class StoreApiController extends Controller {
     public Result placeOrder() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Order body;
-
-        body = mapper.readValue(nodebody.toString(), Order.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Order.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         Order obj = imp.placeOrder(body);
         obj.validate();
         JsonNode result = mapper.valueToTree(obj);

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/controllers/UserApiController.java
@@ -37,10 +37,12 @@ public class UserApiController extends Controller {
     public Result createUser() throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUser(body);
         return ok();
     }
@@ -49,12 +51,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithArrayInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithArrayInput(body);
         return ok();
     }
@@ -63,12 +67,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithListInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithListInput(body);
         return ok();
     }
@@ -91,14 +97,18 @@ public class UserApiController extends Controller {
     public Result loginUser() throws Exception {
         String valueusername = request().getQueryString("username");
         String username;
-
-        username = valueusername;
-
+        if (valueusername != null) {
+            username = valueusername;
+        } else {
+            throw new IllegalArgumentException("'username' parameter is required");
+        }
         String valuepassword = request().getQueryString("password");
         String password;
-
-        password = valuepassword;
-
+        if (valuepassword != null) {
+            password = valuepassword;
+        } else {
+            throw new IllegalArgumentException("'password' parameter is required");
+        }
         String obj = imp.loginUser(username, password);
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);
@@ -114,10 +124,12 @@ public class UserApiController extends Controller {
     public Result updateUser(String username) throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updateUser(username, body);
         return ok();
     }

--- a/samples/server/petstore/java-play-framework-fake-endpoints/conf/routes
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/conf/routes
@@ -5,6 +5,9 @@
 GET     /api                        controllers.ApiDocController.api
 
 
+#Functions for AnotherFake API
+PATCH     /v2/another-fake/dummy                     controllers.AnotherFakeApiController.testSpecialTags()
+
 #Functions for Fake API
 POST     /v2/fake/outer/boolean                     controllers.FakeApiController.fakeOuterBooleanSerialize()
 POST     /v2/fake/outer/composite                     controllers.FakeApiController.fakeOuterCompositeSerialize()

--- a/samples/server/petstore/java-play-framework-fake-endpoints/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/public/swagger.json
@@ -9,7 +9,7 @@
       "email" : "apiteam@swagger.io"
     },
     "license" : {
-      "name" : "Apache 2.0",
+      "name" : "Apache-2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },
@@ -1087,6 +1087,35 @@
         "x-contentType" : "application/json",
         "x-accepts" : "application/json"
       }
+    },
+    "/another-fake/dummy" : {
+      "patch" : {
+        "tags" : [ "$another-fake?" ],
+        "summary" : "To test special tags",
+        "description" : "To test special tags",
+        "operationId" : "test_special_tags",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "client model",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/Client"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/Client"
+            }
+          }
+        },
+        "x-contentType" : "application/json",
+        "x-accepts" : "application/json"
+      }
     }
   },
   "securityDefinitions" : {
@@ -1744,15 +1773,6 @@
       "type" : "string",
       "enum" : [ "placed", "approved", "delivered" ]
     },
-    "OuterNumber" : {
-      "type" : "number"
-    },
-    "OuterString" : {
-      "type" : "string"
-    },
-    "OuterBoolean" : {
-      "type" : "boolean"
-    },
     "OuterComposite" : {
       "type" : "object",
       "properties" : {
@@ -1771,6 +1791,15 @@
         "my_number" : { },
         "my_boolean" : { }
       }
+    },
+    "OuterNumber" : {
+      "type" : "number"
+    },
+    "OuterString" : {
+      "type" : "string"
+    },
+    "OuterBoolean" : {
+      "type" : "boolean"
     }
   },
   "externalDocs" : {

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/PetApiController.java
@@ -37,9 +37,11 @@ public class PetApiController extends Controller {
     public Result addPet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.addPet(body);
         return ok();
     }
@@ -50,7 +52,6 @@ public class PetApiController extends Controller {
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;
-        
         } else {
             apiKey = null;
         }
@@ -60,7 +61,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByStatus() throws Exception {
-        List<String> statusList = SwaggerUtils.parametersToList("csv", request().queryString().get("status"));
+        String[] statusArray = request().queryString().get("status");
+        if (statusArray == null) {
+            throw new IllegalArgumentException("'status' parameter is required");
+        }
+        List<String> statusList = SwaggerUtils.parametersToList("csv", statusArray);
         List<String> status = new ArrayList<String>();
         for (String curParam : statusList) {
             //noinspection UseBulkOperation
@@ -73,7 +78,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByTags() throws Exception {
-        List<String> tagsList = SwaggerUtils.parametersToList("csv", request().queryString().get("tags"));
+        String[] tagsArray = request().queryString().get("tags");
+        if (tagsArray == null) {
+            throw new IllegalArgumentException("'tags' parameter is required");
+        }
+        List<String> tagsList = SwaggerUtils.parametersToList("csv", tagsArray);
         List<String> tags = new ArrayList<String>();
         for (String curParam : tagsList) {
             //noinspection UseBulkOperation
@@ -95,9 +104,11 @@ public class PetApiController extends Controller {
     public Result updatePet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updatePet(body);
         return ok();
     }
@@ -108,7 +119,6 @@ public class PetApiController extends Controller {
         String name;
         if (valuename != null) {
             name = valuename;
-        
         } else {
             name = null;
         }
@@ -116,7 +126,6 @@ public class PetApiController extends Controller {
         String status;
         if (valuestatus != null) {
             status = valuestatus;
-        
         } else {
             status = null;
         }
@@ -130,7 +139,6 @@ public class PetApiController extends Controller {
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
             additionalMetadata = valueadditionalMetadata;
-        
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/StoreApiController.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/StoreApiController.java
@@ -56,9 +56,11 @@ public class StoreApiController extends Controller {
     public Result placeOrder() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Order body;
-
-        body = mapper.readValue(nodebody.toString(), Order.class);
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Order.class);
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         Order obj = imp.placeOrder(body);
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);

--- a/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/app/controllers/UserApiController.java
@@ -36,9 +36,11 @@ public class UserApiController extends Controller {
     public Result createUser() throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUser(body);
         return ok();
     }
@@ -47,9 +49,11 @@ public class UserApiController extends Controller {
     public Result createUsersWithArrayInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUsersWithArrayInput(body);
         return ok();
     }
@@ -58,9 +62,11 @@ public class UserApiController extends Controller {
     public Result createUsersWithListInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUsersWithListInput(body);
         return ok();
     }
@@ -82,14 +88,18 @@ public class UserApiController extends Controller {
     public Result loginUser() throws Exception {
         String valueusername = request().getQueryString("username");
         String username;
-
-        username = valueusername;
-
+        if (valueusername != null) {
+            username = valueusername;
+        } else {
+            throw new IllegalArgumentException("'username' parameter is required");
+        }
         String valuepassword = request().getQueryString("password");
         String password;
-
-        password = valuepassword;
-
+        if (valuepassword != null) {
+            password = valuepassword;
+        } else {
+            throw new IllegalArgumentException("'password' parameter is required");
+        }
         String obj = imp.loginUser(username, password);
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);
@@ -105,9 +115,11 @@ public class UserApiController extends Controller {
     public Result updateUser(String username) throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updateUser(username, body);
         return ok();
     }

--- a/samples/server/petstore/java-play-framework-no-bean-validation/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/public/swagger.json
@@ -9,7 +9,7 @@
       "email" : "apiteam@swagger.io"
     },
     "license" : {
-      "name" : "Apache 2.0",
+      "name" : "Apache-2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/PetApiController.java
@@ -39,10 +39,12 @@ public class PetApiController extends Controller {
     public Result addPet() throws IOException {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.addPet(body);
         return ok();
     }
@@ -53,7 +55,6 @@ public class PetApiController extends Controller {
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;
-        
         } else {
             apiKey = null;
         }
@@ -63,7 +64,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByStatus()  {
-        List<String> statusList = SwaggerUtils.parametersToList("csv", request().queryString().get("status"));
+        String[] statusArray = request().queryString().get("status");
+        if (statusArray == null) {
+            throw new IllegalArgumentException("'status' parameter is required");
+        }
+        List<String> statusList = SwaggerUtils.parametersToList("csv", statusArray);
         List<String> status = new ArrayList<String>();
         for (String curParam : statusList) {
             //noinspection UseBulkOperation
@@ -79,7 +84,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByTags()  {
-        List<String> tagsList = SwaggerUtils.parametersToList("csv", request().queryString().get("tags"));
+        String[] tagsArray = request().queryString().get("tags");
+        if (tagsArray == null) {
+            throw new IllegalArgumentException("'tags' parameter is required");
+        }
+        List<String> tagsList = SwaggerUtils.parametersToList("csv", tagsArray);
         List<String> tags = new ArrayList<String>();
         for (String curParam : tagsList) {
             //noinspection UseBulkOperation
@@ -105,10 +114,12 @@ public class PetApiController extends Controller {
     public Result updatePet() throws IOException {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updatePet(body);
         return ok();
     }
@@ -119,7 +130,6 @@ public class PetApiController extends Controller {
         String name;
         if (valuename != null) {
             name = valuename;
-        
         } else {
             name = null;
         }
@@ -127,7 +137,6 @@ public class PetApiController extends Controller {
         String status;
         if (valuestatus != null) {
             status = valuestatus;
-        
         } else {
             status = null;
         }
@@ -141,7 +150,6 @@ public class PetApiController extends Controller {
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
             additionalMetadata = valueadditionalMetadata;
-        
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/StoreApiController.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/StoreApiController.java
@@ -59,10 +59,12 @@ public class StoreApiController extends Controller {
     public Result placeOrder() throws IOException {
         JsonNode nodebody = request().body().asJson();
         Order body;
-
-        body = mapper.readValue(nodebody.toString(), Order.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Order.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         Order obj = imp.placeOrder(body);
         obj.validate();
         JsonNode result = mapper.valueToTree(obj);

--- a/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/app/controllers/UserApiController.java
@@ -38,10 +38,12 @@ public class UserApiController extends Controller {
     public Result createUser() throws IOException {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUser(body);
         return ok();
     }
@@ -50,12 +52,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithArrayInput() throws IOException {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithArrayInput(body);
         return ok();
     }
@@ -64,12 +68,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithListInput() throws IOException {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithListInput(body);
         return ok();
     }
@@ -92,14 +98,18 @@ public class UserApiController extends Controller {
     public Result loginUser()  {
         String valueusername = request().getQueryString("username");
         String username;
-
-        username = valueusername;
-
+        if (valueusername != null) {
+            username = valueusername;
+        } else {
+            throw new IllegalArgumentException("'username' parameter is required");
+        }
         String valuepassword = request().getQueryString("password");
         String password;
-
-        password = valuepassword;
-
+        if (valuepassword != null) {
+            password = valuepassword;
+        } else {
+            throw new IllegalArgumentException("'password' parameter is required");
+        }
         String obj = imp.loginUser(username, password);
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);
@@ -115,10 +125,12 @@ public class UserApiController extends Controller {
     public Result updateUser(String username) throws IOException {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updateUser(username, body);
         return ok();
     }

--- a/samples/server/petstore/java-play-framework-no-exception-handling/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/public/swagger.json
@@ -9,7 +9,7 @@
       "email" : "apiteam@swagger.io"
     },
     "license" : {
-      "name" : "Apache 2.0",
+      "name" : "Apache-2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },

--- a/samples/server/petstore/java-play-framework-no-interface/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-interface/app/controllers/PetApiController.java
@@ -38,10 +38,12 @@ public class PetApiController extends Controller {
     public Result addPet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.addPet(body);
         return ok();
     }
@@ -52,7 +54,6 @@ public class PetApiController extends Controller {
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;
-        
         } else {
             apiKey = null;
         }
@@ -62,7 +63,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByStatus() throws Exception {
-        List<String> statusList = SwaggerUtils.parametersToList("csv", request().queryString().get("status"));
+        String[] statusArray = request().queryString().get("status");
+        if (statusArray == null) {
+            throw new IllegalArgumentException("'status' parameter is required");
+        }
+        List<String> statusList = SwaggerUtils.parametersToList("csv", statusArray);
         List<String> status = new ArrayList<String>();
         for (String curParam : statusList) {
             //noinspection UseBulkOperation
@@ -78,7 +83,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByTags() throws Exception {
-        List<String> tagsList = SwaggerUtils.parametersToList("csv", request().queryString().get("tags"));
+        String[] tagsArray = request().queryString().get("tags");
+        if (tagsArray == null) {
+            throw new IllegalArgumentException("'tags' parameter is required");
+        }
+        List<String> tagsList = SwaggerUtils.parametersToList("csv", tagsArray);
         List<String> tags = new ArrayList<String>();
         for (String curParam : tagsList) {
             //noinspection UseBulkOperation
@@ -104,10 +113,12 @@ public class PetApiController extends Controller {
     public Result updatePet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updatePet(body);
         return ok();
     }
@@ -118,7 +129,6 @@ public class PetApiController extends Controller {
         String name;
         if (valuename != null) {
             name = valuename;
-        
         } else {
             name = null;
         }
@@ -126,7 +136,6 @@ public class PetApiController extends Controller {
         String status;
         if (valuestatus != null) {
             status = valuestatus;
-        
         } else {
             status = null;
         }
@@ -140,7 +149,6 @@ public class PetApiController extends Controller {
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
             additionalMetadata = valueadditionalMetadata;
-        
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-interface/app/controllers/StoreApiController.java
+++ b/samples/server/petstore/java-play-framework-no-interface/app/controllers/StoreApiController.java
@@ -58,10 +58,12 @@ public class StoreApiController extends Controller {
     public Result placeOrder() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Order body;
-
-        body = mapper.readValue(nodebody.toString(), Order.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Order.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         Order obj = imp.placeOrder(body);
         obj.validate();
         JsonNode result = mapper.valueToTree(obj);

--- a/samples/server/petstore/java-play-framework-no-interface/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-interface/app/controllers/UserApiController.java
@@ -37,10 +37,12 @@ public class UserApiController extends Controller {
     public Result createUser() throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUser(body);
         return ok();
     }
@@ -49,12 +51,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithArrayInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithArrayInput(body);
         return ok();
     }
@@ -63,12 +67,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithListInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithListInput(body);
         return ok();
     }
@@ -91,14 +97,18 @@ public class UserApiController extends Controller {
     public Result loginUser() throws Exception {
         String valueusername = request().getQueryString("username");
         String username;
-
-        username = valueusername;
-
+        if (valueusername != null) {
+            username = valueusername;
+        } else {
+            throw new IllegalArgumentException("'username' parameter is required");
+        }
         String valuepassword = request().getQueryString("password");
         String password;
-
-        password = valuepassword;
-
+        if (valuepassword != null) {
+            password = valuepassword;
+        } else {
+            throw new IllegalArgumentException("'password' parameter is required");
+        }
         String obj = imp.loginUser(username, password);
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);
@@ -114,10 +124,12 @@ public class UserApiController extends Controller {
     public Result updateUser(String username) throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updateUser(username, body);
         return ok();
     }

--- a/samples/server/petstore/java-play-framework-no-interface/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-interface/public/swagger.json
@@ -9,7 +9,7 @@
       "email" : "apiteam@swagger.io"
     },
     "license" : {
-      "name" : "Apache 2.0",
+      "name" : "Apache-2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/PetApiController.java
@@ -38,10 +38,12 @@ public class PetApiController extends Controller {
     public Result addPet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.addPet(body);
         return ok();
     }
@@ -52,7 +54,6 @@ public class PetApiController extends Controller {
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;
-        
         } else {
             apiKey = null;
         }
@@ -62,7 +63,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByStatus() throws Exception {
-        List<String> statusList = SwaggerUtils.parametersToList("csv", request().queryString().get("status"));
+        String[] statusArray = request().queryString().get("status");
+        if (statusArray == null) {
+            throw new IllegalArgumentException("'status' parameter is required");
+        }
+        List<String> statusList = SwaggerUtils.parametersToList("csv", statusArray);
         List<String> status = new ArrayList<String>();
         for (String curParam : statusList) {
             //noinspection UseBulkOperation
@@ -78,7 +83,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByTags() throws Exception {
-        List<String> tagsList = SwaggerUtils.parametersToList("csv", request().queryString().get("tags"));
+        String[] tagsArray = request().queryString().get("tags");
+        if (tagsArray == null) {
+            throw new IllegalArgumentException("'tags' parameter is required");
+        }
+        List<String> tagsList = SwaggerUtils.parametersToList("csv", tagsArray);
         List<String> tags = new ArrayList<String>();
         for (String curParam : tagsList) {
             //noinspection UseBulkOperation
@@ -104,10 +113,12 @@ public class PetApiController extends Controller {
     public Result updatePet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updatePet(body);
         return ok();
     }
@@ -118,7 +129,6 @@ public class PetApiController extends Controller {
         String name;
         if (valuename != null) {
             name = valuename;
-        
         } else {
             name = null;
         }
@@ -126,7 +136,6 @@ public class PetApiController extends Controller {
         String status;
         if (valuestatus != null) {
             status = valuestatus;
-        
         } else {
             status = null;
         }
@@ -140,7 +149,6 @@ public class PetApiController extends Controller {
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
             additionalMetadata = valueadditionalMetadata;
-        
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/StoreApiController.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/StoreApiController.java
@@ -58,10 +58,12 @@ public class StoreApiController extends Controller {
     public Result placeOrder() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Order body;
-
-        body = mapper.readValue(nodebody.toString(), Order.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Order.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         Order obj = imp.placeOrder(body);
         obj.validate();
         JsonNode result = mapper.valueToTree(obj);

--- a/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-swagger-ui/app/controllers/UserApiController.java
@@ -37,10 +37,12 @@ public class UserApiController extends Controller {
     public Result createUser() throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUser(body);
         return ok();
     }
@@ -49,12 +51,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithArrayInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithArrayInput(body);
         return ok();
     }
@@ -63,12 +67,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithListInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithListInput(body);
         return ok();
     }
@@ -91,14 +97,18 @@ public class UserApiController extends Controller {
     public Result loginUser() throws Exception {
         String valueusername = request().getQueryString("username");
         String username;
-
-        username = valueusername;
-
+        if (valueusername != null) {
+            username = valueusername;
+        } else {
+            throw new IllegalArgumentException("'username' parameter is required");
+        }
         String valuepassword = request().getQueryString("password");
         String password;
-
-        password = valuepassword;
-
+        if (valuepassword != null) {
+            password = valuepassword;
+        } else {
+            throw new IllegalArgumentException("'password' parameter is required");
+        }
         String obj = imp.loginUser(username, password);
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);
@@ -114,10 +124,12 @@ public class UserApiController extends Controller {
     public Result updateUser(String username) throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updateUser(username, body);
         return ok();
     }

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/PetApiController.java
@@ -37,10 +37,12 @@ public class PetApiController extends Controller {
     public Result addPet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.addPet(body);
         return ok();
     }
@@ -51,7 +53,6 @@ public class PetApiController extends Controller {
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;
-        
         } else {
             apiKey = null;
         }
@@ -61,7 +62,11 @@ public class PetApiController extends Controller {
 
     
     public Result findPetsByStatus() throws Exception {
-        List<String> statusList = SwaggerUtils.parametersToList("csv", request().queryString().get("status"));
+        String[] statusArray = request().queryString().get("status");
+        if (statusArray == null) {
+            throw new IllegalArgumentException("'status' parameter is required");
+        }
+        List<String> statusList = SwaggerUtils.parametersToList("csv", statusArray);
         List<String> status = new ArrayList<String>();
         for (String curParam : statusList) {
             //noinspection UseBulkOperation
@@ -77,7 +82,11 @@ public class PetApiController extends Controller {
 
     
     public Result findPetsByTags() throws Exception {
-        List<String> tagsList = SwaggerUtils.parametersToList("csv", request().queryString().get("tags"));
+        String[] tagsArray = request().queryString().get("tags");
+        if (tagsArray == null) {
+            throw new IllegalArgumentException("'tags' parameter is required");
+        }
+        List<String> tagsList = SwaggerUtils.parametersToList("csv", tagsArray);
         List<String> tags = new ArrayList<String>();
         for (String curParam : tagsList) {
             //noinspection UseBulkOperation
@@ -103,10 +112,12 @@ public class PetApiController extends Controller {
     public Result updatePet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updatePet(body);
         return ok();
     }
@@ -117,7 +128,6 @@ public class PetApiController extends Controller {
         String name;
         if (valuename != null) {
             name = valuename;
-        
         } else {
             name = null;
         }
@@ -125,7 +135,6 @@ public class PetApiController extends Controller {
         String status;
         if (valuestatus != null) {
             status = valuestatus;
-        
         } else {
             status = null;
         }
@@ -139,7 +148,6 @@ public class PetApiController extends Controller {
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
             additionalMetadata = valueadditionalMetadata;
-        
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/StoreApiController.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/StoreApiController.java
@@ -57,10 +57,12 @@ public class StoreApiController extends Controller {
     public Result placeOrder() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Order body;
-
-        body = mapper.readValue(nodebody.toString(), Order.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Order.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         Order obj = imp.placeOrder(body);
         obj.validate();
         JsonNode result = mapper.valueToTree(obj);

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/app/controllers/UserApiController.java
@@ -36,10 +36,12 @@ public class UserApiController extends Controller {
     public Result createUser() throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUser(body);
         return ok();
     }
@@ -48,12 +50,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithArrayInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithArrayInput(body);
         return ok();
     }
@@ -62,12 +66,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithListInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithListInput(body);
         return ok();
     }
@@ -90,14 +96,18 @@ public class UserApiController extends Controller {
     public Result loginUser() throws Exception {
         String valueusername = request().getQueryString("username");
         String username;
-
-        username = valueusername;
-
+        if (valueusername != null) {
+            username = valueusername;
+        } else {
+            throw new IllegalArgumentException("'username' parameter is required");
+        }
         String valuepassword = request().getQueryString("password");
         String password;
-
-        password = valuepassword;
-
+        if (valuepassword != null) {
+            password = valuepassword;
+        } else {
+            throw new IllegalArgumentException("'password' parameter is required");
+        }
         String obj = imp.loginUser(username, password);
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);
@@ -113,10 +123,12 @@ public class UserApiController extends Controller {
     public Result updateUser(String username) throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updateUser(username, body);
         return ok();
     }

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/public/swagger.json
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/public/swagger.json
@@ -9,7 +9,7 @@
       "email" : "apiteam@swagger.io"
     },
     "license" : {
-      "name" : "Apache 2.0",
+      "name" : "Apache-2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },

--- a/samples/server/petstore/java-play-framework/app/controllers/PetApiController.java
+++ b/samples/server/petstore/java-play-framework/app/controllers/PetApiController.java
@@ -38,10 +38,12 @@ public class PetApiController extends Controller {
     public Result addPet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.addPet(body);
         return ok();
     }
@@ -52,7 +54,6 @@ public class PetApiController extends Controller {
         String apiKey;
         if (valueapiKey != null) {
             apiKey = valueapiKey;
-        
         } else {
             apiKey = null;
         }
@@ -62,7 +63,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByStatus() throws Exception {
-        List<String> statusList = SwaggerUtils.parametersToList("csv", request().queryString().get("status"));
+        String[] statusArray = request().queryString().get("status");
+        if (statusArray == null) {
+            throw new IllegalArgumentException("'status' parameter is required");
+        }
+        List<String> statusList = SwaggerUtils.parametersToList("csv", statusArray);
         List<String> status = new ArrayList<String>();
         for (String curParam : statusList) {
             //noinspection UseBulkOperation
@@ -78,7 +83,11 @@ public class PetApiController extends Controller {
 
     @ApiAction
     public Result findPetsByTags() throws Exception {
-        List<String> tagsList = SwaggerUtils.parametersToList("csv", request().queryString().get("tags"));
+        String[] tagsArray = request().queryString().get("tags");
+        if (tagsArray == null) {
+            throw new IllegalArgumentException("'tags' parameter is required");
+        }
+        List<String> tagsList = SwaggerUtils.parametersToList("csv", tagsArray);
         List<String> tags = new ArrayList<String>();
         for (String curParam : tagsList) {
             //noinspection UseBulkOperation
@@ -104,10 +113,12 @@ public class PetApiController extends Controller {
     public Result updatePet() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Pet body;
-
-        body = mapper.readValue(nodebody.toString(), Pet.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Pet.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updatePet(body);
         return ok();
     }
@@ -118,7 +129,6 @@ public class PetApiController extends Controller {
         String name;
         if (valuename != null) {
             name = valuename;
-        
         } else {
             name = null;
         }
@@ -126,7 +136,6 @@ public class PetApiController extends Controller {
         String status;
         if (valuestatus != null) {
             status = valuestatus;
-        
         } else {
             status = null;
         }
@@ -140,7 +149,6 @@ public class PetApiController extends Controller {
         String additionalMetadata;
         if (valueadditionalMetadata != null) {
             additionalMetadata = valueadditionalMetadata;
-        
         } else {
             additionalMetadata = null;
         }

--- a/samples/server/petstore/java-play-framework/app/controllers/StoreApiController.java
+++ b/samples/server/petstore/java-play-framework/app/controllers/StoreApiController.java
@@ -58,10 +58,12 @@ public class StoreApiController extends Controller {
     public Result placeOrder() throws Exception {
         JsonNode nodebody = request().body().asJson();
         Order body;
-
-        body = mapper.readValue(nodebody.toString(), Order.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), Order.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         Order obj = imp.placeOrder(body);
         obj.validate();
         JsonNode result = mapper.valueToTree(obj);

--- a/samples/server/petstore/java-play-framework/app/controllers/UserApiController.java
+++ b/samples/server/petstore/java-play-framework/app/controllers/UserApiController.java
@@ -37,10 +37,12 @@ public class UserApiController extends Controller {
     public Result createUser() throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.createUser(body);
         return ok();
     }
@@ -49,12 +51,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithArrayInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithArrayInput(body);
         return ok();
     }
@@ -63,12 +67,14 @@ public class UserApiController extends Controller {
     public Result createUsersWithListInput() throws Exception {
         JsonNode nodebody = request().body().asJson();
         List<User> body;
-
-        body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
-        for (User curItem : body) {
-            curItem.validate();
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), new TypeReference<List<User>>(){});
+            for (User curItem : body) {
+                curItem.validate();
+            }
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
         }
-
         imp.createUsersWithListInput(body);
         return ok();
     }
@@ -91,14 +97,18 @@ public class UserApiController extends Controller {
     public Result loginUser() throws Exception {
         String valueusername = request().getQueryString("username");
         String username;
-
-        username = valueusername;
-
+        if (valueusername != null) {
+            username = valueusername;
+        } else {
+            throw new IllegalArgumentException("'username' parameter is required");
+        }
         String valuepassword = request().getQueryString("password");
         String password;
-
-        password = valuepassword;
-
+        if (valuepassword != null) {
+            password = valuepassword;
+        } else {
+            throw new IllegalArgumentException("'password' parameter is required");
+        }
         String obj = imp.loginUser(username, password);
         JsonNode result = mapper.valueToTree(obj);
         return ok(result);
@@ -114,10 +124,12 @@ public class UserApiController extends Controller {
     public Result updateUser(String username) throws Exception {
         JsonNode nodebody = request().body().asJson();
         User body;
-
-        body = mapper.readValue(nodebody.toString(), User.class);
-        body.validate();
-
+        if (nodebody != null) {
+            body = mapper.readValue(nodebody.toString(), User.class);
+            body.validate();
+        } else {
+            throw new IllegalArgumentException("'body' parameter is required");
+        }
         imp.updateUser(username, body);
         return ok();
     }

--- a/samples/server/petstore/java-play-framework/public/swagger.json
+++ b/samples/server/petstore/java-play-framework/public/swagger.json
@@ -9,7 +9,7 @@
       "email" : "apiteam@swagger.io"
     },
     "license" : {
-      "name" : "Apache 2.0",
+      "name" : "Apache-2.0",
       "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   },


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

There was no validation when a required parameter was null, creating crash and null pointer exception further down the line in the business code. Now, it throws a InvalidArgumentException.

This makes the server rock solid and it returns a clear error about the missing parameters instead of crashing in business code relying on this parameter.

