### PR TITLE
[JAXRS-CXF] Add constructors to POJOs

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenProperty.java
@@ -37,7 +37,8 @@ public class CodegenProperty implements Cloneable {
     public boolean exclusiveMinimum;
     public boolean exclusiveMaximum;
     public boolean hasMore, required, secondaryParam;
-    public boolean hasMoreNonReadOnly; // for model constructor, true if next properyt is not readonly
+    public boolean hasMoreNonReadOnly; // for model constructor, true if next property is not readonly
+    public boolean isFirstRequired = false;
     public boolean isPrimitiveType, isContainer, isNotContainer;
     public boolean isString, isNumeric, isInteger, isLong, isFloat, isDouble, isByteArray, isBinary, isFile, isBoolean, isDate, isDateTime, isUuid;
     public boolean isListContainer, isMapContainer;

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -3088,6 +3088,7 @@ public class DefaultCodegen {
             Map<String, Property> allProperties, List<String> allRequired) {
 
         m.hasRequired = false;
+        m.hasOptional = false;
         if (properties != null && !properties.isEmpty()) {
             m.hasVars = true;
             m.hasEnums = false;
@@ -3125,7 +3126,8 @@ public class DefaultCodegen {
                 LOGGER.warn("null property for " + key);
             } else {
                 final CodegenProperty cp = fromProperty(key, prop);
-                cp.required = mandatory.contains(key) ? true : false;
+                cp.required = mandatory.contains(key);
+                cp.isFirstRequired = cp.required && !m.hasRequired; // true only for the first required property
                 m.hasRequired = m.hasRequired || cp.required;
                 m.hasOptional = m.hasOptional || !cp.required;
                 if (cp.isEnum) {

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -30,6 +30,28 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/vars}}
 
+  public {{classname}}() {}
+
+{{#hasVars}}
+{{#hasRequired}}
+  public {{classname}}({{#vars}}{{#required}}{{^isFirstRequired}}, {{/isFirstRequired}}{{{datatypeWithEnum}}} {{name}}{{/required}}{{/vars}}) {
+  {{#vars}}
+  {{#required}}
+    this.{{name}} = {{name}};
+  {{/required}}
+  {{/vars}}
+  }
+{{/hasRequired}}
+
+{{#hasOptional}}
+  public {{classname}}({{#vars}}{{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}{{/vars}}) {
+  {{#vars}}
+    this.{{name}} = {{name}};
+  {{/vars}}
+  }
+{{/hasOptional}}
+{{/hasVars}}
+
   {{#vars}}
  /**
   {{#description}}

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/api/PetApi.java
@@ -30,7 +30,7 @@ public interface PetApi  {
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Add a new pet to the store", tags={ "pet",  })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void addPet(@Valid Pet body);
 
@@ -38,7 +38,7 @@ public interface PetApi  {
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Deletes a pet", tags={ "pet",  })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 400, message = "Invalid pet value") })
     public void deletePet(@PathParam("petId") Long petId, @HeaderParam("api_key") String apiKey);
 
@@ -46,7 +46,7 @@ public interface PetApi  {
     @Path("/pet/findByStatus")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Finds Pets by status", tags={ "pet",  })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid status value") })
     public List<Pet> findPetsByStatus(@QueryParam("status") @NotNull List<String> status);
@@ -55,7 +55,7 @@ public interface PetApi  {
     @Path("/pet/findByTags")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Finds Pets by tags", tags={ "pet",  })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Invalid tag value") })
     public List<Pet> findPetsByTags(@QueryParam("tags") @NotNull List<String> tags);
@@ -64,7 +64,7 @@ public interface PetApi  {
     @Path("/pet/{petId}")
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Find pet by ID", tags={ "pet",  })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 200, message = "successful operation", response = Pet.class),
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found") })
@@ -75,7 +75,7 @@ public interface PetApi  {
     @Consumes({ "application/json", "application/xml" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Update an existing pet", tags={ "pet",  })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 400, message = "Invalid ID supplied"),
         @ApiResponse(code = 404, message = "Pet not found"),
         @ApiResponse(code = 405, message = "Validation exception") })
@@ -86,7 +86,7 @@ public interface PetApi  {
     @Consumes({ "application/x-www-form-urlencoded" })
     @Produces({ "application/xml", "application/json" })
     @ApiOperation(value = "Updates a pet in the store with form data", tags={ "pet",  })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 405, message = "Invalid input") })
     public void updatePetWithForm(@PathParam("petId") Long petId, @Multipart(value = "name", required = false)  String name, @Multipart(value = "status", required = false)  String status);
 
@@ -95,7 +95,7 @@ public interface PetApi  {
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
     @ApiOperation(value = "uploads an image", tags={ "pet" })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public ModelApiResponse uploadFile(@PathParam("petId") Long petId, @Multipart(value = "additionalMetadata", required = false)  String additionalMetadata,  @Multipart(value = "file" , required = false) Attachment fileDetail);
 }

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Category.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Category.java
@@ -18,6 +18,14 @@ public class Category  {
   @ApiModelProperty(value = "")
   private String name = null;
 
+  public Category() {}
+
+
+  public Category(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
  /**
    * Get id
    * @return id

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/ModelApiResponse.java
@@ -20,6 +20,15 @@ public class ModelApiResponse  {
   @ApiModelProperty(value = "")
   private String message = null;
 
+  public ModelApiResponse() {}
+
+
+  public ModelApiResponse(Integer code, String type, String message) {
+    this.code = code;
+    this.type = type;
+    this.message = message;
+  }
+
  /**
    * Get code
    * @return code

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Order.java
@@ -60,6 +60,18 @@ public enum StatusEnum {
   @ApiModelProperty(value = "")
   private Boolean complete = false;
 
+  public Order() {}
+
+
+  public Order(Long id, Long petId, Integer quantity, javax.xml.datatype.XMLGregorianCalendar shipDate, StatusEnum status, Boolean complete) {
+    this.id = id;
+    this.petId = petId;
+    this.quantity = quantity;
+    this.shipDate = shipDate;
+    this.status = status;
+    this.complete = complete;
+  }
+
  /**
    * Get id
    * @return id

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Pet.java
@@ -63,6 +63,22 @@ public enum StatusEnum {
   @ApiModelProperty(value = "pet status in the store")
   private StatusEnum status = null;
 
+  public Pet() {}
+
+  public Pet(String name, List<String> photoUrls) {
+    this.name = name;
+    this.photoUrls = photoUrls;
+  }
+
+  public Pet(Long id, Category category, String name, List<String> photoUrls, List<Tag> tags, StatusEnum status) {
+    this.id = id;
+    this.category = category;
+    this.name = name;
+    this.photoUrls = photoUrls;
+    this.tags = tags;
+    this.status = status;
+  }
+
  /**
    * Get id
    * @return id

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Tag.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/Tag.java
@@ -18,6 +18,14 @@ public class Tag  {
   @ApiModelProperty(value = "")
   private String name = null;
 
+  public Tag() {}
+
+
+  public Tag(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
  /**
    * Get id
    * @return id

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/io/swagger/model/User.java
@@ -30,6 +30,20 @@ public class User  {
   @ApiModelProperty(value = "User Status")
   private Integer userStatus = null;
 
+  public User() {}
+
+
+  public User(Long id, String username, String firstName, String lastName, String email, String password, String phone, Integer userStatus) {
+    this.id = id;
+    this.username = username;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+    this.password = password;
+    this.phone = phone;
+    this.userStatus = userStatus;
+  }
+
  /**
    * Get id
    * @return id


### PR DESCRIPTION
Before this change, POJOs where generated without regular constructors.This would mean you have to use the default constructor and setters or builder-style methods.
This is problematic when trying to make changes to the swagger file by adding required fields.
Before the change, the model consumer code will compile even when the callers does not supply all required fields when constructing a model object.
After the change, such addition will break the compilation and by that move important model validation from runtime to compile time.
For that reason, Our project code style requires use of constructors, and that is the motivation for this contribution.
This change adds a regular constructor to all POJOs, and specifically to the generated models.