### PR TITLE
[PHP] Fix #5338: InvalidArgumentException

### DIFF
--- a/modules/swagger-codegen/src/main/resources/php/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/php/api.mustache
@@ -417,8 +417,12 @@ use {{invokerPackage}}\ObjectSerializer;
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];

--- a/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/swagger-codegen/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -898,6 +898,27 @@ paths:
       responses:
         '200':
           description: successful operation
+  /fake/inline-additionalProperties:
+    post:
+      tags:
+        - fake
+      summary: test inline additionalProperties
+      description: ''
+      operationId: testInlineAdditionalProperties
+      consumes:
+        - application/json
+      parameters:
+        - name: param
+          in: body
+          description: request body
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '200':
+          description: successful operation
   /another-fake/dummy:
     patch:
       tags:

--- a/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore-security-test/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -246,8 +246,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];

--- a/samples/client/petstore/php/SwaggerClient-php/README.md
+++ b/samples/client/petstore/php/SwaggerClient-php/README.md
@@ -83,6 +83,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**testClientModel**](docs/Api/FakeApi.md#testclientmodel) | **PATCH** /fake | To test \&quot;client\&quot; model
 *FakeApi* | [**testEndpointParameters**](docs/Api/FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
 *FakeApi* | [**testEnumParameters**](docs/Api/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
+*FakeApi* | [**testInlineAdditionalProperties**](docs/Api/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**testJsonFormData**](docs/Api/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
 *FakeClassnameTags123Api* | [**testClassname**](docs/Api/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**addPet**](docs/Api/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store

--- a/samples/client/petstore/php/SwaggerClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/SwaggerClient-php/docs/Api/FakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 [**testClientModel**](FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 [**testEndpointParameters**](FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트
 [**testEnumParameters**](FakeApi.md#testEnumParameters) | **GET** /fake | To test enum parameters
+[**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
@@ -368,6 +369,50 @@ No authorization required
 
  - **Content-Type**: */*
  - **Accept**: */*
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+# **testInlineAdditionalProperties**
+> testInlineAdditionalProperties($param)
+
+test inline additionalProperties
+
+
+
+### Example
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+$api_instance = new Swagger\Client\Api\FakeApi(new \Http\Adapter\Guzzle6\Client());
+$param = new \stdClass; // object | request body
+
+try {
+    $api_instance->testInlineAdditionalProperties($param);
+} catch (Exception $e) {
+    echo 'Exception when calling FakeApi->testInlineAdditionalProperties: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **param** | **object**| request body |
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/AnotherFakeApi.php
@@ -288,8 +288,12 @@ class AnotherFakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -1982,6 +1982,221 @@ class FakeApi
     }
 
     /**
+     * Operation testInlineAdditionalProperties
+     *
+     * test inline additionalProperties
+     *
+     * @param  object $param request body (required)
+     *
+     * @throws \Swagger\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function testInlineAdditionalProperties($param)
+    {
+        $this->testInlineAdditionalPropertiesWithHttpInfo($param);
+    }
+
+    /**
+     * Operation testInlineAdditionalPropertiesWithHttpInfo
+     *
+     * test inline additionalProperties
+     *
+     * @param  object $param request body (required)
+     *
+     * @throws \Swagger\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function testInlineAdditionalPropertiesWithHttpInfo($param)
+    {
+        $returnType = '';
+        $request = $this->testInlineAdditionalPropertiesRequest($param);
+
+        try {
+
+            try {
+                $response = $this->client->send($request);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()
+                );
+            }
+
+            return [null, $statusCode, $response->getHeaders()];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation testInlineAdditionalPropertiesAsync
+     *
+     * test inline additionalProperties
+     *
+     * @param  object $param request body (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function testInlineAdditionalPropertiesAsync($param)
+    {
+        return $this->testInlineAdditionalPropertiesAsyncWithHttpInfo($param)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation testInlineAdditionalPropertiesAsyncWithHttpInfo
+     *
+     * test inline additionalProperties
+     *
+     * @param  object $param request body (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function testInlineAdditionalPropertiesAsyncWithHttpInfo($param)
+    {
+        $returnType = '';
+        $request = $this->testInlineAdditionalPropertiesRequest($param);
+
+        return $this->client
+            ->sendAsync($request)
+            ->then(
+                function ($response) use ($returnType) {
+                    return [null, $response->getStatusCode(), $response->getHeaders()];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'testInlineAdditionalProperties'
+     *
+     * @param  object $param request body (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    protected function testInlineAdditionalPropertiesRequest($param)
+    {
+        // verify the required parameter 'param' is set
+        if ($param === null) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $param when calling testInlineAdditionalProperties'
+            );
+        }
+
+        $resourcePath = '/fake/inline-additionalProperties';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+        // body params
+        $_tempBody = null;
+        if (isset($param)) {
+            $_tempBody = $param;
+        }
+
+        if ($multipart) {
+            $headers= $this->headerSelector->selectHeadersForMultipart(
+                []
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                [],
+                ['application/json']
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
+
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $multipartContents[] = [
+                        'name' => $formParamName,
+                        'contents' => $formParamValue
+                    ];
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'POST',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
      * Operation testJsonFormData
      *
      * test json serialization of form data

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeApi.php
@@ -278,8 +278,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -520,8 +524,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -762,8 +770,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1004,8 +1016,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1256,8 +1272,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1654,8 +1674,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1937,8 +1961,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -2152,8 +2180,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -2383,8 +2415,12 @@ class FakeApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -288,8 +288,12 @@ class FakeClassnameTags123Api
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/PetApi.php
@@ -251,8 +251,12 @@ class PetApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -484,8 +488,12 @@ class PetApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -744,8 +752,12 @@ class PetApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1004,8 +1016,12 @@ class PetApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1265,8 +1281,12 @@ class PetApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1485,8 +1505,12 @@ class PetApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1727,8 +1751,12 @@ class PetApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -2007,8 +2035,12 @@ class PetApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/StoreApi.php
@@ -256,8 +256,12 @@ class StoreApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -494,8 +498,12 @@ class StoreApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -763,8 +771,12 @@ class StoreApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1015,8 +1027,12 @@ class StoreApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];

--- a/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/SwaggerClient-php/lib/Api/UserApi.php
@@ -251,8 +251,12 @@ class UserApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -466,8 +470,12 @@ class UserApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -681,8 +689,12 @@ class UserApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -901,8 +913,12 @@ class UserApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1158,8 +1174,12 @@ class UserApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1426,8 +1446,12 @@ class UserApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1627,8 +1651,12 @@ class UserApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];
@@ -1861,8 +1889,12 @@ class UserApi
 
         // for model (json/xml)
         if (isset($_tempBody)) {
-            $httpBody = $_tempBody; // $_tempBody is the method argument, if present
-
+            // $_tempBody is the method argument, if present
+            $httpBody = $_tempBody;
+            // \stdClass has no __toString(), so we should encode it manually
+            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
                 $multipartContents = [];

--- a/samples/client/petstore/php/SwaggerClient-php/tests/ParametersTest.php
+++ b/samples/client/petstore/php/SwaggerClient-php/tests/ParametersTest.php
@@ -45,6 +45,16 @@ class ParametersTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['string1,string2'], $headers['enum_header_string_array']);
     }
 
+    public function testInlineAdditionalProperties()
+    {
+        $param = new \stdClass();
+        $param->foo = 'bar';
+        $this->fakeApi->testInlineAdditionalProperties($param);
+
+        $request = $this->fakeHttpClient->getLastRequest();
+        $this->assertSame('{"foo":"bar"}', $request->getBody()->getContents());
+    }
+
 //    missing example for collection path param in config
 //    public function testPathParamCollection()
 //    {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [x] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

This PR fixes the bug reported in https://github.com/swagger-api/swagger-codegen/issues/5338#issuecomment-292502895 .

##### Sample codes that reproduces it

Currently, the conditions which produces the bug, and error message by the bug differs from https://github.com/swagger-api/swagger-codegen/issues/5338#issuecomment-292502895.
Following reproduces the bug on latest master.

- spec.json

```json
{
  "swagger": "2.0",
  "paths": {
    "/": {
      "post": {
        "operationId": "postIt",
        "consumes": ["application/json"],
        "parameters": [{
          "name": "body",
          "in": "body",
          "required": true,
          "schema": {
            "type": "object",
            "additionalProperties": {
              "type": "string"
            }
          }
        }]
      }
    }
  }
}
```

- server.php

```php
<?php
file_put_contents(__DIR__ . '/log.txt', file_get_contents('php://input') . "\n");
```

- client.php

```php
<?php
require 'SwaggerClient-php/vendor/autoload.php';
$api = new Swagger\Client\Api\DefaultApi(
    null,
    (new Swagger\Client\Configuration())->setHost('http://localhost:9001')
);

$body = new \stdClass;
$body->question1 = 'foo';
$body->question2 = 'bar';

$api->postIt($body);
// PHP Fatal error:  Uncaught InvalidArgumentException: Invalid resource type: object in /Users/akihito1/dev/swagger-codegen/SwaggerClient-php/vendor/guzzlehttp/psr7/src/functions.php:116
// Stack trace:
// #0 /Users/akihito1/dev/swagger-codegen/SwaggerClient-php/vendor/guzzlehttp/psr7/src/Request.php(53): GuzzleHttp\Psr7\stream_for(Object(stdClass))
// #1 /Users/akihito1/dev/swagger-codegen/SwaggerClient-php/lib/Api/DefaultApi.php(286): GuzzleHttp\Psr7\Request->__construct('POST', Object(GuzzleHttp\Psr7\Uri), Array, Object(stdClass))
// #2 /Users/akihito1/dev/swagger-codegen/SwaggerClient-php/lib/Api/DefaultApi.php(105): Swagger\Client\Api\DefaultApi->postItRequest(Object(stdClass))
// #3 /Users/akihito1/dev/swagger-codegen/SwaggerClient-php/lib/Api/DefaultApi.php(90): Swagger\Client\Api\DefaultApi->postItWithHttpInfo(Object(stdClass))
// #4 /Users/akihito1/dev/swagger-codegen/client.php(13): Swagger\Client\Api\DefaultApi->postIt(Object(stdClass))
// #5 {main}
//   thrown in /Users/akihito1/dev/swagger-codegen/SwaggerClient-php/vendor/guzzlehttp/psr7/src/functions.php on line 116```
